### PR TITLE
feat(actions): implement workflow for meeting notes archival

### DIFF
--- a/.github/workflows/archive_meeting.yml
+++ b/.github/workflows/archive_meeting.yml
@@ -1,0 +1,58 @@
+name: Archive Meeting Notes
+
+on:
+  issues:
+    types:
+      - closed
+
+jobs:
+  archive-meeting:
+    runs-on: ubuntu-latest
+    if: >
+      contains(join(' ', github.event.issue.labels.*.name), 'meeting')
+
+    steps:
+      # Vérification du dépôt
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Créer le fichier Markdown pour le compte-rendu
+      - name: Generate meeting notes
+        run: |
+          echo "Generating meeting notes..."
+          ISSUE_TITLE=$(echo "${{ github.event.issue.title }}" | tr ' ' '_')
+          ISSUE_DATE=$(date +"%Y_%m_%d")
+          ISSUE_BODY="${{ github.event.issue.body }}"
+          OUTPUT_FILE="docs/meeting_notes/${ISSUE_TITLE}_${ISSUE_DATE}.md"
+
+          # Créer le fichier Markdown basé sur le template
+          cat > $OUTPUT_FILE <<- EOM
+          # Compte-Rendu de Réunion - ${{ github.event.issue.title }}
+
+          ## Participants
+          (À compléter)
+
+          ## Décisions
+          - (À compléter)
+
+          ## Actions à Suivre
+          | **Action**         | **Responsable** | **Échéance**   |
+          |--------------------|-----------------|----------------|
+
+          ## Questions en Suspens
+          - (À compléter)
+
+          ## Notes Additionnelles
+          $ISSUE_BODY
+          EOM
+
+          echo "File created: $OUTPUT_FILE"
+
+      # Ajouter les modifications au dépôt
+      - name: Commit changes
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+          git add docs/meeting_notes/
+          git commit -m "chore: archive meeting notes for ${{ github.event.issue.title }}"
+          git push

--- a/.github/workflows/archive_meeting.yml
+++ b/.github/workflows/archive_meeting.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Generate meeting notes
         run: |
           echo "Generating meeting notes..."
-          ISSUE_TITLE=$(echo "${{ github.event.issue.title }}" | tr ' ' '_')
+          MEETING_TYPE=$(echo "${{ github.event.issue.labels.*.name }}" | grep -oE '(kick-off|follow-up|validation)' || echo "meeting")
           ISSUE_DATE=$(date +"%Y_%m_%d")
-          ISSUE_BODY="${{ github.event.issue.body }}"
-          OUTPUT_FILE="docs/meeting_notes/${ISSUE_TITLE}_${ISSUE_DATE}.md"
+          ISSUE_TITLE=$(echo "${{ github.event.issue.title }}" | tr ' ' '_')
+          OUTPUT_FILE="docs/meeting_notes/${MEETING_TYPE}_meeting_${ISSUE_DATE}.md"
 
           # Créer le fichier Markdown basé sur le template
           cat > $OUTPUT_FILE <<- EOM
@@ -43,7 +43,7 @@ jobs:
           - (À compléter)
 
           ## Notes Additionnelles
-          $ISSUE_BODY
+          ${{ github.event.issue.body }}
           EOM
 
           echo "File created: $OUTPUT_FILE"


### PR DESCRIPTION
### **Description**
This pull request adds a GitHub Actions workflow to automate the generation and archival of meeting notes. The workflow creates a Markdown file in `docs/meeting_notes/` whenever an issue with the `meeting` label is closed.

**Progress on Issue #62: Automatiser l’Archivage des Réunions**

---

### **Changes**
1. **GitHub Actions Workflow**:
   - File: `.github/workflows/archive_meeting.yml`
   - Automatically generates a meeting note based on the issue body and saves it in `docs/meeting_notes/`.

2. **File Naming**:
   - The workflow adheres to the naming format `[type]_[YYYY_MM_DD].md`.
   - Supports meeting types: `kick-off`, `follow-up`, `validation`.

---

### **How to Test**
1. Close an issue with the `meeting` label (e.g., `kick-off`, `follow-up`, `validation`).
2. Verify that a Markdown file is created in `docs/meeting_notes/`.
3. Ensure the file name follows the format `[type]_[YYYY_MM_DD].md`.

---

### **Notes**
- This is an intermediate PR and does not fully close Issue #62. Additional steps, such as validation and final testing, will follow.