### PR TITLE
fix(ci): set release-please group PR title pattern to include version

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -5,6 +5,50 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ---
 
+## 2026-04-24
+
+### Release-please pipeline activation + first releases ([PR #667](https://github.com/benoit-bremaud/brasse-bouillon/pull/667), [#668](https://github.com/benoit-bremaud/brasse-bouillon/pull/668), [#669](https://github.com/benoit-bremaud/brasse-bouillon/pull/669), [#670](https://github.com/benoit-bremaud/brasse-bouillon/pull/670), [#671](https://github.com/benoit-bremaud/brasse-bouillon/pull/671), [#672](https://github.com/benoit-bremaud/brasse-bouillon/pull/672), [#675](https://github.com/benoit-bremaud/brasse-bouillon/pull/675), [#676](https://github.com/benoit-bremaud/brasse-bouillon/pull/676))
+
+End-to-end activation of the release-please automation, with 4 packages
+going through their first automated release cycle. Sequence of PRs:
+
+- #667 — set up `release-please-config.json`, manifest, workflow, and
+  the `refs/tags/v*` tag-protection ruleset.
+- #668 — fix #623 Ingredients home counter + fix CI coverage reporter
+  (`--coverageReporters=lcov,text` split into two flags).
+- #669 — first release-please-generated PR: `encyclopedia-v0.2.1` cut.
+- #670 — `website-v0.1.1` cut (manifest merge conflict resolved
+  manually because release-please did not auto-rebase).
+- #672 — auto-apply metadata workflow on release PRs + Prettier
+  ignore for CHANGELOG/app.json (unblocks mobile-app CI on release
+  PRs).
+- #671 — app libs release PR merged; **release-please aborted** with
+  "There are untagged, merged release PRs outstanding" because the
+  default group PR title template (`chore${scope}: release ${component}`)
+  omits `${version}`, so release-please could not parse the merged PR
+  title. Tags `mobile-app-v0.1.1-alpha1` and `api-v0.1.1-alpha1` had
+  to be created manually via `gh release create` at commit `3240639`,
+  and PR #671 label flipped `autorelease: pending` →
+  `autorelease: tagged`.
+- #675 — add `workflow_dispatch` to release-please.yml so operators
+  can retry manually via `gh workflow run "Release Please"` if the
+  state machine gets stuck.
+- #676 — fix the group PR title template
+  (`chore${scope}: release app libraries ${version}`) so future
+  app-group releases produce parseable titles and do not need manual
+  tagging.
+
+Also opened 2 tracking follow-ups from Copilot review:
+- #673 — align `packages/beer-encyclopedia/package.json` version with
+  `pyproject.toml` (drift every release).
+- #674 — delete vestigial per-package `packages/*/package-lock.json`
+  files (npm workspaces uses only the root lockfile; these are
+  pre-monorepo leftovers).
+
+Tags produced today (all immutable via `refs/tags/v*` ruleset):
+`encyclopedia-v0.2.1`, `website-v0.1.1`, `mobile-app-v0.1.1-alpha1`,
+`api-v0.1.1-alpha1`.
+
 ## 2026-04-22
 
 ### Root README refactor for dev onboarding ([PR #572](https://github.com/benoit-bremaud/brasse-bouillon/pull/572))

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -49,5 +49,6 @@
       "groupName": "app",
       "components": ["mobile-app", "api"]
     }
-  ]
+  ],
+  "group-pull-request-title-pattern": "chore${scope}: release app libraries ${version}"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -50,5 +50,5 @@
       "components": ["mobile-app", "api"]
     }
   ],
-  "group-pull-request-title-pattern": "chore${scope}: release app libraries ${version}"
+  "group-pull-request-title-pattern": "chore${scope}: release ${component} ${version}"
 }


### PR DESCRIPTION
## Summary

Fixes the root cause of the missing `mobile-app-v0.1.1-alpha1` / `api-v0.1.1-alpha1` tags after #671 merged. The `linked-versions` plugin's default group PR title template is `chore\${scope}: release \${component}` — **missing `\${version}`**. When the release PR merges, release-please tries to parse the merged PR title to extract the version to tag, fails with "Bad pull request title", and aborts without creating the tags.

Adding `group-pull-request-title-pattern` at root level with `\${version}` fixes future app-group releases.

## What I had to do manually for #671

Since release-please aborted, I created the tags + releases manually:

- `mobile-app-v0.1.1-alpha1` → tag + GitHub Pre-release at commit `3240639`
- `api-v0.1.1-alpha1` → tag + GitHub Pre-release at commit `3240639`
- PR #671 label flipped `autorelease: pending` → `autorelease: tagged`

See `PROJECT_LOG.md` entry (added in a follow-up commit) for the incident trail.

## Checklist

- [x] Single-line addition to `release-please-config.json`
- [x] Preserves existing linked-versions plugin behaviour
- [x] Format includes `\${version}` (the fix) and `\${scope}` / `\${component}` for future-compat

## Test plan

- [ ] CI green on this PR
- [ ] After merge, next commit touching `packages/mobile-app/**` or `packages/api/**` opens a release PR with title like `chore(main): release app libraries 0.1.2-alpha1` (not `release app libraries` alone)
- [ ] Merging that release PR cuts both `mobile-app-v*` and `api-v*` tags cleanly, no manual intervention needed