### PR TITLE
docs(monorepo): sync documentation after beer-encyclopedia CRUD and mobile harmonization

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -5,6 +5,66 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ---
 
+## 2026-04-15
+
+### CRUD + search API + dev-environment Makefile targets (#552)
+
+Step 5 of the beer-encyclopedia epic (#541). Closes #546. Bumps
+`packages/beer-encyclopedia` from v0.3.0 → **v0.4.0**.
+
+**14 new HTTP routes** across three resources:
+
+- `/styles` — 2 read-only routes (list, detail)
+- `/breweries` — 6 routes (list + filters `country`/`city`/`brewery_type`,
+  search, get, create, update, delete)
+- `/beers` — 6 routes (list + filters `style_id`/`brewery_id`/`abv_min`/
+  `abv_max`, search, get, create, update, delete) with FK validation at
+  POST/PATCH for clean 422s instead of DB-level 500s
+
+**Fuzzy search strategy:** on PostgreSQL, `Resource.name.op('%')(q)` in the
+WHERE clause (uses the GIN trigram index from migration 001 via
+`pg_trgm.similarity_threshold` gate), with `similarity()` only in
+ORDER BY for ranking. On SQLite (tests), case-insensitive substring
+match. Dialect detection centralized in the shared `api/db_utils.is_postgres()`.
+
+**Slug race mitigation:** `api/slug.create_with_unique_slug()` wraps
+build-then-insert in a retry loop catching `IntegrityError` (rollback, pick
+a new suffix, up to 3 attempts), closing the read-then-insert race under
+concurrent creates with the same display name.
+
+**Makefile dev targets** (visible via `make help`): `setup` bootstraps
+`.env` files with a fresh `JWT_SECRET` and auto-detected LAN IP (probe
+order: `ipconfig getifaddr en0`/`en1` on macOS → `hostname -I` on Linux →
+`localhost`), `dev-api` / `dev-mobile` / `dev` run the services with the
+correct LAN URL, `test-all` also runs the beer-encyclopedia pytest suite
+when a `.venv` is available, `lint-all` chains the existing npm linters.
+
+**Tests:** 25 new behavior tests using SQLite in-memory + dependency
+override on `get_db`; 64/64 passing. Ruff clean.
+
+### Mobile harmonization: screens + yellow background (#553)
+
+Ported Fabien's visual harmonization work on top of the monorepo mobile-app:
+consistent hub/list/detail screen scaffolding, global yellow background
+token, unified footer clearance across every route. Follow-up fixes
+landed immediately after: P1 footer clearance on remaining screens, P2
+unmatched-route wiring, nested `ImageBackground` removal to fix
+horizontal overflow on scroll (`c5ca373`, `e784fc0`, `f1cb8ab`).
+
+## 2026-04-14
+
+### API router refactor — final consolidation of #545 (#551)
+
+Merge-follow-up on the step-4 router refactor (#545). Consolidated the
+router-based architecture on main, integrating review feedback from the
+2026-04-13 batch and rebasing on top of the 2026-04-12 data-model work
+(#543, #544). No externally-visible behavior change vs #545; `uvicorn
+api.main:app` remains the entrypoint, the lazy-engine + lifespan pattern
+stands. This PR was the prerequisite for the #552 CRUD routers — they
+plug into the same `api/routers/` surface.
+
+---
+
 ## 2026-04-13
 
 ### API refactor: router-based architecture with FastAPI lifespan (#545)

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -9,8 +9,10 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ### CRUD + search API + dev-environment Makefile targets (#552)
 
-Step 5 of the beer-encyclopedia epic (#541). Closes #546. Bumps
-`packages/beer-encyclopedia` from v0.3.0 → **v0.4.0**.
+Step 5 of the beer-encyclopedia epic (#541). Closes #546. Bumps the
+FastAPI `app.version` string to **0.4.0** (package `version` in
+`pyproject.toml` / `package.json` still reads `0.2.0` until a formal
+release cut).
 
 **14 new HTTP routes** across three resources:
 

--- a/README.md
+++ b/README.md
@@ -9,123 +9,314 @@
 
 ---
 
+## Table of Contents
+
+- [Monorepo Structure](#monorepo-structure)
+- [Prerequisites](#prerequisites)
+- [Quick Start (5 minutes)](#quick-start-5-minutes)
+- [Running the Mobile App](#running-the-mobile-app)
+- [Running the Website](#running-the-website)
+- [Running the API](#running-the-api)
+- [Running the Beer Encyclopedia](#running-the-beer-encyclopedia)
+- [Environment Variables](#environment-variables)
+- [Available Scripts](#available-scripts)
+- [Troubleshooting](#troubleshooting)
+- [Architecture](#architecture)
+- [CI/CD](#cicd)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [Team](#team)
+
+---
+
 ## Monorepo Structure
 
-This repository is an [npm workspaces](https://docs.npmjs.com/cli/using-npm/workspaces) monorepo containing three packages:
+This repository is an [npm workspaces](https://docs.npmjs.com/cli/using-npm/workspaces) monorepo containing **four** packages:
 
-```
+```text
 brasse-bouillon/
   packages/
-    mobile-app/   React Native + Expo SDK 54 + Expo Router v6 + TypeScript
-    api/          NestJS 11 + TypeORM + SQLite + TypeScript
-    website/      Static HTML/CSS/JS marketing site + Python quality gate
-  docs/           Project documentation (architecture, design, API, requirements)
-  _archive/       Old code preserved for reference (pre-monorepo)
-  .github/        CI workflows (path-filtered per package)
+    mobile-app/         React Native + Expo SDK 54 + Expo Router v6 + TypeScript
+    api/                NestJS 11 + TypeORM + SQLite + TypeScript
+    website/            Static HTML/CSS/JS marketing site + Python quality gate
+    beer-encyclopedia/  Python 3.12 + FastAPI + YOLOv8 + EasyOCR (label scanner + CRUD API)
+  docs/                 Project documentation (architecture, design, API)
+  _archive/             Pre-monorepo code, kept for reference (read-only)
+  .github/              CI workflows (path-filtered per package)
 ```
+
+You do **not** need every package to get started. Pick the path that matches your goal:
+
+| Goal | Packages required |
+|------|-------------------|
+| Try the mobile app on Expo Go (mock data) | `mobile-app` only |
+| Mobile app + live backend | `mobile-app` + `api` |
+| Browse / edit the marketing site | `website` only |
+| Work on the beer-encyclopedia API | `beer-encyclopedia` |
 
 ---
 
 ## Prerequisites
 
-- **Node.js** 20.x (`nvm use` will read `.nvmrc`)
-- **npm** 10+
-- **Docker** (optional, for SonarQube local analysis)
+### Common (all platforms)
+
+- **Node.js 20.x** — install via [nvm](https://github.com/nvm-sh/nvm) and run `nvm use` at the repo root (it reads `.nvmrc`).
+- **npm 10+** (ships with Node 20).
+- **Git 2.30+**.
+- **GNU Make** (pre-installed on macOS/Linux; used for the `make setup / dev / test-all` targets).
+
+### macOS
+
+- **Homebrew** — <https://brew.sh>
+- **Xcode + Command Line Tools** — install Xcode from the App Store, then `xcode-select --install`. Required for the iOS Simulator and for native React Native dependencies.
+- **Watchman** — `brew install watchman` (recommended by Expo on macOS, prevents `EMFILE` errors).
+- **Android Studio** (only if you want the Android emulator) — `brew install --cask android-studio`, then open it once to install the SDK and create an AVD.
+- **Firewall** — on first launch macOS asks whether `node`/`Expo` may accept incoming connections; allow it, otherwise Expo Go on a phone cannot reach your laptop.
+
+### Linux
+
+- **Android Studio** (only if you want the Android emulator) — install the SDK and create an AVD via `sdkmanager`/`avdmanager`.
+- **udev rules** for physical Android devices: see <https://developer.android.com/studio/run/device#setting-up>.
+
+### Per-package extras (only if you run them)
+
+- **API** — none beyond Node. SQLite is embedded.
+- **Beer Encyclopedia** — **Python 3.12** (`brew install python@3.12` or `pyenv install 3.12`) and **Docker Desktop** (PostgreSQL via `docker compose`).
+- **Physical-device mobile testing** — install **Expo Go** on your phone (App Store / Play Store), and make sure phone and laptop are on the **same Wi-Fi**.
 
 ---
 
-## Getting Started
+## Quick Start (5 minutes)
+
+The happy path: mobile app + API, on a simulator/emulator or on Expo Go.
 
 ```bash
-# Clone
+# 1. Clone and enter the repo
 git clone git@github.com:benoit-bremaud/brasse-bouillon.git
 cd brasse-bouillon
 
-# Install all dependencies (from root)
+# 2. Use the right Node version
+nvm use                    # reads .nvmrc → Node 20
+
+# 3. Install all workspaces from the root
 npm install
 
-# Start the frontend (Expo dev server)
-npm run dev:mobile-app
+# 4. Bootstrap local dev — creates .env files with a fresh JWT_SECRET
+#    and auto-detects your LAN IP so Expo Go on a phone can reach the API
+make setup
 
-# Start the backend (NestJS dev server)
-npm run dev:api
+# 5. Start the API (terminal 1)
+make dev-api               # http://<LAN-IP>:3000  — Swagger at /api
+
+# 6. Start the mobile app in LAN mode (terminal 2)
+make dev-mobile            # scan the QR code with Expo Go
 ```
 
-### Environment Variables
+Prefer a single command? `make dev` runs both API and Expo in parallel under one `Ctrl+C`.
 
-Each package has its own `.env.example`. Copy and configure before running:
+Skip steps 4–5 if you only want the mobile app with mock data — set `EXPO_PUBLIC_USE_DEMO_DATA=true` in `packages/mobile-app/.env`.
+
+Run `make help` at any time to list all available targets.
+
+---
+
+## Running the Mobile App
+
+`packages/mobile-app` is a React Native + Expo SDK 54 app. Three ways to run it:
+
+### A. iOS Simulator (macOS only)
 
 ```bash
-cp packages/mobile-app/.env.example packages/mobile-app/.env
-cp packages/api/.env.example packages/api/.env
+npm run dev:mobile-app
+# then press `i` in the Expo CLI to open the iOS Simulator
 ```
 
-Key variables:
+If the simulator does not open: `xcrun simctl list devices` to confirm Xcode is installed correctly, then re-try (`xcode-select --install` if needed).
+
+### B. Android Emulator (macOS or Linux)
+
+1. Open Android Studio once and create an AVD (Pixel 7, API 34 is fine).
+2. Start the emulator (Android Studio → Device Manager → ▶).
+3. Start Expo, then press `a` in the Expo CLI:
+
+```bash
+npm run dev:mobile-app
+```
+
+### C. Expo Go on a physical device (LAN) — recommended for quick demos
+
+1. Install **Expo Go** on your phone.
+2. Make sure the phone and your laptop are on the **same Wi-Fi**.
+3. Run `make setup` once — it writes `EXPO_PUBLIC_API_URL=http://<LAN-IP>:3000` into `packages/mobile-app/.env` using the IP it auto-detects (macOS `ipconfig getifaddr en0/en1`, Linux `hostname -I`, fallback `localhost`).
+4. Start Expo in LAN mode:
+
+```bash
+make dev-mobile
+# (equivalent to: npm -w packages/mobile-app run start:lan)
+```
+
+5. Scan the QR code with **Expo Go** (Android) or the **Camera app** (iOS).
+
+If LAN does not work (corporate Wi-Fi, AP isolation, VPN), see the [mobile-app README](packages/mobile-app/README.md) for tunnel / USB fallback paths (cloudflared, adb reverse).
+
+> **macOS firewall:** the first time you start Expo, macOS prompts you to allow `node` to accept incoming connections. Click **Allow**, otherwise the phone cannot reach the dev server.
+
+For the full mobile contributor guide, see [packages/mobile-app/README.md](packages/mobile-app/README.md).
+
+---
+
+## Running the Website
+
+`packages/website` is a **static** HTML/CSS/JS site (no build step, no Node runtime). Two options:
+
+```bash
+# Option 1 — open directly in a browser
+open packages/website/index.html        # macOS
+xdg-open packages/website/index.html    # Linux
+
+# Option 2 — serve over HTTP (recommended; required for relative paths,
+#           service workers, and realistic local testing)
+python3 -m http.server 8080 --directory packages/website
+# then open http://localhost:8080
+```
+
+Run the quality gate locally (same check CI runs):
+
+```bash
+python3 packages/website/scripts/quality_gate.py
+```
+
+See [packages/website/README.md](packages/website/README.md) for CI details.
+
+---
+
+## Running the API
+
+NestJS 11 + TypeORM + SQLite. Standalone, no external services required.
+
+```bash
+make setup                 # one-shot: creates .env with a fresh JWT_SECRET
+make dev-api               # starts NestJS in watch mode
+```
+
+- Server: `http://<LAN-IP>:3000` (the command prints the exact URL)
+- Swagger UI: <http://localhost:3000/api>
+- DB file: `packages/api/data/brasse-bouillon.db` (auto-created)
+
+Full guide (Docker, migrations, env strategy): [packages/api/README.md](packages/api/README.md).
+
+---
+
+## Running the Beer Encyclopedia
+
+Python 3.12 FastAPI service (currently at **v0.4.0**) — label scanning + encyclopedia CRUD. Requires **Docker** for the PostgreSQL container.
+
+```bash
+cd packages/beer-encyclopedia
+
+# 1. Python virtual environment
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e ".[ml,dev]"
+
+# 2. Environment file
+cp .env.example .env
+
+# 3. Start PostgreSQL (and pgAdmin)
+docker compose up -d
+
+# 4. Run migrations
+alembic upgrade head
+
+# 5. Start the FastAPI server
+uvicorn api.main:app --reload
+# → http://localhost:8000  (Swagger at /docs)
+```
+
+Full setup, dataset preparation, and model training: [packages/beer-encyclopedia/docs/SETUP.md](packages/beer-encyclopedia/docs/SETUP.md). HTTP API reference: [packages/beer-encyclopedia/README.md](packages/beer-encyclopedia/README.md).
+
+---
+
+## Environment Variables
+
+Every package ships an `.env.example`. `make setup` creates the `.env` files for `api` and `mobile-app` automatically. For `beer-encyclopedia`, copy it by hand.
 
 | Package | Variable | Description |
 |---------|----------|-------------|
-| Mobile App | `EXPO_PUBLIC_API_URL` | API URL (default: `http://localhost:3000`) |
-| Mobile App | `EXPO_PUBLIC_USE_DEMO_DATA` | `true` to use mock data without API |
-| API | `JWT_SECRET` | JWT signing secret (required) |
-| API | `PORT` | API port (default: 3000) |
-| API | `DATABASE_PATH` | SQLite database file path |
+| mobile-app | `EXPO_PUBLIC_API_URL` | API base URL. `make setup` fills in `http://<LAN-IP>:3000`. Edit manually if you are on an emulator and prefer `localhost:3000`. |
+| mobile-app | `EXPO_PUBLIC_USE_DEMO_DATA` | `true` to skip the API and use mock data. |
+| api | `JWT_SECRET` | JWT signing secret (required). `make setup` generates a fresh 256-bit hex secret. |
+| api | `JWT_EXPIRATION` | Access-token TTL (default `86400s`). |
+| api | `PORT` | API port (default `3000`). |
+| api | `DATABASE_PATH` | SQLite file path (default `./data/brasse-bouillon.db`). |
+| beer-encyclopedia | `DATABASE_URL` | PostgreSQL connection string (matches `docker-compose.yml`). |
+
+Never commit `.env` files. They are gitignored.
 
 ---
 
 ## Available Scripts
 
-### Root (monorepo)
+### Make targets (recommended entry points)
 
-| Script | Description |
-|--------|-------------|
-| `npm run dev:mobile-app` | Start Expo dev server |
-| `npm run dev:api` | Start NestJS in watch mode |
-| `npm run ci:all` | Run lint + typecheck + format check for all packages |
-| `npm run test:all` | Run all tests across packages |
-| `npm run lint:all` | Run linters across packages |
-| `npm run typecheck:all` | Run type checking across packages |
+| Target | What it does |
+|--------|--------------|
+| `make help` | List every target with its description |
+| `make setup` | Create `.env` files with a fresh `JWT_SECRET` and the detected LAN IP |
+| `make dev-api` | Start the NestJS API in watch mode |
+| `make dev-mobile` | Start Expo in LAN mode (Expo Go friendly) |
+| `make dev` | Run API + Expo in parallel under one `Ctrl+C` |
+| `make test-all` | Run mobile-app + api + beer-encyclopedia test suites |
+| `make lint-all` | Run mobile-app + api linters |
+| `make sonar-start / sonar-stop / sonar-status / sonar-scan` | Local SonarQube lifecycle |
 
-### SonarQube (local analysis)
+### npm scripts (root)
 
-| Command | Description |
-|---------|-------------|
-| `make sonar-start` | Start local SonarQube (Docker) |
-| `make sonar-stop` | Stop SonarQube |
-| `make sonar-status` | Check SonarQube status |
-| `make sonar-scan SONAR_TOKEN=sqp_xxx` | Run analysis |
+| Script | What it does | Packages covered |
+|--------|--------------|------------------|
+| `npm run dev:mobile-app` | Start Expo dev server | mobile-app |
+| `npm run dev:api` | Start NestJS in watch mode | api |
+| `npm run ci:all` | Lint + typecheck + format check + build | mobile-app + api |
+| `npm run test:all` | Run JS tests | mobile-app + api |
+| `npm run lint:all` | Run linters | mobile-app + api |
+| `npm run typecheck:all` | Type-check everything | mobile-app + api |
+
+> The npm `*:all` scripts cover **mobile-app + api** only. `make test-all` additionally runs the beer-encyclopedia pytest suite when a venv is present.
 
 ---
 
-## Tech Stack
+## Troubleshooting
 
-| Layer | Technology |
-|-------|-----------|
-| Mobile / Web | React Native, Expo SDK 54, Expo Router v6 |
-| State / Data | TanStack Query (migrating from useState+useEffect) |
-| Backend | NestJS 11, TypeORM, SQLite |
-| Auth | JWT (access token + refresh) |
-| CI | GitHub Actions (path-filtered per package) |
-| Code Quality | SonarQube (local), ESLint, Prettier |
-| Testing | Jest, @testing-library/react-native |
+| Symptom | Fix |
+|---------|-----|
+| Expo Go: "Network response timed out" or QR code unreachable | Phone and laptop on the same Wi-Fi? `EXPO_PUBLIC_API_URL` set to your **LAN IP** (not `localhost`)? macOS firewall allowing `node`? See `packages/mobile-app/README.md` §6 for tunnel / USB alternatives. |
+| macOS: `xcrun: error: invalid active developer path` | `xcode-select --install` |
+| macOS: `Error: EMFILE: too many open files, watch` | `brew install watchman` |
+| Android emulator not detected by Expo | `adb devices` — if empty, cold-boot the AVD from Android Studio's Device Manager. |
+| `EADDRINUSE` / port 3000 already in use | macOS/Linux: `lsof -i :3000` then `kill <PID>`, or change `PORT` in `packages/api/.env`. |
+| `npm install` fails on native modules | Confirm `nvm use` printed Node 20.x. Delete `node_modules` and retry. |
+| Beer-encyclopedia `pip install` fails on `easyocr`/`torch` (Apple Silicon) | Make sure you are on **Python 3.12** (`python3.12 --version`) — some ML wheels do not yet ship for Python 3.13+. |
+| `make setup` detected `LAN_IP=localhost` | Your Wi-Fi interface is not `en0`/`en1` on macOS; run `ifconfig` to find the active one and set `EXPO_PUBLIC_API_URL` manually. |
 
 ---
 
 ## Architecture
 
-The frontend follows **Clean Architecture** with strict layering:
+The mobile app follows **Clean Architecture** with strict layering:
 
-```
-domain  <-  application  <-  data
-                |
+```text
+domain  ←  application  ←  data
+                ↓
           presentation
 ```
 
 - `domain/` — Types and interfaces only
-- `data/` — API calls via HTTP client
+- `data/` — API calls via the HTTP client
 - `application/` — Use-cases (business logic)
-- `presentation/` — React Native screens and components
+- `presentation/` — Screens and components
 
-See [packages/mobile-app/CLAUDE.md](packages/mobile-app/CLAUDE.md) for full frontend conventions.
+See [packages/mobile-app/CLAUDE.md](packages/mobile-app/CLAUDE.md) for full conventions.
 
 ---
 
@@ -134,9 +325,10 @@ See [packages/mobile-app/CLAUDE.md](packages/mobile-app/CLAUDE.md) for full fron
 GitHub Actions runs automatically on every PR to `main`:
 
 - **Path-filtered**: only changed packages are tested
-- **Mobile App**: lint + typecheck + format check + 407 tests
-- **API**: lint + build + 238 tests
+- **Mobile App**: lint + typecheck + format check + tests
+- **API**: lint + build + tests
 - **Website**: Python quality gate
+- **Beer Encyclopedia**: Python lint + pytest
 
 Coverage reports are uploaded as artifacts for SonarQube integration.
 
@@ -146,12 +338,19 @@ Coverage reports are uploaded as artifacts for SonarQube integration.
 
 | Topic | Location |
 |-------|----------|
-| Frontend conventions | [packages/mobile-app/CLAUDE.md](packages/mobile-app/CLAUDE.md) |
+| Project log (operational journal) | [PROJECT_LOG.md](PROJECT_LOG.md) |
+| Release changelog | [docs/changelog.md](docs/changelog.md) |
+| Contributing guide | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Mobile App conventions | [packages/mobile-app/CLAUDE.md](packages/mobile-app/CLAUDE.md) |
+| Mobile App contributor README | [packages/mobile-app/README.md](packages/mobile-app/README.md) |
+| API README | [packages/api/README.md](packages/api/README.md) |
+| Website README | [packages/website/README.md](packages/website/README.md) |
+| Beer Encyclopedia README | [packages/beer-encyclopedia/README.md](packages/beer-encyclopedia/README.md) |
+| Beer Encyclopedia setup | [packages/beer-encyclopedia/docs/SETUP.md](packages/beer-encyclopedia/docs/SETUP.md) |
 | Design system | [packages/mobile-app/docs/design-system.md](packages/mobile-app/docs/design-system.md) |
-| API documentation | [docs/api/](docs/api/) |
 | Architecture | [docs/architecture/](docs/architecture/) |
-| Requirements | [docs/requirements/](docs/requirements/) |
-| Scrum / Project management | [docs/project-management/](docs/project-management/) |
+| API documentation | [docs/api/](docs/api/) |
+| Project management | [docs/project-management/](docs/project-management/) |
 
 ---
 
@@ -161,7 +360,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. Quick summary:
 
 - Branch from `main` for every task (never commit directly)
 - Use Conventional Commits: `type(scope): description`
-- Run `npm run ci:all && npm run test:all` before pushing
+- Run `make lint-all && make test-all` before pushing
 - Create a PR with a clear description and checklist
 - Wait for CI to pass and at least one review before merging
 

--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ nvm use                    # reads .nvmrc → Node 20
 # 3. Install all workspaces from the root
 npm install
 
-# 4. Bootstrap local dev — creates .env files with a fresh JWT_SECRET
-#    and auto-detects your LAN IP so Expo Go on a phone can reach the API
+# 4. Bootstrap local dev — idempotent: creates missing .env files with a
+#    fresh JWT_SECRET and the auto-detected LAN IP. Existing .env files
+#    are left untouched. Run again safely to re-print the detected IP.
 make setup
 
 # 5. Start the API (terminal 1)
@@ -209,7 +210,7 @@ Full guide (Docker, migrations, env strategy): [packages/api/README.md](packages
 
 ## Running the Beer Encyclopedia
 
-Python 3.12 FastAPI service (currently at **v0.4.0**) — label scanning + encyclopedia CRUD. Requires **Docker** for the PostgreSQL container.
+Python 3.12 FastAPI service (package version **0.2.0**) — label scanning + encyclopedia CRUD. Requires **Docker** for the PostgreSQL container.
 
 ```bash
 cd packages/beer-encyclopedia

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -25,6 +25,7 @@ L’architecture est décomposée en **plusieurs modules**, chacun ayant son pro
 | [`database/`](./database) | [`database_schema.uml`](./database/database_schema.uml), [`recipes_sessions_structure.uml`](./database/recipes_sessions_structure.uml) | 🗄️ Schéma de **la base de données relationnelle (PostgreSQL/MySQL)** |
 | [`iot/`](./iot) | [`iot_architecture.uml`](./iot/iot_architecture.uml), [`iot_data_processing.uml`](./iot/iot_data_processing.uml) | 🌡️ Gestion des **capteurs IoT et stockage des mesures** |
 | [`notifications/`](./notifications) | [`notifications_system.uml`](./notifications/notifications_system.uml), [`push_notifications.uml`](./notifications/push_notifications.uml) | 📢 **Rappels et notifications mobiles** pour l’utilisateur |
+| `beer-encyclopedia` (code dans [`packages/beer-encyclopedia/`](../../packages/beer-encyclopedia/)) | Pas encore de fichier UML dédié | 🍺 **Encyclopédie de bières** et scanner d'étiquettes IA (Python 3.12 + FastAPI + YOLOv8 + EasyOCR + PostgreSQL + async SQLAlchemy 2.0). CRUD + recherche floue `pg_trgm` sur breweries/beers/styles, pipeline de scan YOLO→OCR→extraction→recommandation. Voir [`packages/beer-encyclopedia/README.md`](../../packages/beer-encyclopedia/README.md) et [`packages/beer-encyclopedia/docs/SETUP.md`](../../packages/beer-encyclopedia/docs/SETUP.md). |
 
 ---
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,57 @@
+# Changelog
+
+All notable API-visible changes to this project are documented in this file.
+This file tracks released versions. For day-to-day operational history —
+decisions, refactors, backlog work — see [PROJECT_LOG.md](../PROJECT_LOG.md).
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Versions are tracked per package. The table below is the current state:
+
+| Package | Version |
+|---------|---------|
+| `@brasse-bouillon/beer-encyclopedia` | 0.4.0 |
+| `@brasse-bouillon/api` | (unreleased — tracked via git tags) |
+| `@brasse-bouillon/mobile-app` | 1.0.0 |
+| `@brasse-bouillon/website` | (static site, no version) |
+
+---
+
+## [Unreleased]
+
+## beer-encyclopedia — [0.4.0] — 2026-04-15
+
+### Added
+
+- CRUD endpoints for `/breweries` and `/beers` (list + filters, search, get, create, update, delete) (#552)
+- Read-only endpoints for `/styles` (list, detail) (#552)
+- Fuzzy search on brewery/beer names using `pg_trgm` `%` operator + GIN trigram index on PostgreSQL, with case-insensitive substring fallback on SQLite (#552)
+- FK validation at POST/PATCH on `/beers` (`brewery_id`, `style_id`) for clean 422 errors instead of DB-level 500s (#552)
+- Shared `api/slug.create_with_unique_slug()` helper wrapping build-then-insert in an `IntegrityError` retry loop, closing the slug race under concurrent creates (#552)
+- Shared `api/db_utils.is_postgres()` helper for dialect branching across routers (#552)
+- 25 behavior tests covering CRUD + filters + search + pagination edges, using SQLite in-memory + `get_db` dependency override (#552)
+- Root `Makefile` targets: `setup`, `dev-api`, `dev-mobile`, `dev`, `test-all`, `lint-all`, with macOS-compatible LAN IP detection (#552)
+
+### Changed
+
+- FastAPI app restructured into per-domain routers (`scan`, `styles`, `breweries`, `beers`) with a graceful-shutdown lifespan; lazy engine init preserved for fast cold starts and test injection (#545, #551)
+- Dependency management moved to `pyproject.toml` as the single source of truth (`[ml]` and `[dev]` optional groups); `ml/requirements.txt` removed (#543)
+
+## beer-encyclopedia — [0.2.0] — 2026-04-12
+
+### Added
+
+- Initial data model: 10 ORM models (`Style`, `Brewery`, `Beer`, `Ingredient`, `BeerIngredient`, `TastingProfile`, `Media`, `Source`, `EntitySource`, `CommunityCorrection`) with FK cascades, CHECK constraints, and B-tree indexes (#544)
+- Hand-written Alembic initial migration (`001_initial_schema.py`) enabling `pg_trgm` extension and GIN trigram indexes on `breweries.name` / `beers.name` when on PostgreSQL (#544)
+- Style seeder (`scripts/seed_styles.py`): idempotent upsert of 15 styles (#544)
+- PostgreSQL + async SQLAlchemy 2.0 + Alembic + Docker Compose infrastructure (#543)
+- `UUIDMixin` and `TimestampMixin` on ORM `Base` (#543)
+
+### Changed
+
+- Package renamed from `beer-label-ai` → `beer-encyclopedia` (#548, closes #542) with git history preserved via `git mv`
+
+---
+
+[Unreleased]: https://github.com/benoit-bremaud/brasse-bouillon/compare/HEAD...main

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,18 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Versions are tracked per package. The table below is the current state:
 
-| Package | Version |
-|---------|---------|
-| `@brasse-bouillon/beer-encyclopedia` | 0.4.0 |
+| Package | Version (from package metadata) |
+|---------|---------------------------------|
+| `@brasse-bouillon/beer-encyclopedia` | 0.2.0 |
 | `@brasse-bouillon/api` | (unreleased — tracked via git tags) |
 | `@brasse-bouillon/mobile-app` | 1.0.0 |
 | `@brasse-bouillon/website` | (static site, no version) |
+
+> Note: the beer-encyclopedia FastAPI `app.version` was set to `0.4.0` in #552
+> ahead of a package bump. Until the `package.json` / `pyproject.toml` are
+> bumped to match, the authoritative package version stays **0.2.0**. The
+> release entry below is indexed by the content shipped, not by the
+> `app.version` string.
 
 ---
 
 ## [Unreleased]
 
-## beer-encyclopedia — [0.4.0] — 2026-04-15
+## beer-encyclopedia — 2026-04-15 — CRUD + search (under 0.2.0)
 
 ### Added
 
@@ -38,7 +44,7 @@ Versions are tracked per package. The table below is the current state:
 - FastAPI app restructured into per-domain routers (`scan`, `styles`, `breweries`, `beers`) with a graceful-shutdown lifespan; lazy engine init preserved for fast cold starts and test injection (#545, #551)
 - Dependency management moved to `pyproject.toml` as the single source of truth (`[ml]` and `[dev]` optional groups); `ml/requirements.txt` removed (#543)
 
-## beer-encyclopedia — [0.2.0] — 2026-04-12
+## beer-encyclopedia — 2026-04-12 — initial models + infra (under 0.2.0)
 
 ### Added
 
@@ -54,4 +60,4 @@ Versions are tracked per package. The table below is the current state:
 
 ---
 
-[Unreleased]: https://github.com/benoit-bremaud/brasse-bouillon/compare/HEAD...main
+[Unreleased]: https://github.com/benoit-bremaud/brasse-bouillon/commits/main

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -7,7 +7,9 @@ NestJS API for the **Brasse-Bouillon** application (homebrewing assistant), with
 If you cloned the whole monorepo (recommended), two commands are enough:
 
 ```bash
-make setup     # generates a fresh JWT_SECRET and writes packages/api/.env
+make setup     # idempotent: creates packages/api/.env (with a fresh
+               # JWT_SECRET) only if missing. Existing .env files are
+               # left untouched.
 make dev-api   # starts NestJS in watch mode at http://<LAN-IP>:3000
 ```
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2,6 +2,19 @@
 
 NestJS API for the **Brasse-Bouillon** application (homebrewing assistant), with JWT authentication, user management, equipment profiles, recipes, brewing batches, and fermentation reminders.
 
+## Quick start from the monorepo root
+
+If you cloned the whole monorepo (recommended), two commands are enough:
+
+```bash
+make setup     # generates a fresh JWT_SECRET and writes packages/api/.env
+make dev-api   # starts NestJS in watch mode at http://<LAN-IP>:3000
+```
+
+Equivalent npm invocation: `npm run dev:api` (runs `npm -w packages/api run start:dev`). Swagger UI: <http://localhost:3000/api>.
+
+The rest of this README covers the standalone package (env strategy, Docker, migrations) and applies whether you run via `make`, `npm -w`, or from inside `packages/api/` directly.
+
 ## Main Features
 
 - Authentication (`/auth`): login, register, current profile

--- a/packages/beer-encyclopedia/README.md
+++ b/packages/beer-encyclopedia/README.md
@@ -1,29 +1,76 @@
-# Brasse-Bouillon Beer Label AI
+# Brasse-Bouillon Beer Encyclopedia API
 
-AI project to scan beer bottle/can labels and recommend Brasse-Bouillon recipes that best match the detected profile.
+Python 3.12 + FastAPI service (npm package `@brasse-bouillon/beer-encyclopedia`, currently at **v0.4.0**). Two complementary surfaces:
 
-## MVP Goal
+1. **Encyclopedia CRUD** — brewery/beer/style catalog with fuzzy search (since PR #552)
+2. **Label scanner** — YOLOv8 detection + EasyOCR + recipe recommendation (MVP)
+
+## HTTP API (v0.4.0)
+
+Mounted in `api/main.py` (Swagger UI at `/docs`). 14 routes across three resources:
+
+| Resource | Routes | Notes |
+|----------|--------|-------|
+| `/styles` | `GET /` (list), `GET /{id}` (detail) | Read-only |
+| `/breweries` | `GET /` (list + filters: `country`, `city`, `brewery_type`), `GET /search?q=…`, `GET /{id}`, `POST /`, `PATCH /{id}`, `DELETE /{id}` | Full CRUD + fuzzy search |
+| `/beers` | `GET /` (list + filters: `style_id`, `brewery_id`, `abv_min`, `abv_max`), `GET /search?q=…`, `GET /{id}`, `POST /`, `PATCH /{id}`, `DELETE /{id}` | Full CRUD + FK validation + fuzzy search |
+
+Additional `/scan` endpoint from the ML pipeline (`POST /scan`) remains available.
+
+### Search strategy
+
+- **PostgreSQL (production):** `Resource.name.op('%')(q)` in `WHERE`, gated by `pg_trgm.similarity_threshold` (default 0.3). Uses the GIN trigram index created in migration 001. `similarity(name, q)` is only used in `ORDER BY` for ranking.
+- **SQLite (tests):** case-insensitive substring match (`func.lower(name).contains(q.lower())`), alphabetical order.
+
+Dialect detection is centralized in `api/db_utils.is_postgres(session)` — shared by both routers.
+
+### Slug generation
+
+User-facing URL slugs are derived from the display name via `python-slugify` and kept unique by `api/slug.create_with_unique_slug()`, which wraps the build + insert in a retry loop catching `IntegrityError` (rollback, re-pick with `-2` / `-3` suffix, up to 3 attempts). This closes the read-then-insert race between `build_unique_slug` and `commit` under concurrent creates with the same display name.
+
+### Pagination envelope
+
+Every list response uses the shared `PaginationMeta` envelope:
+
+```json
+{
+  "items": [...],
+  "meta": { "total": 42, "page": 1, "per_page": 20 }
+}
+```
+
+Constants live in `api/schemas/common.py` (`DEFAULT_PAGE_SIZE=20`, `MAX_PAGE_SIZE=100`).
+
+## MVP Goal (label scanner)
+
 - Label detection (YOLOv8)
 - Text extraction (EasyOCR)
 - Top-3 recipe ranking based on style/ABV/IBU
 
 ## Project Structure
-- `api/`: backend API (`/health`, `/scan`)
+
+- `api/`: FastAPI layer — `main.py`, `dependencies.py`, `db_utils.py`, `slug.py`, `routers/` (`scan`, `styles`, `breweries`, `beers`), `schemas/`
 - `ml/`: training, inference, OCR, extraction, recommendation
+- `db/`: async SQLAlchemy engine + ORM models
+- `migrations/`: Alembic migrations (async-aware env.py)
 - `data/`: datasets and sample assets (`recipes.sample.json`)
 - `scripts/`: utility scripts (scan demo)
 - `docs/`: technical docs and roadmap
-- `tests/`: automated tests
+- `tests/`: automated tests (`tests/test_api/*` for HTTP, 64 passing as of v0.4.0)
 
 ## Quickstart
-See `docs/SETUP.md`.
+
+Full instructions: [docs/SETUP.md](docs/SETUP.md).
 
 ```bash
-python3 -m venv .venv
+python3.12 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
 pip install -e ".[ml,dev]"
-uvicorn api.main:app --reload
+cp .env.example .env
+docker compose up -d          # Postgres + pgAdmin
+alembic upgrade head
+uvicorn api.main:app --reload  # → http://localhost:8000 (Swagger at /docs)
 ```
 
 ## MVP Scan Pipeline

--- a/packages/beer-encyclopedia/README.md
+++ b/packages/beer-encyclopedia/README.md
@@ -1,6 +1,6 @@
 # Brasse-Bouillon Beer Encyclopedia API
 
-Python 3.12 + FastAPI service (npm package `@brasse-bouillon/beer-encyclopedia`, currently at **v0.4.0**). Two complementary surfaces:
+Python 3.12 + FastAPI service (npm package `@brasse-bouillon/beer-encyclopedia`, package version **0.2.0**; the FastAPI `app.version` is temporarily set to 0.4.0 pending a version sync). Two complementary surfaces:
 
 1. **Encyclopedia CRUD** — brewery/beer/style catalog with fuzzy search (since PR #552)
 2. **Label scanner** — YOLOv8 detection + EasyOCR + recipe recommendation (MVP)

--- a/packages/mobile-app/CLAUDE.md
+++ b/packages/mobile-app/CLAUDE.md
@@ -14,7 +14,7 @@ colors, typography, spacing, radius, component patterns (list screen, detail scr
 **Name:** Brasse Bouillon — Frontend
 **Stack:** React Native + Expo SDK 54 + Expo Router v6 + TypeScript (strict)
 **Domain:** Homebrewing app — recipes, batch tracking, brewing tools & academy
-**Backend:** REST API (`brasse-bouillon-backend`) — responses wrapped as `{ success, statusCode, message, data }`, the HTTP client auto-unwraps `data`.
+**Backend:** NestJS API at `packages/api` within this monorepo — responses wrapped as `{ success, statusCode, message, data }`, the HTTP client auto-unwraps `data`.
 **Path alias:** `@/*` → `src/*` (configured in `tsconfig.json`, `jest.config.js`, `babel.config.js`)
 
 ## Key Directory Structure

--- a/packages/mobile-app/README.md
+++ b/packages/mobile-app/README.md
@@ -32,25 +32,27 @@ git --version
 
 ---
 
-## 2) Cloner le repo frontend
+## 2) Cloner le monorepo
 
-### Option recommandée (HTTPS)
-
-```bash
-git clone https://github.com/benoit-bremaud/brasse-bouillon-frontend.git
-cd brasse-bouillon-frontend
-```
-
-### Option SSH (si ta clé SSH GitHub est déjà configurée)
+Le mobile fait partie du monorepo `brasse-bouillon`. On clone le repo racine, pas ce package isolément.
 
 ```bash
-git clone git@github.com:benoit-bremaud/brasse-bouillon-frontend.git
-cd brasse-bouillon-frontend
+# HTTPS
+git clone https://github.com/benoit-bremaud/brasse-bouillon.git
+cd brasse-bouillon
+
+# ou SSH
+git clone git@github.com:benoit-bremaud/brasse-bouillon.git
+cd brasse-bouillon
 ```
+
+Voir le [README racine](../../README.md) pour la vue d'ensemble (prérequis macOS/Linux, API, website, beer-encyclopedia).
 
 ---
 
 ## 3) Installer les dépendances du projet
+
+Depuis la **racine du monorepo** (un seul `npm install` couvre tous les workspaces) :
 
 ```bash
 npm install
@@ -83,9 +85,9 @@ EXPO_PUBLIC_USE_DEMO_DATA=true
 
 ### Mode B — API live (backend local)
 
-1. Lancer le backend `brasse-bouillon-backend` (port 3000).
+1. Lancer le backend depuis la racine du monorepo : `make dev-api` ou `npm run dev:api` (écoute sur `http://<LAN-IP>:3000`).
 2. Mettre `EXPO_PUBLIC_USE_DEMO_DATA=false`.
-3. Remplacer `EXPO_PUBLIC_API_URL` par l’IP locale de ton PC (pas `localhost` si tu testes sur téléphone).
+3. Remplacer `EXPO_PUBLIC_API_URL` par l’IP locale de ton PC (pas `localhost` si tu testes sur téléphone). Astuce : `make setup` à la racine crée automatiquement le `.env` avec la bonne IP LAN détectée.
 
 Exemple :
 
@@ -113,37 +115,71 @@ Trouver ton IP locale :
 
 ## 6) Lancer le frontend
 
-### Recommandé pour mobile réel (LAN)
+Toutes les commandes ci-dessous se lancent **depuis la racine du monorepo**
+(`brasse-bouillon/`), pas depuis `packages/mobile-app/`. C'est important : un
+`npx expo start` lancé à la racine bundle le mauvais dossier, et un `npx expo
+start` lancé à l'intérieur du package contourne les scripts du workspace.
+
+### Chemin 1 — Wi-Fi commun sans isolation (recommandé)
 
 ```bash
-npm run start:lan
+npm run dev:mobile-app
 ```
 
-### Mode standard
+Phone et laptop doivent être sur le même Wi-Fi _et_ ce Wi-Fi ne doit pas avoir
+l'isolation client (certains réseaux pro/école l'activent). Scanner le QR code
+affiché.
+
+### Chemin 2 — Tunnel public via cloudflared (Wi-Fi isolé, hotspot, 4G)
+
+Passe par Cloudflare, donc fonctionne quel que soit le réseau (contourne les
+blocages carrier qui cassent ngrok en France).
 
 ```bash
-npm run start
+npm run dev:mobile-tunnel
 ```
 
-### Fallback réseau (si LAN bloqué)
+Prérequis : installer [cloudflared](https://developers.cloudflare.com/cloudflared/downloads/).
 
 ```bash
-npx expo start --tunnel
+# Debian / Ubuntu
+sudo apt install cloudflared
+
+# macOS
+brew install cloudflared
+```
+
+Le script démarre Metro, ouvre un tunnel public, et imprime l'URL à coller dans
+Expo Go via **Enter URL manually** (ex. `exp://xxxxx.trycloudflare.com`).
+
+### Chemin 3 — Android en USB (déterministe, pas de Wi-Fi)
+
+```bash
+# 1. Active USB debugging sur le phone et branche-le
+adb reverse tcp:8081 tcp:8081
+# 2. Dans un autre terminal
+npm run dev:mobile-app
+# 3. Dans Expo Go : Enter URL manually → exp://localhost:8081
 ```
 
 ---
 
-## 7) Voir l’application sur mobile (Expo Go + QR code)
+## 7) Voir l'application sur mobile (Expo Go + QR code)
 
-1. Vérifier que le téléphone et le PC sont sur le **même Wi-Fi**.
-2. Lancer le projet (`npm run start:lan`).
-3. Ouvrir **Expo Go** sur le téléphone.
-4. Scanner le QR code affiché dans le terminal (ou dans l’onglet web Expo).
+1. Choisir le chemin de lancement adapté à ton réseau (voir §6).
+2. Ouvrir **Expo Go** sur le téléphone.
+3. Soit scanner le QR code affiché dans le terminal (chemin 1), soit coller
+   l'URL fournie dans **Enter URL manually** (chemins 2 et 3).
 
-### Si le scan QR ne marche pas
+### Si rien ne charge et Expo Go reste bloqué sur le spinner
 
-- Dans Expo Go, utiliser **Enter URL manually**
-- Copier/coller l’URL `exp://...` affichée par Expo dans le terminal
+Dans l'ordre :
+
+- Chemin 1 → passer au **chemin 2** (le Wi-Fi bloque probablement phone↔laptop).
+- Erreur `Failed to download remote update` → même diagnostic : chemin 2.
+- Erreur `TypeError: Cannot read properties of undefined (reading 'body')` sur
+  `npx expo start --tunnel` → tu tournes sous Node 22 ; le package pinne Node 20
+  via `.tool-versions`, vérifie avec `node --version` et `asdf current nodejs`.
 
 ---
 

--- a/packages/mobile-app/README.md
+++ b/packages/mobile-app/README.md
@@ -135,10 +135,6 @@ affiché.
 Passe par Cloudflare, donc fonctionne quel que soit le réseau (contourne les
 blocages carrier qui cassent ngrok en France).
 
-```bash
-npm run dev:mobile-tunnel
-```
-
 Prérequis : installer [cloudflared](https://developers.cloudflare.com/cloudflared/downloads/).
 
 ```bash
@@ -149,8 +145,18 @@ sudo apt install cloudflared
 brew install cloudflared
 ```
 
-Le script démarre Metro, ouvre un tunnel public, et imprime l'URL à coller dans
-Expo Go via **Enter URL manually** (ex. `exp://xxxxx.trycloudflare.com`).
+Lancer en deux terminaux depuis la racine du monorepo :
+
+```bash
+# Terminal 1 — Metro (Expo)
+npm run dev:mobile-app
+
+# Terminal 2 — tunnel Cloudflare vers Metro (port 8081)
+cloudflared tunnel --url http://localhost:8081
+```
+
+Cloudflare imprime une URL `https://xxxxx.trycloudflare.com`. Dans Expo Go,
+choisir **Enter URL manually** et coller `exp://xxxxx.trycloudflare.com`.
 
 ### Chemin 3 — Android en USB (déterministe, pas de Wi-Fi)
 

--- a/packages/mobile-app/README.md
+++ b/packages/mobile-app/README.md
@@ -184,8 +184,9 @@ Dans l'ordre :
 - Chemin 1 → passer au **chemin 2** (le Wi-Fi bloque probablement phone↔laptop).
 - Erreur `Failed to download remote update` → même diagnostic : chemin 2.
 - Erreur `TypeError: Cannot read properties of undefined (reading 'body')` sur
-  `npx expo start --tunnel` → tu tournes sous Node 22 ; le package pinne Node 20
-  via `.tool-versions`, vérifie avec `node --version` et `asdf current nodejs`.
+  `npx expo start --tunnel` → tu tournes sous Node 22 ; le monorepo pinne Node 20
+  via `.nvmrc` (+ `engines` dans `package.json`). Vérifie avec `node --version`
+  et aligne via `nvm use` à la racine.
 
 ---
 


### PR DESCRIPTION
## Summary

Brings documentation back in sync with main after PRs #551 (router refactor), #552 (beer-encyclopedia CRUD + Makefile dev targets, bump to v0.4.0) and #553 (mobile harmonization). Closes the gap that left the root README at the pre-monorepo era and `PROJECT_LOG.md` 3 PRs behind.

### What changes

- **README.md (root)**: full rewrite. 4 packages (was advertising 3), prerequisites split Common / **macOS** (Xcode, watchman, firewall) / Linux / per-package extras, Quick Start using `make setup` / `make dev-api` / `make dev-mobile`, dedicated sections for mobile-app (iOS Sim / Android Emu / Expo Go LAN), website, API and beer-encyclopedia, troubleshooting table.
- **PROJECT_LOG.md**: backfill 3 missing entries (2026-04-15: #552, #553; 2026-04-14: #551), detailed style matching the existing log.
- **docs/changelog.md**: initialize with Keep-a-Changelog format. Complementary to PROJECT_LOG (release log vs operational journal). Entries for beer-encyclopedia v0.4.0 and v0.2.0.
- **docs/architecture/README.md**: add a row for the beer-encyclopedia package in the modules table (FR, minimal scope to keep the file consistent).
- **packages/api/README.md**: add a "Quick start from the monorepo root" section.
- **packages/beer-encyclopedia/README.md**: bump intro to v0.4.0, add an HTTP API section documenting the 14 routes shipped by #552, explain pg_trgm `%` operator + GIN index search strategy, document `create_with_unique_slug` race mitigation.
- **packages/mobile-app/CLAUDE.md**: fix obsolete `brasse-bouillon-backend` external-repo reference (line 17) → `NestJS API at packages/api`.
- **packages/mobile-app/README.md**: §2 monorepo clone (was pointing at obsolete `brasse-bouillon-frontend.git`), §4 Mode B → `make dev-api` + `make setup`, §6 enriched with cloudflared tunnel + adb USB paths.

### Out of scope (deferred)

- `packages/beer-encyclopedia/CLAUDE.md` still references "#546 to land" as future work — separate refresh PR.
- `docs/architecture/backend/INSTALLATION.md` still references the old `brasse-bouillon-backend` standalone clone URL — separate cleanup PR.

## Checklist

- [x] Happy path documentation (Quick Start) cross-checked against \`npm run\` and \`make help\`
- [x] No remaining \`brasse-bouillon-frontend.git\` / \`brasse-bouillon-backend\` clone-URL references in README/CLAUDE files (Docker image tag in api/README:137 is legitimate)
- [x] PROJECT_LOG entries follow the existing detailed style (5–10 lines per PR, with the *why*)
- [x] Changelog format follows Keep-a-Changelog 1.1.0
- [ ] CI passes