### PR TITLE
chore(ci): add coverage gates, ruff lint, and security audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,11 +204,11 @@ jobs:
       - name: Check coverage threshold (70%)
         run: |
           COVERAGE=$(python -c "
-          import re, sys
+          import re
           data = open('coverage/lcov.info').read()
-          hits = sum(int(m) for m in re.findall(r'^DA:\d+,(\d+)', data, re.M))
+          covered = sum(1 for m in re.findall(r'^DA:\d+,(\d+)', data, re.M) if int(m) > 0)
           total = len(re.findall(r'^DA:\d+,', data, re.M))
-          print(f'{100*hits/total:.1f}' if total else '0')
+          print(f'{100*covered/total:.1f}' if total else '0')
           " 2>/dev/null || echo "0")
           echo "Coverage: ${COVERAGE}%"
           if [ "$(echo "$COVERAGE < 70" | bc -l 2>/dev/null || echo 1)" = "1" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,13 @@
 # Brasse-Bouillon — Unified CI Pipeline
 # Runs path-filtered jobs for mobile-app, api, website, and beer-label-ai
 # on every PR to main.
+#
+# Quality gates:
+#   - Mobile App: lint + typecheck + format + tests (70% coverage minimum)
+#   - API: lint + build + tests (70% coverage minimum)
+#   - Website: Python quality gate
+#   - Beer Label AI: ruff lint + compile check + tests (70% coverage minimum)
+#   - Security: npm audit for Node packages
 # ==============================================================================
 
 name: CI
@@ -46,7 +53,7 @@ jobs:
               - 'packages/beer-label-ai/**'
 
   # ============================================================================
-  # Mobile App: lint + typecheck + format + tests
+  # Mobile App: lint + typecheck + format + tests + coverage gate
   # ============================================================================
   mobile-app:
     needs: changes
@@ -73,6 +80,14 @@ jobs:
       - name: Run tests with coverage
         run: npm run test:coverage
 
+      - name: Check coverage threshold (70%)
+        run: |
+          COVERAGE=$(npx lcov-summary coverage/lcov.info 2>/dev/null | grep -oP 'Lines:\s+\K[\d.]+' || echo "0")
+          echo "Coverage: ${COVERAGE}%"
+          if [ "$(echo "$COVERAGE < 70" | bc -l 2>/dev/null || echo 1)" = "1" ]; then
+            echo "::warning::Coverage is ${COVERAGE}% — below 70% threshold"
+          fi
+
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
@@ -82,7 +97,7 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # API: lint + build + tests
+  # API: lint + build + tests + coverage gate
   # ============================================================================
   api:
     needs: changes
@@ -111,6 +126,14 @@ jobs:
 
       - name: Run tests with coverage
         run: npm run test:cov
+
+      - name: Check coverage threshold (70%)
+        run: |
+          COVERAGE=$(npx lcov-summary coverage/lcov.info 2>/dev/null | grep -oP 'Lines:\s+\K[\d.]+' || echo "0")
+          echo "Coverage: ${COVERAGE}%"
+          if [ "$(echo "$COVERAGE < 70" | bc -l 2>/dev/null || echo 1)" = "1" ]; then
+            echo "::warning::Coverage is ${COVERAGE}% — below 70% threshold"
+          fi
 
       - name: Upload coverage report
         if: always()
@@ -146,7 +169,7 @@ jobs:
           fi
 
   # ============================================================================
-  # Beer Label AI: Python compile + lint + tests
+  # Beer Label AI: ruff lint + compile check + tests + coverage
   # ============================================================================
   beer-label-ai:
     needs: changes
@@ -166,9 +189,52 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r ml/requirements.txt
+          pip install ruff pytest-cov
+
+      - name: Lint (ruff)
+        run: ruff check .
 
       - name: Python compile sanity
         run: python -m py_compile api/main.py ml/*.py scripts/*.py
 
-      - name: Run tests
-        run: pytest -q tests/
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ --cov=ml --cov=api --cov-report=term --cov-report=lcov:coverage/lcov.info -q
+
+      - name: Check coverage threshold (70%)
+        run: |
+          COVERAGE=$(python -c "
+          import re, sys
+          data = open('coverage/lcov.info').read()
+          hits = sum(int(m) for m in re.findall(r'^DA:\d+,(\d+)', data, re.M))
+          total = len(re.findall(r'^DA:\d+,', data, re.M))
+          print(f'{100*hits/total:.1f}' if total else '0')
+          " 2>/dev/null || echo "0")
+          echo "Coverage: ${COVERAGE}%"
+          if [ "$(echo "$COVERAGE < 70" | bc -l 2>/dev/null || echo 1)" = "1" ]; then
+            echo "::warning::Coverage is ${COVERAGE}% — below 70% threshold"
+          fi
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: beer-label-ai-coverage
+          path: packages/beer-label-ai/coverage/lcov.info
+          retention-days: 7
+
+  # ============================================================================
+  # Security: dependency audit
+  # ============================================================================
+  security-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Audit Node dependencies
+        run: npm audit --audit-level=high || true
+        continue-on-error: true

--- a/packages/beer-label-ai/api/main.py
+++ b/packages/beer-label-ai/api/main.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import Optional
 
 from fastapi import FastAPI, File, HTTPException, UploadFile
 
@@ -24,7 +23,7 @@ def healthcheck() -> dict[str, str]:
 @app.post("/scan", response_model=ScanResponse)
 async def scan_endpoint(
     file: UploadFile = File(...),
-    model_path: Optional[str] = None,
+    model_path: str | None = None,
     recipes_path: str = "data/recipes.sample.json",
     top_n: int = 3,
 ) -> ScanResponse:

--- a/packages/beer-label-ai/ml/extract.py
+++ b/packages/beer-label-ai/ml/extract.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, List, Optional
 
 from ml.schemas import ExtractedFields
 
-
-STYLE_KEYWORDS: Dict[str, List[str]] = {
+STYLE_KEYWORDS: dict[str, list[str]] = {
     "ipa": ["ipa", "india pale ale"],
     "lager": ["lager", "pils", "pilsner", "helles", "blonde"],
     "wheat": ["wheat", "witbier", "weiss", "blanche"],
@@ -22,7 +20,7 @@ def _normalize(text: str) -> str:
     return re.sub(r"\s+", " ", text.lower()).strip()
 
 
-def extract_abv(text: str) -> Optional[float]:
+def extract_abv(text: str) -> float | None:
     match = re.search(r"(\d{1,2}(?:[\.,]\d)?)\s*%", text)
     if not match:
         return None
@@ -33,7 +31,7 @@ def extract_abv(text: str) -> Optional[float]:
         return None
 
 
-def infer_style(text: str) -> Optional[str]:
+def infer_style(text: str) -> str | None:
     normalized = _normalize(text)
     for style, keywords in STYLE_KEYWORDS.items():
         if any(keyword in normalized for keyword in keywords):
@@ -41,7 +39,7 @@ def infer_style(text: str) -> Optional[str]:
     return None
 
 
-def extract_brewery(text: str) -> Optional[str]:
+def extract_brewery(text: str) -> str | None:
     pattern = re.compile(r"(?:brewery|brewer|brasserie)\s*[:\-]?\s*([\w\-\s]{3,40})", re.IGNORECASE)
     match = pattern.search(text)
     if match:
@@ -49,7 +47,7 @@ def extract_brewery(text: str) -> Optional[str]:
     return None
 
 
-def extract_name(text: str, style: Optional[str], brewery: Optional[str]) -> Optional[str]:
+def extract_name(text: str, style: str | None, brewery: str | None) -> str | None:
     lines = [line.strip(" -|\t") for line in text.splitlines() if line.strip()]
     for line in lines:
         normalized_line = _normalize(line)

--- a/packages/beer-label-ai/ml/infer.py
+++ b/packages/beer-label-ai/ml/infer.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 import cv2
 
@@ -19,9 +18,9 @@ class DetectedRegionRaw:
 
 def detect_label_regions(
     image_path: str | Path,
-    model_path: Optional[str | Path] = None,
+    model_path: str | Path | None = None,
     conf_threshold: float = 0.25,
-) -> Tuple[List[DetectedRegionRaw], List[str]]:
+) -> tuple[list[DetectedRegionRaw], list[str]]:
     """Detect label regions with YOLO if available, otherwise return full-image fallback."""
     path = Path(image_path)
     if not path.exists():
@@ -32,8 +31,8 @@ def detect_label_regions(
         raise ValueError(f"Unable to read image: {path}")
 
     h, w = image.shape[:2]
-    notes: List[str] = []
-    regions: List[DetectedRegionRaw] = []
+    notes: list[str] = []
+    regions: list[DetectedRegionRaw] = []
 
     if model_path:
         model_file = Path(model_path)

--- a/packages/beer-label-ai/ml/ocr.py
+++ b/packages/beer-label-ai/ml/ocr.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from functools import lru_cache
 from pathlib import Path
-from typing import Iterable, List, Sequence, Tuple
 
 import cv2
 import numpy as np
@@ -30,8 +30,8 @@ def _preprocess_for_ocr(crop: np.ndarray) -> np.ndarray:
     )
 
 
-def _read_text(crop: np.ndarray, languages: Sequence[str]) -> Tuple[str, float, List[str]]:
-    notes: List[str] = []
+def _read_text(crop: np.ndarray, languages: Sequence[str]) -> tuple[str, float, list[str]]:
+    notes: list[str] = []
     if crop.size == 0:
         return "", 0.0, ["Empty crop for OCR."]
 
@@ -40,9 +40,9 @@ def _read_text(crop: np.ndarray, languages: Sequence[str]) -> Tuple[str, float, 
     except Exception as exc:  # noqa: BLE001
         return "", 0.0, [f"EasyOCR unavailable: {exc}"]
 
-    def parse(results: Iterable) -> Tuple[List[str], List[float]]:
-        texts: List[str] = []
-        confs: List[float] = []
+    def parse(results: Iterable) -> tuple[list[str], list[float]]:
+        texts: list[str] = []
+        confs: list[float] = []
         for item in results:
             if len(item) < 3:
                 continue
@@ -76,16 +76,16 @@ def ocr_regions(
     image_path: str | Path,
     regions: Sequence[DetectedRegionRaw],
     languages: Sequence[str] = ("en", "fr"),
-) -> Tuple[str, float, List[str]]:
+) -> tuple[str, float, list[str]]:
     path = Path(image_path)
     image = cv2.imread(str(path))
     if image is None:
         raise ValueError(f"Unable to read image for OCR: {path}")
 
     h, w = image.shape[:2]
-    all_notes: List[str] = []
-    chunk_texts: List[str] = []
-    chunk_confs: List[float] = []
+    all_notes: list[str] = []
+    chunk_texts: list[str] = []
+    chunk_confs: list[float] = []
 
     for region in regions:
         x1 = max(0, min(w, region.x1))

--- a/packages/beer-label-ai/ml/pipeline.py
+++ b/packages/beer-label-ai/ml/pipeline.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional, Sequence
 
 from ml.extract import extract_fields_from_text
 from ml.infer import detect_label_regions
@@ -17,7 +17,7 @@ def _clamp01(value: float) -> float:
 def scan_image(
     image_path: str | Path,
     recipes_path: str | Path,
-    model_path: Optional[str | Path] = None,
+    model_path: str | Path | None = None,
     top_n: int = 3,
     languages: Sequence[str] = ("en", "fr"),
 ) -> ScanResponse:

--- a/packages/beer-label-ai/ml/recommender.py
+++ b/packages/beer-label-ai/ml/recommender.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
-from typing import List, Sequence
 
 from ml.schemas import ExtractedFields, Recipe, RecipeSuggestion
 
 
-def load_recipes(path: str | Path) -> List[Recipe]:
+def load_recipes(path: str | Path) -> list[Recipe]:
     recipe_file = Path(path)
     if not recipe_file.exists():
         raise FileNotFoundError(f"Recipe file not found: {recipe_file}")
@@ -54,7 +54,7 @@ def _numeric_score(value_a: float | None, value_b: float | None, tolerated_gap: 
     return max(0.0, 1.0 - min(gap / tolerated_gap, 1.0))
 
 
-def score_recipe(extracted: ExtractedFields, recipe: Recipe) -> tuple[float, List[str]]:
+def score_recipe(extracted: ExtractedFields, recipe: Recipe) -> tuple[float, list[str]]:
     style_score = _style_score(extracted.style, recipe.style)
     abv_score = _numeric_score(extracted.abv, recipe.abv, tolerated_gap=5.0)
     ibu_score = _numeric_score(None, recipe.ibu, tolerated_gap=30.0)
@@ -62,7 +62,7 @@ def score_recipe(extracted: ExtractedFields, recipe: Recipe) -> tuple[float, Lis
     total = 0.60 * style_score + 0.25 * abv_score + 0.15 * ibu_score
     total = max(0.0, min(1.0, total))
 
-    reasons: List[str] = []
+    reasons: list[str] = []
     if extracted.style and recipe.style:
         reasons.append(f"Detected style: {extracted.style} vs recipe style: {recipe.style}")
     if extracted.abv is not None and recipe.abv is not None:
@@ -77,8 +77,8 @@ def recommend_recipes(
     extracted: ExtractedFields,
     recipes: Sequence[Recipe],
     top_n: int = 3,
-) -> List[RecipeSuggestion]:
-    scored: List[RecipeSuggestion] = []
+) -> list[RecipeSuggestion]:
+    scored: list[RecipeSuggestion] = []
     for recipe in recipes:
         score, reasons = score_recipe(extracted, recipe)
         scored.append(

--- a/packages/beer-label-ai/ml/schemas.py
+++ b/packages/beer-label-ai/ml/schemas.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
-from typing import List, Optional
-
 from pydantic import BaseModel, Field
 
 
 class ExtractedFields(BaseModel):
-    name: Optional[str] = None
-    style: Optional[str] = None
-    abv: Optional[float] = None
-    brewery: Optional[str] = None
+    name: str | None = None
+    style: str | None = None
+    abv: float | None = None
+    brewery: str | None = None
 
 
 class DetectionRegion(BaseModel):
@@ -25,26 +23,26 @@ class ScanExtraction(BaseModel):
     detected_text: str = ""
     fields: ExtractedFields
     confidence: float = Field(ge=0.0, le=1.0)
-    notes: List[str] = Field(default_factory=list)
-    regions: List[DetectionRegion] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+    regions: list[DetectionRegion] = Field(default_factory=list)
 
 
 class Recipe(BaseModel):
     id: str
     name: str
     style: str
-    abv: Optional[float] = None
-    ibu: Optional[float] = None
-    description: Optional[str] = None
-    ingredients: List[str] = Field(default_factory=list)
+    abv: float | None = None
+    ibu: float | None = None
+    description: str | None = None
+    ingredients: list[str] = Field(default_factory=list)
 
 
 class RecipeSuggestion(BaseModel):
     recipe: Recipe
     score: float = Field(ge=0.0, le=1.0)
-    match_reasons: List[str] = Field(default_factory=list)
+    match_reasons: list[str] = Field(default_factory=list)
 
 
 class ScanResponse(BaseModel):
     extraction: ScanExtraction
-    recommendations: List[RecipeSuggestion] = Field(default_factory=list)
+    recommendations: list[RecipeSuggestion] = Field(default_factory=list)

--- a/packages/beer-label-ai/ruff.toml
+++ b/packages/beer-label-ai/ruff.toml
@@ -1,0 +1,27 @@
+# Ruff configuration for beer-label-ai
+# https://docs.astral.sh/ruff/
+
+target-version = "py312"
+line-length = 100
+
+[lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "N",    # pep8-naming
+    "UP",   # pyupgrade
+    "B",    # flake8-bugbear
+    "SIM",  # flake8-simplify
+    "TCH",  # flake8-type-checking
+]
+ignore = [
+    "E501",   # line too long (handled by line-length)
+    "B008",   # function call in default argument (FastAPI pattern: File(...))
+    "TCH",    # type-checking block — imports are used at runtime
+    "SIM103", # return condition directly — readability preference
+]
+
+[lint.isort]
+known-first-party = ["ml", "api"]

--- a/packages/beer-label-ai/scripts/dataset_sanity_check.py
+++ b/packages/beer-label-ai/scripts/dataset_sanity_check.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import argparse
 from collections import Counter
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
-
 
 ALLOWED_CLASS_IDS = {0}
 REQUIRED_SPLITS = ("train", "val")

--- a/packages/beer-label-ai/tests/conftest.py
+++ b/packages/beer-label-ai/tests/conftest.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))


### PR DESCRIPTION
## Summary

- Add **70% coverage warning gate** to mobile-app and api CI jobs (warn, not fail)
- Add **beer-label-ai CI job**: ruff lint, compile sanity check, pytest with lcov coverage report + 70% warning gate
- Add **ruff.toml** config for beer-label-ai (Python 3.12, line-length 100, pycodestyle + pyflakes + isort + bugbear + pyupgrade rules)
- Apply ruff auto-fixes to all beer-label-ai Python files (modernize `Optional[X]` → `X | None`, `List` → `list`, etc.)
- Upload **coverage artifacts** for all three packages (mobile-app, api, beer-label-ai) — ready for SonarQube integration
- Add **npm audit** security check job (high severity, non-blocking)

## Test plan

- [ ] CI pipeline runs successfully on this PR
- [ ] beer-label-ai job: ruff check passes, pytest 10/10 green, coverage report generated
- [ ] mobile-app and api jobs: coverage threshold check runs correctly
- [ ] security-audit job completes without blocking
- [ ] Coverage artifacts uploaded for all packages

Closes #496