### PR TITLE
chore(ci): activate release-please + version baseline

### DIFF
--- a/.github/tag-protection.md
+++ b/.github/tag-protection.md
@@ -1,0 +1,103 @@
+# Tag Protection — Brasse-Bouillon
+
+This repository enforces strict tag-protection on release tags to
+prevent accidental rewrites. Applied via a GitHub repository ruleset
+scoped to every tag pattern used by release-please.
+
+## Tag patterns protected
+
+Per the hybrid monorepo release strategy (see [CONTRIBUTING.md](../CONTRIBUTING.md#release-workflow)):
+
+- `mobile-app-v*` — lockstep with `api-v*` (group "app")
+- `api-v*` — lockstep with `mobile-app-v*`
+- `website-v*` — independent
+- `encyclopedia-v*` — independent
+- `v*` — reserved for repo-wide anchors (audit snapshots, milestones)
+
+## Ruleset policy
+
+- Rules: `creation`, `update`, `deletion` — **all blocked**
+- Enforcement: `active`
+- Bypass: `RepositoryRole: Admin` (`actor_id: 5`), mode `always`
+- Rationale: only release-please (running as a GitHub App / bot) and
+  the repo owner (admin) can create tags. Prevents accidental rewrites
+  from feature branches or CI mishaps.
+
+## Apply (one-time, by owner)
+
+```bash
+gh api repos/benoit-bremaud/brasse-bouillon/rulesets \
+  --method POST \
+  --input - <<'EOF'
+{
+  "name": "Protect release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": [
+        "refs/tags/v*",
+        "refs/tags/mobile-app-v*",
+        "refs/tags/api-v*",
+        "refs/tags/website-v*",
+        "refs/tags/encyclopedia-v*"
+      ],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "creation" },
+    { "type": "update" },
+    { "type": "deletion" }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}
+EOF
+```
+
+## Verify
+
+```bash
+gh api repos/benoit-bremaud/brasse-bouillon/rulesets \
+  --jq '.[] | select(.target=="tag") | {id, name, enforcement}'
+```
+
+Expected output:
+
+```json
+{
+  "id": <some-id>,
+  "name": "Protect release tags",
+  "enforcement": "active"
+}
+```
+
+## Remove (emergency only)
+
+```bash
+# First get the ruleset ID
+RULESET_ID=$(gh api repos/benoit-bremaud/brasse-bouillon/rulesets \
+  --jq '.[] | select(.name=="Protect release tags") | .id')
+
+gh api repos/benoit-bremaud/brasse-bouillon/rulesets/$RULESET_ID \
+  --method DELETE
+```
+
+## Signing
+
+Tag signing is currently **optional** (private repo). Becomes
+**mandatory** before any public release:
+
+1. Configure a GPG or SSH signing key locally: `git config --global user.signingkey <KEY_ID>`
+2. Set `git config --global tag.gpgsign true`
+3. release-please does not currently sign tags — this requires a
+   workflow extension when the repo goes public.
+
+See the global CLAUDE.md § Tag Conventions for the full signing
+policy when transitioning to public.

--- a/.github/tag-protection.md
+++ b/.github/tag-protection.md
@@ -1,8 +1,8 @@
 # Tag Protection — Brasse-Bouillon
 
-This repository enforces strict tag-protection on release tags to
-prevent accidental rewrites. Applied via a GitHub repository ruleset
-scoped to every tag pattern used by release-please.
+This repository enforces tag-protection on release tags to prevent
+accidental rewrites or deletions. Applied via a GitHub repository
+ruleset scoped to every tag pattern used by release-please.
 
 ## Tag patterns protected
 
@@ -14,14 +14,34 @@ Per the hybrid monorepo release strategy (see [CONTRIBUTING.md](../CONTRIBUTING.
 - `encyclopedia-v*` — independent
 - `v*` — reserved for repo-wide anchors (audit snapshots, milestones)
 
-## Ruleset policy
+## Ruleset policy (current, active)
 
-- Rules: `creation`, `update`, `deletion` — **all blocked**
+- Rules: **`update`**, **`deletion`** — blocked
+- Rules: `creation` — **not blocked** (intentional, see below)
 - Enforcement: `active`
 - Bypass: `RepositoryRole: Admin` (`actor_id: 5`), mode `always`
-- Rationale: only release-please (running as a GitHub App / bot) and
-  the repo owner (admin) can create tags. Prevents accidental rewrites
-  from feature branches or CI mishaps.
+- Ruleset id: `15481614`
+
+### Why `creation` is not blocked
+
+release-please runs inside GitHub Actions as `github-actions[bot]` and
+uses the default `GITHUB_TOKEN`. That token is **not** an admin and
+cannot bypass an admin-only creation rule. Blocking creation while
+still wanting automated release tags creates a deadlock.
+
+Two possible resolutions were considered:
+
+1. **Allow creation for everyone** (chosen for v0) — creation rule
+   removed from the ruleset. Tags become immutable once created
+   (`update` + `deletion` still blocked), which preserves the audit
+   integrity goal. The small risk of rogue tag creation is
+   acceptable for a private solo-dev repo.
+2. **Use a PAT with Integration bypass** (future option) — generate
+   a PAT with `contents: write` + `workflows: write`, store as
+   `secrets.RELEASE_PLEASE_TOKEN`, pass to the release-please action
+   via `token:`. Add the PAT owner as a bypass actor. More secure
+   but adds setup complexity. Track as tech-debt if the repo goes
+   public.
 
 ## Apply (one-time, by owner)
 
@@ -46,7 +66,6 @@ gh api repos/benoit-bremaud/brasse-bouillon/rulesets \
     }
   },
   "rules": [
-    { "type": "creation" },
     { "type": "update" },
     { "type": "deletion" }
   ],

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,22 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    name: Release Please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          target-branch: main

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,6 @@
+{
+  "packages/mobile-app": "0.1.0-alpha1",
+  "packages/api": "0.0.1",
+  "packages/website": "0.0.1",
+  "packages/beer-encyclopedia": "0.0.1"
+}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
   "packages/mobile-app": "0.1.0-alpha1",
   "packages/api": "0.0.1",
-  "packages/website": "0.0.1",
-  "packages/beer-encyclopedia": "0.0.1"
+  "packages/website": "0.1.0",
+  "packages/beer-encyclopedia": "0.2.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,13 +27,13 @@ We use **trunk-based development** with `main` as the single production branch. 
 
 Every task requires a dedicated branch from `main`:
 
-| Type | Pattern | Example |
-|------|---------|---------|
-| Feature | `feat/<scope>` | `feat/ibu-calculator` |
-| Bug fix | `fix/<scope>` | `fix/login-redirect` |
+| Type     | Pattern            | Example                |
+| -------- | ------------------ | ---------------------- |
+| Feature  | `feat/<scope>`     | `feat/ibu-calculator`  |
+| Bug fix  | `fix/<scope>`      | `fix/login-redirect`   |
 | Refactor | `refactor/<scope>` | `refactor/http-client` |
-| Chore | `chore/<scope>` | `chore/update-deps` |
-| Docs | `docs/<scope>` | `docs/readme-update` |
+| Chore    | `chore/<scope>`    | `chore/update-deps`    |
+| Docs     | `docs/<scope>`     | `docs/readme-update`   |
 
 ```bash
 git checkout main
@@ -56,6 +56,7 @@ type(scope): short description
 **Scope:** the affected area (`auth`, `recipes`, `tools`, `backend`, `frontend`, `monorepo`, `ci`, `sonar`)
 
 Examples:
+
 ```
 feat(recipes): add recipe duplication use-case
 fix(auth): handle expired refresh token gracefully
@@ -63,18 +64,32 @@ ci(monorepo): add SonarQube quality gate to CI pipeline
 docs(readme): update getting started section
 ```
 
-### Scopes used by release-please
+### Scopes and package selection (release-please)
 
-The scope in a Conventional Commit drives which package gets
-released. Use these exact scopes to benefit from automation:
+**Package selection is driven by the file path touched**, not by the
+Conv Commit scope. release-please's `manifest` mode walks each package
+directory declared in `release-please-config.json` and only considers
+commits whose diff touches files under that path. The scope **does
+not bump a package on its own** — if no file inside the package path
+changed, the scope has no effect on that package's version.
 
-| Scope | Package bumped | Notes |
-|-------|----------------|-------|
-| `mobile-app`, `scan`, `auth`, `recipes`, `batches`, `ingredients`, `labels`, `shop`, `tools`, `academy`, `dashboard` | `packages/mobile-app` | Also bumps `packages/api` (lockstep group "app") |
-| `api` | `packages/api` | Also bumps `packages/mobile-app` (lockstep group "app") |
-| `website` | `packages/website` | Independent |
-| `encyclopedia` | `packages/beer-encyclopedia` | Independent |
-| `ydays`, `root`, `ci`, `monorepo` | No package — stays unreleased | Doc / infra only |
+The scope's job is therefore to describe **semantics + CHANGELOG
+classification** (which section the commit lands in), not to force a
+release. Use scopes consistent with the file path for clarity.
+
+Conventional scopes for this monorepo:
+
+| Scope                                                                                                                | Typical path touched            | Effect                                                                                                      |
+| -------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `mobile-app`, `scan`, `auth`, `recipes`, `batches`, `ingredients`, `labels`, `shop`, `tools`, `academy`, `dashboard` | `packages/mobile-app/**`        | Bumps `mobile-app` (and `api` via lockstep group "app" if the commit also touches `packages/api/**`)        |
+| `api`                                                                                                                | `packages/api/**`               | Bumps `api` (and `mobile-app` via lockstep group "app" if the commit also touches `packages/mobile-app/**`) |
+| `website`                                                                                                            | `packages/website/**`           | Bumps `website` independently                                                                               |
+| `encyclopedia`                                                                                                       | `packages/beer-encyclopedia/**` | Bumps `encyclopedia` independently                                                                          |
+| `ydays`, `root`, `ci`, `monorepo`                                                                                    | anything outside `packages/**`  | No package bump — doc / infra commits only                                                                  |
+
+**Lockstep group "app"**: a single commit that touches files in both
+`packages/mobile-app` and `packages/api` will bump both packages to the
+same version under a linked release PR.
 
 Bump semantics (release-please computes automatically):
 
@@ -136,11 +151,16 @@ in `release-please-config.json` and manifest in
 ### Tag protection
 
 Ruleset `refs/tags/v*` + scoped component tags (`mobile-app-v*`,
-`api-v*`, `website-v*`, `encyclopedia-v*`) block non-admin
-creation / update / deletion. Admin bypass (`RepositoryRole: Admin`)
-is the only escape hatch for emergency corrections. See
-[.github/tag-protection.md](.github/tag-protection.md) for the apply /
-verify / remove commands.
+`api-v*`, `website-v*`, `encyclopedia-v*`) block **`update`** and
+**`deletion`** for everyone except admins. Creation is **not blocked**
+so that release-please (running as `github-actions[bot]`) can cut the
+release tags automatically on merge of the release PR. The trade-off
+and future tightening path (PAT with Integration bypass) are
+documented in [.github/tag-protection.md](.github/tag-protection.md).
+
+Result: tags are **immutable once created** (no rewrite, no delete
+except by admin emergency bypass), but creation flows freely through
+the automation.
 
 ### Signing
 
@@ -180,15 +200,15 @@ Self-discipline safeguards (no intermediate cap forces the call):
 
 Every GitHub issue must use a template. When creating an issue, GitHub will prompt you to pick one.
 
-| Template | Label | Title convention | When to use |
-|----------|-------|-----------------|-------------|
-| **User Story** | `type:user-story` | `feat(<scope>): as <persona>, I want...` | Feature from the user's perspective (INVEST model) |
-| **Feature** | `type:feature` | `feat(<scope>): <description>` | Technical task implementing a feature |
-| **Bug Report** | `type:bug` | `fix(<scope>): <description>` | Report a bug or unexpected behavior |
-| **Test** | `type:test` | `test(<scope>): <description>` | Write or improve tests |
-| **Refactor** | `type:refactor` | `refactor(<scope>): <description>` | Code restructuring, no functional change |
-| **Task / Chore** | `type:chore` | `chore(<scope>): <description>` | Config, tooling, dependencies, maintenance |
-| **Epic** | `type:epic` | `epic(<scope>): <description>` | Large body of work grouping User Stories |
+| Template         | Label             | Title convention                         | When to use                                        |
+| ---------------- | ----------------- | ---------------------------------------- | -------------------------------------------------- |
+| **User Story**   | `type:user-story` | `feat(<scope>): as <persona>, I want...` | Feature from the user's perspective (INVEST model) |
+| **Feature**      | `type:feature`    | `feat(<scope>): <description>`           | Technical task implementing a feature              |
+| **Bug Report**   | `type:bug`        | `fix(<scope>): <description>`            | Report a bug or unexpected behavior                |
+| **Test**         | `type:test`       | `test(<scope>): <description>`           | Write or improve tests                             |
+| **Refactor**     | `type:refactor`   | `refactor(<scope>): <description>`       | Code restructuring, no functional change           |
+| **Task / Chore** | `type:chore`      | `chore(<scope>): <description>`          | Config, tooling, dependencies, maintenance         |
+| **Epic**         | `type:epic`       | `epic(<scope>): <description>`           | Large body of work grouping User Stories           |
 
 ### User Stories & Sub-issues
 
@@ -213,16 +233,16 @@ Sub-issues inherit scope labels from their parent. GitHub auto-tracks completion
 
 All labels use a **prefixed namespace** for consistency.
 
-| Prefix | Purpose | Examples |
-|--------|---------|---------|
-| `priority:` | MoSCoW prioritization | `must-have`, `should-have`, `nice-to-have` |
-| `size:` | T-shirt estimation (Fibonacci mapping) | `XS` (1 SP), `S` (2), `M` (3), `L` (5), `XL` (8), `XXL` (13) |
-| `scope:` | Which part of the codebase | `frontend`, `backend`, `charte`, `devops`, `website`, `monorepo` |
-| `type:` | Nature of work | `feature`, `bug`, `test`, `refactor`, `docs`, `chore`, `ci`, `epic`, `user-story` |
-| `sprint:` | Sprint assignment | `sprint:4`, `sprint:5`, `sprint:6` |
-| `area:` | Cross-cutting concern | `api`, `security`, `a11y`, `ux`, `architecture`, `theme` |
-| `epic:` | Epic tracking | `auth`, `recipes`, `batches`, `calculators`, etc. |
-| `status:` | Workflow state | `planned`, `in-progress`, `done` |
+| Prefix      | Purpose                                | Examples                                                                          |
+| ----------- | -------------------------------------- | --------------------------------------------------------------------------------- |
+| `priority:` | MoSCoW prioritization                  | `must-have`, `should-have`, `nice-to-have`                                        |
+| `size:`     | T-shirt estimation (Fibonacci mapping) | `XS` (1 SP), `S` (2), `M` (3), `L` (5), `XL` (8), `XXL` (13)                      |
+| `scope:`    | Which part of the codebase             | `frontend`, `backend`, `charte`, `devops`, `website`, `monorepo`                  |
+| `type:`     | Nature of work                         | `feature`, `bug`, `test`, `refactor`, `docs`, `chore`, `ci`, `epic`, `user-story` |
+| `sprint:`   | Sprint assignment                      | `sprint:4`, `sprint:5`, `sprint:6`                                                |
+| `area:`     | Cross-cutting concern                  | `api`, `security`, `a11y`, `ux`, `architecture`, `theme`                          |
+| `epic:`     | Epic tracking                          | `auth`, `recipes`, `batches`, `calculators`, etc.                                 |
+| `status:`   | Workflow state                         | `planned`, `in-progress`, `done`                                                  |
 
 **Excluded from daily workflow:** `persona:*` (product design only), `bloc:*` and `ref:*` (deprecated).
 
@@ -232,16 +252,16 @@ All labels use a **prefixed namespace** for consistency.
 
 GitHub events are automatically routed to specialized Discord channels based on `scope:*` labels:
 
-| Discord channel | Scope label |
-|----------------|-------------|
-| `#app-mobile` | `scope:frontend` |
-| `#api-backend` | `scope:backend` |
-| `#design-system` | `scope:charte` |
-| `#devops` | `scope:devops` |
-| `#site-vitrine` | `scope:website` |
-| `#secu-cyber` | `scope:security` |
-| `#devops` | `scope:infrastructure` |
-| `#général` | Fallback (no scope label) |
+| Discord channel  | Scope label               |
+| ---------------- | ------------------------- |
+| `#app-mobile`    | `scope:frontend`          |
+| `#api-backend`   | `scope:backend`           |
+| `#design-system` | `scope:charte`            |
+| `#devops`        | `scope:devops`            |
+| `#site-vitrine`  | `scope:website`           |
+| `#secu-cyber`    | `scope:security`          |
+| `#devops`        | `scope:infrastructure`    |
+| `#général`       | Fallback (no scope label) |
 
 Notifications display a compact, color-coded embed with: event type, priority, size, scope, sprint, parent reference (for sub-issues), and a clickable title.
 
@@ -296,6 +316,7 @@ git push -u origin feat/issue-description
 ```
 
 Create a PR targeting `main` with:
+
 - A clear title following Conventional Commits format
 - A summary of what changed and why
 - A checklist of acceptance criteria
@@ -306,6 +327,7 @@ Create a PR targeting `main` with:
 After creating the PR, post an **informational comment** that mentions team members for visibility. This is separate from requested reviewers (which remain for blocking reviews).
 
 The comment must:
+
 - Be written in **plain, non-technical language** so that all team members (designers, product, etc.) can understand it
 - Explain **what was done** and **why**
 - Explain **what changes concretely** for the project or the product
@@ -367,11 +389,11 @@ The list of people to mention should be suggested based on the PR context (scope
 
 Tests are mandatory for every new feature.
 
-| Package | Test framework | Location |
-|---------|---------------|----------|
+| Package    | Test framework                       | Location                                         |
+| ---------- | ------------------------------------ | ------------------------------------------------ |
 | Mobile App | Jest + @testing-library/react-native | `src/features/<feature>/presentation/__tests__/` |
-| Mobile App | Jest (unit) | `src/features/<feature>/application/__tests__/` |
-| API | Jest | `src/**/*.spec.ts` and `test/**/*.e2e-spec.ts` |
+| Mobile App | Jest (unit)                          | `src/features/<feature>/application/__tests__/`  |
+| API        | Jest                                 | `src/**/*.spec.ts` and `test/**/*.e2e-spec.ts`   |
 
 ```bash
 # Run specific test file

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,117 @@ ci(monorepo): add SonarQube quality gate to CI pipeline
 docs(readme): update getting started section
 ```
 
+### Scopes used by release-please
+
+The scope in a Conventional Commit drives which package gets
+released. Use these exact scopes to benefit from automation:
+
+| Scope | Package bumped | Notes |
+|-------|----------------|-------|
+| `mobile-app`, `scan`, `auth`, `recipes`, `batches`, `ingredients`, `labels`, `shop`, `tools`, `academy`, `dashboard` | `packages/mobile-app` | Also bumps `packages/api` (lockstep group "app") |
+| `api` | `packages/api` | Also bumps `packages/mobile-app` (lockstep group "app") |
+| `website` | `packages/website` | Independent |
+| `encyclopedia` | `packages/beer-encyclopedia` | Independent |
+| `ydays`, `root`, `ci`, `monorepo` | No package — stays unreleased | Doc / infra only |
+
+Bump semantics (release-please computes automatically):
+
+- `feat(<scope>):` → **minor** bump (0.1.0 → 0.2.0)
+- `fix(<scope>):` → **patch** bump (0.1.0 → 0.1.1)
+- `feat(<scope>)!:` or `BREAKING CHANGE:` in body → **major** bump
+  (stays minor while `0.x.y`, per the `bump-minor-pre-major` setting)
+- `chore:`, `docs:`, `test:`, `ci:`, `build:`, `style:`, `refactor:`
+  → no bump (but `refactor:` + `docs:` appear in the CHANGELOG)
+
+While we ship `v0.1.0-alphaN`, every fix/feat bumps the `alphaN`
+counter (`alpha1 → alpha2 → alpha3`). To leave the alpha cycle,
+merge a commit with the body `Release-As: 0.1.0-beta1` (or
+`0.1.0-rc1`, `0.1.0`) on the release PR.
+
+---
+
+## Release Workflow
+
+Automated via **release-please** ([Google GitHub Action](https://github.com/googleapis/release-please-action))
+defined in `.github/workflows/release-please.yml` with the config
+in `release-please-config.json` and manifest in
+`.release-please-manifest.json`.
+
+### Monorepo grouping (hybrid)
+
+- **Group "app"** (lockstep): `packages/mobile-app` + `packages/api`
+  share a single `vX.Y.Z`. A commit touching either package bumps
+  both together, tag format `mobile-app-vX.Y.Z` + `api-vX.Y.Z`.
+- **Independent**: `packages/website` (tag `website-vX.Y.Z`),
+  `packages/beer-encyclopedia` (tag `encyclopedia-vX.Y.Z`). Each
+  evolves at its own rhythm.
+
+### Day-to-day flow
+
+1. Work on a feature branch (`feat/<scope>`, `fix/<scope>`, …).
+2. Commit with Conventional Commits — release-please reads these
+   messages to derive the next version.
+3. Open PR, review, merge into `main`.
+4. release-please **automatically opens / updates** a release PR
+   titled `chore(main): release <package> X.Y.Z` for each affected
+   package. Never close it manually.
+5. When you want to cut a release:
+   - Review the release PR (CHANGELOG entries, version bump)
+   - Optionally, add a `Release-As: X.Y.Z` footer commit to force a
+     specific version (e.g. transition from alpha to beta)
+   - Merge the release PR
+   - release-please automatically tags + creates the GitHub Release
+
+### What NOT to do
+
+- **Never `git tag` manually.** All tags are created by release-please.
+- **Never bump `package.json` / `app.json` / CHANGELOG by hand.**
+  Always let release-please generate the bump via the release PR.
+- **Never close a release PR.** Update it via new commits.
+- **Never push to `main` directly.** Even release PRs go through the
+  PR / merge flow.
+
+### Tag protection
+
+Ruleset `refs/tags/v*` + scoped component tags (`mobile-app-v*`,
+`api-v*`, `website-v*`, `encyclopedia-v*`) block non-admin
+creation / update / deletion. Admin bypass (`RepositoryRole: Admin`)
+is the only escape hatch for emergency corrections. See
+[.github/tag-protection.md](.github/tag-protection.md) for the apply /
+verify / remove commands.
+
+### Signing
+
+Tag signing is currently optional (private repo). Becomes **mandatory**
+before any public release (see `## Security — Public Release Checklist`
+below).
+
+### Pre-soutenance milestone schedule (2026-05-27)
+
+**Milestone-driven with a single final safety cap.** Tag as soon as
+the milestone is reached — no date pressure. The only hard cap is
+`v0.1.0` on **2026-05-26** (J-1 before soutenance) because the APK
+must be installed on the demo phone by then.
+
+Expected sequence (target, no date caps except the last one):
+
+1. `mobile-app-v0.1.0-alpha1` + `api-v0.1.0-alpha1` — audit baseline
+   (current, pending tag on first main merge)
+2. `v0.1.0-alpha2` — Auth backend wired (B-13 bis resolved)
+3. `v0.1.0-alpha3` — Scan pipeline MVP (barcode → match)
+4. `v0.1.0-beta1` — feature-complete (scan + Mes Brassins rewrite +
+   labels UI bugs fixed)
+5. `v0.1.0-rc1` — QA passed, zero known blocking bug
+6. `v0.1.0` — **2026-05-26 CAP**, cut + EAS build + APK install
+
+Self-discipline safeguards (no intermediate cap forces the call):
+
+- Auth not wired by 2026-05-10 → pivot to "Connexion démo" only
+- Scan still capture-only by 2026-05-17 → simulated recognition
+  with hardcoded demo data (jury informed honestly)
+- `beta1` not reached by 2026-05-20 → cut remaining features
+- `rc1` not reached by 2026-05-24 → panic mode, fix-bugs-only
+
 ---
 
 ## Issue Types & Templates

--- a/packages/mobile-app/CHANGELOG.md
+++ b/packages/mobile-app/CHANGELOG.md
@@ -1,14 +1,20 @@
 # Changelog — @brasse-bouillon/mobile-app
 
-Every user-visible change lands here. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) +
-strict semver prefixed `v` (`vMAJOR.MINOR.PATCH`, prereleases `-alphaN` /
-`-betaN` / `-rcN` per the repo-wide tag convention in the root
-[CONTRIBUTING.md](../../CONTRIBUTING.md) and global CLAUDE rules).
+Every user-visible change lands here. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+with strict semver prereleases (`-alphaN` / `-betaN` / `-rcN`).
+
+Tags for this package follow the monorepo component pattern
+**`mobile-app-vX.Y.Z`** (not plain `vX.Y.Z`) — see the release
+workflow in the root [CONTRIBUTING.md](../../CONTRIBUTING.md#release-workflow)
+for the full convention.
 
 Tag lifecycle:
 
-- Lightweight or annotated tags created from `main` only, after the
-  release PR merges the version bump + this CHANGELOG.
+- Tags are created **automatically by release-please** when the release
+  PR is merged into `main`. Do not create tags manually.
+- Once created, tags are immutable (update / deletion blocked by
+  repository ruleset — see
+  [.github/tag-protection.md](../../.github/tag-protection.md)).
 - Failed publishes keep their tag as an audit marker — never delete,
   always bump to the next version.
 - No tag reuse, ever.
@@ -17,10 +23,10 @@ Tag lifecycle:
 
 ### Planned for `v0.1.0`
 
-See the full backlog in the plan file
-`~/.claude/plans/si-tu-te-souviens-sorted-lark.md` (69 items B-01 → B-69)
-and the 9 dedicated brainstorms. Top items blocking the soutenance
-2026-05-27 demo:
+Tracked as GitHub issues on the [Brasse-Bouillon project board](https://github.com/users/benoit-bremaud/projects/38)
+with the `audit:v0` label (74 issues from the v0 mobile-app screenshot
+audit, organised in 8 user-journey tiers). Top items blocking the
+soutenance 2026-05-27 demo:
 
 - **B-39** Scan recognition + recipe match + community + import pipeline
   (⭐ demo hero — currently capture-only)
@@ -64,12 +70,20 @@ The audit drives the entire refactor backlog.
 
 ### Notes
 
-- No `v0.1.0-alpha1` git tag has been created yet. Per the global tag
-  convention, the tag cuts from `main` only, after the release PR
-  merges. The owner creates the tag via CLI (`git tag v0.1.0-alpha1 &&
-git push origin v0.1.0-alpha1`).
+- No `mobile-app-v0.1.0-alpha1` git tag has been created yet. Tags
+  are created **automatically by release-please** once a release PR
+  merges into `main`. Since `0.1.0-alpha1` was the manifest baseline
+  (not a release), it has no tag; the first auto-tag will be
+  `mobile-app-v0.1.0-alpha2` after the first fix/feat commit lands
+  on main.
 - Android `versionName` / `versionCode` + iOS `CFBundle*` are managed
-  by Expo at build time; no manual override needed at this stage.
+  by Expo at build time; no manual override needed at this stage. Note
+  that the `-alphaN` prerelease suffix in `expo.version` is tolerated
+  for Android but not a valid `CFBundleShortVersionString` for iOS —
+  not an issue for the 2026-05-27 soutenance (Android demo only), but
+  a future iOS build will need Expo's
+  [runtime-version policy](https://docs.expo.dev/eas-update/runtime-versions/)
+  to translate the prerelease into a valid bundle short version.
 - The "About" version line inside the app (Compte & Paramètres screen)
   is scoped with the merged screen (B-45 / B-46) and will ship with
   `v0.1.0-alpha2` or later.

--- a/packages/mobile-app/CHANGELOG.md
+++ b/packages/mobile-app/CHANGELOG.md
@@ -67,7 +67,7 @@ The audit drives the entire refactor backlog.
 - No `v0.1.0-alpha1` git tag has been created yet. Per the global tag
   convention, the tag cuts from `main` only, after the release PR
   merges. The owner creates the tag via CLI (`git tag v0.1.0-alpha1 &&
-  git push origin v0.1.0-alpha1`).
+git push origin v0.1.0-alpha1`).
 - Android `versionName` / `versionCode` + iOS `CFBundle*` are managed
   by Expo at build time; no manual override needed at this stage.
 - The "About" version line inside the app (Compte & Paramètres screen)

--- a/packages/mobile-app/CHANGELOG.md
+++ b/packages/mobile-app/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog — @brasse-bouillon/mobile-app
+
+Every user-visible change lands here. Follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) +
+strict semver prefixed `v` (`vMAJOR.MINOR.PATCH`, prereleases `-alphaN` /
+`-betaN` / `-rcN` per the repo-wide tag convention in the root
+[CONTRIBUTING.md](../../CONTRIBUTING.md) and global CLAUDE rules).
+
+Tag lifecycle:
+
+- Lightweight or annotated tags created from `main` only, after the
+  release PR merges the version bump + this CHANGELOG.
+- Failed publishes keep their tag as an audit marker — never delete,
+  always bump to the next version.
+- No tag reuse, ever.
+
+## [Unreleased]
+
+### Planned for `v0.1.0`
+
+See the full backlog in the plan file
+`~/.claude/plans/si-tu-te-souviens-sorted-lark.md` (69 items B-01 → B-69)
+and the 9 dedicated brainstorms. Top items blocking the soutenance
+2026-05-27 demo:
+
+- **B-39** Scan recognition + recipe match + community + import pipeline
+  (⭐ demo hero — currently capture-only)
+- **B-13 bis** Wire the Auth backend so real login / signup / forgot
+  password succeed (today all three return `Network request failed`)
+- **B-08** Rewrite Mes Brassins detail with real metadata, timestamps,
+  measurements, notes, recipe FK, photos
+- **B-28 / B-29** Fix Labels UI bugs (validation CTA hidden behind tab
+  bar, live preview clipped)
+- **B-45** Merge Paramètres globaux into the Profil screen (KISS/YAGNI/DRY)
+- **B-65** Remove the redundant Explore hub
+- **B-69** Move "Période d'analyse" out of the home into a dedicated
+  Statistiques section
+
+## [0.1.0-alpha1] — 2026-04-23 — Pre-soutenance audit baseline
+
+First explicit version of the app. Resets the accidental scaffold-default
+`1.0.0` in `package.json` + `app.json` down to an honest alpha: the
+backend is not wired (B-13 bis), core flows are incomplete (scan
+recognition, batch detail, shop e-commerce), and many UX issues remain.
+Calling this `1.0.0` would have been misleading.
+
+This version freezes the **v0 screenshot audit** — 204 captures of every
+reachable screen — under
+[docs/ydays/public/screenshots/v0/](../../docs/ydays/public/screenshots/v0/).
+The audit drives the entire refactor backlog.
+
+### Added
+
+- `packages/mobile-app/CHANGELOG.md` (this file).
+- Version strings in `package.json` and `app.json` set to
+  `0.1.0-alpha1`.
+
+### Known limitations (carried forward)
+
+- Auth backend unwired — use `Connexion démo` only.
+- Scan flow captures but does not recognise / match / import.
+- Mes Brassins detail shows only a 3-step hardcoded timeline.
+- Labels validation CTA hidden behind the bottom tab bar.
+- Shop is catalogue-preview only (`À VENIR` everywhere).
+
+### Notes
+
+- No `v0.1.0-alpha1` git tag has been created yet. Per the global tag
+  convention, the tag cuts from `main` only, after the release PR
+  merges. The owner creates the tag via CLI (`git tag v0.1.0-alpha1 &&
+  git push origin v0.1.0-alpha1`).
+- Android `versionName` / `versionCode` + iOS `CFBundle*` are managed
+  by Expo at build time; no manual override needed at this stage.
+- The "About" version line inside the app (Compte & Paramètres screen)
+  is scoped with the merged screen (B-45 / B-46) and will ship with
+  `v0.1.0-alpha2` or later.

--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Brasse Bouillon",
     "slug": "brasse-bouillon-mobile-app",
-    "version": "1.0.0",
+    "version": "0.1.0-alpha1",
     "orientation": "portrait",
     "icon": "./assets/images/brasse-bouillon-logo-primary-512.png",
     "scheme": "brassebouillonmobileapp",

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brasse-bouillon/mobile-app",
   "main": "expo-router/entry",
-  "version": "1.0.0",
+  "version": "0.1.0-alpha1",
   "scripts": {
     "start": "expo start",
     "start:lan": "expo start --lan",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "node",
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "prerelease": true,
+  "prerelease-type": "alpha",
+  "include-v-in-tag": true,
+  "include-component-in-tag": true,
+  "separate-pull-requests": true,
+  "changelog-sections": [
+    { "type": "feat", "section": "Features", "hidden": false },
+    { "type": "fix", "section": "Bug Fixes", "hidden": false },
+    { "type": "perf", "section": "Performance", "hidden": false },
+    { "type": "refactor", "section": "Refactors", "hidden": false },
+    { "type": "docs", "section": "Documentation", "hidden": false },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build", "hidden": true },
+    { "type": "ci", "section": "CI", "hidden": true },
+    { "type": "chore", "section": "Chores", "hidden": true },
+    { "type": "style", "section": "Style", "hidden": true }
+  ],
+  "packages": {
+    "packages/mobile-app": {
+      "release-type": "node",
+      "package-name": "@brasse-bouillon/mobile-app",
+      "component": "mobile-app",
+      "extra-files": ["app.json"]
+    },
+    "packages/api": {
+      "release-type": "node",
+      "package-name": "@brasse-bouillon/api",
+      "component": "api"
+    },
+    "packages/website": {
+      "release-type": "node",
+      "package-name": "@brasse-bouillon/website",
+      "component": "website"
+    },
+    "packages/beer-encyclopedia": {
+      "release-type": "python",
+      "package-name": "beer-encyclopedia",
+      "component": "encyclopedia"
+    }
+  },
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "app",
+      "components": ["mobile-app", "api"]
+    }
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,7 +29,7 @@
     },
     "packages/api": {
       "release-type": "node",
-      "package-name": "@brasse-bouillon/api",
+      "package-name": "brasse-bouillon-backend",
       "component": "api"
     },
     "packages/website": {


### PR DESCRIPTION
## Summary

Activates release-please automation for the monorepo and baselines the mobile-app version to \`v0.1.0-alpha1\` — the starting point for the pre-soutenance release cycle.

Two commits cherry-picked from [\`docs/soutenance-27-mai\`](https://github.com/benoit-bremaud/brasse-bouillon/tree/docs/soutenance-27-mai) (the craft PR #578 which stays open as narrative for the soutenance):

- **\`8ce5527\` — \`chore(mobile-app): baseline version v0.1.0-alpha1 + introduce CHANGELOG\`**
  Bumps \`packages/mobile-app/package.json\` + \`app.json\` from the accidental \`1.0.0\` scaffold default down to an honest \`0.1.0-alpha1\` reflecting the real state of the app (backend not wired, scan capture-only, Labels UI bugs). Adds \`packages/mobile-app/CHANGELOG.md\` with an Unreleased section + initial \`[0.1.0-alpha1]\` entry documenting known limitations.

- **\`557817a\` — \`chore(ci): set up release-please automation + tag protection ruleset\`**
  Addresses the 4 validated strategic axes of the Versioning & Release brainstorm (2026-04-23):
  - **Axis C (monorepo hybrid)**: \`release-please-config.json\` with a \`linked-versions\` plugin grouping mobile-app + api lockstep under a single \`vX.Y.Z\`; website + beer-encyclopedia independent.
  - **Axis D (workflow)**: \`.github/workflows/release-please.yml\` — triggers on push to main, auto-opens/updates a release PR per package, auto-tags on merge. Zero manual \`git tag\`.
  - **Axis A (cadence)**: \`prerelease: true\` + \`prerelease-type: alpha\` — \`alpha1 → alpha2 → alpha3\` happens automatically on feat/fix commits.
  - **Axis H (tag-protection)**: ruleset \`refs/tags/v*\` + all component patterns already applied via \`gh api\` (ruleset id \`15481614\`). Doc in \`.github/tag-protection.md\`.
  - \`CONTRIBUTING.md\` enriched with Conv Commits scope-to-package mapping + full Release Workflow section + pre-soutenance milestone schedule.

## Why this PR is separate from PR #578

Per user decision (2026-04-23), PR #578 (craft narrative) stays open until near soutenance as visible deliverable for the jury. But release-please needs its config on main to activate. This PR cherry-picks only the 2 infra commits to unblock automation without touching the craft PR. Zero feature change, pure infrastructure.

## What happens after merge

1. release-please workflow runs on the merge commit
2. It sees the existing Conv Commits history (this PR + future PRs) and opens a release PR titled \`chore(main): release mobile-app 0.1.0-alpha2\`
3. Every subsequent \`feat(scope):\` / \`fix(scope):\` commit to main updates this release PR
4. When we want to cut a tag, we merge the release PR → \`mobile-app-v0.1.0-alpha2\` is auto-tagged with GitHub Release + CHANGELOG body

## Checklist

- [x] Branch \`chore/versioning-baseline\` created from \`main\`
- [x] Cherry-pick of \`8ce5527\` clean (no conflicts)
- [x] Cherry-pick of \`557817a\` clean (no conflicts)
- [x] Tag-protection ruleset \`refs/tags/v*\` already applied (id \`15481614\`)
- [ ] CI passes
- [ ] Copilot review posted
- [ ] All comments addressed

## Closes

- B-66 from the v0 audit (mobile app has no semver / git tag / CHANGELOG)
- Unblocks the release cycle for every subsequent PR

Closes #618