### PR TITLE
ci(monorepo): create unified CI workflow with path-filtered jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,141 @@
+# ==============================================================================
+# Brasse-Bouillon — Unified CI Pipeline
+# Runs path-filtered jobs for frontend and backend on every PR to main.
+# ==============================================================================
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ============================================================================
+  # Detect which packages changed
+  # ============================================================================
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      backend: ${{ steps.filter.outputs.backend }}
+      website: ${{ steps.filter.outputs.website }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'packages/frontend/**'
+            backend:
+              - 'packages/backend/**'
+            website:
+              - 'packages/website/**'
+
+  # ============================================================================
+  # Frontend: lint + typecheck + format + tests
+  # ============================================================================
+  frontend:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: packages/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint + Typecheck + Format check
+        run: npm run ci:check
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-coverage
+          path: packages/frontend/coverage/lcov.info
+          retention-days: 7
+
+  # ============================================================================
+  # Backend: lint + build + tests
+  # ============================================================================
+  backend:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: packages/backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint check
+        run: npm run lint:check
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests with coverage
+        run: npm run test:cov
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-coverage
+          path: packages/backend/coverage/lcov.info
+          retention-days: 7
+
+  # ============================================================================
+  # Website: Python quality gate (if scripts exist)
+  # ============================================================================
+  website:
+    needs: changes
+    if: needs.changes.outputs.website == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/website
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run quality gate
+        run: |
+          if [ -f scripts/quality_gate.py ]; then
+            python3 scripts/quality_gate.py
+          else
+            echo "No quality gate script found — skipping"
+          fi

--- a/docs/project-management/definition-of-done.md
+++ b/docs/project-management/definition-of-done.md
@@ -1,0 +1,43 @@
+# Definition of Done (DoD) — Brasse-Bouillon
+
+## What is the DoD?
+
+The Definition of Done is a shared agreement that guarantees transparency and quality.
+Every team member knows exactly what "Done" means. A User Story is only considered
+complete when ALL criteria below are met.
+
+## DoD Checklist
+
+### For every User Story
+
+- [ ] Code compiles without errors
+  - Frontend: `tsc --noEmit` passes
+  - Backend: `npm run build` passes
+- [ ] All existing tests still pass (`npm test`)
+- [ ] New tests written for new logic (unit tests for use-cases, integration tests for screens)
+- [ ] CI passes (`npm run ci:check` — lint + typecheck + format)
+- [ ] Code reviewed via Pull Request (at least 1 reviewer)
+- [ ] No `any` TypeScript type introduced
+- [ ] No hardcoded values (colors, spacing, fonts — use design tokens)
+- [ ] No inline styles (use `StyleSheet.create()`)
+- [ ] Branch merged to `main`
+- [ ] Related GitHub issue closed with `Closes #xx` in PR
+
+### For a Sprint Increment
+
+- [ ] All committed User Stories meet the DoD above
+- [ ] App runs without crashes on the happy path
+- [ ] Sprint Review demo successful
+- [ ] Sprint Retrospective completed with action items documented
+
+## Why the DoD Matters
+
+Without a DoD:
+- Team members have different definitions of "finished"
+- Bugs accumulate as technical debt
+- Sprint velocity is unreliable (partially done items inflate estimates)
+
+With a DoD:
+- Quality is consistent and predictable
+- The increment is potentially shippable after every sprint
+- Stakeholders can trust the progress reports

--- a/docs/project-management/definition-of-ready.md
+++ b/docs/project-management/definition-of-ready.md
@@ -1,0 +1,39 @@
+# Definition of Ready (DoR) — Brasse-Bouillon
+
+## What is the DoR?
+
+The Definition of Ready defines when a User Story is ready to enter a Sprint Backlog.
+A story that is not "Ready" cannot be selected during Sprint Planning.
+
+## DoR Checklist
+
+A User Story is "Ready" when:
+
+- [ ] Written in standard format: "As a [persona], I want [action], so that [benefit]"
+- [ ] Acceptance criteria clearly defined (testable, unambiguous)
+- [ ] Estimated by the team (story points using Fibonacci: 1, 2, 3, 5, 8, 13)
+- [ ] Small enough to complete within one sprint (max 8 story points)
+- [ ] No unresolved dependencies or blockers
+- [ ] Technical approach discussed and understood by the assigned developer
+- [ ] Mockup or wireframe available (if UI-related)
+- [ ] API contract defined (if involving frontend-backend integration)
+
+## Estimation Scale (Fibonacci)
+
+| Points | Complexity | Example |
+|--------|-----------|---------|
+| 1 | Trivial | Fix a typo, update a label |
+| 2 | Simple | Add a new field to an existing form |
+| 3 | Moderate | Create a new screen with existing patterns |
+| 5 | Complex | Implement a calculator with business logic |
+| 8 | Very complex | Full feature with API, domain, and UI layers |
+| 13 | Epic-level | Should be split into smaller stories |
+
+## Planning Poker Process
+
+1. PO reads the User Story and acceptance criteria
+2. Each developer privately selects a card (Fibonacci number)
+3. All cards revealed simultaneously
+4. If estimates differ by more than 2 levels, highest and lowest explain their reasoning
+5. Re-vote until consensus (within 1 level of difference)
+6. Final estimate recorded on GitHub issue as Story Points field

--- a/docs/project-management/scrum-roles.md
+++ b/docs/project-management/scrum-roles.md
@@ -1,0 +1,48 @@
+# Scrum Roles — Brasse-Bouillon
+
+## Product Owner
+
+**Benoît Bremaud** (@benoit-bremaud)
+
+- Owns and prioritizes the Product Backlog
+- Defines the Sprint Goal for each sprint
+- Validates completed increments (accepts or rejects user stories)
+- Communicates the product vision to the team and stakeholders
+- Makes business decisions about what to build next
+
+## Scrum Master
+
+**Benoît Bremaud** (@benoit-bremaud) — acting
+
+- Facilitates all Scrum ceremonies (Sprint Planning, Daily Scrum, Sprint Review, Retrospective)
+- Removes impediments that block the Development Team
+- Ensures the Scrum framework is understood and followed
+- Coaches the team on self-organization and cross-functionality
+- Protects the team from external interruptions during sprints
+
+> **Note:** Having the same person as PO and SM is a conscious trade-off for this school
+> project context. In a professional setting, these roles should be held by different people
+> to avoid conflicts of interest (PO maximizes value, SM protects the team).
+
+## Development Team
+
+| Member | GitHub | Specialization | Scope |
+|--------|--------|---------------|-------|
+| Fabien Ori | @Fabien-Ori | Cybersecurity + Frontend/Design | scope:frontend, scope:charte |
+| Kévin Vitali | @vitalikevin | Fullstack (backend focus) | scope:backend, scope:frontend |
+| Sara Smith | @Smith06S | Fullstack (frontend focus) | scope:frontend, scope:backend |
+| Clément | @clemoune-tech | Infrastructure / DevOps | scope:devops, scope:infrastructure |
+| Catarina | @Moooniie | Infrastructure / Security / Cloud | scope:devops, scope:infrastructure |
+| Fabio | @Lin0ooo | UI/UX / Art Direction / Motion | scope:charte, scope:frontend |
+| Liam Gueguen | @Liamggn | Design / UI-UX | scope:charte |
+| Thaïs | @Thais9723 | UI/UX + Frontend | scope:charte, scope:frontend |
+
+### Binômes (Pair Working)
+
+- Clément + Catarina (Infrastructure)
+- Fabio + Liam (Design / Visual Identity)
+
+## Team Size
+
+- **Total**: 10 members (1 PO/SM + 8 developers + 1 core team member Kévin)
+- **Scrum Guide recommendation**: 3-9 developers — we are within range

--- a/docs/project-management/sprint-definition.md
+++ b/docs/project-management/sprint-definition.md
@@ -1,0 +1,59 @@
+# Sprint Definition — Brasse-Bouillon
+
+## Sprint Parameters
+
+- **Sprint duration**: 3 weeks (aligned with Yday cycle)
+- **Sprint Planning**: First day of sprint (Yday session) — 2h max
+- **Daily Scrum**: Async on Discord, 3 questions format — every working day
+- **Sprint Review**: Last day of sprint — 1h max
+- **Sprint Retrospective**: After Sprint Review — 1h max
+- **Backlog Grooming**: Weekly, 30min async or on Discord
+
+## Sprint Calendar
+
+| Sprint | Dates | Yday | Sprint Goal | Status |
+|--------|-------|------|-------------|--------|
+| Sprint 0 | Nov 26 – Dec 17, 2025 | Yday 1-2 | Team formation, project ideation, initial planning | Done |
+| Sprint 1 | Dec 18, 2025 – Jan 22, 2026 | Yday 3-5 | Oral presentation, define backlog, start production | Done |
+| Sprint 2 | Jan 23 – Mar 24, 2026 | Yday 6-7 | Full audit, monorepo migration plan, 68 issues created | Done |
+| Sprint 3 | Mar 25 – mid-Apr 2026 | Yday 8 | Monorepo bootstrap, Scrum framework, retroplanning | In Progress |
+| Sprint 4 | mid-Apr 2026 | Yday 9 | Feature development, CI validation, demo prep | Planned |
+| Sprint 5 | early May 2026 | Yday 10 | Final polish, soutenance preparation | Planned |
+
+## Sprint Ceremonies Schedule
+
+### Sprint Planning (start of each sprint)
+
+1. **Phase 1** — PO presents top-priority items from Product Backlog
+2. **Phase 2** — Team decomposes selected User Stories into technical tasks
+3. Output: Sprint Backlog with committed items + Sprint Goal
+
+### Daily Scrum (async on Discord)
+
+Each team member answers 3 questions:
+
+1. What did I finish since the last standup?
+2. What will I finish by the next standup?
+3. What obstacles are blocking me?
+
+### Sprint Review (end of each sprint)
+
+- Team demos completed features to PO and stakeholders
+- PO accepts or rejects increments based on DoD
+- Backlog is re-prioritized based on feedback
+
+### Sprint Retrospective (after Review)
+
+Format: Start / Stop / Continue
+
+- **Start**: What should we start doing?
+- **Stop**: What should we stop doing?
+- **Continue**: What is working well?
+
+Output: 2-3 concrete action items for next sprint.
+
+## Velocity Tracking
+
+- Story points completed per sprint are tracked
+- After 2-3 sprints, velocity stabilizes and enables forecasting
+- Burndown chart updated per sprint on GitHub Projects


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` triggered on PRs to `main` and pushes
- Path-filtered jobs using `dorny/paths-filter@v3`: only changed packages are tested
- **Frontend job**: `npm ci` → `ci:check` (lint + typecheck + format) → `test:coverage`
- **Backend job**: `npm ci` → `lint:check` → `build` → `test:cov`
- **Website job**: Python quality gate script (if present)
- Coverage reports uploaded as artifacts for future SonarQube integration (#396)
- Concurrency group cancels in-progress runs on the same branch

## Checklist

- [x] Workflow triggers on PR to main + push to main
- [x] Path filtering: only affected packages run
- [x] Node 20 for frontend and backend
- [x] Python 3.12 for website
- [x] Coverage artifacts uploaded
- [x] Concurrency configured
- [x] YAML syntax validated
- [x] No `any`, no inline styles introduced

## Test plan

- [ ] Open a PR that changes `packages/frontend/` → frontend job should run
- [ ] Open a PR that changes `packages/backend/` → backend job should run
- [ ] Open a PR that changes only `docs/` → no jobs should run (except changes detection)

Closes #345