### PR TITLE
feat(meeting_notes): structure meeting notes folder and implement naming convention

### DIFF
--- a/docs/meeting_notes/kickoff_meeting_2024_12_21.md
+++ b/docs/meeting_notes/kickoff_meeting_2024_12_21.md
@@ -1,0 +1,23 @@
+# Réunion Kick-off - 21 Décembre 2024
+
+## Participants
+
+- Alice Dupont (Chef de Projet)
+- Bob Martin (Développeur Backend)
+- Clara Lopez (Designer UI/UX)
+
+## Décisions
+
+1. Validation des objectifs du projet BeerToBeer.
+2. Définition des jalons pour la phase 1.
+
+## Actions à Suivre
+
+| **Action**                  | **Responsable** | **Échéance**   |
+|-----------------------------|-----------------|----------------|
+| Préparer les maquettes UI   | Clara Lopez     | 2024-12-28     |
+| Finaliser l’architecture    | Bob Martin      | 2024-12-30     |
+
+## Questions en Suspens
+
+1. Quels outils utiliser pour le design collaboratif ?

--- a/docs/meeting_notes/phase1_validation_meeting_2025_01_05.md
+++ b/docs/meeting_notes/phase1_validation_meeting_2025_01_05.md
@@ -1,0 +1,24 @@
+# Réunion de Validation - Phase 1 - 5 Janvier 2025
+
+## Participants
+
+- Alice Dupont (Chef de Projet)
+- Clara Lopez (Designer UI/UX)
+- Bob Martin (Développeur Backend)
+
+## Livrables Validés
+
+1. Maquettes UI.
+2. Documentation API.
+
+## Décisions
+
+1. Passer à la phase 2 avec les fonctionnalités de base validées.
+2. Ajouter des tests QA avant chaque livraison majeure.
+
+## Actions à Suivre
+
+| **Action**                     | **Responsable** | **Échéance**   |
+|--------------------------------|-----------------|----------------|
+| Préparer le plan de la phase 2 | Alice Dupont    | 2025-01-10     |
+| Ajouter les tests QA           | Clara Lopez     | 2025-01-12     |

--- a/docs/meeting_notes/templates/README.md
+++ b/docs/meeting_notes/templates/README.md
@@ -1,6 +1,28 @@
-# Modèles pour les Notes de Réunion
+# Documentation des Notes de Réunion
 
-Ce dossier contient des modèles standardisés pour préparer et documenter les réunions dans le cadre du projet **BeerToBeer**. Ces modèles garantissent une documentation homogène et claire.
+Ce dossier contient les modèles et les fichiers nécessaires pour organiser et archiver les réunions du projet **BeerToBeer**. La structure mise en place permet une navigation claire et un accès rapide aux informations.
+
+---
+
+## **Structure du Dossier**
+
+### **1. Modèles**
+
+- **Emplacement** : `docs/meeting_notes/templates/`
+- **Description** : Contient les modèles standardisés pour :
+  - **Ordre du Jour** : [agenda_template.md](templates/agenda_template.md)
+  - **Compte-Rendu** : [summary_template.md](templates/summary_template.md)
+
+### **2. Comptes-Rendus**
+
+- **Emplacement** : Racine du dossier `docs/meeting_notes/`
+- **Description** : Chaque fichier représente un compte-rendu de réunion, archivé par type et date.
+- **Format de Nommage** :
+  - `[type]_[YYYY_MM_DD].md`
+  - Exemples :
+    - `kickoff_meeting_2024_12_21.md`
+    - `weekly_meeting_2024_12_28.md`
+    - `phase1_validation_meeting_2025_01_05.md`
 
 ---
 
@@ -8,7 +30,7 @@ Ce dossier contient des modèles standardisés pour préparer et documenter les 
 
 ### **1. Modèle pour l’Ordre du Jour**
 
-- **Fichier** : [agenda_template.md](agenda_template.md)
+- **Fichier** : [agenda_template.md](templates/agenda_template.md)
 - **Description** :
   Utilisez ce modèle pour planifier les réunions et définir leur ordre du jour.
 - **Contient les Sections** :
@@ -21,7 +43,7 @@ Ce dossier contient des modèles standardisés pour préparer et documenter les 
 
 ### **2. Modèle pour le Compte-Rendu**
 
-- **Fichier** : [summary_template.md](summary_template.md)
+- **Fichier** : [summary_template.md](templates/summary_template.md)
 - **Description** :
   Utilisez ce modèle pour documenter les résultats des réunions.
 - **Contient les Sections** :
@@ -33,39 +55,28 @@ Ce dossier contient des modèles standardisés pour préparer et documenter les 
 
 ---
 
-## **Emplacement des Modèles**
-
-- Les fichiers sont situés dans ce dossier :
-  ```
-
-  docs/meeting_notes/templates/
-
-  ```
-
----
-
 ## **Utilisation des Modèles**
 
 ### **1. Réunion Kick-off**
 
 - **Avant la Réunion** :
-  - Remplissez l’ordre du jour avec [agenda_template.md](agenda_template.md).
+  - Remplissez l’ordre du jour avec [agenda_template.md](templates/agenda_template.md).
 - **Après la Réunion** :
-  - Documentez les décisions avec [summary_template.md](summary_template.md).
+  - Documentez les décisions avec [summary_template.md](templates/summary_template.md).
 
 ### **2. Réunion de Suivi**
 
 - **Avant la Réunion** :
-  - Préparez les sujets à discuter avec [agenda_template.md](agenda_template.md).
+  - Préparez les sujets à discuter avec [agenda_template.md](templates/agenda_template.md).
 - **Après la Réunion** :
-  - Résumez les progrès réalisés avec [summary_template.md](summary_template.md).
+  - Résumez les progrès réalisés avec [summary_template.md](templates/summary_template.md).
 
 ### **3. Réunion de Validation**
 
 - **Avant la Réunion** :
-  - Listez les points de validation avec [agenda_template.md](agenda_template.md).
+  - Listez les points de validation avec [agenda_template.md](templates/agenda_template.md).
 - **Après la Réunion** :
-  - Capturez les livrables validés avec [summary_template.md](summary_template.md).
+  - Capturez les livrables validés avec [summary_template.md](templates/summary_template.md).
 
 ---
 
@@ -81,3 +92,9 @@ Ce dossier contient des modèles standardisés pour préparer et documenter les 
 
 1. Utilisez ces modèles pour toutes les réunions Kick-off, Suivi, et Validation.
 2. Mettez à jour les modèles si des besoins spécifiques émergent au fil du projet.
+3. Respectez le format de nommage standard pour archiver les comptes-rendus :
+   - `[type]_[YYYY_MM_DD].md`
+   - Exemples :
+     - `kickoff_meeting_2024_12_21.md`
+     - `weekly_meeting_2024_12_28.md`
+     - `phase1_validation_meeting_2025_01_05.md`

--- a/docs/meeting_notes/templates/README.md
+++ b/docs/meeting_notes/templates/README.md
@@ -19,10 +19,24 @@ Ce dossier contient les modèles et les fichiers nécessaires pour organiser et 
 - **Description** : Chaque fichier représente un compte-rendu de réunion, archivé par type et date.
 - **Format de Nommage** :
   - `[type]_[YYYY_MM_DD].md`
+
+### **Description des Composants**
+
+- **`[type]`** : Indique le type de réunion.
   - Exemples :
-    - `kickoff_meeting_2024_12_21.md`
-    - `weekly_meeting_2024_12_28.md`
-    - `phase1_validation_meeting_2025_01_05.md`
+    - `kickoff_meeting`
+    - `weekly_meeting`
+    - `validation_meeting`
+- **`[YYYY_MM_DD]`** : Représente la date de la réunion au format ISO.
+  - `YYYY` : Année (ex. : 2024)
+  - `MM` : Mois (ex. : 12)
+  - `DD` : Jour (ex. : 21)
+
+### **Exemples de Fichiers**
+
+- Réunion Kick-off : `kickoff_meeting_2024_12_21.md`
+- Réunion Hebdomadaire : `weekly_meeting_2024_12_28.md`
+- Réunion de Validation : `phase1_validation_meeting_2025_01_05.md`
 
 ---
 

--- a/docs/meeting_notes/weekly_meeting_2024_12_28.md
+++ b/docs/meeting_notes/weekly_meeting_2024_12_28.md
@@ -1,0 +1,18 @@
+# Réunion Hebdomadaire - 28 Décembre 2024
+
+## Participants
+
+- Alice Dupont (Chef de Projet)
+- Bob Martin (Développeur Backend)
+
+## Progrès Réalisés
+
+1. Maquettes UI finalisées.
+2. Début de l’implémentation de l’API backend.
+
+## Actions à Suivre
+
+| **Action**                | **Responsable** | **Échéance**   |
+|---------------------------|-----------------|----------------|
+| Intégrer les maquettes UI | Bob Martin      | 2025-01-02     |
+| Valider les endpoints API | Alice Dupont    | 2025-01-03     |


### PR DESCRIPTION
### **Description**
This pull request addresses **Issue #60** by implementing a clear structure for meeting notes and templates. The changes ensure an organized and accessible archive for all meeting-related documentation.

### **Changes**
1. **Folder Structure**:
   - Created `docs/meeting_notes/` with the following structure:
     ```
     docs/meeting_notes/
     ├── templates/
     │   ├── agenda_template.md
     │   ├── summary_template.md
     ├── kickoff_meeting_2024_12_21.md
     ├── weekly_meeting_2024_12_28.md
     ├── phase1_validation_meeting_2025_01_05.md
     ```

2. **Naming Convention**:
   - Implemented a standard naming format for meeting notes:
     ```
     [type]_[YYYY_MM_DD].md
     ```
   - Examples:
     - `kickoff_meeting_2024_12_21.md`
     - `weekly_meeting_2024_12_28.md`
     - `phase1_validation_meeting_2025_01_05.md`

3. **Documentation**:
   - Updated `README.md` in `docs/meeting_notes/` to:
     - Explain the folder structure.
     - Describe the usage of templates.
     - Provide examples of the naming convention.

---

### **How to Test**
1. Navigate to the `docs/meeting_notes/` folder.
2. Verify that:
   - Templates are in the `templates/` subfolder.
   - Meeting notes are archived using the naming convention.
3. Review the `README.md` for clear documentation and examples.

---

### **Closes**
Closes **Issue #60**: Structurer le Dossier des Réunions.