### PR TITLE
chore(project): update project log and add security Discord channel

### DIFF
--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -45,6 +45,7 @@ jobs:
           DISCORD_WEBHOOK_DEVOPS: ${{ secrets.DISCORD_WEBHOOK_DEVOPS }}
           DISCORD_WEBHOOK_WEBSITE: ${{ secrets.DISCORD_WEBHOOK_WEBSITE }}
           DISCORD_WEBHOOK_GITHUB: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
+          DISCORD_WEBHOOK_SECU: ${{ secrets.DISCORD_WEBHOOK_SECU }}
         with:
           script: |
             // ── Configuration ────────────────────────────────────────────
@@ -56,6 +57,7 @@ jobs:
               'scope:charte':   process.env.DISCORD_WEBHOOK_CHARTE,
               'scope:devops':   process.env.DISCORD_WEBHOOK_DEVOPS,
               'scope:website':  process.env.DISCORD_WEBHOOK_WEBSITE,
+              'scope:security': process.env.DISCORD_WEBHOOK_SECU,
             };
             const FALLBACK_WEBHOOK = process.env.DISCORD_WEBHOOK_GITHUB;
 
@@ -84,6 +86,7 @@ jobs:
               'scope:charte':         { emoji: '\ud83c\udfa8', text: 'Design' },
               'scope:devops':         { emoji: '\ud83d\udd27', text: 'DevOps' },
               'scope:website':        { emoji: '\ud83c\udf10', text: 'Website' },
+              'scope:security':       { emoji: '\ud83d\udd12', text: 'Security' },
               'scope:monorepo':       { emoji: '\ud83d\udce6', text: 'Monorepo' },
               'scope:marketing':      { emoji: '\ud83d\udce3', text: 'Marketing' },
               'scope:ydays':          { emoji: '\ud83c\udf93', text: 'Ydays' },

--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -45,7 +45,7 @@ jobs:
           DISCORD_WEBHOOK_DEVOPS: ${{ secrets.DISCORD_WEBHOOK_DEVOPS }}
           DISCORD_WEBHOOK_WEBSITE: ${{ secrets.DISCORD_WEBHOOK_WEBSITE }}
           DISCORD_WEBHOOK_GITHUB: ${{ secrets.DISCORD_WEBHOOK_GITHUB }}
-          DISCORD_WEBHOOK_SECU: ${{ secrets.DISCORD_WEBHOOK_SECU }}
+          DISCORD_WEBHOOK_SECURITY: ${{ secrets.DISCORD_WEBHOOK_SECURITY }}
         with:
           script: |
             // ── Configuration ────────────────────────────────────────────
@@ -57,7 +57,7 @@ jobs:
               'scope:charte':   process.env.DISCORD_WEBHOOK_CHARTE,
               'scope:devops':   process.env.DISCORD_WEBHOOK_DEVOPS,
               'scope:website':  process.env.DISCORD_WEBHOOK_WEBSITE,
-              'scope:security': process.env.DISCORD_WEBHOOK_SECU,
+              'scope:security': process.env.DISCORD_WEBHOOK_SECURITY,
             };
             const FALLBACK_WEBHOOK = process.env.DISCORD_WEBHOOK_GITHUB;
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,7 @@ GitHub events are automatically routed to specialized Discord channels based on 
 | `#design-system` | `scope:charte` |
 | `#devops` | `scope:devops` |
 | `#site-vitrine` | `scope:website` |
+| `#secu-cyber` | `scope:security` |
 | `#github` | Fallback (no scope label) |
 
 Notifications display a compact, color-coded embed with: event type, priority, size, scope, sprint, parent reference (for sub-issues), and a clickable title.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ GitHub events are automatically routed to specialized Discord channels based on 
 | `#devops` | `scope:devops` |
 | `#site-vitrine` | `scope:website` |
 | `#secu-cyber` | `scope:security` |
-| `#github` | Fallback (no scope label) |
+| `#général` | Fallback (no scope label) |
 
 Notifications display a compact, color-coded embed with: event type, priority, size, scope, sprint, parent reference (for sub-issues), and a clickable title.
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -25,7 +25,7 @@ Decided to deploy SonarQube on Klouders VM instead of local or SonarCloud. Invit
 
 ### Infrastructure: restructure Discord server
 
-Created #annonces channel (read-only). Merged 5 SCRUM channels into #daily-standup + #ceremonies. Archived #merch, #intervention, #autre-appli-de-brassage, #github. Configured BB Bot webhook on #ceremonies.
+Created #annonces channel (read-only). Merged 5 SCRUM channels into #daily-standup + #ceremonies. Archived #merch, #intervention, #autre-appli-de-brassage. #github channel archived — fallback notifications temporarily routed to #général. Configured BB Bot webhook on #ceremonies.
 
 ### Backlog: close resolved issues and audit milestones
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,42 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-04-01
 
+### Backlog: create soutenance sub-issues mapped to evaluation grid
+
+Created 7 sub-issues under #393 (soutenance deliverables), each mapped to a criterion of the Pitch Entrepreneurial evaluation grid: #522 (elevator pitch, 15pts), #523 (SMART objectives, 15pts), #524 (business model + innovation, 30pts), #525 (live demo, 30pts), #526 (perspective: legal/HR/go-to-market/budget, 20pts), #527 (slide deck, 15pts), #528 (rehearsal, 15pts). All assigned to Sprint 6.
+
+### Backlog: restructure design issues and plan Sprint 4-6
+
+Closed 17 obsolete CG design issues (#231-#262). Created 7 new design issues with clear scope, dependencies, and assignees: #515 (audit charter — Liam+Fabio), #516 (audit UI components — Liam+Fabio), #517 (audit assets — Liam+Fabio), #518 (audit wireframes + create missing screens — Sara+Thaïs), #519 (UI Kit Figma — Sprint 5), #520 (high-fidelity mockups 11 screens — Sprint 5), #521 (security audit — Fabien). Dependency chain established: #515 → #516/#517/#518 → #519 → #520 → dev mobile.
+
+### Backlog: plan Sprint 5 and Sprint 6
+
+Sprint 5 (Apr 15 – May 5): labelled 13 issues — 8 MUST-HAVE recipe CRUD user stories (#410-#417, #420), batch creation (#433), DevOps (#337, #338, #396), design delivery (#519, #520). Sprint 6 (May 6-27): batch measurements (#434), soutenance deliverables (#393 + 7 sub-issues), oral intermédiaire update (#392).
+
+### Decision: SonarQube deployment on Klouders VM
+
+Decided to deploy SonarQube on Klouders VM instead of local or SonarCloud. Invited Thibaut GIANOLA (@astronas, Klouders admin) as collaborator. Updated #396 with decision rationale and implementation plan.
+
+### Infrastructure: restructure Discord server
+
+Created #annonces channel (read-only). Merged 5 SCRUM channels into #daily-standup + #ceremonies. Archived #merch, #intervention, #autre-appli-de-brassage, #github. Configured BB Bot webhook on #ceremonies.
+
+### Backlog: close resolved issues and audit milestones
+
+Closed 10 issues already resolved but left open: #318 (Node 20 compat), #319 (issue triage), #320 (root package.json), #321 (.gitignore), #327 (frontend subtree import), #328 (backend subtree import), #330 (Scrum framework), #333 (meeting notes template), #359 (archive repos), #497 (team mapping). Closed #383 (performance baseline — too late, migration done). Established team member mapping with GitHub + Discord username cross-reference.
+
+### Docs: create PROJECT_LOG.md and Copilot review instructions (PR #514)
+
+Created `PROJECT_LOG.md` operational logbook with backfilled history from PRs #395–#503. Added `.github/copilot-instructions.md` with project-specific review rules (no `any`, named exports, Python type hints, security checks). Referenced project log in root CLAUDE.md. Closes #513.
+
+### Infrastructure: enable Copilot automated code review
+
+Activated Copilot code review ruleset on the default branch with automated reviews on push. Closed #339 as resolved.
+
+### Backlog: consolidate CI issues and assign team members
+
+Consolidated SonarQube issues (#357, #358 into #396). Updated issue bodies for #337, #338, #396 to reflect package renames. Reassigned all CI issues to appropriate team members based on scope labels. Closed #339 (resolved), #357, #358 (duplicates). Updated #338 scope from GitHub Pages deployment to removal (migrated to Klouders VM).
+
 ### Backlog: create i18n translation issues for all French documentation
 
 Created 9 issues (#504–#512) to systematically translate all remaining French content to English across the repository: sequence diagrams, vision, personas, requirements, user scenarios, design docs, project management, meeting notes, and mobile app UI strings. All assigned to milestone "Documentation Refactoring" except #512 (DX & Cleanup).


### PR DESCRIPTION
## Summary

- Update `PROJECT_LOG.md` with all activity from 2026-04-01: design issue restructure (17 closed, 7 created), sprint 4/5/6 planning, SonarQube Klouders decision, Discord server reorganization, milestone audit, soutenance sub-issues
- Add `#secu-cyber` Discord channel routing for `scope:security` label in notification workflow
- Document security channel in `CONTRIBUTING.md` routing table

## Test plan

- [ ] PROJECT_LOG.md entries are chronologically correct
- [ ] Discord notification triggers for `scope:security` label → `#secu-cyber` channel
- [ ] CONTRIBUTING.md routing table matches workflow configuration