### PR TITLE
docs(scrum): add sprint templates, velocity tracking, and design audit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Default — project lead reviews everything
+* @benoit-bremaud
+
+# Frontend
+packages/frontend/ @benoit-bremaud @Fabien-Ori @Smith06S @Thais9723
+
+# Backend
+packages/backend/ @benoit-bremaud @vitalikevin @Smith06S
+
+# Website
+packages/website/ @benoit-bremaud @Lin0ooo
+
+# Design documentation
+docs/design/ @benoit-bremaud @Fabien-Ori @Lin0ooo @Liamggn @Thais9723
+
+# Infrastructure & CI
+.github/ @benoit-bremaud @clemoune-tech @Moooniie
+Makefile @benoit-bremaud @clemoune-tech @Moooniie
+sonar-project.properties @benoit-bremaud @clemoune-tech @Moooniie
+
+# Project documentation
+docs/project-management/ @benoit-bremaud
+docs/architecture/ @benoit-bremaud

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+| Version    | Supported |
+| ---------- | --------- |
+| main (HEAD) | Yes       |
+| < main      | No        |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do NOT open a public issue.**
+2. Email the project lead at **bbd.concept@gmail.com** with:
+   - Description of the vulnerability
+   - Steps to reproduce
+   - Potential impact
+3. You will receive an acknowledgment within **48 hours**.
+4. A fix will be prioritized based on severity.
+
+## Security Practices
+
+- Dependencies are monitored via GitHub Dependabot alerts.
+- JWT secrets are never committed (enforced via `.gitignore` and `.env.example` patterns).
+- SQL injection is mitigated by TypeORM parameterized queries.
+- XSS protection follows React Native's default output escaping.
+- All API endpoints require JWT authentication (except public routes).
+
+Thank you for helping keep Brasse-Bouillon secure.


### PR DESCRIPTION
## Summary

- Create sprint ceremony templates (planning, review, retrospective) in `docs/project-management/sprints/`
- Add velocity tracking table in `docs/project-management/velocity.md`
- Rewrite `sprint-definition.md` with finalized ceremony decisions adapted to Ydays context
- Rewrite `docs/design/README.md`: fix broken links, add deliverable workflow and file naming conventions
- Populate `docs/design/07_tech-constraints/technical_constraints.md` (was empty)
- Remove emojis from 3 design docs (design-charter, styleguide, colors)
- Add `scope:scrum` routing to Discord notification workflow

## Sprint Ceremonies (finalized)

- **Daily Standup** — written async in #daily-standup, every Wednesday (daily during Ydays)
- **Sprint Planning** — in-person, 1st day of sprint (Ydays), 2h max
- **Sprint Review** — in-person, last day of sprint, 1h max, 5 min demo/person
- **Retrospective** — in-person, after review, 30 min, Start/Stop/Continue
- **Backlog Grooming** — PO prepares alone, validates in Planning

## New Files

- `docs/project-management/sprints/TEMPLATE-sprint-planning.md`
- `docs/project-management/sprints/TEMPLATE-sprint-review.md`
- `docs/project-management/sprints/TEMPLATE-sprint-retrospective.md`
- `docs/project-management/velocity.md`

## Checklist

- [x] All referenced files exist and are not empty
- [x] Emojis removed from design docs
- [x] Broken links fixed in design README
- [x] `scope:scrum` label created on GitHub
- [x] `DISCORD_WEBHOOK_SCRUM` secret configured
- [x] Workflow routes `scope:scrum` to #sprint-planning
- [x] YAML validates