### PR TITLE
docs(monorepo): rewrite README.md and CONTRIBUTING.md for monorepo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,173 +1,221 @@
-# Guide de Contribution - Brasse-Bouillon
+# Contributing to Brasse-Bouillon
 
-## 1. Introduction
-
-Bienvenue dans **Brasse-Bouillon** ! 🎉 Ce document explique **comment configurer l’environnement de développement** et **contribuer efficacement** au projet. Nous suivons une méthodologie collaborative avec des bonnes pratiques pour garantir un code de qualité et une expérience fluide pour tous les contributeurs.
+Thank you for contributing to Brasse-Bouillon. This guide covers the workflow, conventions, and quality standards for the monorepo.
 
 ---
 
-## 2. Configuration de l’Environnement
+## Prerequisites
 
-### 🔹 **Prérequis**
+- **Node.js** 20.x (see `.nvmrc`)
+- **npm** 10+
+- **Git** 2.30+
 
-Avant de commencer, assure-toi d’avoir installé :
-
-- **Git** (`>= 2.30`)
-- **Node.js** (`>= 18.x`) et **npm** (`>= 9.x`)
-- **Docker** (optionnel, pour l’environnement de test)
-- **MySQL** (`>= 8.x`) pour la base de données
-
-### 🔹 **Installation du projet**
-
-1️⃣ **Cloner le dépôt :**
-
-```sh
-git clone https://github.com/benoit-bremaud/brasse-bouillon.git
+```bash
+# Clone and install
+git clone git@github.com:benoit-bremaud/brasse-bouillon.git
 cd brasse-bouillon
-```
-
-2️⃣ **Installer les dépendances :**
-
-```sh
 npm install
 ```
 
-3️⃣ **Configurer l’environnement :**
+---
 
-- Copier le fichier d’exemple `.env.example` en `.env` :
+## Branching Strategy
 
-```sh
-cp .env.example .env
-```
+We use **trunk-based development** with `main` as the single production branch. Never commit directly to `main`.
 
-- Modifier les variables selon ta configuration locale.
+### Branch Naming
 
-4️⃣ **Lancer l’application en mode développement :**
+Every task requires a dedicated branch from `main`:
 
-```sh
-npm run dev
+| Type | Pattern | Example |
+|------|---------|---------|
+| Feature | `feat/<scope>` | `feat/ibu-calculator` |
+| Bug fix | `fix/<scope>` | `fix/login-redirect` |
+| Refactor | `refactor/<scope>` | `refactor/http-client` |
+| Chore | `chore/<scope>` | `chore/update-deps` |
+| Docs | `docs/<scope>` | `docs/readme-update` |
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feat/my-feature
 ```
 
 ---
 
-## 3. Workflow de Contribution
+## Commit Convention
 
-### 🔹 **Convention de Nommage des Branches**
-
-Les branches doivent être nommées de manière claire selon le type de travail effectué :
+Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
-feature/nom-fonctionnalité  → Pour une nouvelle fonctionnalité
-fix/nom-correction         → Pour une correction de bug
-refactor/nom-refactoring   → Pour une amélioration du code sans modification fonctionnelle
-hotfix/nom-correction      → Pour une correction urgente en production
+type(scope): short description
 ```
 
-Exemple :
+**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`
 
-```sh
-git checkout -b feature/ajout-authentification
+**Scope:** the affected area (`auth`, `recipes`, `tools`, `backend`, `frontend`, `monorepo`, `ci`, `sonar`)
+
+Examples:
 ```
-
-### 🔹 **Structure des Branches**
-
-Le projet suit un modèle de branches inspiré de **Git Flow** :
-
-```
-main       → Branche stable et prête pour la production
-
-develop    → Branche principale pour le développement
-
-feature/*  → Branches pour le développement de nouvelles fonctionnalités
-fix/*      → Branches pour les corrections de bugs
-release/*  → Branches de préparation avant un déploiement
-hotfix/*   → Branches pour les corrections urgentes sur `main`
-```
-
-### 🔹 **Convention de Nommage des Commits**
-
-Respecte la structure suivante pour chaque commit :
-
-```
-[Type] (Scope) : Message court et explicite
-
-Description plus détaillée (si nécessaire)
-```
-
-📌 **Types de commits acceptés :**
-
-- **feat** : Ajout d'une nouvelle fonctionnalité
-- **fix** : Correction d'un bug
-- **docs** : Modification de la documentation
-- **style** : Modification du format ou du style (indentation, espaces…)
-- **refactor** : Refactoring du code sans modification fonctionnelle
-- **test** : Ajout/modification de tests
-- **chore** : Mise à jour des dépendances, configuration
-
-Exemple de commit valide :
-
-```sh
-git commit -m "feat(auth): Implémentation de l'authentification JWT"
-```
-
-### 🔹 **Créer une Pull Request (PR)**
-
-1️⃣ **Vérifier son code avant de pousser :**
-
-```sh
-git push origin feature/ajout-authentification
-```
-
-2️⃣ **Créer une PR sur GitHub en respectant ces consignes :**
-
-- La PR doit être assignée à un reviewer.
-- Ajouter une description claire des changements apportés.
-- Lier la PR à une issue si applicable.
-
-Exemple de titre de PR :
-
-```
-[Feature] Ajout de l'authentification JWT
+feat(recipes): add recipe duplication use-case
+fix(auth): handle expired refresh token gracefully
+ci(monorepo): add SonarQube quality gate to CI pipeline
+docs(readme): update getting started section
 ```
 
 ---
 
-## 4. Règles de Code et Style
+## Development Workflow
 
-📌 **Standards suivis :**
+### 1. Pick an issue
 
-- **ESLint + Prettier** pour le formatage automatique.
-- Respect des **principes SOLID** et d’une **architecture modulaire**.
-- Documentation des fonctions et API avec **JSDoc**.
+Assign yourself on the GitHub issue before starting. Check the project board for priority.
+
+### 2. Create a branch
+
+```bash
+git checkout -b feat/issue-description main
+```
+
+### 3. Make changes
+
+Follow the architecture and code style conventions (see below).
+
+### 4. Run checks locally
+
+```bash
+# Frontend
+npm -w packages/frontend run ci:check   # lint + typecheck + format
+npm -w packages/frontend test           # 407 tests
+
+# Backend
+npm -w packages/backend run lint:check
+npm -w packages/backend run build
+npm -w packages/backend test            # 238 tests
+
+# Or run everything at once
+npm run ci:all && npm run test:all
+```
+
+### 5. Push and open a PR
+
+```bash
+git push -u origin feat/issue-description
+```
+
+Create a PR targeting `main` with:
+- A clear title following Conventional Commits format
+- A summary of what changed and why
+- A checklist of acceptance criteria
+- `Closes #<issue-number>` in the body
+
+### 6. Wait for review
+
+- CI must pass (GitHub Actions runs automatically)
+- At least one reviewer must approve
+- Address review comments before merging
 
 ---
 
-## 5. Tests et CI/CD
+## Code Style
 
-📌 **Avant de soumettre une PR, vérifie que :**
+### TypeScript
 
-- Les **tests unitaires passent** (`npm test`).
-- Le code respecte les **règles de linting** (`npm run lint`).
-- La **pipeline CI/CD** s’exécute sans erreur sur GitHub Actions.
+- Strict mode enabled everywhere
+- **No `any` type** — ever
+- **Named exports only** — no default exports for screens, use-cases, or API modules
+- `interface` for object shapes, `type` for unions and utility types
+
+### Frontend (React Native / Expo)
+
+- **Clean Architecture**: domain -> application -> data -> presentation
+- `StyleSheet.create()` for all styles — no inline style objects
+- Design tokens from `packages/frontend/src/core/theme/` — never hardcode colors, spacing, or fonts
+- TanStack Query for data fetching (no `useState + useEffect` for remote data)
+- Path alias: `@/*` maps to `src/*`
+
+### Backend (NestJS)
+
+- TypeORM for database access
+- DTOs with `class-validator` decorators for request validation
+- Standardized response format: `{ success, statusCode, message, data }`
+
+### Import Order
+
+1. React / React Native
+2. Expo / third-party libraries
+3. Internal `@/core/...`
+4. Internal `@/features/...`
+5. Relative imports
 
 ---
 
-## 6. Bonnes Pratiques de Développement
+## Testing
 
-📌 **À respecter pour maintenir un projet propre et scalable :**
+Tests are mandatory for every new feature.
 
-- Écrire du code **lisible et documenté**.
-- **Éviter les commits volumineux**, privilégier des modifications **petites et cohérentes**.
-- Ne pas pousser directement sur `main` ou `develop`, toujours passer par une **PR**.
-- Tester **localement** avant d’ouvrir une PR.
+| Package | Test framework | Location |
+|---------|---------------|----------|
+| Frontend | Jest + @testing-library/react-native | `src/features/<feature>/presentation/__tests__/` |
+| Frontend | Jest (unit) | `src/features/<feature>/application/__tests__/` |
+| Backend | Jest | `src/**/*.spec.ts` and `test/**/*.e2e-spec.ts` |
+
+```bash
+# Run specific test file
+npm -w packages/frontend test -- path/to/test.ts
+
+# Run with coverage
+npm -w packages/frontend run test:coverage
+npm -w packages/backend run test:cov
+```
 
 ---
 
-## 7. Communication et Support
+## PR Checklist
 
-📢 **Besoin d’aide ?**
+Before requesting review, verify:
 
-- **Ouvre une issue GitHub** en cas de bug ou de question.
-- **Rejoins notre canal Slack/Discord** pour discuter avec l’équipe.
+- [ ] Branch is up to date with `main`
+- [ ] `npm run ci:all` passes (lint + typecheck + format)
+- [ ] `npm run test:all` passes (all tests green)
+- [ ] No `any` types introduced
+- [ ] No inline styles introduced
+- [ ] No hardcoded colors, spacing, or font values
+- [ ] PR title follows Conventional Commits format
+- [ ] PR body includes `Closes #<issue-number>`
 
-📌 **Merci pour ta contribution ! 🚀**
+---
+
+## Project Structure
+
+```
+brasse-bouillon/
+  packages/
+    frontend/         Expo SDK 54 + Router v6 + TypeScript
+      src/
+        core/           Shared: auth, http client, theme, UI primitives
+        features/       Feature modules (auth, recipes, batches, tools...)
+          <feature>/
+            domain/       Types and interfaces only
+            data/         API calls
+            application/  Use-cases (business logic)
+            presentation/ Screens and components
+      app/              Expo Router file-based routes
+    backend/          NestJS 11 + TypeORM + SQLite
+      src/              Application source code
+      test/             E2E tests
+    website/          Static marketing site
+  docs/               Project documentation
+  _archive/           Pre-monorepo code (preserved for reference)
+  .github/workflows/  CI/CD pipelines
+```
+
+---
+
+## Useful Links
+
+- [Frontend conventions (CLAUDE.md)](packages/frontend/CLAUDE.md)
+- [Design system](packages/frontend/docs/design-system.md)
+- [Definition of Done](docs/project-management/definition-of-done.md)
+- [Definition of Ready](docs/project-management/definition-of-ready.md)
+- [Sprint structure](docs/project-management/sprint-definition.md)

--- a/README.md
+++ b/README.md
@@ -1,130 +1,188 @@
 # Brasse-Bouillon
 
-[![Build](https://img.shields.io/github/actions/workflow/status/benoit-bremaud/brasse-bouillon/ci.yml?branch=main)](https://github.com/benoit-bremaud/brasse-bouillon/actions)
+[![CI](https://img.shields.io/github/actions/workflow/status/benoit-bremaud/brasse-bouillon/ci.yml?branch=main&label=CI)](https://github.com/benoit-bremaud/brasse-bouillon/actions)
 [![License](https://img.shields.io/github/license/benoit-bremaud/brasse-bouillon)](LICENSE)
 [![Issues](https://img.shields.io/github/issues/benoit-bremaud/brasse-bouillon)](https://github.com/benoit-bremaud/brasse-bouillon/issues)
-[![Last Commit](https://img.shields.io/github/last-commit/benoit-bremaud/brasse-bouillon)](https://github.com/benoit-bremaud/brasse-bouillon/commits/main)
-[![Docker](https://img.shields.io/badge/docker-enabled-blue?logo=docker)](https://www.docker.com/)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D18.0.0-green?logo=node.js)](https://nodejs.org/)
-[![Platform](https://img.shields.io/badge/platform-local--dev-lightgrey)](https://github.com/benoit-bremaud/brasse-bouillon)
+[![Node](https://img.shields.io/badge/node-%3E%3D20%20%3C21-green?logo=node.js)](https://nodejs.org/)
 
-**Brasse-Bouillon** is an open-source mobile and web application designed to support amateur brewers in managing and sharing their brewing recipes. It provides essential tools to calculate brewing parameters and organize batches efficiently.
+**Brasse-Bouillon** is an open-source mobile and web application for amateur brewers. It provides recipe management, batch tracking, brewing calculators, and an educational academy — all in one app.
 
 ---
 
-## Table of Contents
+## Monorepo Structure
 
-* [Project Overview](#project-overview)
-* [Installation](#installation)
-* [Usage](#usage)
-* [Contributing](#contributing)
-* [Documentation](#documentation)
-* [Project Status](#project-status)
-* [Website](#website)
-* [Contact](#contact)
-* [License](#license)
+This repository is an [npm workspaces](https://docs.npmjs.com/cli/using-npm/workspaces) monorepo containing three packages:
 
----
-
-## Project Overview
-
-This project follows an Agile methodology and is structured into modular GitHub Projects (Frontend, Backend, Design System, etc.).
-
-**Main Features:**
-
-* Recipe creation and editing
-* Brewing parameter calculations (ABV, IBU, OG/FG)
-* Session tracking
-* User-friendly mobile experience
-
----
-
-## Installation
-
-To install and run the project locally:
-
-```bash
-# Clone the repository
-git clone https://github.com/benoit-bremaud/brasse-bouillon.git
-cd brasse-bouillon
+```
+brasse-bouillon/
+  packages/
+    frontend/     React Native + Expo SDK 54 + Expo Router v6 + TypeScript
+    backend/      NestJS 11 + TypeORM + SQLite + TypeScript
+    website/      Static HTML/CSS/JS marketing site + Python quality gate
+  docs/           Project documentation (architecture, design, API, requirements)
+  _archive/       Old code preserved for reference (pre-monorepo)
+  .github/        CI workflows (path-filtered per package)
 ```
 
-Next, follow the setup instructions for each component:
+---
 
-* [Backend Installation Guide](./backend/README.md)
+## Prerequisites
 
-* [Frontend Installation Guide](./frontend/README.md)
-
-Each guide contains detailed steps to configure the environment, install dependencies, and run the application.
+- **Node.js** 20.x (`nvm use` will read `.nvmrc`)
+- **npm** 10+
+- **Docker** (optional, for SonarQube local analysis)
 
 ---
 
-## Usage
+## Getting Started
 
-Once installed, you can:
+```bash
+# Clone
+git clone git@github.com:benoit-bremaud/brasse-bouillon.git
+cd brasse-bouillon
 
-* Access the frontend via Expo to simulate the mobile interface
-* Interact with the backend via REST endpoints
-* Add or manage recipes
-* View calculated data for each batch
+# Install all dependencies (from root)
+npm install
+
+# Start the frontend (Expo dev server)
+npm run dev:frontend
+
+# Start the backend (NestJS dev server)
+npm run dev:backend
+```
+
+### Environment Variables
+
+Each package has its own `.env.example`. Copy and configure before running:
+
+```bash
+cp packages/frontend/.env.example packages/frontend/.env
+cp packages/backend/.env.example packages/backend/.env
+```
+
+Key variables:
+
+| Package | Variable | Description |
+|---------|----------|-------------|
+| Frontend | `EXPO_PUBLIC_API_URL` | Backend API URL (default: `http://localhost:3000`) |
+| Frontend | `EXPO_PUBLIC_USE_DEMO_DATA` | `true` to use mock data without backend |
+| Backend | `JWT_SECRET` | JWT signing secret (required) |
+| Backend | `PORT` | API port (default: 3000) |
+| Backend | `DATABASE_PATH` | SQLite database file path |
 
 ---
 
-## Contributing
+## Available Scripts
 
-Contributions are welcome! Please follow the project's conventions:
+### Root (monorepo)
 
-* Follow our [CONVENTIONS.md](./docs/CONVENTIONS.md) file.
-* Use [Angular-style commit messages](https://www.conventionalcommits.org/en/v1.0.0/): `type(scope): short description`
-* Reference issues using `Closes #<issue-number>`.
-* Create PRs with clear checklists and descriptions.
-* See also: [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+| Script | Description |
+|--------|-------------|
+| `npm run dev:frontend` | Start Expo dev server |
+| `npm run dev:backend` | Start NestJS in watch mode |
+| `npm run ci:all` | Run lint + typecheck + format check for all packages |
+| `npm run test:all` | Run all tests across packages |
+| `npm run lint:all` | Run linters across packages |
+| `npm run typecheck:all` | Run type checking across packages |
+
+### SonarQube (local analysis)
+
+| Command | Description |
+|---------|-------------|
+| `make sonar-start` | Start local SonarQube (Docker) |
+| `make sonar-stop` | Stop SonarQube |
+| `make sonar-status` | Check SonarQube status |
+| `make sonar-scan SONAR_TOKEN=sqp_xxx` | Run analysis |
+
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Mobile / Web | React Native, Expo SDK 54, Expo Router v6 |
+| State / Data | TanStack Query (migrating from useState+useEffect) |
+| Backend | NestJS 11, TypeORM, SQLite |
+| Auth | JWT (access token + refresh) |
+| CI | GitHub Actions (path-filtered per package) |
+| Code Quality | SonarQube (local), ESLint, Prettier |
+| Testing | Jest, @testing-library/react-native |
+
+---
+
+## Architecture
+
+The frontend follows **Clean Architecture** with strict layering:
+
+```
+domain  <-  application  <-  data
+                |
+          presentation
+```
+
+- `domain/` — Types and interfaces only
+- `data/` — API calls via HTTP client
+- `application/` — Use-cases (business logic)
+- `presentation/` — React Native screens and components
+
+See [packages/frontend/CLAUDE.md](packages/frontend/CLAUDE.md) for full frontend conventions.
+
+---
+
+## CI/CD
+
+GitHub Actions runs automatically on every PR to `main`:
+
+- **Path-filtered**: only changed packages are tested
+- **Frontend**: lint + typecheck + format check + 407 tests
+- **Backend**: lint + build + 238 tests
+- **Website**: Python quality gate
+
+Coverage reports are uploaded as artifacts for SonarQube integration.
 
 ---
 
 ## Documentation
 
-Project documentation is stored in the `docs/` folder and dedicated subproject READMEs.
-
-Notable files:
-
-* [`frontend/README.md`](./frontend/README.md) – Guide for launching and developing the mobile app
-
-* [`backend/README.md`](./backend/README.md) – Technical guide for backend setup and usage
-
-* [`docs/design/charte_graphique.md`](./docs/design/charte_graphique.md)
-
-* [`docs/backend/api-overview.md`](./docs/backend/api-overview.md)
-
-* [`docs/frontend/navigation-structure.md`](./docs/frontend/navigation-structure.md)
+| Topic | Location |
+|-------|----------|
+| Frontend conventions | [packages/frontend/CLAUDE.md](packages/frontend/CLAUDE.md) |
+| Design system | [packages/frontend/docs/design-system.md](packages/frontend/docs/design-system.md) |
+| API documentation | [docs/api/](docs/api/) |
+| Architecture | [docs/architecture/](docs/architecture/) |
+| Requirements | [docs/requirements/](docs/requirements/) |
+| Scrum / Project management | [docs/project-management/](docs/project-management/) |
 
 ---
 
-## Project Status
+## Contributing
 
-| Phase                        | Status         |
-| ---------------------------- | -------------- |
-| Phase 1 – Initialisation     | ✅ Completed    |
-| Phase 2 – Conception         | ✅ Completed    |
-| Phase 3 – Development        | 🚧 In Progress |
-| Phase 4 – Testing & QA       | 📝 Planned     |
-| Phase 5 – Deployment         | ⏳ Upcoming     |
-| Phase 6 – Final Presentation | ⏳ Upcoming     |
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. Quick summary:
 
----
-
-## Website
-
-Visit the official website: [https://brasse-bouillon.com](https://brasse-bouillon.com)
+- Branch from `main` for every task (never commit directly)
+- Use Conventional Commits: `type(scope): description`
+- Run `npm run ci:all && npm run test:all` before pushing
+- Create a PR with a clear description and checklist
+- Wait for CI to pass and at least one review before merging
 
 ---
 
-## Contact
+## Team
 
-Project maintained by [@benoit-bremaud](https://github.com/benoit-bremaud). For any inquiries, open an issue or contact via GitHub.
+| Member | Role | Scope |
+|--------|------|-------|
+| Benoit | Project lead, Fullstack, Design | Frontend, Backend, Monorepo, DevOps |
+| Fabien | Cybersecurity, Frontend/Design | Frontend, Design, Security |
+| Kevin | Fullstack (backend focus) | Backend, Frontend |
+| Sara | Fullstack (frontend focus) | Frontend, Backend |
+| Clement | Infrastructure, DevOps | DevOps, Infrastructure |
+| Catarina | Infrastructure, Security, Cloud | DevOps, Infrastructure, Security |
+| Fabio | UI/UX, Art Direction | Design, Frontend |
+| Liam | Design, UI/UX | Design |
+| Thais | UI/UX, Frontend | Design, Frontend |
 
 ---
 
 ## License
 
-Distributed under the MIT License. See the `LICENSE` file for more details.
+Distributed under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- Rewrite `README.md` for the monorepo: structure, getting started, env vars, scripts, tech stack, architecture, CI, team listing
- Rewrite `CONTRIBUTING.md` in English: trunk-based workflow, Conventional Commits, code style, testing requirements, PR checklist, project structure

## Checklist

- [x] README documents monorepo structure and all 3 packages
- [x] README getting started works with `npm install` from root
- [x] README links point to correct paths (packages/ not old root dirs)
- [x] CONTRIBUTING in English (was French)
- [x] CONTRIBUTING uses trunk-based (was Git Flow with develop)
- [x] CONTRIBUTING documents code style, testing, PR workflow
- [x] No hardcoded values, no `any`, no inline styles introduced

Closes #351
Closes #352