### PR TITLE
chore(discord): add infrastructure routing and priority display

### DIFF
--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -62,7 +62,7 @@ jobs:
             };
             const FALLBACK_WEBHOOK = process.env.DISCORD_WEBHOOK_GITHUB;
 
-            // Priority display (MoSCoW) — warm color gradient, short labels
+            // Priority display (MoSCoW for user stories, high/medium/low for chores)
             const PRIORITY_MAP = {
               'priority:must-have':    { emoji: '\ud83d\udd34', text: 'P0' },
               'priority:should-have':  { emoji: '\ud83d\udfe0', text: 'P1' },

--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -57,7 +57,8 @@ jobs:
               'scope:charte':   process.env.DISCORD_WEBHOOK_CHARTE,
               'scope:devops':   process.env.DISCORD_WEBHOOK_DEVOPS,
               'scope:website':  process.env.DISCORD_WEBHOOK_WEBSITE,
-              'scope:security': process.env.DISCORD_WEBHOOK_SECURITY,
+              'scope:security':       process.env.DISCORD_WEBHOOK_SECURITY,
+              'scope:infrastructure': process.env.DISCORD_WEBHOOK_DEVOPS,
             };
             const FALLBACK_WEBHOOK = process.env.DISCORD_WEBHOOK_GITHUB;
 
@@ -66,6 +67,9 @@ jobs:
               'priority:must-have':    { emoji: '\ud83d\udd34', text: 'P0' },
               'priority:should-have':  { emoji: '\ud83d\udfe0', text: 'P1' },
               'priority:nice-to-have': { emoji: '\u26aa', text: 'P2' },
+              'priority:high':        { emoji: '\ud83d\udd34', text: 'High' },
+              'priority:medium':      { emoji: '\ud83d\udfe0', text: 'Medium' },
+              'priority:low':         { emoji: '\u26aa', text: 'Low' },
             };
 
             // Size display (T-shirt → Fibonacci) — warm color gradient
@@ -87,6 +91,7 @@ jobs:
               'scope:devops':         { emoji: '\ud83d\udd27', text: 'DevOps' },
               'scope:website':        { emoji: '\ud83c\udf10', text: 'Website' },
               'scope:security':       { emoji: '\ud83d\udd12', text: 'Security' },
+              'scope:infrastructure': { emoji: '\ud83c\udfd7\ufe0f', text: 'Infra' },
               'scope:monorepo':       { emoji: '\ud83d\udce6', text: 'Monorepo' },
               'scope:marketing':      { emoji: '\ud83d\udce3', text: 'Marketing' },
               'scope:ydays':          { emoji: '\ud83c\udf93', text: 'Ydays' },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,7 @@ GitHub events are automatically routed to specialized Discord channels based on 
 | `#devops` | `scope:devops` |
 | `#site-vitrine` | `scope:website` |
 | `#secu-cyber` | `scope:security` |
+| `#devops` | `scope:infrastructure` |
 | `#général` | Fallback (no scope label) |
 
 Notifications display a compact, color-coded embed with: event type, priority, size, scope, sprint, parent reference (for sub-issues), and a clickable title.


### PR DESCRIPTION
## Summary

- Route `scope:infrastructure` issues to `#devops` Discord channel (shared webhook, no new secret needed)
- Add `priority:high/medium/low` display mapping in Discord notification embeds (complements existing MoSCoW mapping)
- Document infrastructure routing in CONTRIBUTING.md routing table

Part of a broader label audit that also included (applied directly via GitHub API, not in this PR):
- Fixed 7 label corrections across issues (#538, #406, #512, #435, #437, #420, #532, #534)
- Created `area:i18n` label and fixed 9 i18n issues (#504-#512)
- Added `scope:backend` to 5 full-stack user stories (#419, #418, #416, #441, #461)
- Added `size:` estimations to all 37 Sprint 4/5/6 issues
- Created 13 new `area:*` labels for cross-cutting concerns

## Checklist

- [x] Workflow YAML syntax valid
- [x] CONTRIBUTING.md routing table matches workflow configuration
- [x] No secrets introduced
- [x] Existing tests still green (no code changes)

Closes #none — infrastructure improvement