### PR TITLE
docs(design-charter): add core values and culture & spirit sections

### DIFF
--- a/docs/design/design-charter.md
+++ b/docs/design/design-charter.md
@@ -9,3 +9,42 @@ It serves as a collaborative reference for all contributors: developers, designe
 Key sections include core values, visual identity, tone of communication, logo usage, color palette, typography, and UI principles.
 
 **Updates and improvements are welcome at every stage of the project to reflect Brasse-Bouillon’s spirit of creativity, innovation, and community.**
+
+## 1.1 Core Values
+
+Brasse-Bouillon is built upon a set of core values that shape every aspect of the project and community.  
+These values ensure consistency with our mission and guide both product development and user experience.
+
+1. **Community**  
+   Empowering users to connect, share, and grow together as passionate homebrewers.
+
+2. **Accessibility**  
+   Making brewing knowledge and tools available to everyone, regardless of experience or background.
+
+3. **Quality**  
+   Committing to a reliable, enjoyable, and robust experience across all features and interfaces.
+
+4. **Transparency**  
+   Operating openly, communicating clearly, and sharing knowledge through open-source principles.
+
+5. **Innovation**  
+   Continuously improving and offering new solutions to simplify and enrich the homebrewing journey.
+
+## 1.2 Culture & Spirit
+
+Brasse-Bouillon is more than a tool – it’s a collaborative, creative adventure inspired by the DIY spirit and a love for brewing.
+
+- **DIY Spirit**  
+  Fostering hands-on experimentation and empowering every user to brew, learn, and innovate by themselves.
+
+- **Creativity**  
+  Encouraging everyone to explore new recipes, personalize their brews, and share unique ideas.
+
+- **Collaboration**  
+  Building together – from recipes and advice to events and features – Brasse-Bouillon is a collective journey.
+
+- **Learning & Knowledge Sharing**  
+  Promoting continuous learning and open sharing of successes, failures, and tips within the community.
+
+- **Openness**  
+  Welcoming all backgrounds, tastes, and skill levels in a spirit of kindness and constructive feedback.

--- a/docs/design/design-charter.md
+++ b/docs/design/design-charter.md
@@ -1,0 +1,11 @@
+# Brasse-Bouillon – Design Charter
+
+> This document defines the visual and identity foundations of the Brasse-Bouillon project.  
+> It provides clear guidelines to ensure visual consistency, reinforce brand identity, and support a unique user experience.
+
+This design charter will evolve continuously throughout the development of Brasse-Bouillon.  
+It serves as a collaborative reference for all contributors: developers, designers, and community members.
+
+Key sections include core values, visual identity, tone of communication, logo usage, color palette, typography, and UI principles.
+
+**Updates and improvements are welcome at every stage of the project to reflect Brasse-Bouillon’s spirit of creativity, innovation, and community.**


### PR DESCRIPTION
This PR adds the "Core Values" and "Culture & Spirit" sections to the design-charter.md file.  
Each value includes a concise description and has been checked for consistency with the overall project vision.

Closes #291 

---
### Summary
- Added section 1.1 "Core Values" with five main values and descriptions
- Added section 1.2 "Culture & Spirit" with key cultural pillars
- Confirmed full alignment with project vision

### Checklist
- [x] Section 1.1 "Core Values" added
- [x] Section 1.2 "Culture & Spirit" added
- [x] Values reviewed for consistency with vision
- [x] File renamed to `design-charter.md` (kebab-case, English)
- [x] PR follows Brasse-Bouillon conventions

_No breaking changes_

**Screenshots:** N/A (documentation only)
