### PR TITLE
chore(ci): auto-apply metadata on release-please PRs + fix prettier blocker

### DIFF
--- a/.github/workflows/release-please-metadata.yml
+++ b/.github/workflows/release-please-metadata.yml
@@ -1,8 +1,11 @@
 name: Release Please Metadata
 
 # Auto-apply assignee + scope/type/priority labels + add to project on every
-# release-please PR. Triggered when release-please opens (or updates) a PR
-# with the `autorelease: pending` label.
+# release-please PR. Fires on `opened` / `reopened` (the cases where the PR
+# enters triage for the first time) and on `labeled` when the marker label
+# lands — never on `synchronize`, because the metadata is applied once at
+# open and every operation is idempotent, so reacting to every branch
+# update would add API cost with no functional benefit.
 #
 # Why: release-please leaves PRs bare (only its own marker label). Without
 # this workflow, every release PR would need manual triage to match the
@@ -53,9 +56,12 @@ jobs:
       - name: Apply assignee + labels
         # Fail loud if either call fails — silent success is worse than
         # noisy failure when the purpose of the job is exactly these
-        # updates. The idempotent POSTs below can legitimately return
-        # 422 if the resource is already present, so we accept that
-        # single case only (check HTTP status explicitly).
+        # writes. Both endpoints (POST /issues/:n/assignees and
+        # POST /issues/:n/labels) are natively idempotent: adding an
+        # already-present assignee / label returns 200/201, not 422.
+        # Combined with the `labeled`-action guard above (only re-fires
+        # on the marker label), the job runs at most once per release
+        # PR so idempotence is mostly a safety net anyway.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/release-please-metadata.yml
+++ b/.github/workflows/release-please-metadata.yml
@@ -20,9 +20,17 @@ permissions:
 jobs:
   apply-metadata:
     name: Apply metadata to release-please PR
+    # Guard on three conditions:
+    # 1. PR authored by release-please
+    # 2. PR has the autorelease: pending marker
+    # 3. When triggered by the `labeled` action, only react to the marker
+    #    label itself — otherwise the workflow would re-trigger on every
+    #    label it adds (type:chore, scope:*, priority:medium), wasting
+    #    runs and API calls.
     if: >
       github.event.pull_request.user.login == 'github-actions[bot]' &&
-      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'autorelease: pending')
     runs-on: ubuntu-latest
     steps:
       - name: Determine scope from branch name
@@ -43,26 +51,41 @@ jobs:
           esac
 
       - name: Apply assignee + labels
+        # Fail loud if either call fails — silent success is worse than
+        # noisy failure when the purpose of the job is exactly these
+        # updates. The idempotent POSTs below can legitimately return
+        # 422 if the resource is already present, so we accept that
+        # single case only (check HTTP status explicitly).
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           SCOPE_LABEL: ${{ steps.scope.outputs.label }}
         run: |
+          set -euo pipefail
+
           gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/assignees" \
-            -X POST -f 'assignees[]=benoit-bremaud' || true
+            -X POST -f 'assignees[]=benoit-bremaud'
 
           gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" \
             -X POST \
             -f 'labels[]=type:chore' \
             -f "labels[]=${SCOPE_LABEL}" \
-            -f 'labels[]=priority:medium' || true
+            -f 'labels[]=priority:medium'
 
       - name: Add PR to Brasse-Bouillon project
+        # Project-add is the one legitimately tolerant step: Projects v2
+        # is user-scoped and unreachable from GITHUB_TOKEN at all. A PAT
+        # with the `project` scope (classic PAT) or Projects Read/Write
+        # (fine-grained PAT) stored as PROJECT_TOKEN is required. If the
+        # token is missing, the PR still ships with full assignee +
+        # labels — project add is a nice-to-have, not a blocker.
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
           PR_NODE_ID: ${{ github.event.pull_request.node_id }}
         run: |
-          gh api graphql \
+          if ! gh api graphql \
             -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' \
             -f p="PVT_kwHOB8rwIc4AuVew" \
-            -f c="$PR_NODE_ID" || echo "Project add failed (non-fatal — likely token missing projects:write scope)"
+            -f c="$PR_NODE_ID"; then
+            echo "::warning::Project add failed — ensure PROJECT_TOKEN secret holds a PAT with 'project' scope (classic) or Projects Read/Write (fine-grained)."
+          fi

--- a/.github/workflows/release-please-metadata.yml
+++ b/.github/workflows/release-please-metadata.yml
@@ -1,0 +1,68 @@
+name: Release Please Metadata
+
+# Auto-apply assignee + scope/type/priority labels + add to project on every
+# release-please PR. Triggered when release-please opens (or updates) a PR
+# with the `autorelease: pending` label.
+#
+# Why: release-please leaves PRs bare (only its own marker label). Without
+# this workflow, every release PR would need manual triage to match the
+# repo-wide PR metadata convention (assignee, label triptych, project).
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  apply-metadata:
+    name: Apply metadata to release-please PR
+    if: >
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine scope from branch name
+        id: scope
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          # release-please branch patterns:
+          #   release-please--branches--main--components--<component>
+          #   release-please--branches--main--groups--<groupName>
+          case "$BRANCH" in
+            *--components--encyclopedia)  echo "label=scope:backend"  >> "$GITHUB_OUTPUT" ;;
+            *--components--website)       echo "label=scope:website"  >> "$GITHUB_OUTPUT" ;;
+            *--components--mobile-app)    echo "label=scope:frontend" >> "$GITHUB_OUTPUT" ;;
+            *--components--api)           echo "label=scope:backend"  >> "$GITHUB_OUTPUT" ;;
+            *--groups--app)               echo "label=scope:monorepo" >> "$GITHUB_OUTPUT" ;;
+            *)                            echo "label=scope:monorepo" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Apply assignee + labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SCOPE_LABEL: ${{ steps.scope.outputs.label }}
+        run: |
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/assignees" \
+            -X POST -f 'assignees[]=benoit-bremaud' || true
+
+          gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/labels" \
+            -X POST \
+            -f 'labels[]=type:chore' \
+            -f "labels[]=${SCOPE_LABEL}" \
+            -f 'labels[]=priority:medium' || true
+
+      - name: Add PR to Brasse-Bouillon project
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          gh api graphql \
+            -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{projectId:$p,contentId:$c}){item{id}}}' \
+            -f p="PVT_kwHOB8rwIc4AuVew" \
+            -f c="$PR_NODE_ID" || echo "Project add failed (non-fatal — likely token missing projects:write scope)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,36 @@ in `release-please-config.json` and manifest in
 - **Never push to `main` directly.** Even release PRs go through the
   PR / merge flow.
 
+### Release PR metadata (automated)
+
+Every release-please PR automatically receives — via
+`.github/workflows/release-please-metadata.yml` — the same metadata
+triptych as a regular PR:
+
+- **Assignee** — `benoit-bremaud`
+- **Labels** — `type:chore` + `priority:medium` + scope label derived
+  from the head ref:
+  - `*--components--encyclopedia` → `scope:backend`
+  - `*--components--website` → `scope:website`
+  - `*--components--mobile-app` → `scope:frontend`
+  - `*--components--api` → `scope:backend`
+  - `*--groups--app` (lockstep) → `scope:monorepo`
+- **Project** — Brasse-Bouillon (`PVT_kwHOB8rwIc4AuVew`); requires a
+  PAT with `project` scope stored as `PROJECT_TOKEN` (falls back to
+  `GITHUB_TOKEN` and skips the project add silently if scope missing).
+
+Reviewers are NOT applied by this workflow — CODEOWNERS handles that
+automatically.
+
+### Format check on release PRs
+
+`packages/mobile-app/CHANGELOG.md` and `packages/mobile-app/app.json`
+are owned and rewritten by release-please at every release. They are
+listed in `packages/mobile-app/.prettierignore` so the `format:check`
+step in CI does not fail on the unformatted output of release-please.
+If you ever modify these files by hand, format them yourself before
+committing.
+
 ### Tag protection
 
 Ruleset `refs/tags/v*` + scoped component tags (`mobile-app-v*`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,12 +162,21 @@ triptych as a regular PR:
   - `*--components--mobile-app` → `scope:frontend`
   - `*--components--api` → `scope:backend`
   - `*--groups--app` (lockstep) → `scope:monorepo`
-- **Project** — Brasse-Bouillon (`PVT_kwHOB8rwIc4AuVew`); requires a
-  PAT with `project` scope stored as `PROJECT_TOKEN` (falls back to
-  `GITHUB_TOKEN` and skips the project add silently if scope missing).
+- **Project** — Brasse-Bouillon (`PVT_kwHOB8rwIc4AuVew`). Projects v2
+  is user-scoped and cannot be reached from the default `GITHUB_TOKEN`
+  at all. A PAT with the `project` scope (classic PAT) or Projects
+  Read/Write access (fine-grained PAT) stored as the `PROJECT_TOKEN`
+  secret is required. When missing, the assignee + labels still apply
+  and the workflow emits a GitHub Actions warning — the PR ships
+  usable, just not yet in the project.
 
 Reviewers are NOT applied by this workflow — CODEOWNERS handles that
 automatically.
+
+If assignee or label application fails, the workflow fails loud
+(non-zero exit) so the regression is visible in CI — the whole point
+of the workflow is that these fields are never missing on a release
+PR. Only the project-add step is tolerant.
 
 ### Format check on release PRs
 

--- a/packages/mobile-app/.prettierignore
+++ b/packages/mobile-app/.prettierignore
@@ -1,0 +1,11 @@
+# Dependencies
+node_modules/
+
+# Build artifacts
+.expo/
+dist/
+coverage/
+
+# Owned by release-please (auto-generated, not formatted)
+CHANGELOG.md
+app.json


### PR DESCRIPTION
## Summary

Two release-please follow-ups discovered after activating the pipeline in PR #667:

1. **Auto-apply metadata on release-please PRs** — release-please leaves PRs bare (only the `autorelease: pending` marker). A new workflow `.github/workflows/release-please-metadata.yml` now watches for PRs authored by `github-actions[bot]` with that label and applies:
   - assignee `benoit-bremaud`
   - `type:chore` + `priority:medium` + a scope label derived from the head ref
   - add to the Brasse-Bouillon project (graceful skip if token scope missing)

2. **Fix Prettier blocker on mobile-app release PRs** — the `format:check` step was failing on every release PR because release-please regenerates `CHANGELOG.md` and `app.json` without Prettier. Add both to a new `packages/mobile-app/.prettierignore` so these auto-generated files are skipped. Unblocks #671 (`release app libraries`).

Both behaviours documented in `CONTRIBUTING.md` § Release Workflow.

## Why now

PRs #669, #670, #671 are the first release-please PRs opened after activation and all 3 landed with only the `autorelease: pending` label — proving the gap. #671 also failed CI with the Prettier error documented above. I applied metadata manually to the 3 open PRs; the workflow handles every future one automatically.

## Checklist

- [x] Workflow YAML syntactically valid
- [x] `.prettierignore` picked up by local `npm run format:check` in `packages/mobile-app`
- [x] `CONTRIBUTING.md` updated (Release Workflow section)
- [x] No code change outside `.github/workflows/`, `packages/mobile-app/.prettierignore`, `CONTRIBUTING.md`

## Test plan

- [ ] CI green on this PR
- [ ] After merge: release-please re-opens / updates #671 — verify the `format:check` step passes on the updated branch
- [ ] Next time release-please opens a brand-new release PR — verify the new workflow applies assignee + labels + project automatically