### PR TITLE
feat(recipes): add GET /recipes/:id endpoint to fetch a recipe by ID

### DIFF
--- a/backend/controllers/recipeController.js
+++ b/backend/controllers/recipeController.js
@@ -3,7 +3,7 @@
 const db = require('../models');
 const Recipe = db.Recipe; 
 const RecipeIngredient = db.RecipeIngredient;
-
+const Ingredient = db.Ingredient;
 
 /**
  * GET /recipes
@@ -18,6 +18,33 @@ const getAllRecipes = async (req, res) => {
     res.status(500).json({ error: 'Internal Server Error' });
   }
 };
+
+/**
+ * GET /recipes/:id
+ * Fetch a specific recipe by ID with its associated ingredients
+ */
+const getRecipeById = async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const recipe = await Recipe.findByPk(id, {
+      include: {
+        model: Ingredient,
+        through: { attributes: ['quantity', 'unit'] },
+      },
+    });
+
+    if (!recipe) {
+      return res.status(404).json({ error: 'Recipe not found' });
+    }
+
+    res.status(200).json(recipe);
+  } catch (error) {
+    console.error('Error fetching recipe by ID:', error);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+};
+
 
 /**
  * POST /recipes
@@ -70,4 +97,5 @@ const createRecipe = async (req, res) => {
 module.exports = {
   getAllRecipes,
   createRecipe,
+  getRecipeById
 };

--- a/backend/routes/recipeRoutes.js
+++ b/backend/routes/recipeRoutes.js
@@ -7,6 +7,8 @@ const authenticateToken = require('../middleware/authenticateToken');
 
 // GET /recipes
 router.get('/', authenticateToken, recipeController.getAllRecipes);
+// GET /recipes/:id
+router.get('/:id', authenticateToken, recipeController.getRecipeById);
 // POST /recipes
 router.post('/', authenticateToken, recipeController.createRecipe);
 


### PR DESCRIPTION
Summary:

This PR introduces a new endpoint GET /recipes/:id that allows users to retrieve a specific recipe by its ID, including its associated ingredients via Sequelize’s include option. Returns a 404 if not found.

What’s included:

 Route defined in recipeRoutes.js

 Controller method using Recipe.findByPk(id, { include })

 Returns 200 with full recipe details and ingredient list

 Returns 404 if recipe is not found

 Postman tests performed (status 200 & 404)

Related Issue:

Closes #158 