### PR TITLE
feat(beer-encyclopedia): add PostgreSQL infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,18 +188,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r ml/requirements.txt
-          pip install ruff pytest-cov
+          pip install -e ".[ml,dev]"
 
       - name: Lint (ruff)
         run: ruff check .
 
       - name: Python compile sanity
-        run: python -m py_compile api/main.py ml/*.py scripts/*.py
+        run: python -m py_compile api/main.py ml/*.py db/*.py db/models/*.py scripts/*.py
 
       - name: Run tests with coverage
         run: |
-          pytest tests/ --cov=ml --cov=api --cov-report=term --cov-report=lcov:coverage/lcov.info -q
+          pytest tests/ --cov=ml --cov=api --cov=db --cov-report=term --cov-report=lcov:coverage/lcov.info -q
 
       - name: Check coverage threshold (70%)
         run: |

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,12 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-04-12
 
+### Infrastructure: PostgreSQL + async SQLAlchemy + Alembic + Docker Compose (#543)
+
+Step 2 of the beer-encyclopedia epic (#541). Added the persistence infrastructure the upcoming data models will rely on: async SQLAlchemy 2.0 engine + session factory (`db/engine.py`), ORM `Base` with `UUIDMixin` and `TimestampMixin` (`db/models/base.py`), async-aware Alembic scaffolding (`alembic.ini`, `migrations/env.py`, `migrations/script.py.mako`), and local Docker Compose stack with PostgreSQL 16 + pgAdmin (`docker-compose.yml`, `.env.example`).
+
+Switched dependency management to `pyproject.toml` as the single source of truth with `[ml]` and `[dev]` optional groups; deleted the legacy `ml/requirements.txt` and updated the CI step to `pip install -e ".[ml,dev]"`. Added 6 behavior tests for the engine/session/get_db dependency (total: 16 tests passing, ruff clean).
+
 ### Epic: transform beer-label-ai into beer-encyclopedia
 
 Kicked off a major initiative to evolve `packages/beer-label-ai` into `packages/beer-encyclopedia` — a comprehensive beer encyclopedia aiming to catalog all beers in the world. The existing ML scan pipeline becomes a sub-module feeding the encyclopedia; new capabilities include PostgreSQL persistence, multi-source data ingestion (Open Brewery DB first), community corrections, CRUD + fuzzy search API, and multi-channel consumption (mobile app + future web UI).

--- a/packages/beer-encyclopedia/.env.example
+++ b/packages/beer-encyclopedia/.env.example
@@ -1,5 +1,18 @@
-# Database connection — async SQLAlchemy + asyncpg driver
-DATABASE_URL=postgresql+asyncpg://beer_enc:beer_enc_dev@localhost:5432/beer_encyclopedia
+# Copy this file to `.env` and replace every CHANGE_ME value with your own.
+# `.env` is gitignored — never commit real credentials.
+
+# -- PostgreSQL (used by docker-compose.yml and the app) ---------------------
+POSTGRES_DB=beer_encyclopedia
+POSTGRES_USER=CHANGE_ME_POSTGRES_USER
+POSTGRES_PASSWORD=CHANGE_ME_POSTGRES_PASSWORD
+
+# -- Application database URL (async SQLAlchemy + asyncpg driver) ------------
+# Must match the credentials above. Required — the app fails fast if unset.
+DATABASE_URL=postgresql+asyncpg://CHANGE_ME_POSTGRES_USER:CHANGE_ME_POSTGRES_PASSWORD@localhost:5432/beer_encyclopedia
 
 # Echo SQL statements to stdout (development only)
 DATABASE_ECHO=false
+
+# -- pgAdmin (local dev UI only) ---------------------------------------------
+PGADMIN_DEFAULT_EMAIL=CHANGE_ME_PGADMIN_EMAIL
+PGADMIN_DEFAULT_PASSWORD=CHANGE_ME_PGADMIN_PASSWORD

--- a/packages/beer-encyclopedia/.env.example
+++ b/packages/beer-encyclopedia/.env.example
@@ -1,0 +1,5 @@
+# Database connection — async SQLAlchemy + asyncpg driver
+DATABASE_URL=postgresql+asyncpg://beer_enc:beer_enc_dev@localhost:5432/beer_encyclopedia
+
+# Echo SQL statements to stdout (development only)
+DATABASE_ECHO=false

--- a/packages/beer-encyclopedia/.gitignore
+++ b/packages/beer-encyclopedia/.gitignore
@@ -7,6 +7,19 @@ venv/
 env/
 .pytest_cache/
 .mypy_cache/
+.ruff_cache/
+*.egg-info/
+.coverage
+coverage/
+
+# Environment
+.env
+.env.local
+
+# Database
+*.db
+*.sqlite
+*.sqlite3
 
 # Jupyter
 .ipynb_checkpoints/

--- a/packages/beer-encyclopedia/CLAUDE.md
+++ b/packages/beer-encyclopedia/CLAUDE.md
@@ -3,8 +3,8 @@
 ## Package Overview
 
 **Name:** @brasse-bouillon/beer-encyclopedia
-**Stack:** Python 3.12 + FastAPI + YOLOv8 (Ultralytics) + EasyOCR + Pydantic
-**Purpose:** ML pipeline for beer label scanning — detection, OCR, field extraction, and recipe recommendation
+**Stack:** Python 3.12 + FastAPI + YOLOv8 (Ultralytics) + EasyOCR + PostgreSQL + async SQLAlchemy 2.0 + Alembic + Pydantic
+**Purpose:** Beer encyclopedia with ML label scanning (detection + OCR + field extraction), persistent brewery/beer database, and recipe recommendation
 
 ---
 
@@ -20,14 +20,20 @@ ml/               Core ML pipeline
   ├── recommender.py  Deterministic recipe ranking algorithm
   ├── schemas.py      Pydantic models (ExtractedFields, ScanResponse, etc.)
   └── train.py        YOLOv8 training script
+db/               Database layer (async SQLAlchemy 2.0)
+  ├── engine.py       Async engine factory + get_db FastAPI dependency
+  └── models/         ORM models (Base, TimestampMixin, UUIDMixin, …)
+migrations/       Alembic migrations (async-aware env.py)
+  └── versions/       Individual migration scripts
 scripts/          CLI tools and dataset utilities
-tests/            pytest test suite
+tests/            pytest test suite (pytest-asyncio auto mode)
 configs/          Training configuration (YAML)
 data/             Sample recipes + dataset templates
 docs/             Governance (AGENT.md), ADRs, dataset guides
 ```
 
-**Data flow:** API → pipeline → infer → ocr → extract → recommender → response
+**Data flow (scan):** API → pipeline → infer → ocr → extract → recommender → response
+**Data flow (encyclopedia):** API → db session → ORM models → PostgreSQL
 
 ---
 
@@ -68,24 +74,31 @@ docs/             Governance (AGENT.md), ADRs, dataset guides
 
 ## Dependencies
 
-- Defined in `ml/requirements.txt`
-- **No version pinning yet** — add `pip-compile` lock file before production
-- Key deps: ultralytics, easyocr, opencv-python, numpy, pydantic, fastapi, uvicorn, pytest
+- Defined in `pyproject.toml` (single source of truth)
+- Core runtime deps are mandatory; ML deps are gated behind the `[ml]` extra; test/lint deps are under `[dev]`
+- Install locally with `pip install -e ".[ml,dev]"`
 
 ---
 
 ## Running Locally
 
 ```bash
-# Setup
+# 1. Python environment
 python -m venv .venv
 source .venv/bin/activate
-pip install -r ml/requirements.txt
+pip install -e ".[ml,dev]"
 
-# Start API
+# 2. Local PostgreSQL (Docker Compose)
+cp .env.example .env         # edit DATABASE_URL if needed
+docker compose up -d         # starts postgres on :5432 and pgadmin on :5050
+
+# 3. Database migrations
+alembic upgrade head
+
+# 4. Start API
 uvicorn api.main:app --reload
 
-# Run tests
+# 5. Run tests
 pytest -q tests/
 ```
 

--- a/packages/beer-encyclopedia/README.md
+++ b/packages/beer-encyclopedia/README.md
@@ -22,7 +22,7 @@ See `docs/SETUP.md`.
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-pip install -r ml/requirements.txt
+pip install -e ".[ml,dev]"
 uvicorn api.main:app --reload
 ```
 

--- a/packages/beer-encyclopedia/alembic.ini
+++ b/packages/beer-encyclopedia/alembic.ini
@@ -1,0 +1,52 @@
+[alembic]
+# Migration script location
+script_location = migrations
+
+# Migration file naming: <rev>_<slug>.py
+file_template = %%(rev)s_%%(slug)s
+
+# Timezone for migration timestamps
+timezone = UTC
+
+# Path separator for sys.path inserts
+path_separator = os
+
+# sqlalchemy.url is read from the DATABASE_URL environment variable via env.py.
+# Do NOT hardcode it here.
+
+[post_write_hooks]
+# Placeholder — can enable ruff/black formatting of generated migrations later.
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/packages/beer-encyclopedia/db/__init__.py
+++ b/packages/beer-encyclopedia/db/__init__.py
@@ -1,0 +1,5 @@
+"""Database layer for the beer-encyclopedia package.
+
+Exposes the async engine, session factory, and ORM base classes used by the
+encyclopedia data model and importers.
+"""

--- a/packages/beer-encyclopedia/db/engine.py
+++ b/packages/beer-encyclopedia/db/engine.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import os
 from collections.abc import AsyncIterator
 
+from dotenv import load_dotenv
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -16,13 +17,26 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
-DEFAULT_DATABASE_URL = (
-    "postgresql+asyncpg://beer_enc:beer_enc_dev@localhost:5432/beer_encyclopedia"
-)
+# Load .env once at import time so every entry point (FastAPI app, Alembic,
+# pytest, ad-hoc scripts) shares the same configuration without each having to
+# remember to call load_dotenv themselves.
+load_dotenv()
 
 
-def _database_url() -> str:
-    return os.environ.get("DATABASE_URL", DEFAULT_DATABASE_URL)
+class DatabaseConfigurationError(RuntimeError):
+    """Raised when mandatory database configuration is missing."""
+
+
+def get_database_url() -> str:
+    """Return the configured DATABASE_URL or fail fast with a clear message."""
+
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        raise DatabaseConfigurationError(
+            "DATABASE_URL is not set. Copy .env.example to .env and fill it in, "
+            "or export DATABASE_URL in your shell before starting the app."
+        )
+    return url
 
 
 def _echo_enabled() -> bool:
@@ -36,7 +50,7 @@ def create_engine(url: str | None = None, *, echo: bool | None = None) -> AsyncE
     isolated engines and the application can swap URLs between runs.
     """
 
-    resolved_url = url if url is not None else _database_url()
+    resolved_url = url if url is not None else get_database_url()
     resolved_echo = echo if echo is not None else _echo_enabled()
     return create_async_engine(resolved_url, echo=resolved_echo, future=True)
 
@@ -62,7 +76,10 @@ def get_engine() -> AsyncEngine:
 def get_session_factory() -> async_sessionmaker[AsyncSession]:
     if _session_factory is None:
         get_engine()
-    assert _session_factory is not None
+    if _session_factory is None:
+        raise DatabaseConfigurationError(
+            "Session factory could not be initialized — the engine setup likely failed."
+        )
     return _session_factory
 
 

--- a/packages/beer-encyclopedia/db/engine.py
+++ b/packages/beer-encyclopedia/db/engine.py
@@ -1,0 +1,84 @@
+"""Async SQLAlchemy engine and session factory.
+
+Reads the connection string from the ``DATABASE_URL`` environment variable and
+exposes a FastAPI-compatible ``get_db`` dependency that yields an AsyncSession.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import AsyncIterator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+DEFAULT_DATABASE_URL = (
+    "postgresql+asyncpg://beer_enc:beer_enc_dev@localhost:5432/beer_encyclopedia"
+)
+
+
+def _database_url() -> str:
+    return os.environ.get("DATABASE_URL", DEFAULT_DATABASE_URL)
+
+
+def _echo_enabled() -> bool:
+    return os.environ.get("DATABASE_ECHO", "false").lower() in {"1", "true", "yes"}
+
+
+def create_engine(url: str | None = None, *, echo: bool | None = None) -> AsyncEngine:
+    """Create a fresh AsyncEngine.
+
+    Exposed as a factory (not a module-level singleton) so tests can create
+    isolated engines and the application can swap URLs between runs.
+    """
+
+    resolved_url = url if url is not None else _database_url()
+    resolved_echo = echo if echo is not None else _echo_enabled()
+    return create_async_engine(resolved_url, echo=resolved_echo, future=True)
+
+
+def create_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
+
+
+def get_engine() -> AsyncEngine:
+    """Lazy-initialize and return the process-wide async engine."""
+
+    global _engine, _session_factory
+    if _engine is None:
+        _engine = create_engine()
+        _session_factory = create_session_factory(_engine)
+    return _engine
+
+
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    if _session_factory is None:
+        get_engine()
+    assert _session_factory is not None
+    return _session_factory
+
+
+async def dispose_engine() -> None:
+    """Dispose the process-wide engine and reset module state."""
+
+    global _engine, _session_factory
+    if _engine is not None:
+        await _engine.dispose()
+    _engine = None
+    _session_factory = None
+
+
+async def get_db() -> AsyncIterator[AsyncSession]:
+    """FastAPI dependency yielding a scoped AsyncSession."""
+
+    factory = get_session_factory()
+    async with factory() as session:
+        yield session

--- a/packages/beer-encyclopedia/db/models/__init__.py
+++ b/packages/beer-encyclopedia/db/models/__init__.py
@@ -1,0 +1,5 @@
+"""SQLAlchemy ORM models for the beer-encyclopedia database."""
+
+from db.models.base import Base, TimestampMixin, UUIDMixin
+
+__all__ = ["Base", "TimestampMixin", "UUIDMixin"]

--- a/packages/beer-encyclopedia/db/models/base.py
+++ b/packages/beer-encyclopedia/db/models/base.py
@@ -1,0 +1,43 @@
+"""Shared ORM base class and mixins.
+
+All encyclopedia models inherit from ``Base`` and typically compose ``UUIDMixin``
+and ``TimestampMixin`` to obtain a primary key and ``created_at``/``updated_at``
+columns without boilerplate.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Declarative base for all ORM models."""
+
+
+class UUIDMixin:
+    """Adds a UUID primary key generated on the Python side."""
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+
+
+class TimestampMixin:
+    """Adds ``created_at`` / ``updated_at`` columns populated by the database."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/packages/beer-encyclopedia/docker-compose.yml
+++ b/packages/beer-encyclopedia/docker-compose.yml
@@ -4,26 +4,28 @@ services:
     container_name: beer-encyclopedia-postgres
     restart: unless-stopped
     environment:
-      POSTGRES_DB: beer_encyclopedia
-      POSTGRES_USER: beer_enc
-      POSTGRES_PASSWORD: beer_enc_dev
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB must be set in .env}
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER must be set in .env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env}
     ports:
       - "5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U beer_enc -d beer_encyclopedia"]
+      test:
+        - CMD-SHELL
+        - pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}"
       interval: 5s
       timeout: 5s
       retries: 10
 
   pgadmin:
-    image: dpage/pgadmin4:latest
+    image: dpage/pgadmin4:8.12
     container_name: beer-encyclopedia-pgadmin
     restart: unless-stopped
     environment:
-      PGADMIN_DEFAULT_EMAIL: admin@brasse-bouillon.local
-      PGADMIN_DEFAULT_PASSWORD: admin_dev
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:?PGADMIN_DEFAULT_EMAIL must be set in .env}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:?PGADMIN_DEFAULT_PASSWORD must be set in .env}
       PGADMIN_CONFIG_SERVER_MODE: "False"
     ports:
       - "5050:80"

--- a/packages/beer-encyclopedia/docker-compose.yml
+++ b/packages/beer-encyclopedia/docker-compose.yml
@@ -1,0 +1,38 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: beer-encyclopedia-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: beer_encyclopedia
+      POSTGRES_USER: beer_enc
+      POSTGRES_PASSWORD: beer_enc_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U beer_enc -d beer_encyclopedia"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    container_name: beer-encyclopedia-pgadmin
+    restart: unless-stopped
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@brasse-bouillon.local
+      PGADMIN_DEFAULT_PASSWORD: admin_dev
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+    ports:
+      - "5050:80"
+    volumes:
+      - pgadmin-data:/var/lib/pgadmin
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  pgdata:
+  pgadmin-data:

--- a/packages/beer-encyclopedia/docs/SETUP.md
+++ b/packages/beer-encyclopedia/docs/SETUP.md
@@ -9,15 +9,27 @@ pip install --upgrade pip
 pip install -e ".[ml,dev]"
 ```
 
-## 2) Start local PostgreSQL
+## 2) Create your `.env` file
 
 ```bash
-cp .env.example .env         # edit DATABASE_URL if needed
+cp .env.example .env
+# Open .env and replace every CHANGE_ME value with real ones.
+# `.env` is gitignored — credentials never reach the repo.
+```
+
+All entry points (`uvicorn`, `alembic`, `pytest`) automatically load this file
+via `python-dotenv` (called once in `db/engine.py`), so no manual `export` is
+needed. `DATABASE_URL`, `POSTGRES_USER` and `POSTGRES_PASSWORD` are mandatory
+— the app and `docker compose` both fail fast with a clear message if missing.
+
+## 3) Start local PostgreSQL
+
+```bash
 docker compose up -d         # postgres on :5432, pgadmin on :5050
 alembic upgrade head
 ```
 
-## 3) Start the scan API
+## 4) Start the scan API
 
 ```bash
 uvicorn api.main:app --reload
@@ -27,13 +39,13 @@ Then test:
 - `GET http://127.0.0.1:8000/health`
 - `POST http://127.0.0.1:8000/scan` (multipart image file)
 
-## 4) Run a CLI scan demo
+## 5) Run a CLI scan demo
 
 ```bash
 python scripts/run_scan_demo.py --image /path/to/beer-photo.jpg
 ```
 
-## 5) Train YOLOv8
+## 6) Train YOLOv8
 
 ```bash
 python ml/train.py --data /path/to/data.yaml --epochs 50 --imgsz 640 --batch 16

--- a/packages/beer-encyclopedia/docs/SETUP.md
+++ b/packages/beer-encyclopedia/docs/SETUP.md
@@ -6,10 +6,18 @@
 python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-pip install -r ml/requirements.txt
+pip install -e ".[ml,dev]"
 ```
 
-## 2) Start the scan API
+## 2) Start local PostgreSQL
+
+```bash
+cp .env.example .env         # edit DATABASE_URL if needed
+docker compose up -d         # postgres on :5432, pgadmin on :5050
+alembic upgrade head
+```
+
+## 3) Start the scan API
 
 ```bash
 uvicorn api.main:app --reload
@@ -19,13 +27,13 @@ Then test:
 - `GET http://127.0.0.1:8000/health`
 - `POST http://127.0.0.1:8000/scan` (multipart image file)
 
-## 3) Run a CLI scan demo
+## 4) Run a CLI scan demo
 
 ```bash
 python scripts/run_scan_demo.py --image /path/to/beer-photo.jpg
 ```
 
-## 4) Train YOLOv8
+## 5) Train YOLOv8
 
 ```bash
 python ml/train.py --data /path/to/data.yaml --epochs 50 --imgsz 640 --batch 16
@@ -42,7 +50,7 @@ python scripts/run_scan_demo.py --image ./sample.jpg --model runs/detect/train/w
 pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision
 ```
 
-Run this before `pip install -r ml/requirements.txt` if you do not need GPU.
+Run this before `pip install -e ".[ml,dev]"` if you do not need GPU.
 
 ## Development governance
 

--- a/packages/beer-encyclopedia/migrations/env.py
+++ b/packages/beer-encyclopedia/migrations/env.py
@@ -9,14 +9,16 @@ from alembic import context
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
-from db.engine import _database_url
+from db.engine import get_database_url
 from db.models import Base
 
 # Alembic Config object, provides access to values in alembic.ini
 config = context.config
 
-# Inject the runtime DATABASE_URL so offline/online migrations share one source
-config.set_main_option("sqlalchemy.url", _database_url())
+# Inject the runtime DATABASE_URL so offline/online migrations share one source.
+# Escape `%` by doubling it: ConfigParser treats `%` as interpolation syntax and
+# would raise ValueError on URL-encoded credentials like `%40` (= `@`).
+config.set_main_option("sqlalchemy.url", get_database_url().replace("%", "%%"))
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)

--- a/packages/beer-encyclopedia/migrations/env.py
+++ b/packages/beer-encyclopedia/migrations/env.py
@@ -1,0 +1,64 @@
+"""Alembic environment configured for async SQLAlchemy."""
+
+from __future__ import annotations
+
+import asyncio
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy.engine import Connection
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from db.engine import _database_url
+from db.models import Base
+
+# Alembic Config object, provides access to values in alembic.ini
+config = context.config
+
+# Inject the runtime DATABASE_URL so offline/online migrations share one source
+config.set_main_option("sqlalchemy.url", _database_url())
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Target metadata for autogenerate support
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations without a live DB connection (emits SQL to stdout)."""
+
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection: Connection) -> None:
+    context.configure(connection=connection, target_metadata=target_metadata)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_migrations_online() -> None:
+    """Run migrations against the async engine defined by ``DATABASE_URL``."""
+
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        future=True,
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    asyncio.run(run_migrations_online())

--- a/packages/beer-encyclopedia/migrations/script.py.mako
+++ b/packages/beer-encyclopedia/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/packages/beer-encyclopedia/ml/requirements.txt
+++ b/packages/beer-encyclopedia/ml/requirements.txt
@@ -1,9 +1,0 @@
-ultralytics
-easyocr
-opencv-python
-numpy
-pydantic
-fastapi
-uvicorn[standard]
-python-multipart
-pytest

--- a/packages/beer-encyclopedia/pyproject.toml
+++ b/packages/beer-encyclopedia/pyproject.toml
@@ -1,0 +1,49 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "beer-encyclopedia"
+version = "0.2.0"
+description = "Comprehensive beer encyclopedia with ML label scanning, brewery/beer database, and recipe recommendation"
+requires-python = ">=3.12"
+readme = "README.md"
+license = { text = "UNLICENSED" }
+authors = [
+    { name = "Benoît Bremaud" },
+]
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.30",
+    "pydantic>=2.0",
+    "python-multipart>=0.0.9",
+    "sqlalchemy[asyncio]>=2.0",
+    "asyncpg>=0.29",
+    "alembic>=1.13",
+    "python-slugify>=8.0",
+    "httpx>=0.27",
+]
+
+[project.optional-dependencies]
+ml = [
+    "ultralytics",
+    "easyocr",
+    "opencv-python",
+    "numpy",
+]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "pytest-cov>=5.0",
+    "ruff>=0.6",
+    "aiosqlite>=0.20",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["api*", "ml*", "db*", "importers*"]
+exclude = ["tests*", "scripts*", "configs*", "data*", "docs*", "migrations*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/packages/beer-encyclopedia/pyproject.toml
+++ b/packages/beer-encyclopedia/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "asyncpg>=0.29",
     "alembic>=1.13",
     "python-slugify>=8.0",
+    "python-dotenv>=1.0",
     "httpx>=0.27",
 ]
 

--- a/packages/beer-encyclopedia/ruff.toml
+++ b/packages/beer-encyclopedia/ruff.toml
@@ -24,4 +24,4 @@ ignore = [
 ]
 
 [lint.isort]
-known-first-party = ["ml", "api"]
+known-first-party = ["ml", "api", "db", "importers"]

--- a/packages/beer-encyclopedia/tests/test_db/test_engine.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_engine.py
@@ -1,0 +1,100 @@
+"""Behavior tests for the async engine factory and session dependency."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+
+from db.engine import (
+    create_engine,
+    create_session_factory,
+    dispose_engine,
+    get_db,
+    get_engine,
+    get_session_factory,
+)
+
+
+@pytest.fixture
+def sqlite_url() -> str:
+    return "sqlite+aiosqlite:///:memory:"
+
+
+async def test_create_engine_returns_async_engine(sqlite_url: str) -> None:
+    engine = create_engine(sqlite_url)
+    try:
+        assert isinstance(engine, AsyncEngine)
+        async with engine.connect() as conn:
+            result = await conn.execute(text("SELECT 1"))
+            assert result.scalar_one() == 1
+    finally:
+        await engine.dispose()
+
+
+async def test_session_factory_opens_and_closes_session(sqlite_url: str) -> None:
+    engine = create_engine(sqlite_url)
+    factory = create_session_factory(engine)
+    try:
+        async with factory() as session:
+            assert isinstance(session, AsyncSession)
+            result = await session.execute(text("SELECT 42"))
+            assert result.scalar_one() == 42
+    finally:
+        await engine.dispose()
+
+
+async def test_get_engine_is_memoized(monkeypatch: pytest.MonkeyPatch, sqlite_url: str) -> None:
+    monkeypatch.setenv("DATABASE_URL", sqlite_url)
+    await dispose_engine()
+    try:
+        first = get_engine()
+        second = get_engine()
+        assert first is second
+    finally:
+        await dispose_engine()
+
+
+async def test_dispose_engine_resets_state(
+    monkeypatch: pytest.MonkeyPatch, sqlite_url: str
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", sqlite_url)
+    await dispose_engine()
+    get_engine()
+    await dispose_engine()
+    # A fresh call rebuilds the engine cleanly.
+    rebuilt = get_engine()
+    try:
+        assert isinstance(rebuilt, AsyncEngine)
+    finally:
+        await dispose_engine()
+
+
+async def test_get_db_yields_active_session(
+    monkeypatch: pytest.MonkeyPatch, sqlite_url: str
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", sqlite_url)
+    await dispose_engine()
+    try:
+        agen = get_db()
+        session = await agen.__anext__()
+        try:
+            assert isinstance(session, AsyncSession)
+            result = await session.execute(text("SELECT 7"))
+            assert result.scalar_one() == 7
+        finally:
+            # Close the generator so the session context manager exits cleanly.
+            with pytest.raises(StopAsyncIteration):
+                await agen.__anext__()
+    finally:
+        await dispose_engine()
+
+
+def test_session_factory_requires_prior_engine_or_initializes(
+    monkeypatch: pytest.MonkeyPatch, sqlite_url: str
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", sqlite_url)
+    # Without running the async teardown, we just check that requesting the
+    # factory does not explode when called before ``get_engine``.
+    factory = get_session_factory()
+    assert factory is not None

--- a/packages/beer-encyclopedia/tests/test_db/test_engine.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_engine.py
@@ -90,11 +90,19 @@ async def test_get_db_yields_active_session(
         await dispose_engine()
 
 
-def test_session_factory_requires_prior_engine_or_initializes(
+async def test_session_factory_initializes_engine_on_demand(
     monkeypatch: pytest.MonkeyPatch, sqlite_url: str
 ) -> None:
+    """Requesting the session factory before ``get_engine`` must transparently
+    initialize both. Always dispose afterward so the module-level state does
+    not leak into sibling tests."""
+
     monkeypatch.setenv("DATABASE_URL", sqlite_url)
-    # Without running the async teardown, we just check that requesting the
-    # factory does not explode when called before ``get_engine``.
-    factory = get_session_factory()
-    assert factory is not None
+    await dispose_engine()
+    try:
+        factory = get_session_factory()
+        assert factory is not None
+        async with factory() as session:
+            assert isinstance(session, AsyncSession)
+    finally:
+        await dispose_engine()


### PR DESCRIPTION
## Summary

Step 2 of 6 for epic #541. This PR adds the persistence foundation that upcoming data models (#544) will rely on.

- Async SQLAlchemy 2.0 engine + session factory (lazy memoized, FastAPI-compatible `get_db` dependency)
- ORM `Base` + `UUIDMixin` + `TimestampMixin` ready to be composed by domain models
- Async-aware Alembic scaffolding (`alembic.ini`, `migrations/env.py`, `migrations/script.py.mako`) reading `DATABASE_URL` from env
- Local Docker Compose stack: PostgreSQL 16 + pgAdmin on ports 5432 / 5050
- `.env.example` template
- `pyproject.toml` becomes the single source of truth for dependencies with `[ml]` and `[dev]` optional groups; legacy `ml/requirements.txt` removed
- CI migrated to `pip install -e ".[ml,dev]"`, coverage extended to `db/`

No domain models yet — those land in #544.

## Checklist

- [x] Happy path + sad path + edge cases covered
- [x] `tsc --noEmit` passes (N/A — Python package)
- [x] Build passes (`docker compose config`, `alembic check` clean)
- [x] Existing tests still green (10 + 6 new = 16/16)
- [x] No \`any\`, no inline styles introduced

Closes #543