### PR TITLE
docs(project): create PROJECT_LOG.md operational logbook

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+# Copilot Code Review Instructions — Brasse-Bouillon
+
+## Project context
+
+npm workspaces monorepo with 4 packages:
+
+- `packages/mobile-app` — React Native + Expo SDK 54 + TypeScript (strict)
+- `packages/api` — NestJS 11 + TypeORM + SQLite + TypeScript
+- `packages/website` — Static HTML/CSS/JS + Python scripts
+- `packages/beer-label-ai` — Python 3.12 + FastAPI + YOLOv8 + EasyOCR
+
+## TypeScript rules (mobile-app + api)
+
+- **Never allow `any`** — flag every occurrence, no exceptions
+- **Named exports only** — no default exports for screens, use-cases, or API modules
+- `interface` for object shapes; `type` for unions, mapped types, utility types
+- No inline style objects in mobile-app — must use `StyleSheet.create()`
+- No hardcoded colors, spacing, or font values in mobile-app — must use theme tokens
+- No direct `fetch()` calls outside `packages/mobile-app/src/core/http/http-client.ts`
+
+## Python rules (beer-label-ai)
+
+- Type hints required on all function signatures and return types
+- Pydantic models for all request/response boundaries (no raw dicts)
+- No `typing.Any` without justification
+- No hardcoded file paths — use relative paths or env vars
+- Must pass `ruff check` (config in `packages/beer-label-ai/ruff.toml`)
+
+## Security — always flag
+
+- Command injection, XSS, SQL injection
+- Hardcoded secrets, API keys, or tokens
+- `.env` files or credentials in committed code
+- Unsafe deserialization or unvalidated user input
+
+## Testing
+
+- Every new feature must have tests
+- Coverage target: 70% minimum per package
+- Flag untested public functions or API endpoints
+
+## Code quality
+
+- Flag dead code, unused imports, unreachable branches
+- Flag overly complex functions (cyclomatic complexity)
+- Flag missing error handling at system boundaries (user input, external APIs)
+- Do NOT flag missing error handling for internal code paths
+
+## What NOT to flag
+
+- Brewing domain terminology in English (IBU, ABV, wort, mash, etc.)
+- `from __future__ import annotations` in Python files (required for type union syntax)
+- `File(...)` as default argument in FastAPI endpoints (intentional pattern, B008 ignored)
+- Files in `_archive/` directory — read-only historical reference, do not review

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,10 +144,23 @@ DATABASE_PATH=./data/brasse-bouillon.db
 
 ---
 
+## Project Log
+
+This project maintains a [PROJECT_LOG.md](PROJECT_LOG.md) — a chronological, agent-agnostic operational logbook recording all significant project activity (merged PRs, architectural decisions, backlog changes).
+
+**Rules:**
+
+- Update after every merged PR, significant decision, or backlog change
+- Entries are append-only (never delete), most recent first
+- This is NOT `CHANGELOG.md` — the changelog tracks releases, the project log tracks daily operations
+
+---
+
 ## Documentation
 
 | Topic | Location |
 |-------|----------|
+| Project log | [PROJECT_LOG.md](PROJECT_LOG.md) |
 | Mobile App conventions | [packages/mobile-app/CLAUDE.md](packages/mobile-app/CLAUDE.md) |
 | Design system | [packages/mobile-app/docs/design-system.md](packages/mobile-app/docs/design-system.md) |
 | Contributing guide | [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,8 +151,8 @@ This project maintains a [PROJECT_LOG.md](PROJECT_LOG.md) — a chronological, a
 **Rules:**
 
 - Update after every merged PR, significant decision, or backlog change
-- Entries are append-only (never delete), most recent first
-- This is NOT `CHANGELOG.md` — the changelog tracks releases, the project log tracks daily operations
+- Entries are add-only — never delete or modify past entries; add new entries at the top (most recent first)
+- This is NOT `docs/changelog.md` — the changelog tracks releases, the project log tracks daily operations
 
 ---
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -1,7 +1,7 @@
 # Project Log — Brasse-Bouillon
 
-Chronological record of all project activity. Most recent entries first.
-This is the operational logbook, not the release changelog (see CHANGELOG.md).
+Reverse-chronological record of all project activity (most recent entries first).
+This is the operational logbook, not the release changelog (see [docs/changelog.md](docs/changelog.md)).
 
 ---
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -1,0 +1,106 @@
+# Project Log — Brasse-Bouillon
+
+Chronological record of all project activity. Most recent entries first.
+This is the operational logbook, not the release changelog (see CHANGELOG.md).
+
+---
+
+## 2026-04-01
+
+### Backlog: create i18n translation issues for all French documentation
+
+Created 9 issues (#504–#512) to systematically translate all remaining French content to English across the repository: sequence diagrams, vision, personas, requirements, user scenarios, design docs, project management, meeting notes, and mobile app UI strings. All assigned to milestone "Documentation Refactoring" except #512 (DX & Cleanup).
+
+## 2026-03-31
+
+### CI/CD: add coverage gates, ruff lint, and security audit (PR #503)
+
+Added 70% coverage warning gate to mobile-app and api CI jobs. Added full beer-label-ai CI job with ruff linting, compile sanity check, pytest with lcov coverage report, and coverage artifact upload. Added npm audit security check job. Applied ruff auto-fixes (pyupgrade) to all beer-label-ai Python files. Closes #496.
+
+## 2026-03-30
+
+### Refactor: rename packages to match Discord channels (PR #502)
+
+Renamed `packages/frontend` → `packages/mobile-app` and `packages/backend` → `packages/api`. Updated all references across CI, SonarQube config, root scripts, CLAUDE.md, CONTRIBUTING.md, and package.json workspaces. Closes #501.
+
+### Fix: reduce Discord notification spam (PR #500)
+
+Reduced Discord notification triggers from ~10 per action to max 3 per PR lifecycle. Removed `review_requested`, `labeled`, and comment events. Kept only `issues:opened`, `pull_request:opened`, and `pull_request:closed` (merged only). Closes #498.
+
+### Infrastructure: import beer-label-ai into monorepo (PR #495)
+
+Imported beer-label-ai standalone repo via `git subtree add` into `packages/beer-label-ai`. Added to npm workspaces. Created CLAUDE.md for the package. Cleaned up `_archive/` (removed 20MB act binary). All 4 standalone repos now archived on GitHub with deprecation notices.
+
+### Fix: sync website package with standalone repo (PR #494)
+
+Fixed `packages/website/` to match standalone repo HEAD. Fixed SyntaxError in `weekly_digest.py` (line 610: `]` → `)`). Closes #491.
+
+### Docs: add sprint templates and design audit (PR #493)
+
+Added sprint definition, velocity tracking templates, and design audit documentation for Scrum workflow.
+
+## 2026-03-27
+
+### Docs: rewrite CONVENTIONS.md for monorepo (PR #492)
+
+Rewrote project conventions to reflect the monorepo structure. Covers naming, branching, commit messages, PR workflow, and code quality standards.
+
+## 2026-03-26
+
+### Infrastructure: add Discord notifications and issue templates (PR #490)
+
+Created GitHub-to-Discord notification workflow. Added issue templates adapted for monorepo package structure.
+
+### Infrastructure: update GitHub issue templates (PR #477)
+
+Updated issue templates (bug report, feature request, task) to work with the monorepo multi-package structure.
+
+## 2026-03-25
+
+### Docs: create unified Product Backlog (PR #476)
+
+Created single Product Backlog document with 63 User Stories organized by epic, with personas and priority classification.
+
+### Docs: create root CLAUDE.md and rewrite README/CONTRIBUTING (PRs #401, #402)
+
+Established cross-cutting development conventions for the monorepo in CLAUDE.md. Rewrote README.md and CONTRIBUTING.md for the new monorepo structure.
+
+### CI/CD: create unified CI workflow (PR #398)
+
+Created path-filtered GitHub Actions CI pipeline. Each package only runs its checks when its files change. Mobile-app: lint + typecheck + format + tests. API: lint + build + tests. Website: Python quality gate. Beer-label-ai: compile + tests.
+
+### Infrastructure: add SonarQube configuration (PR #397)
+
+Added `sonar-project.properties` and Makefile target for local SonarQube analysis. Configured sources, tests, coverage paths, and exclusions for TypeScript packages.
+
+### Fix: validate packages and fix lint errors (PR #399)
+
+Fixed ESLint and TypeScript errors across packages to ensure CI passes on the newly consolidated monorepo.
+
+## 2026-03-24
+
+### Infrastructure: bootstrap monorepo (PR #395)
+
+Consolidated 4 standalone repos into one monorepo using `git subtree`. Set up npm workspaces. Imported: brasse-bouillon-frontend, brasse-bouillon-backend, brasse-bouillon-website. Established root `package.json` with workspace scripts.
+
+### Decision: monorepo consolidation strategy
+
+Decided to consolidate all 5 standalone repos (frontend, backend, website, beer-label-ai, main) into a single monorepo using `git subtree` (preserving history). Motivation: reduce dual maintenance risk, simplify CI, unify conventions.
+
+## 2026-02-11
+
+### Feature: add JWT tests for backend (PR #316)
+
+Added automated tests for JWT authentication on protected API routes.
+
+## 2025-07-18
+
+### Feature: add wireframe PNGs for MVP screens (PR #315)
+
+Added low-fidelity wireframe images for all MVP screens to support UI development.
+
+## 2025-07-02 – 2025-07-11
+
+### Docs: complete design charter (PRs #301–#313)
+
+Series of PRs completing the visual design system: logo assets, typography (Inter), color system with accessibility audit, UI component styles (tooltips, buttons, inputs, alerts), grid/spacing/radii system, form input documentation, moodboard, and screen identification for wireframes.


### PR DESCRIPTION
## Summary

- Create `PROJECT_LOG.md` at repo root — chronological, agent-agnostic operational logbook
- Backfill history from PRs #395–#503 (2025-07-02 to 2026-04-01)
- Reference the project log in root `CLAUDE.md` (new section + documentation table entry)

### Design principles

- **Agent-agnostic** — no dependency on any specific AI tool
- **DIP-compliant** — tools depend on the log, not the inverse
- **Chronological** — most recent entries first
- **Exhaustive** — every merged PR, decision, and backlog change logged

## Test plan

- [ ] `PROJECT_LOG.md` exists at repo root
- [ ] All entries from PRs #395–#503 are present with correct dates
- [ ] `CLAUDE.md` references `PROJECT_LOG.md` in both Project Log section and Documentation table

Closes #513