### PR TITLE
chore(ci): add workflow_dispatch to release-please for manual retry

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  # Manual escape hatch — needed when a merged release PR is left with
+  # `autorelease: pending` (race condition in release-please-action that
+  # occasionally aborts with "There are untagged, merged release PRs
+  # outstanding"). Re-triggering the workflow picks up the pending PRs
+  # and cuts the tags.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

`release-please-action@v4` aborted mid-run after PR #671 merged with:

```
⚠ There are untagged, merged release PRs outstanding - aborting
```

Result: no `mobile-app-v0.1.1-alpha1` / `api-v0.1.1-alpha1` tags created despite CI reporting success. The fix per release-please docs is to re-run the workflow — but our workflow only triggers on push to main, so there is no manual retry path today.

This PR adds `workflow_dispatch:` so operators can re-fire release-please on demand via `gh workflow run "Release Please"` or the Actions UI.

**Secondary effect**: merging this PR triggers release-please via the `push` event, which should finally cut the missing tags for #671.

## Checklist

- [x] Single-line addition to `.github/workflows/release-please.yml`
- [x] No semantic change to existing triggers
- [x] Comment explains the race condition and when to use the manual trigger

## Test plan

- [ ] CI green
- [ ] After merge: release-please auto-fires on push → detects #671 pending tags → creates `mobile-app-v0.1.1-alpha1` + `api-v0.1.1-alpha1`
- [ ] Confirm `gh workflow run \"Release Please\" --ref main` works manually afterward