### PR TITLE
feat(ci): wire SonarCloud analysis on every PR

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -26,6 +27,14 @@ jobs:
   sonarcloud:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
+    # Skip on pull requests from forks: secrets.SONAR_TOKEN is not shared
+    # with forked repositories by GitHub Actions, so the scan step would
+    # fail with a misleading error. Forked PRs can still be analyzed by
+    # an authorized maintainer who re-runs the workflow on a branch of
+    # this repo (or merges after a local rebase).
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout (full history for Sonar blame)
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for Sonar blame)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -64,10 +64,13 @@ jobs:
         run: npm run test:cov
 
       # ────────────────────────────────────────────────────────────────────────
-      # SonarCloud scan — reads sonar-project.properties at repo root
+      # SonarCloud scan — reads sonar-project.properties at repo root.
+      # Uses the unified sonarqube-scan-action (works for both SonarCloud
+      # and self-hosted SonarQube). Pinned to a full commit SHA per the
+      # project's "Actions pinned by SHA" CI security policy.
       # ────────────────────────────────────────────────────────────────────────
       - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@v3.1.0
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,73 @@
+# ==============================================================================
+# Brasse-Bouillon — SonarCloud Analysis
+# Runs on PRs to main and pushes to main.
+# Scans packages/mobile-app + packages/api with Jest lcov coverage reports.
+# Quality Gate is enforced by SonarCloud (configurable at sonarcloud.io).
+#
+# Requirements:
+#   - GitHub secret SONAR_TOKEN (user token from sonarcloud.io/account/security)
+#   - Project must exist in SonarCloud under the benoit-bremaud organization
+#   - Automatic Analysis must be OFF in the SonarCloud project settings
+# ==============================================================================
+
+name: SonarCloud
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for Sonar blame)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            packages/mobile-app/package-lock.json
+            packages/api/package-lock.json
+
+      # ────────────────────────────────────────────────────────────────────────
+      # Mobile App — install + test with coverage
+      # ────────────────────────────────────────────────────────────────────────
+      - name: Install mobile-app dependencies
+        working-directory: packages/mobile-app
+        run: npm ci
+
+      - name: Run mobile-app tests with coverage
+        working-directory: packages/mobile-app
+        run: npm run test:coverage
+
+      # ────────────────────────────────────────────────────────────────────────
+      # API — install + test with coverage
+      # ────────────────────────────────────────────────────────────────────────
+      - name: Install api dependencies
+        working-directory: packages/api
+        run: npm ci
+
+      - name: Run api tests with coverage
+        working-directory: packages/api
+        run: npm run test:cov
+
+      # ────────────────────────────────────────────────────────────────────────
+      # SonarCloud scan — reads sonar-project.properties at repo root
+      # ────────────────────────────────────────────────────────────────────────
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v3.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -275,9 +275,10 @@ GitHub Actions runs automatically on every PR to `main` and every push to `main`
   - **api** — lint + build + tests (70% coverage target — CI warning)
   - **website** — Python quality gate
   - **beer-encyclopedia** — ruff lint + compile check + pytest (70% coverage target — CI warning)
+- [`.github/workflows/sonarcloud.yml`](.github/workflows/sonarcloud.yml) — runs SonarCloud analysis on every PR and on pushes to `main`. Installs mobile-app + api, runs both Jest suites with coverage, then feeds the `lcov.info` reports into SonarCloud. Quality Gate is enforced server-side on the `benoit-bremaud_brasse-bouillon` project.
 - [`.github/workflows/discord-notifications.yml`](.github/workflows/discord-notifications.yml) — routes issue and pull-request lifecycle events (`issues:opened`, `pull_request:opened|closed`) to Discord channels based on `scope:*` labels.
 
-Each job uploads its `lcov.info` as a GitHub Actions artifact. There is **no SonarQube job in CI** today — Sonar analysis is local-only, driven by `make sonar-scan` against a local SonarQube Community Edition running in Docker (see `sonar-project.properties`).
+`ci.yml` also uploads each `lcov.info` as a GitHub Actions artifact (7-day retention). Local SonarQube Community Edition analysis remains available via `make sonar-scan` — see the [Testing & Quality](#testing--quality) section.
 
 ---
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,11 +1,19 @@
-# SonarQube project configuration — Brasse-Bouillon monorepo
+# SonarCloud / SonarQube project configuration — Brasse-Bouillon monorepo
 # Targets: TypeScript packages (mobile-app + api)
-# SonarQube server: http://localhost:9000 (Community Edition, local Docker)
-# Authentication: SONAR_TOKEN env var — never hardcode tokens here
 #
-# Usage: make sonar-scan SONAR_TOKEN=sqp_xxxx
+# Default target: SonarCloud (https://sonarcloud.io). The CI workflow
+# .github/workflows/sonarcloud.yml supplies SONAR_HOST_URL automatically
+# via SonarSource/sonarcloud-github-action.
+#
+# Local usage against the Dockerized SonarQube Community Edition:
+#   SONAR_HOST_URL=http://localhost:9000 make sonar-scan SONAR_TOKEN=sqp_xxxx
+# Local usage against SonarCloud:
+#   SONAR_HOST_URL=https://sonarcloud.io make sonar-scan SONAR_TOKEN=<sonarcloud-token>
+#
+# Authentication: SONAR_TOKEN env var — never hardcode tokens here.
 
-sonar.projectKey=brasse-bouillon
+sonar.projectKey=benoit-bremaud_brasse-bouillon
+sonar.organization=benoit-bremaud
 sonar.projectName=Brasse Bouillon
 sonar.projectVersion=1.0
 
@@ -63,6 +71,9 @@ sonar.coverage.exclusions=\
   packages/api/src/database/data-source.ts,\
   packages/api/src/main.ts
 
-# —— SonarQube server ————————————————————————————————————————————————————————
-# Override with SONAR_HOST_URL env var for non-local deployments.
-sonar.host.url=http://localhost:9000
+# —— Server URL ——————————————————————————————————————————————————————————————
+# No sonar.host.url here. The URL is supplied by the environment:
+#   - CI (GitHub Actions): set automatically by SonarSource/sonarcloud-github-action
+#   - Local SonarQube (Docker): tools/ci/sonar-scan.sh defaults SONAR_HOST_URL to
+#     http://localhost:9000 when the env var is unset.
+#   - Local SonarCloud scan: export SONAR_HOST_URL=https://sonarcloud.io.


### PR DESCRIPTION
## Summary

Enable SonarCloud analysis on every PR and push to `main`, using the now-onboarded `benoit-bremaud_brasse-bouillon` project. The Quality Gate is enforced server-side by SonarCloud; this PR only wires the CI side so coverage and static analysis get reported on every change.

**What changes**
- New workflow `.github/workflows/sonarcloud.yml` — installs `packages/mobile-app` + `packages/api`, runs each Jest suite with coverage, then invokes `SonarSource/sonarcloud-github-action@v3.1.0` with `SONAR_TOKEN` and a `fetch-depth: 0` checkout so Sonar can compute blame annotations.
- `sonar-project.properties` — migrated to the SonarCloud project key format (`benoit-bremaud_brasse-bouillon`) and now declares `sonar.organization=benoit-bremaud`. The hardcoded `sonar.host.url=http://localhost:9000` is removed; the URL is supplied by the environment (GitHub Action for CI, `tools/ci/sonar-scan.sh` default for local Docker, env override for local SonarCloud scans).
- README — the CI/CD section now lists the new workflow and clarifies that `make sonar-scan` against the local Docker image remains available.

## Prerequisites for this workflow to run green

- [x] `SONAR_TOKEN` added as a GitHub repository secret (done out of band)
- [x] Automatic Analysis **disabled** on the SonarCloud project (CI-based and Automatic are mutually exclusive)
- [ ] First run on this PR will confirm the end-to-end path. If the Quality Gate fails, that is a content finding (code smells / coverage), not a wiring issue — comments will appear inline.

## What does not change

- `ci.yml` is untouched. It still runs the existing per-package jobs and uploads `lcov.info` artifacts.
- `tools/ci/sonar-scan.sh` and the `make sonar-*` Makefile targets keep working against a local Dockerized SonarQube Community Edition.
- `packages/website` and `packages/beer-encyclopedia` are not analyzed by SonarCloud in this PR (`sonar.exclusions` already excludes them, and adding Python coverage is a separate opt-in).

## Checklist

- [x] Workflow triggers on `pull_request` (opened/synchronize/reopened) and `push` to `main`
- [x] Node 20 pinned; per-package `npm ci` mirrors the pattern used in `ci.yml`
- [x] No secrets in tracked files — `SONAR_TOKEN` read from `${{ secrets.SONAR_TOKEN }}`
- [x] Properties file points at `benoit-bremaud_brasse-bouillon` under org `benoit-bremaud`
- [x] Existing local-Docker flow preserved (documented in properties header)

Closes nothing (no tracking issue yet — this came from a live conversation about the absence of Sonar CI in the repo).