### PR TITLE
feat(backend): add secure recipe deletion endpoint (DELETE /recipes/:id)

### DIFF
--- a/backend/controllers/recipeController.js
+++ b/backend/controllers/recipeController.js
@@ -45,7 +45,6 @@ const getRecipeById = async (req, res) => {
   }
 };
 
-
 /**
  * POST /recipes
  * Create a new recipe (requires authentication)
@@ -174,11 +173,44 @@ const updateRecipe = async (req, res) => {
   }
 };
 
+/**
+ * Delete a recipe by its ID (only allowed for the creator or admin).
+ * Route: DELETE /recipes/:id
+ * Access: Private (JWT required)
+ */
+const deleteRecipe = async (req, res) => {
+  try {
+    const recipeId = req.params.id;
+    const userId = req.user.id;
+    // Optional: const userRole = req.user.role;
 
+    // 1. Retrieve the recipe
+    const recipe = await Recipe.findByPk(recipeId);
+
+    if (!recipe) {
+      return res.status(404).json({ message: 'Recipe not found' });
+    }
+
+    // 2. Ownership check (and admin if applicable)
+    if (recipe.UserId !== userId /* && userRole !== 'admin' */) {
+      return res.status(403).json({ message: 'Forbidden: You are not allowed to delete this recipe' });
+    }
+
+    // 3. Delete the recipe (assumes ON DELETE CASCADE on RecipeIngredient)
+    await recipe.destroy();
+
+    return res.status(200).json({ message: '✅ Recipe successfully deleted.' });
+
+  } catch (error) {
+    console.error('Error deleting recipe:', error);
+    return res.status(500).json({ message: 'Internal Server Error', error: error.message });
+  }
+};
 
 module.exports = {
   getAllRecipes,
   createRecipe,
   getRecipeById,
-  updateRecipe
+  updateRecipe,
+  deleteRecipe
 };

--- a/backend/controllers/recipeController.js
+++ b/backend/controllers/recipeController.js
@@ -203,7 +203,7 @@ const deleteRecipe = async (req, res) => {
 
   } catch (error) {
     console.error('Error deleting recipe:', error);
-    return res.status(500).json({ message: 'Internal Server Error', error: error.message });
+    return res.status(500).json({ message: 'Internal Server Error' });
   }
 };
 

--- a/backend/routes/recipeRoutes.js
+++ b/backend/routes/recipeRoutes.js
@@ -18,4 +18,11 @@ router.post('/', authenticateToken, recipeController.createRecipe);
  */
 router.put('/:id', authenticateToken, recipeController.updateRecipe);
 
+/**
+ * @route DELETE /recipes/:id
+ * @desc Delete a recipe (creator or admin only)
+ * @access Private (JWT required)
+ */
+router.delete('/:id', authenticateToken, recipeController.deleteRecipe);
+
 module.exports = router;


### PR DESCRIPTION
### ✨ Summary

Implements the endpoint `DELETE /recipes/:id` to allow secure deletion of a recipe by its owner (or admin in the future).  
Associated `RecipeIngredient` entries are deleted automatically (cascade).

---

### ✅ Main Changes

- Adds `DELETE /recipes/:id` endpoint
- Applies `authenticateToken` middleware to protect the route
- Enforces ownership: only the recipe creator can delete (admin logic is ready to extend)
- Handles all error cases:
  - `401 Unauthorized` if token is missing or malformed
  - `403 Forbidden` if not the owner
  - `404 Not Found` if recipe does not exist
- Deletes all associated `RecipeIngredient` rows via cascade
- Returns `200 OK` and confirmation message on success

---

### 🧪 Manual Testing

- [x] Owner can delete recipe → `200 OK`
- [x] Non-owner receives `403 Forbidden`
- [x] Invalid recipe ID returns `404 Not Found`
- [x] Missing/invalid token returns `401 Unauthorized`
- [x] Associated RecipeIngredient links are deleted

---

### 📌 Linked Issue

Closes #215 
