### PR TITLE
feat(meeting_notes): add templates for agenda and summary with documentation

### DIFF
--- a/docs/meeting_notes/templates/README.md
+++ b/docs/meeting_notes/templates/README.md
@@ -8,7 +8,7 @@ Ce dossier contient des modèles standardisés pour préparer et documenter les 
 
 ### **1. Modèle pour l’Ordre du Jour**
 
-- **Fichier** : `agenda_template.md`
+- **Fichier** : [agenda_template.md](agenda_template.md)
 - **Description** :
   Utilisez ce modèle pour planifier les réunions et définir leur ordre du jour.
 - **Contient les Sections** :
@@ -21,7 +21,7 @@ Ce dossier contient des modèles standardisés pour préparer et documenter les 
 
 ### **2. Modèle pour le Compte-Rendu**
 
-- **Fichier** : `summary_template.md`
+- **Fichier** : [summary_template.md](summary_template.md)
 - **Description** :
   Utilisez ce modèle pour documenter les résultats des réunions.
 - **Contient les Sections** :
@@ -36,35 +36,36 @@ Ce dossier contient des modèles standardisés pour préparer et documenter les 
 ## **Emplacement des Modèles**
 
 - Les fichiers sont situés dans ce dossier :
-
   ```
+
   docs/meeting_notes/templates/
+
   ```
 
 ---
 
-## **Exemples d’Utilisation**
+## **Utilisation des Modèles**
 
-### **1. Avant une Réunion : Ordre du Jour**
+### **1. Réunion Kick-off**
 
-- **Utilisez** : `agenda_template.md`
-- **Étapes** :
-  1. Remplissez la section **Participants** avec les noms et rôles des personnes invitées.
-  2. Définissez les **Objectifs** à atteindre pendant la réunion.
-  3. Planifiez les **Sujets à Discuter** dans la section **Agenda**.
-  4. Ajoutez les liens vers les **Documents Associés** si nécessaire.
+- **Avant la Réunion** :
+  - Remplissez l’ordre du jour avec [agenda_template.md](agenda_template.md).
+- **Après la Réunion** :
+  - Documentez les décisions avec [summary_template.md](summary_template.md).
 
----
+### **2. Réunion de Suivi**
 
-### **2. Après une Réunion : Compte-Rendu**
+- **Avant la Réunion** :
+  - Préparez les sujets à discuter avec [agenda_template.md](agenda_template.md).
+- **Après la Réunion** :
+  - Résumez les progrès réalisés avec [summary_template.md](summary_template.md).
 
-- **Utilisez** : `summary_template.md`
-- **Étapes** :
-  1. Listez les participants présents dans la réunion.
-  2. Documentez les **Décisions** prises pendant la réunion.
-  3. Remplissez le tableau **Actions à Suivre** avec les tâches, responsables et échéances.
-  4. Ajoutez les **Questions en Suspens** qui nécessitent une action ultérieure.
-  5. Ajoutez les liens vers les documents pertinents dans **Documents Associés**.
+### **3. Réunion de Validation**
+
+- **Avant la Réunion** :
+  - Listez les points de validation avec [agenda_template.md](agenda_template.md).
+- **Après la Réunion** :
+  - Capturez les livrables validés avec [summary_template.md](summary_template.md).
 
 ---
 

--- a/docs/meeting_notes/templates/README.md
+++ b/docs/meeting_notes/templates/README.md
@@ -1,0 +1,82 @@
+# Modèles pour les Notes de Réunion
+
+Ce dossier contient des modèles standardisés pour préparer et documenter les réunions dans le cadre du projet **BeerToBeer**. Ces modèles garantissent une documentation homogène et claire.
+
+---
+
+## **Liste des Modèles Disponibles**
+
+### **1. Modèle pour l’Ordre du Jour**
+
+- **Fichier** : `agenda_template.md`
+- **Description** :
+  Utilisez ce modèle pour planifier les réunions et définir leur ordre du jour.
+- **Contient les Sections** :
+  - **Participants** : Liste des participants à la réunion avec leurs rôles.
+  - **Objectifs** : Liste des objectifs spécifiques de la réunion.
+  - **Agenda** : Liste des sujets à discuter, avec durées et descriptions.
+  - **Documents Associés** : Liens vers les documents nécessaires à la réunion.
+
+---
+
+### **2. Modèle pour le Compte-Rendu**
+
+- **Fichier** : `summary_template.md`
+- **Description** :
+  Utilisez ce modèle pour documenter les résultats des réunions.
+- **Contient les Sections** :
+  - **Participants** : Liste des participants et de leurs rôles.
+  - **Décisions** : Résumé des décisions prises pendant la réunion.
+  - **Actions à Suivre** : Tableau des tâches avec responsables et échéances.
+  - **Questions en Suspens** : Liste des points ouverts nécessitant une action ultérieure.
+  - **Documents Associés** : Liens vers les documents discutés ou validés.
+
+---
+
+## **Emplacement des Modèles**
+
+- Les fichiers sont situés dans ce dossier :
+
+  ```
+  docs/meeting_notes/templates/
+  ```
+
+---
+
+## **Exemples d’Utilisation**
+
+### **1. Avant une Réunion : Ordre du Jour**
+
+- **Utilisez** : `agenda_template.md`
+- **Étapes** :
+  1. Remplissez la section **Participants** avec les noms et rôles des personnes invitées.
+  2. Définissez les **Objectifs** à atteindre pendant la réunion.
+  3. Planifiez les **Sujets à Discuter** dans la section **Agenda**.
+  4. Ajoutez les liens vers les **Documents Associés** si nécessaire.
+
+---
+
+### **2. Après une Réunion : Compte-Rendu**
+
+- **Utilisez** : `summary_template.md`
+- **Étapes** :
+  1. Listez les participants présents dans la réunion.
+  2. Documentez les **Décisions** prises pendant la réunion.
+  3. Remplissez le tableau **Actions à Suivre** avec les tâches, responsables et échéances.
+  4. Ajoutez les **Questions en Suspens** qui nécessitent une action ultérieure.
+  5. Ajoutez les liens vers les documents pertinents dans **Documents Associés**.
+
+---
+
+## **Liens Utiles**
+
+- [Documentation Générale des Réunions](../README.md)
+- [Types de Réunions](../../meetings/meeting_types.md)
+- [Diagrammes des Réunions](../../meetings/)
+
+---
+
+## **Prochaines Étapes**
+
+1. Utilisez ces modèles pour toutes les réunions Kick-off, Suivi, et Validation.
+2. Mettez à jour les modèles si des besoins spécifiques émergent au fil du projet.

--- a/docs/meeting_notes/templates/agenda_template.md
+++ b/docs/meeting_notes/templates/agenda_template.md
@@ -1,0 +1,43 @@
+# Ordre du Jour de la Réunion
+
+## Informations Générales
+
+- **Date** : [Insérer la date]
+- **Heure** : [Insérer l'heure]
+- **Lieu/En ligne** : Salle de conférence ou [Lien Zoom](https://zoom.us/j/123456789)
+- **Facilitateur** : Alice Dupont (Chef de Projet)
+- **Participants** :
+  - Alice Dupont (Chef de Projet)
+  - Bob Martin (Développeur Backend)
+  - Clara Lopez (Designer UI/UX)
+  - David Chen (Responsable QA)
+
+---
+
+## Objectifs
+
+1. Finaliser la charte graphique.
+2. Valider le planning du sprint 2.
+3. Identifier les risques liés à l’intégration backend.
+
+---
+
+## Agenda
+
+1. **Introduction** *(10 min)* :
+   - Présentation des objectifs de la réunion.
+2. **Discussion** *(60 min)* :
+   - Sujet 1 : Charte graphique (Clara Lopez).
+   - Sujet 2 : Planification du sprint 2 (Bob Martin).
+   - Sujet 3 : Analyse des risques QA (David Chen).
+3. **Clôture** *(20 min)* :
+   - Résumé des décisions prises.
+   - Attribution des tâches.
+   - Planification des prochaines étapes.
+
+---
+
+## Documents Associés
+
+- [Charte graphique (projetée)](https://example.com/charte-graphique)
+- [Planning du sprint 2](https://example.com/planning-sprint2)

--- a/docs/meeting_notes/templates/summary_template.md
+++ b/docs/meeting_notes/templates/summary_template.md
@@ -1,0 +1,60 @@
+# Compte-Rendu de Réunion
+
+## Informations Générales
+
+- **Date** : [Insérer la date]
+- **Heure** : [Insérer l'heure]
+- **Facilitateur** : Alice Dupont (Chef de Projet)
+- **Participants** :
+  - Alice Dupont (Chef de Projet)
+  - Bob Martin (Développeur Backend)
+  - Clara Lopez (Designer UI/UX)
+  - David Chen (Responsable QA)
+
+---
+
+## Points Clés
+
+- Clara Lopez a présenté la nouvelle charte graphique.
+- David Chen a soulevé un risque potentiel sur les délais QA.
+
+---
+
+## Décisions
+
+*Résumé des décisions prises pendant la réunion* :
+
+1. La charte graphique est validée avec des ajustements mineurs.
+2. Le sprint 2 commencera le 2024-01-20 et inclura les tâches identifiées.
+3. Une vérification QA sera ajoutée à chaque livrable.
+
+---
+
+## Actions à Suivre
+
+| **Action**                  | **Responsable** | **Échéance (YYYY-MM-DD)** |
+|-----------------------------|-----------------|---------------------------|
+| Réviser la charte graphique | Clara Lopez     | 2024-01-17               |
+| Mettre à jour le planning   | Bob Martin      | 2024-01-18               |
+| Préparer les tests QA       | David Chen      | 2024-01-19               |
+
+---
+
+## Questions en Suspens
+
+1. Quelles fonctionnalités doivent être prioritaires pour le sprint 3 ?
+2. Quels outils QA devraient être intégrés pour le sprint suivant ?
+
+---
+
+## Documents Associés
+
+- [Charte graphique validée](#)
+- [Planning du sprint 2](#)
+
+---
+
+## Commentaires Généraux
+
+- [ ] Les participants sont alignés sur les prochaines étapes.
+- [ ] Les risques identifiés ont été documentés et suivis.

--- a/docs/meetings/meeting_types.md
+++ b/docs/meetings/meeting_types.md
@@ -1,0 +1,118 @@
+# Identification des Types de Réunions
+
+## **Introduction**
+
+Dans le cadre du projet **BeerToBeer**, une étude a été menée pour identifier les types de réunions nécessaires, leurs objectifs principaux, et les éléments essentiels à inclure pour chaque type. L’objectif est de standardiser les formats de réunions afin d’assurer une communication efficace et homogène tout au long du projet.
+
+---
+
+## **1. Types de Réunions Standardisées**
+
+### **1.1. Réunion Kick-off**
+
+- **Description** : Réunion initiale d’une phase ou d’un projet pour aligner les équipes sur les objectifs et priorités.
+- **Objectifs** :
+  - Définir les priorités et objectifs clés.
+  - Identifier les rôles et responsabilités.
+  - Valider le calendrier et les jalons principaux.
+- **Éléments Essentiels** :
+  - **Participants** : Responsables de phase, parties prenantes, membres de l’équipe.
+  - **Ordre du jour** :
+    - Présentation des objectifs et du contexte.
+    - Discussion sur le périmètre du projet.
+    - Attribution des rôles et responsabilités.
+    - Planification initiale des jalons.
+  - **Résultats attendus** :
+    - Feuille de route validée.
+    - Priorités et responsabilités attribuées.
+
+### **1.2. Réunion de Suivi**
+
+- **Description** : Réunions régulières pour évaluer l’avancement et résoudre les points bloquants.
+- **Objectifs** :
+  - Suivre les progrès par rapport aux objectifs définis.
+  - Identifier et résoudre les problèmes et blocages.
+  - Réaligner les priorités si nécessaire.
+- **Éléments Essentiels** :
+  - **Participants** : Équipe opérationnelle, responsable projet.
+  - **Ordre du jour** :
+    - Revue des progrès réalisés depuis la dernière réunion.
+    - Identification des points bloquants et analyse des risques.
+    - Discussion sur les ajustements nécessaires.
+    - Mise à jour des tâches et des échéances.
+  - **Résultats attendus** :
+    - Liste des actions mise à jour.
+    - Blocages résolus ou plan d’action défini.
+    - Statut des jalons et des tâches validé.
+
+### **1.3. Réunion de Validation**
+
+- **Description** : Réunion finale pour valider les livrables d’une phase ou d’un projet.
+- **Objectifs** :
+  - Vérifier que les livrables respectent les critères d’acceptation.
+  - Obtenir une approbation formelle pour clôturer la phase.
+  - Identifier les ajustements nécessaires avant de passer à l’étape suivante.
+- **Éléments Essentiels** :
+  - **Participants** : Responsable projet, membres de l’équipe, parties prenantes.
+  - **Ordre du jour** :
+    - Présentation des livrables.
+    - Comparaison avec les critères d’acceptation.
+    - Discussion des ajustements nécessaires.
+    - Validation ou rejet des livrables.
+  - **Résultats attendus** :
+    - Livrables validés ou plan de correction défini.
+    - Décisions formalisées pour clôturer la phase.
+    - Prochaine étape planifiée.
+
+---
+
+## **2. Diagrammes Visuels**
+
+### **Diagramme Kick-off (Mermaid)**
+
+```mermaid
+graph TD
+    A[Start Meeting] --> B[Present Objectives and Agenda]
+    B --> C[Discuss Project Scope]
+    C --> D[Define Roles and Responsibilities]
+    D --> E[Set Timeline and Milestones]
+    E --> F[Close Meeting]
+```
+
+### **Diagramme Suivi (Mermaid)**
+
+```mermaid
+graph TD
+    A[Start Meeting] --> B[Review Previous Progress]
+    B --> C[Discuss Current Issues]
+    C --> D[Resolve Blockers]
+    D --> E[Update Tasks and Responsibilities]
+    E --> F[Close Meeting]
+```
+
+### **Diagramme Validation (Mermaid)**
+
+```mermaid
+graph TD
+    A[Start Meeting] --> B[Present Deliverables]
+    B --> C[Verify Against Criteria]
+    C --> D[Discuss Feedback and Adjustments]
+    D --> E[Approve Deliverables]
+    E --> F[Close Meeting]
+```
+
+---
+
+## **3. Suggestions d’Optimisation**
+
+1. **Ajout de Durées Estimées** : Définir un temps précis pour chaque étape de chaque type de réunion afin d’éviter les dérives temporelles.
+2. **Processus Post-Réunion** : Inclure une étape de suivi pour vérifier l’état des actions décidées pendant la réunion.
+3. **Validation par l’Équipe** : Tester ces formats lors de réunions pilotes et collecter les retours pour ajuster les modèles si nécessaire.
+
+---
+
+### **4. Livrables**
+
+1. Documentation détaillée des types de réunions, incluant les objectifs, les participants, les éléments essentiels et les résultats attendus.
+2. Diagrammes Mermaid pour une visualisation claire du déroulé de chaque réunion.
+3. Bases pour la création de templates GitHub liés aux réunions.


### PR DESCRIPTION
Description:
This pull request addresses Issue #59 by adding the following:

Templates for Meeting Notes:

agenda_template.md: A standardized template for preparing meeting agendas, including sections for Participants, Objectives, Agenda, and Associated Documents.
summary_template.md: A standardized template for documenting meeting outcomes, including sections for Participants, Decisions, Actions, Open Questions, and Associated Documents.
Documentation:

Updated README.md in docs/meeting_notes/templates/ to describe the templates and their usage for Kick-off, Follow-up, and Validation meetings.
Includes links to the templates for easy access.
Changes
Added docs/meeting_notes/templates/agenda_template.md.
Added docs/meeting_notes/templates/summary_template.md.
Updated docs/meeting_notes/templates/README.md with detailed descriptions and usage instructions.
How to Test
Review the templates in the docs/meeting_notes/templates/ directory.
Verify that:
The agenda template includes sections for Participants, Objectives, Agenda, and Associated Documents.
The summary template includes sections for Participants, Decisions, Actions, Open Questions, and Associated Documents.
Check that the README.md provides clear guidance on using the templates for different types of meetings.

Closes Issue #59 : Rédiger les Modèles pour la Documentation des Réunions.

