### PR TITLE
feat(beer-encyclopedia): add data models and initial schema migration

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,34 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-04-12
 
+### Data models: 10-table encyclopedia schema + pg_trgm search + style seed (#544)
+
+Step 3 of the beer-encyclopedia epic (#541). Designed and implemented the full
+encyclopedia data model on top of the PostgreSQL infrastructure added in #543.
+
+**10 ORM models** (`db/models/`): `Style`, `Brewery`, `Beer`, `Ingredient` +
+`BeerIngredient` junction, `TastingProfile` (1-to-1 with Beer), `Media`
+(polymorphic on beer_id/brewery_id), `Source` + `EntitySource` for
+provenance tracking with JSONB raw_data (JSON fallback on SQLite),
+`CommunityCorrection` for moderation queue.
+
+**Hand-written initial migration** (`migrations/versions/001_initial_schema.py`):
+all 10 tables with FK cascades (`ON DELETE CASCADE` for dependent rows,
+`ON DELETE SET NULL` for `beers.brewery_id`/`style_id` so historical records
+survive), CHECK constraints (ABV ranges on styles, 1–5 scales on tasting
+profiles, media parent required), B-tree indexes on common filter paths
+(city/country/brewery_type/FKs/abv/moderation-queue), and PostgreSQL-only
+steps guarded by `_is_postgres()`: `CREATE EXTENSION pg_trgm` + GIN
+trigram indexes on `breweries.name` and `beers.name` for fuzzy search.
+
+**Style seeder** (`scripts/seed_styles.py`): idempotent upsert of 15 styles
+(the 8 slugs recognized by `ml/extract.py` + 7 mainstream additions:
+porter, pilsner, hefeweizen, dubbel, quadrupel, barleywine, blonde ale).
+
+**14 new tests** covering relationships, cascades, unique constraints,
+check constraints, and seeder idempotence. Total: 30/30 passing on SQLite
+in-memory. Ruff clean. Migration upgrade + downgrade validated on SQLite.
+
 ### Infrastructure: PostgreSQL + async SQLAlchemy + Alembic + Docker Compose (#543)
 
 Step 2 of the beer-encyclopedia epic (#541). Added the persistence infrastructure the upcoming data models will rely on: async SQLAlchemy 2.0 engine + session factory (`db/engine.py`), ORM `Base` with `UUIDMixin` and `TimestampMixin` (`db/models/base.py`), async-aware Alembic scaffolding (`alembic.ini`, `migrations/env.py`, `migrations/script.py.mako`), and local Docker Compose stack with PostgreSQL 16 + pgAdmin (`docker-compose.yml`, `.env.example`).

--- a/packages/beer-encyclopedia/db/models/__init__.py
+++ b/packages/beer-encyclopedia/db/models/__init__.py
@@ -1,5 +1,31 @@
-"""SQLAlchemy ORM models for the beer-encyclopedia database."""
+"""SQLAlchemy ORM models for the beer-encyclopedia database.
+
+Importing this package registers every model class with ``Base.metadata``,
+which Alembic reads for autogenerate support.
+"""
 
 from db.models.base import Base, TimestampMixin, UUIDMixin
+from db.models.beer import Beer
+from db.models.brewery import Brewery
+from db.models.correction import CommunityCorrection
+from db.models.ingredient import BeerIngredient, Ingredient
+from db.models.media import Media
+from db.models.source import EntitySource, Source
+from db.models.style import Style
+from db.models.tasting_profile import TastingProfile
 
-__all__ = ["Base", "TimestampMixin", "UUIDMixin"]
+__all__ = [
+    "Base",
+    "Beer",
+    "BeerIngredient",
+    "Brewery",
+    "CommunityCorrection",
+    "EntitySource",
+    "Ingredient",
+    "Media",
+    "Source",
+    "Style",
+    "TastingProfile",
+    "TimestampMixin",
+    "UUIDMixin",
+]

--- a/packages/beer-encyclopedia/db/models/beer.py
+++ b/packages/beer-encyclopedia/db/models/beer.py
@@ -59,4 +59,6 @@ class Beer(Base, UUIDMixin, TimestampMixin):
     media: Mapped[list[Media]] = relationship(
         back_populates="beer",
         primaryjoin="Beer.id == Media.beer_id",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )

--- a/packages/beer-encyclopedia/db/models/beer.py
+++ b/packages/beer-encyclopedia/db/models/beer.py
@@ -1,0 +1,62 @@
+"""Beer model."""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, ForeignKey, Numeric, SmallInteger, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db.models.base import Base, TimestampMixin, UUIDMixin
+
+if TYPE_CHECKING:
+    from db.models.brewery import Brewery
+    from db.models.ingredient import BeerIngredient
+    from db.models.media import Media
+    from db.models.style import Style
+    from db.models.tasting_profile import TastingProfile
+
+
+class Beer(Base, UUIDMixin, TimestampMixin):
+    """Individual beer — a named product from a brewery.
+
+    A beer may outlive its brewery (``ON DELETE SET NULL``) because the
+    encyclopedia keeps historical records of defunct breweries.
+    """
+
+    __tablename__ = "beers"
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    brewery_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("breweries.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    style_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("styles.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    abv: Mapped[Decimal | None] = mapped_column(Numeric(4, 2), nullable=True)
+    ibu: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    srm: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    is_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    brewery: Mapped[Brewery | None] = relationship(back_populates="beers")
+    style: Mapped[Style | None] = relationship(back_populates="beers")
+    tasting_profile: Mapped[TastingProfile | None] = relationship(
+        back_populates="beer",
+        uselist=False,
+        cascade="all, delete-orphan",
+    )
+    ingredients: Mapped[list[BeerIngredient]] = relationship(
+        back_populates="beer",
+        cascade="all, delete-orphan",
+    )
+    media: Mapped[list[Media]] = relationship(
+        back_populates="beer",
+        primaryjoin="Beer.id == Media.beer_id",
+    )

--- a/packages/beer-encyclopedia/db/models/brewery.py
+++ b/packages/beer-encyclopedia/db/models/brewery.py
@@ -1,0 +1,45 @@
+"""Brewery model."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, Numeric, SmallInteger, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db.models.base import Base, TimestampMixin, UUIDMixin
+
+if TYPE_CHECKING:
+    from db.models.beer import Beer
+    from db.models.media import Media
+
+
+class Brewery(Base, UUIDMixin, TimestampMixin):
+    """Brewery entity — the producer of one or more beers."""
+
+    __tablename__ = "breweries"
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    slug: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
+    brewery_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    address_1: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    address_2: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    address_3: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    city: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    state_province: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    postal_code: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    country: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    longitude: Mapped[Decimal | None] = mapped_column(Numeric(11, 8), nullable=True)
+    latitude: Mapped[Decimal | None] = mapped_column(Numeric(10, 8), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(30), nullable=True)
+    website_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    founded_year: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    is_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    beers: Mapped[list[Beer]] = relationship(back_populates="brewery")
+    media: Mapped[list[Media]] = relationship(
+        back_populates="brewery",
+        primaryjoin="Brewery.id == Media.brewery_id",
+    )

--- a/packages/beer-encyclopedia/db/models/brewery.py
+++ b/packages/beer-encyclopedia/db/models/brewery.py
@@ -42,4 +42,6 @@ class Brewery(Base, UUIDMixin, TimestampMixin):
     media: Mapped[list[Media]] = relationship(
         back_populates="brewery",
         primaryjoin="Brewery.id == Media.brewery_id",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
     )

--- a/packages/beer-encyclopedia/db/models/correction.py
+++ b/packages/beer-encyclopedia/db/models/correction.py
@@ -1,0 +1,40 @@
+"""Community corrections — moderation queue for user-submitted edits."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.models.base import Base, UUIDMixin
+
+
+class CommunityCorrection(Base, UUIDMixin):
+    """Pending / approved / rejected correction submitted by a community member.
+
+    Applies to any entity (brewery, beer) via a polymorphic
+    (``entity_type``, ``entity_id``) pair. Moderation state lives in
+    ``status`` with auditable reviewer + timestamp columns.
+    """
+
+    __tablename__ = "community_corrections"
+
+    entity_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(nullable=False)
+    field_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    old_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    new_value: Mapped[str] = mapped_column(Text, nullable=False)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+    submitted_by: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    reviewed_by: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    reviewed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )

--- a/packages/beer-encyclopedia/db/models/ingredient.py
+++ b/packages/beer-encyclopedia/db/models/ingredient.py
@@ -1,0 +1,46 @@
+"""Ingredient model and beer↔ingredient junction."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db.models.base import Base, TimestampMixin, UUIDMixin
+
+if TYPE_CHECKING:
+    from db.models.beer import Beer
+
+
+class Ingredient(Base, UUIDMixin, TimestampMixin):
+    """A single ingredient (malt, hop, yeast, adjunct, etc.)."""
+
+    __tablename__ = "ingredients"
+
+    name: Mapped[str] = mapped_column(String(150), unique=True, nullable=False)
+    category: Mapped[str] = mapped_column(String(50), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    beer_links: Mapped[list[BeerIngredient]] = relationship(back_populates="ingredient")
+
+
+class BeerIngredient(Base):
+    """Composite-keyed junction between ``beers`` and ``ingredients``."""
+
+    __tablename__ = "beer_ingredients"
+
+    beer_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("beers.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    ingredient_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("ingredients.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    amount: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    usage_phase: Mapped[str | None] = mapped_column(String(30), nullable=True)
+
+    beer: Mapped[Beer] = relationship(back_populates="ingredients")
+    ingredient: Mapped[Ingredient] = relationship(back_populates="beer_links")

--- a/packages/beer-encyclopedia/db/models/media.py
+++ b/packages/beer-encyclopedia/db/models/media.py
@@ -1,0 +1,51 @@
+"""Media attachments (label photos, logos, bottle shots)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, CheckConstraint, ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db.models.base import Base, TimestampMixin, UUIDMixin
+
+if TYPE_CHECKING:
+    from db.models.beer import Beer
+    from db.models.brewery import Brewery
+
+
+class Media(Base, UUIDMixin, TimestampMixin):
+    """Image or asset attached to a beer or brewery.
+
+    Exactly one of ``beer_id`` / ``brewery_id`` must be set (enforced by a
+    CHECK constraint). Polymorphic parent avoids a separate media table per
+    entity type while keeping referential integrity.
+    """
+
+    __tablename__ = "media"
+    __table_args__ = (
+        CheckConstraint(
+            "beer_id IS NOT NULL OR brewery_id IS NOT NULL",
+            name="ck_media_parent_required",
+        ),
+    )
+
+    beer_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("beers.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    brewery_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("breweries.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    media_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    url: Mapped[str] = mapped_column(String(1024), nullable=False)
+    alt_text: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    is_primary: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    uploaded_by: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    beer: Mapped[Beer | None] = relationship(back_populates="media", foreign_keys=[beer_id])
+    brewery: Mapped[Brewery | None] = relationship(
+        back_populates="media", foreign_keys=[brewery_id]
+    )

--- a/packages/beer-encyclopedia/db/models/media.py
+++ b/packages/beer-encyclopedia/db/models/media.py
@@ -26,7 +26,8 @@ class Media(Base, UUIDMixin, TimestampMixin):
     __tablename__ = "media"
     __table_args__ = (
         CheckConstraint(
-            "beer_id IS NOT NULL OR brewery_id IS NOT NULL",
+            "(beer_id IS NOT NULL AND brewery_id IS NULL) OR "
+            "(beer_id IS NULL AND brewery_id IS NOT NULL)",
             name="ck_media_parent_required",
         ),
     )

--- a/packages/beer-encyclopedia/db/models/source.py
+++ b/packages/beer-encyclopedia/db/models/source.py
@@ -1,0 +1,66 @@
+"""Data source registry and polymorphic provenance link."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.types import JSON
+
+from db.models.base import Base, TimestampMixin, UUIDMixin
+
+# Use JSONB on PostgreSQL (indexable, faster) but fall back to JSON on other
+# dialects (e.g. SQLite in tests) so the metadata is still portable.
+_JsonType = JSON().with_variant(JSONB(), "postgresql")
+
+
+class Source(Base, UUIDMixin, TimestampMixin):
+    """Authoritative registry of every external data source we ingest from."""
+
+    __tablename__ = "sources"
+
+    name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    source_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    base_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    entity_links: Mapped[list[EntitySource]] = relationship(back_populates="source")
+
+
+class EntitySource(Base, UUIDMixin):
+    """Polymorphic link between a Source and any tracked entity.
+
+    ``entity_type`` is the discriminator ('brewery' | 'beer'); ``entity_id``
+    is the UUID of the target row. ``external_id`` is the id on the source
+    system, used for idempotent re-imports. ``raw_data`` keeps the original
+    payload (JSONB on PG) so the transform can be re-run without a re-fetch.
+    """
+
+    __tablename__ = "entity_sources"
+    __table_args__ = (
+        UniqueConstraint(
+            "source_id", "entity_type", "external_id", name="uq_entity_sources_triplet"
+        ),
+    )
+
+    source_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("sources.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    entity_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(nullable=False)
+    external_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    last_synced_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    raw_data: Mapped[dict | None] = mapped_column(_JsonType, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    source: Mapped[Source] = relationship(back_populates="entity_links")

--- a/packages/beer-encyclopedia/db/models/style.py
+++ b/packages/beer-encyclopedia/db/models/style.py
@@ -1,0 +1,45 @@
+"""Beer style reference model."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from sqlalchemy import CheckConstraint, Numeric, SmallInteger, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db.models.base import Base, TimestampMixin, UUIDMixin
+
+if TYPE_CHECKING:
+    from db.models.beer import Beer
+
+
+class Style(Base, UUIDMixin, TimestampMixin):
+    """Beer style taxonomy entry.
+
+    The ``slug`` column bridges to the keys used by the ML field extractor
+    (``ml/extract.py``) so the scan pipeline can look up enriched metadata.
+    """
+
+    __tablename__ = "styles"
+    __table_args__ = (
+        CheckConstraint("abv_min IS NULL OR abv_min >= 0", name="ck_styles_abv_min_positive"),
+        CheckConstraint("abv_max IS NULL OR abv_max >= 0", name="ck_styles_abv_max_positive"),
+        CheckConstraint(
+            "abv_min IS NULL OR abv_max IS NULL OR abv_min <= abv_max",
+            name="ck_styles_abv_range",
+        ),
+    )
+
+    name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
+    slug: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    category: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    abv_min: Mapped[Decimal | None] = mapped_column(Numeric(4, 2), nullable=True)
+    abv_max: Mapped[Decimal | None] = mapped_column(Numeric(4, 2), nullable=True)
+    ibu_min: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    ibu_max: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    srm_min: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    srm_max: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+
+    beers: Mapped[list[Beer]] = relationship(back_populates="style")

--- a/packages/beer-encyclopedia/db/models/tasting_profile.py
+++ b/packages/beer-encyclopedia/db/models/tasting_profile.py
@@ -1,0 +1,55 @@
+"""Tasting profile model (one-to-one with Beer)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import CheckConstraint, ForeignKey, SmallInteger, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from db.models.base import Base, TimestampMixin, UUIDMixin
+
+if TYPE_CHECKING:
+    from db.models.beer import Beer
+
+
+class TastingProfile(Base, UUIDMixin, TimestampMixin):
+    """Qualitative + quantitative tasting notes for a single beer."""
+
+    __tablename__ = "tasting_profiles"
+    __table_args__ = (
+        CheckConstraint(
+            "bitterness IS NULL OR bitterness BETWEEN 1 AND 5",
+            name="ck_tasting_bitterness_range",
+        ),
+        CheckConstraint(
+            "sweetness IS NULL OR sweetness BETWEEN 1 AND 5",
+            name="ck_tasting_sweetness_range",
+        ),
+        CheckConstraint(
+            "body IS NULL OR body BETWEEN 1 AND 5",
+            name="ck_tasting_body_range",
+        ),
+        CheckConstraint(
+            "carbonation IS NULL OR carbonation BETWEEN 1 AND 5",
+            name="ck_tasting_carbonation_range",
+        ),
+    )
+
+    beer_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("beers.id", ondelete="CASCADE"),
+        unique=True,
+        nullable=False,
+    )
+    aroma: Mapped[str | None] = mapped_column(Text, nullable=True)
+    appearance: Mapped[str | None] = mapped_column(Text, nullable=True)
+    flavor: Mapped[str | None] = mapped_column(Text, nullable=True)
+    mouthfeel: Mapped[str | None] = mapped_column(Text, nullable=True)
+    overall: Mapped[str | None] = mapped_column(Text, nullable=True)
+    bitterness: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    sweetness: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    body: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    carbonation: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+
+    beer: Mapped[Beer] = relationship(back_populates="tasting_profile")

--- a/packages/beer-encyclopedia/migrations/versions/001_initial_schema.py
+++ b/packages/beer-encyclopedia/migrations/versions/001_initial_schema.py
@@ -1,0 +1,301 @@
+"""Initial beer encyclopedia schema.
+
+Creates the 10 core tables (styles, breweries, beers, ingredients,
+beer_ingredients, tasting_profiles, media, sources, entity_sources,
+community_corrections), the ``pg_trgm`` extension and its associated GIN
+trigram indexes for fuzzy name search, plus the B-tree indexes used by the
+common filter/lookup paths.
+
+Revision ID: 001
+Revises:
+Create Date: 2026-04-12
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "001"
+down_revision: str | None = None
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+def _is_postgres() -> bool:
+    """Return True when the current connection targets PostgreSQL.
+
+    Guards PG-only DDL (extensions, GIN trigram indexes) so the same
+    migration runs unchanged against SQLite in unit tests.
+    """
+
+    return op.get_bind().dialect.name == "postgresql"
+
+
+def upgrade() -> None:
+    # --- PostgreSQL extension (pg_trgm powers fuzzy name search) -----------
+    if _is_postgres():
+        op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+
+    # --- styles ------------------------------------------------------------
+    op.create_table(
+        "styles",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("slug", sa.String(length=50), nullable=False),
+        sa.Column("category", sa.String(length=50), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("abv_min", sa.Numeric(precision=4, scale=2), nullable=True),
+        sa.Column("abv_max", sa.Numeric(precision=4, scale=2), nullable=True),
+        sa.Column("ibu_min", sa.SmallInteger(), nullable=True),
+        sa.Column("ibu_max", sa.SmallInteger(), nullable=True),
+        sa.Column("srm_min", sa.SmallInteger(), nullable=True),
+        sa.Column("srm_max", sa.SmallInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+        sa.UniqueConstraint("slug"),
+        sa.CheckConstraint("abv_min IS NULL OR abv_min >= 0", name="ck_styles_abv_min_positive"),
+        sa.CheckConstraint("abv_max IS NULL OR abv_max >= 0", name="ck_styles_abv_max_positive"),
+        sa.CheckConstraint(
+            "abv_min IS NULL OR abv_max IS NULL OR abv_min <= abv_max",
+            name="ck_styles_abv_range",
+        ),
+    )
+
+    # --- breweries ---------------------------------------------------------
+    op.create_table(
+        "breweries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("slug", sa.String(length=255), nullable=False),
+        sa.Column("brewery_type", sa.String(length=50), nullable=True),
+        sa.Column("address_1", sa.String(length=255), nullable=True),
+        sa.Column("address_2", sa.String(length=255), nullable=True),
+        sa.Column("address_3", sa.String(length=255), nullable=True),
+        sa.Column("city", sa.String(length=100), nullable=True),
+        sa.Column("state_province", sa.String(length=100), nullable=True),
+        sa.Column("postal_code", sa.String(length=20), nullable=True),
+        sa.Column("country", sa.String(length=100), nullable=True),
+        sa.Column("longitude", sa.Numeric(precision=11, scale=8), nullable=True),
+        sa.Column("latitude", sa.Numeric(precision=10, scale=8), nullable=True),
+        sa.Column("phone", sa.String(length=30), nullable=True),
+        sa.Column("website_url", sa.String(length=512), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("founded_year", sa.SmallInteger(), nullable=True),
+        sa.Column("is_verified", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+    )
+    op.create_index("ix_breweries_city", "breweries", ["city"])
+    op.create_index("ix_breweries_country", "breweries", ["country"])
+    op.create_index("ix_breweries_brewery_type", "breweries", ["brewery_type"])
+    if _is_postgres():
+        op.execute(
+            "CREATE INDEX ix_breweries_name_trgm ON breweries "
+            "USING gin (name gin_trgm_ops)"
+        )
+
+    # --- beers -------------------------------------------------------------
+    op.create_table(
+        "beers",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("slug", sa.String(length=255), nullable=False),
+        sa.Column("brewery_id", sa.Uuid(), nullable=True),
+        sa.Column("style_id", sa.Uuid(), nullable=True),
+        sa.Column("abv", sa.Numeric(precision=4, scale=2), nullable=True),
+        sa.Column("ibu", sa.SmallInteger(), nullable=True),
+        sa.Column("srm", sa.SmallInteger(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("is_verified", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("slug"),
+        sa.ForeignKeyConstraint(["brewery_id"], ["breweries.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["style_id"], ["styles.id"], ondelete="SET NULL"),
+    )
+    op.create_index("ix_beers_brewery_id", "beers", ["brewery_id"])
+    op.create_index("ix_beers_style_id", "beers", ["style_id"])
+    op.create_index("ix_beers_abv", "beers", ["abv"])
+    if _is_postgres():
+        op.execute(
+            "CREATE INDEX ix_beers_name_trgm ON beers USING gin (name gin_trgm_ops)"
+        )
+
+    # --- ingredients + beer_ingredients -----------------------------------
+    op.create_table(
+        "ingredients",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=150), nullable=False),
+        sa.Column("category", sa.String(length=50), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+    op.create_index("ix_ingredients_category", "ingredients", ["category"])
+
+    op.create_table(
+        "beer_ingredients",
+        sa.Column("beer_id", sa.Uuid(), nullable=False),
+        sa.Column("ingredient_id", sa.Uuid(), nullable=False),
+        sa.Column("amount", sa.String(length=50), nullable=True),
+        sa.Column("usage_phase", sa.String(length=30), nullable=True),
+        sa.PrimaryKeyConstraint("beer_id", "ingredient_id"),
+        sa.ForeignKeyConstraint(["beer_id"], ["beers.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["ingredient_id"], ["ingredients.id"], ondelete="CASCADE"),
+    )
+
+    # --- tasting_profiles --------------------------------------------------
+    op.create_table(
+        "tasting_profiles",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("beer_id", sa.Uuid(), nullable=False),
+        sa.Column("aroma", sa.Text(), nullable=True),
+        sa.Column("appearance", sa.Text(), nullable=True),
+        sa.Column("flavor", sa.Text(), nullable=True),
+        sa.Column("mouthfeel", sa.Text(), nullable=True),
+        sa.Column("overall", sa.Text(), nullable=True),
+        sa.Column("bitterness", sa.SmallInteger(), nullable=True),
+        sa.Column("sweetness", sa.SmallInteger(), nullable=True),
+        sa.Column("body", sa.SmallInteger(), nullable=True),
+        sa.Column("carbonation", sa.SmallInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("beer_id"),
+        sa.ForeignKeyConstraint(["beer_id"], ["beers.id"], ondelete="CASCADE"),
+        sa.CheckConstraint(
+            "bitterness IS NULL OR bitterness BETWEEN 1 AND 5",
+            name="ck_tasting_bitterness_range",
+        ),
+        sa.CheckConstraint(
+            "sweetness IS NULL OR sweetness BETWEEN 1 AND 5",
+            name="ck_tasting_sweetness_range",
+        ),
+        sa.CheckConstraint(
+            "body IS NULL OR body BETWEEN 1 AND 5",
+            name="ck_tasting_body_range",
+        ),
+        sa.CheckConstraint(
+            "carbonation IS NULL OR carbonation BETWEEN 1 AND 5",
+            name="ck_tasting_carbonation_range",
+        ),
+    )
+
+    # --- media -------------------------------------------------------------
+    op.create_table(
+        "media",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("beer_id", sa.Uuid(), nullable=True),
+        sa.Column("brewery_id", sa.Uuid(), nullable=True),
+        sa.Column("media_type", sa.String(length=30), nullable=False),
+        sa.Column("url", sa.String(length=1024), nullable=False),
+        sa.Column("alt_text", sa.String(length=255), nullable=True),
+        sa.Column("is_primary", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("uploaded_by", sa.String(length=100), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["beer_id"], ["beers.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["brewery_id"], ["breweries.id"], ondelete="CASCADE"),
+        sa.CheckConstraint(
+            "beer_id IS NOT NULL OR brewery_id IS NOT NULL",
+            name="ck_media_parent_required",
+        ),
+    )
+    op.create_index("ix_media_beer_id", "media", ["beer_id"])
+    op.create_index("ix_media_brewery_id", "media", ["brewery_id"])
+
+    # --- sources + entity_sources (provenance) ----------------------------
+    op.create_table(
+        "sources",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("source_type", sa.String(length=30), nullable=False),
+        sa.Column("base_url", sa.String(length=512), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name"),
+    )
+
+    op.create_table(
+        "entity_sources",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("source_id", sa.Uuid(), nullable=False),
+        sa.Column("entity_type", sa.String(length=30), nullable=False),
+        sa.Column("entity_id", sa.Uuid(), nullable=False),
+        sa.Column("external_id", sa.String(length=255), nullable=True),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "raw_data",
+            sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+            nullable=True,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["source_id"], ["sources.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "source_id", "entity_type", "external_id",
+            name="uq_entity_sources_triplet",
+        ),
+    )
+    op.create_index(
+        "ix_entity_sources_lookup",
+        "entity_sources",
+        ["entity_type", "entity_id"],
+    )
+
+    # --- community_corrections --------------------------------------------
+    op.create_table(
+        "community_corrections",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("entity_type", sa.String(length=30), nullable=False),
+        sa.Column("entity_id", sa.Uuid(), nullable=False),
+        sa.Column("field_name", sa.String(length=100), nullable=False),
+        sa.Column("old_value", sa.Text(), nullable=True),
+        sa.Column("new_value", sa.Text(), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column("submitted_by", sa.String(length=100), nullable=True),
+        sa.Column("reviewed_by", sa.String(length=100), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_corrections_moderation_queue",
+        "community_corrections",
+        ["status", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    # Drop in reverse dependency order. Indexes are dropped automatically
+    # with their tables on every supported backend.
+    op.drop_table("community_corrections")
+    op.drop_table("entity_sources")
+    op.drop_table("sources")
+    op.drop_table("media")
+    op.drop_table("tasting_profiles")
+    op.drop_table("beer_ingredients")
+    op.drop_table("ingredients")
+    op.drop_table("beers")
+    op.drop_table("breweries")
+    op.drop_table("styles")
+
+    if _is_postgres():
+        # Keep the extension — other schemas on the same database may rely on
+        # pg_trgm. Dropping it here would be destructive beyond our scope.
+        pass

--- a/packages/beer-encyclopedia/migrations/versions/001_initial_schema.py
+++ b/packages/beer-encyclopedia/migrations/versions/001_initial_schema.py
@@ -208,8 +208,12 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["beer_id"], ["beers.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(["brewery_id"], ["breweries.id"], ondelete="CASCADE"),
+        # XOR — each media row belongs to exactly one parent (beer or brewery,
+        # never both, never neither). Enforcing it in SQL keeps the polymorphic
+        # invariant safe even when rows are created outside the ORM.
         sa.CheckConstraint(
-            "beer_id IS NOT NULL OR brewery_id IS NOT NULL",
+            "(beer_id IS NOT NULL AND brewery_id IS NULL) OR "
+            "(beer_id IS NULL AND brewery_id IS NOT NULL)",
             name="ck_media_parent_required",
         ),
     )
@@ -267,7 +271,12 @@ def upgrade() -> None:
         sa.Column("old_value", sa.Text(), nullable=True),
         sa.Column("new_value", sa.Text(), nullable=False),
         sa.Column("reason", sa.Text(), nullable=True),
-        sa.Column("status", sa.String(length=20), nullable=False, server_default="pending"),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
         sa.Column("submitted_by", sa.String(length=100), nullable=True),
         sa.Column("reviewed_by", sa.String(length=100), nullable=True),
         sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),

--- a/packages/beer-encyclopedia/scripts/seed_styles.py
+++ b/packages/beer-encyclopedia/scripts/seed_styles.py
@@ -1,0 +1,107 @@
+"""Seed the ``styles`` table with the core beer style catalog.
+
+The 15 styles seeded here cover:
+- The 8 slugs already recognized by the ML field extractor (ml/extract.py)
+  so the scan pipeline can resolve its output to a persisted row.
+- 7 additional mainstream styles frequently encountered on real labels
+  (porter, pilsner, hefeweizen, dubbel, quadrupel, barleywine, blonde_ale).
+
+This script is idempotent: running it multiple times updates existing rows
+in place (matched by ``slug``) and inserts only what is missing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.engine import create_engine, create_session_factory, get_database_url
+from db.models import Style
+
+# name, slug, category, abv_min, abv_max, ibu_min, ibu_max, srm_min, srm_max
+StyleSeed = tuple[
+    str, str, str,
+    Decimal | None, Decimal | None,
+    int | None, int | None,
+    int | None, int | None,
+]
+
+STYLES: list[StyleSeed] = [
+    # -- already recognized by ml/extract.py ---------------------------------
+    ("India Pale Ale", "ipa", "Ale", Decimal("5.5"), Decimal("7.5"), 40, 70, 6, 14),
+    ("Lager", "lager", "Lager", Decimal("4.0"), Decimal("5.5"), 8, 25, 2, 6),
+    ("Wheat Beer", "wheat", "Ale", Decimal("4.0"), Decimal("5.6"), 8, 20, 3, 9),
+    ("Stout", "stout", "Ale", Decimal("4.0"), Decimal("7.0"), 25, 60, 30, 40),
+    ("Amber Ale", "amber_ale", "Ale", Decimal("4.5"), Decimal("6.2"), 25, 45, 10, 17),
+    ("Sour Ale", "sour", "Ale", Decimal("3.5"), Decimal("6.5"), 5, 25, 3, 20),
+    ("Saison", "saison", "Ale", Decimal("5.0"), Decimal("7.0"), 20, 35, 5, 14),
+    ("Belgian Tripel", "tripel", "Ale", Decimal("7.5"), Decimal("9.5"), 20, 40, 4, 7),
+
+    # -- additional mainstream styles ----------------------------------------
+    ("Porter", "porter", "Ale", Decimal("4.0"), Decimal("6.5"), 25, 50, 20, 35),
+    ("Pilsner", "pilsner", "Lager", Decimal("4.2"), Decimal("5.5"), 25, 45, 2, 6),
+    ("Hefeweizen", "hefeweizen", "Ale", Decimal("4.5"), Decimal("5.6"), 8, 15, 2, 6),
+    ("Belgian Dubbel", "dubbel", "Ale", Decimal("6.0"), Decimal("7.6"), 15, 25, 10, 17),
+    ("Belgian Quadrupel", "quadrupel", "Ale", Decimal("9.0"), Decimal("12.0"), 20, 35, 12, 22),
+    ("Barleywine", "barleywine", "Ale", Decimal("8.0"), Decimal("12.0"), 40, 100, 10, 19),
+    ("Blonde Ale", "blonde_ale", "Ale", Decimal("4.0"), Decimal("5.5"), 15, 28, 3, 6),
+]
+
+
+async def seed_styles(session: AsyncSession) -> tuple[int, int]:
+    """Upsert the style catalog. Returns (created, updated) counts."""
+
+    created = 0
+    updated = 0
+
+    for name, slug, category, abv_min, abv_max, ibu_min, ibu_max, srm_min, srm_max in STYLES:
+        existing = (
+            await session.execute(select(Style).where(Style.slug == slug))
+        ).scalar_one_or_none()
+
+        if existing is None:
+            session.add(
+                Style(
+                    name=name,
+                    slug=slug,
+                    category=category,
+                    abv_min=abv_min,
+                    abv_max=abv_max,
+                    ibu_min=ibu_min,
+                    ibu_max=ibu_max,
+                    srm_min=srm_min,
+                    srm_max=srm_max,
+                )
+            )
+            created += 1
+        else:
+            existing.name = name
+            existing.category = category
+            existing.abv_min = abv_min
+            existing.abv_max = abv_max
+            existing.ibu_min = ibu_min
+            existing.ibu_max = ibu_max
+            existing.srm_min = srm_min
+            existing.srm_max = srm_max
+            updated += 1
+
+    await session.commit()
+    return created, updated
+
+
+async def main() -> None:
+    engine = create_engine(get_database_url())
+    factory = create_session_factory(engine)
+    try:
+        async with factory() as session:
+            created, updated = await seed_styles(session)
+            print(f"Styles seeded: {created} created, {updated} updated.")
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/beer-encyclopedia/tests/test_db/conftest.py
+++ b/packages/beer-encyclopedia/tests/test_db/conftest.py
@@ -1,0 +1,33 @@
+"""Fixtures shared across db/model tests.
+
+Spins up an isolated SQLite database per test function, creates all tables
+via ``Base.metadata.create_all`` (faster than running Alembic for each test),
+and yields an active ``AsyncSession``. Dispose is guaranteed by the fixture
+teardown so no state leaks between tests.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from db.models import Base
+
+
+@pytest_asyncio.fixture
+async def db_session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    try:
+        async with factory() as session:
+            yield session
+    finally:
+        await engine.dispose()

--- a/packages/beer-encyclopedia/tests/test_db/conftest.py
+++ b/packages/beer-encyclopedia/tests/test_db/conftest.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 
 import pytest_asyncio
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import (
     AsyncSession,
     async_sessionmaker,
@@ -20,9 +21,26 @@ from sqlalchemy.ext.asyncio import (
 from db.models import Base
 
 
+def _enable_sqlite_foreign_keys(dbapi_connection, _connection_record) -> None:  # type: ignore[no-untyped-def]
+    """Activate FK constraint enforcement on SQLite connections.
+
+    SQLite disables foreign-key support by default, which silently breaks
+    ``ON DELETE CASCADE`` and ``ON DELETE SET NULL``. PostgreSQL (the
+    production backend) always enforces these, so flipping the pragma on
+    SQLite keeps test behavior aligned with prod.
+    """
+
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
 @pytest_asyncio.fixture
 async def db_session() -> AsyncIterator[AsyncSession]:
     engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    # Attach per-engine so the pragma fires on every aiosqlite connection,
+    # not only on the (unused) sync Engine base class.
+    event.listen(engine.sync_engine, "connect", _enable_sqlite_foreign_keys)
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)

--- a/packages/beer-encyclopedia/tests/test_db/test_models.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_models.py
@@ -151,7 +151,9 @@ async def test_beer_ingredients_composite_primary_key(db_session: AsyncSession) 
         await db_session.commit()
 
 
-async def test_media_requires_beer_or_brewery(db_session: AsyncSession) -> None:
+async def test_media_rejects_no_parent(db_session: AsyncSession) -> None:
+    """XOR parent check — media with neither beer nor brewery is rejected."""
+
     db_session.add(
         Media(
             beer_id=None,
@@ -162,6 +164,44 @@ async def test_media_requires_beer_or_brewery(db_session: AsyncSession) -> None:
     )
     with pytest.raises(IntegrityError):
         await db_session.commit()
+
+
+async def test_media_rejects_both_parents(db_session: AsyncSession) -> None:
+    """XOR parent check — media cannot belong to both a beer and a brewery."""
+
+    brewery = Brewery(name="Dual Owner Brewing", slug="dual-owner-brewing")
+    beer = Beer(name="Dual Owner IPA", slug="dual-owner-ipa")
+    db_session.add_all([brewery, beer])
+    await db_session.flush()
+
+    db_session.add(
+        Media(
+            beer_id=beer.id,
+            brewery_id=brewery.id,
+            media_type="label_photo",
+            url="https://example.com/both.jpg",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_media_accepts_single_parent(db_session: AsyncSession) -> None:
+    """XOR parent check — media with exactly one parent is accepted."""
+
+    brewery = Brewery(name="Solo Brewing", slug="solo-brewing")
+    beer = Beer(name="Solo IPA", slug="solo-ipa")
+    db_session.add_all([brewery, beer])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            Media(beer_id=beer.id, media_type="label_photo", url="https://x/1.jpg"),
+            Media(brewery_id=brewery.id, media_type="logo", url="https://x/2.jpg"),
+        ]
+    )
+    await db_session.commit()
+    # No IntegrityError — both rows commit cleanly.
 
 
 async def test_entity_sources_triplet_is_unique(db_session: AsyncSession) -> None:
@@ -234,3 +274,47 @@ async def test_deleting_beer_cascades_to_tasting_profile_and_ingredients(
     assert links == []
     # The ingredient itself survives — it's shared across beers.
     assert (await db_session.execute(select(Ingredient))).scalar_one().name == "Amarillo"
+
+
+async def test_deleting_beer_cascades_to_media(db_session: AsyncSession) -> None:
+    """Regression test for PR #550: without cascade on Beer.media, deleting a
+    beer with attached media would leave (NULL, NULL) rows that violate the
+    XOR parent check. With passive_deletes + delete-orphan, the media rows
+    are removed via ON DELETE CASCADE without touching the session state."""
+
+    beer = Beer(name="Short-Lived IPA", slug="short-lived-ipa")
+    db_session.add(beer)
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            Media(beer_id=beer.id, media_type="label_photo", url="https://x/a.jpg"),
+            Media(beer_id=beer.id, media_type="bottle_photo", url="https://x/b.jpg"),
+        ]
+    )
+    await db_session.commit()
+
+    await db_session.delete(beer)
+    await db_session.commit()
+
+    remaining = (await db_session.execute(select(Media))).scalars().all()
+    assert remaining == []
+
+
+async def test_deleting_brewery_cascades_to_media(db_session: AsyncSession) -> None:
+    """Symmetric regression test for Brewery.media cascade."""
+
+    brewery = Brewery(name="Short-Lived Brewery", slug="short-lived-brewery")
+    db_session.add(brewery)
+    await db_session.flush()
+
+    db_session.add(
+        Media(brewery_id=brewery.id, media_type="logo", url="https://x/logo.jpg")
+    )
+    await db_session.commit()
+
+    await db_session.delete(brewery)
+    await db_session.commit()
+
+    remaining = (await db_session.execute(select(Media))).scalars().all()
+    assert remaining == []

--- a/packages/beer-encyclopedia/tests/test_db/test_models.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_models.py
@@ -1,0 +1,236 @@
+"""Behavior tests for the encyclopedia ORM models.
+
+Cover the relationships and constraints that are hard to get right:
+cascades on parents with children, unique slugs, required-parent check
+on polymorphic ``media`` rows, one-to-one on ``tasting_profiles``, and
+the provenance triplet uniqueness on ``entity_sources``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from db.models import (
+    Beer,
+    BeerIngredient,
+    Brewery,
+    CommunityCorrection,
+    EntitySource,
+    Ingredient,
+    Media,
+    Source,
+    Style,
+    TastingProfile,
+)
+
+
+async def test_style_is_persisted_with_all_fields(db_session: AsyncSession) -> None:
+    style = Style(
+        name="India Pale Ale",
+        slug="ipa",
+        category="Ale",
+        abv_min=Decimal("5.5"),
+        abv_max=Decimal("7.5"),
+        ibu_min=40,
+        ibu_max=70,
+    )
+    db_session.add(style)
+    await db_session.commit()
+
+    fetched = (
+        await db_session.execute(select(Style).where(Style.slug == "ipa"))
+    ).scalar_one()
+    assert fetched.name == "India Pale Ale"
+    assert fetched.abv_min == Decimal("5.5")
+    assert fetched.created_at is not None
+    assert fetched.updated_at is not None
+
+
+async def test_style_slug_is_unique(db_session: AsyncSession) -> None:
+    db_session.add(Style(name="IPA One", slug="ipa"))
+    await db_session.commit()
+
+    db_session.add(Style(name="IPA Two", slug="ipa"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_beer_links_brewery_and_style(db_session: AsyncSession) -> None:
+    brewery = Brewery(name="Test Brewing Co.", slug="test-brewing-co")
+    style = Style(name="India Pale Ale", slug="ipa")
+    db_session.add_all([brewery, style])
+    await db_session.flush()
+
+    beer = Beer(
+        name="Citra Bomb",
+        slug="citra-bomb",
+        brewery_id=brewery.id,
+        style_id=style.id,
+        abv=Decimal("6.5"),
+        ibu=55,
+    )
+    db_session.add(beer)
+    await db_session.commit()
+
+    stmt = (
+        select(Beer)
+        .where(Beer.slug == "citra-bomb")
+        .options(selectinload(Beer.brewery), selectinload(Beer.style))
+    )
+    fetched = (await db_session.execute(stmt)).scalar_one()
+    assert fetched.brewery is not None and fetched.brewery.name == "Test Brewing Co."
+    assert fetched.style is not None and fetched.style.slug == "ipa"
+
+
+async def test_deleting_brewery_nulls_beer_foreign_key(db_session: AsyncSession) -> None:
+    brewery = Brewery(name="Doomed Brewery", slug="doomed-brewery")
+    db_session.add(brewery)
+    await db_session.flush()
+
+    beer = Beer(name="Survivor IPA", slug="survivor-ipa", brewery_id=brewery.id)
+    db_session.add(beer)
+    await db_session.commit()
+
+    await db_session.delete(brewery)
+    await db_session.commit()
+
+    fetched = (
+        await db_session.execute(select(Beer).where(Beer.slug == "survivor-ipa"))
+    ).scalar_one()
+    # ON DELETE SET NULL means the beer row survives without a brewery.
+    assert fetched.brewery_id is None
+
+
+async def test_tasting_profile_is_one_to_one(db_session: AsyncSession) -> None:
+    beer = Beer(name="Amber One", slug="amber-one")
+    db_session.add(beer)
+    await db_session.flush()
+
+    db_session.add(
+        TastingProfile(
+            beer_id=beer.id,
+            bitterness=3,
+            sweetness=2,
+            body=3,
+            carbonation=3,
+            aroma="Caramel, toasted bread.",
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(TastingProfile(beer_id=beer.id, bitterness=4))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_beer_ingredients_composite_primary_key(db_session: AsyncSession) -> None:
+    beer = Beer(name="Hop Bomb", slug="hop-bomb")
+    hop = Ingredient(name="Citra", category="hop")
+    malt = Ingredient(name="Pale Ale Malt", category="malt")
+    db_session.add_all([beer, hop, malt])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            BeerIngredient(beer_id=beer.id, ingredient_id=hop.id, usage_phase="dry_hop"),
+            BeerIngredient(beer_id=beer.id, ingredient_id=malt.id, usage_phase="mash"),
+        ]
+    )
+    await db_session.commit()
+
+    # A second row with the same (beer, ingredient) pair violates the PK.
+    db_session.add(BeerIngredient(beer_id=beer.id, ingredient_id=hop.id, amount="30g"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_media_requires_beer_or_brewery(db_session: AsyncSession) -> None:
+    db_session.add(
+        Media(
+            beer_id=None,
+            brewery_id=None,
+            media_type="label_photo",
+            url="https://example.com/orphan.jpg",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_entity_sources_triplet_is_unique(db_session: AsyncSession) -> None:
+    source = Source(name="open_brewery_db", source_type="api")
+    db_session.add(source)
+    await db_session.flush()
+
+    brewery_uuid = uuid.uuid4()
+    db_session.add(
+        EntitySource(
+            source_id=source.id,
+            entity_type="brewery",
+            entity_id=brewery_uuid,
+            external_id="obdb-123",
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(
+        EntitySource(
+            source_id=source.id,
+            entity_type="brewery",
+            entity_id=uuid.uuid4(),  # different target, same external_id
+            external_id="obdb-123",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_community_correction_defaults_to_pending(
+    db_session: AsyncSession,
+) -> None:
+    correction = CommunityCorrection(
+        entity_type="brewery",
+        entity_id=uuid.uuid4(),
+        field_name="website_url",
+        new_value="https://new.example.com",
+    )
+    db_session.add(correction)
+    await db_session.commit()
+
+    fetched = (await db_session.execute(select(CommunityCorrection))).scalar_one()
+    assert fetched.status == "pending"
+    assert fetched.created_at is not None
+
+
+async def test_deleting_beer_cascades_to_tasting_profile_and_ingredients(
+    db_session: AsyncSession,
+) -> None:
+    beer = Beer(name="Ephemeral", slug="ephemeral")
+    hop = Ingredient(name="Amarillo", category="hop")
+    db_session.add_all([beer, hop])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            TastingProfile(beer_id=beer.id, overall="Short-lived."),
+            BeerIngredient(beer_id=beer.id, ingredient_id=hop.id),
+        ]
+    )
+    await db_session.commit()
+
+    await db_session.delete(beer)
+    await db_session.commit()
+
+    profiles = (await db_session.execute(select(TastingProfile))).scalars().all()
+    links = (await db_session.execute(select(BeerIngredient))).scalars().all()
+    assert profiles == []
+    assert links == []
+    # The ingredient itself survives — it's shared across beers.
+    assert (await db_session.execute(select(Ingredient))).scalar_one().name == "Amarillo"

--- a/packages/beer-encyclopedia/tests/test_db/test_seed_styles.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_seed_styles.py
@@ -1,0 +1,71 @@
+"""Behavior tests for ``scripts/seed_styles.py``.
+
+Focus on the two invariants that matter in practice: the seeder creates the
+full catalog on a blank DB, and re-running it is idempotent (no duplicates,
+fields refreshed if they change).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Style
+from scripts.seed_styles import STYLES, seed_styles
+
+
+async def test_seed_creates_full_catalog_on_empty_db(db_session: AsyncSession) -> None:
+    created, updated = await seed_styles(db_session)
+
+    assert created == len(STYLES)
+    assert updated == 0
+
+    count = (await db_session.execute(select(func.count()).select_from(Style))).scalar_one()
+    assert count == len(STYLES)
+
+
+async def test_seed_covers_every_ml_extractor_slug(db_session: AsyncSession) -> None:
+    # These slugs must exist in the DB after seeding — they are the keys the
+    # ML pipeline (ml/extract.py) produces.
+    ml_slugs = {"ipa", "lager", "wheat", "stout", "amber_ale", "sour", "saison", "tripel"}
+
+    await seed_styles(db_session)
+
+    rows = (await db_session.execute(select(Style.slug))).scalars().all()
+    assert ml_slugs.issubset(set(rows))
+
+
+async def test_seed_is_idempotent(db_session: AsyncSession) -> None:
+    await seed_styles(db_session)
+
+    created, updated = await seed_styles(db_session)
+    assert created == 0
+    assert updated == len(STYLES)
+
+    count = (await db_session.execute(select(func.count()).select_from(Style))).scalar_one()
+    assert count == len(STYLES)
+
+
+async def test_seed_updates_changed_fields_on_rerun(db_session: AsyncSession) -> None:
+    # First run populates.
+    await seed_styles(db_session)
+
+    # Simulate drift: someone mislabelled the category of an existing row.
+    ipa = (
+        await db_session.execute(select(Style).where(Style.slug == "ipa"))
+    ).scalar_one()
+    assert ipa.category == "Ale"  # sanity check before mutation
+    ipa.category = "Wrong Category"
+    ipa.name = "Wrong Name"
+    await db_session.commit()
+
+    # Re-seeding must restore the canonical metadata.
+    await seed_styles(db_session)
+    refreshed = (
+        await db_session.execute(select(Style).where(Style.slug == "ipa"))
+    ).scalar_one()
+    assert refreshed.category == "Ale"
+    assert refreshed.name == "India Pale Ale"
+    assert refreshed.abv_max == Decimal("7.5")


### PR DESCRIPTION
## Summary

Step 3 of 6 for epic #541. Implements the full encyclopedia schema on top of the PostgreSQL infrastructure merged in #543. No API endpoints yet — those land in #545/#546.

- **10 ORM models** in `db/models/`: `Style`, `Brewery`, `Beer`, `Ingredient` + `BeerIngredient` junction, `TastingProfile` (1-to-1 with Beer), `Media` (polymorphic: exactly one of `beer_id`/`brewery_id` required via CHECK), `Source` + `EntitySource` (provenance tracking with JSONB `raw_data`, JSON fallback on SQLite), `CommunityCorrection` (moderation queue)
- **Hand-written migration** `001_initial_schema.py`:
  - 10 tables with FK cascades (`ON DELETE SET NULL` for `beers.brewery_id`/`beers.style_id` so historical records survive brewery deletion; `CASCADE` for owned rows)
  - CHECK constraints: ABV ranges on styles, 1–5 bounds on tasting scales, media parent requirement
  - B-tree indexes on common filter paths (city, country, brewery_type, FK columns, abv, moderation queue)
  - PostgreSQL-only DDL guarded by `_is_postgres()`: `CREATE EXTENSION pg_trgm` + GIN trigram indexes on `breweries.name` and `beers.name` — ready for the search endpoint in #546
- **Style seeder** `scripts/seed_styles.py`: idempotent upsert of 15 styles (the 8 slugs recognized by `ml/extract.py` + 7 mainstream additions: porter, pilsner, hefeweizen, dubbel, quadrupel, barleywine, blonde ale)
- **14 new tests** covering relationships, cascades, unique + check constraints, polymorphic parents, provenance triplet uniqueness, and seeder idempotence

## Design notes

- The `_is_postgres()` guard in the migration keeps the SQLite path (used in CI and local tests) free of PG-specific DDL without maintaining two migrations.
- `EntitySource.raw_data` uses `JSON().with_variant(JSONB(), "postgresql")` so the metadata is portable.
- The `Style.slug` values are aligned with `ml/extract.py` so the scan pipeline can resolve its string output to a persisted row without a mapping table.

## Checklist

- [x] Happy path + sad path + edge cases covered
- [x] `tsc --noEmit` passes (N/A — Python package)
- [x] Build passes (`alembic upgrade head` + `downgrade base` clean on SQLite)
- [x] Existing tests still green (16 existing + 14 new = 30/30)
- [x] No \`any\`, no inline styles introduced

Closes #544