### PR TITLE
feat(auth): implement role-based access control using JWT and middleware

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -70,7 +70,7 @@ const login = async (req, res) => {
     }
 
     // Création du JWT
-    const payload = { id: user.id, email: user.email };
+    const payload = { id: user.id, email: user.email, role: user.role || 'user' };
     const token = jwt.sign(payload, JWT_SECRET, { expiresIn: '24h' });
 
     res.status(200).json({ message: 'Login successful.', token });

--- a/backend/middleware/authorizeRoles.js
+++ b/backend/middleware/authorizeRoles.js
@@ -1,0 +1,19 @@
+/**
+ * Middleware to restrict access based on user roles.
+ * @param  {...string} allowedRoles - List of roles allowed to access the route.
+ * @returns Express middleware function
+ */
+function authorizeRoles(...allowedRoles) {
+  return (req, res, next) => {
+    const userRole = req.user?.role;
+
+    if (!userRole || !allowedRoles.includes(userRole)) {
+      return res.status(403).json({
+        error: 'Access denied: insufficient permissions.',
+      });
+    }
+    next();
+  };
+}
+
+module.exports = authorizeRoles;

--- a/backend/migrations/20250526164402-add-role-to-users.js
+++ b/backend/migrations/20250526164402-add-role-to-users.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up (queryInterface, Sequelize) {
+    await queryInterface.addColumn('users', 'role', {
+      type: Sequelize.STRING,
+      allowNull: false,
+      toDefaultValue: 'user',
+    });
+  },
+
+  async down (queryInterface) {
+    await queryInterface.removeColumn('users', 'role');
+  }
+};

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -17,6 +17,14 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
+    role: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'user',
+      validate: {
+        isIn: [['user', 'admin']],
+      },
+    }
   }, {
     tableName: 'users', // Nom explicite de la table
     timestamps: true,   // createdAt & updatedAt activés

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const router = express.Router();
+
+const authenticateToken = require('../middleware/authenticateToken');
+const authorizeRoles = require('../middleware/authorizeRoles');
+
+/**
+ * @route   GET /admin/test
+ * @desc    Only accessible by admin users to test admin access
+ * @access  Private – Admin only
+ */
+router.get('/test', authenticateToken, authorizeRoles('admin'), (req, res) => {
+  res.status(200).json({ message: '✅ Access granted: admin route reached.' });
+});
+
+module.exports = router;

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -17,6 +17,8 @@ const userRoutes = require('../routes/userRoutes');
 const ingredientRoutes = require('../routes/ingredientRoutes');
 const authRoutes = require('../routes/authRoutes');
 const favoritesRoutes = require('../routes/favoritesRoutes');
+const adminRoutes = require('../routes/adminRoutes');
+
 
 // Middleware
 app.use(cors({
@@ -60,6 +62,9 @@ connectWithRetry();
 app.get('/ping', (req, res) => {
   res.status(200).json({ message: 'pong' });
 });
+
+// Mount testAdmin routes
+app.use('/admin', adminRoutes);
 
 // Mount user routes
 app.use('/users', userRoutes);


### PR DESCRIPTION
## Summary

This pull request adds a complete role-based access control (RBAC) system to the backend using JWT and middleware.

### ✔️ Key changes:

- Added `role` field to the `User` model (`default: 'user'`)
- Added `role` to the JWT payload at login
- Created a reusable middleware: `authorizeRoles('admin')`
- Added a test route `GET /admin/test` protected by both token and role
- Returns proper error responses with `403 Forbidden` if user is not authorized

### 🔐 Example use case:

An admin user can access:
```

GET /admin/test
Authorization: Bearer \<admin\_token>

```

A normal user or missing role returns:
```

403 Forbidden – Access denied: insufficient permissions.

```

---

## Related

Closes #151 
Parent issue: #27 (Endpoints API)
