### PR TITLE
fix(labels): clear bottom tab bar on Sélection CTA and Éditeur preview

### DIFF
--- a/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
@@ -22,7 +22,14 @@ import {
 } from "@/features/labels/presentation/label-template.constants";
 import { Href, useRouter } from "expo-router";
 import React, { useCallback, useMemo, useState } from "react";
-import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
 
 import { getErrorMessage } from "@/core/http/http-error";
 import { normalizeRouteParam } from "@/core/navigation/route-params";
@@ -30,6 +37,7 @@ import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
+import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
 
@@ -49,6 +57,7 @@ function toButtonLabel(isSaving: boolean): string {
 
 export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
   const router = useRouter();
+  const navigationFooterOffset = useNavigationFooterOffset();
   const normalizedDraftId = normalizeRouteParam(draftIdParam) ?? "";
 
   const [draft, setDraft] = useState<LabelDraft | null>(null);
@@ -205,210 +214,225 @@ export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
         }
       />
 
-      <Card style={styles.sectionCard}>
-        <Text style={styles.sectionTitle}>Texte</Text>
-
-        <Text style={styles.fieldLabel}>Nom</Text>
-        <TextInput
-          accessibilityLabel="Modifier le nom de l’étiquette"
-          value={name}
-          onChangeText={setName}
-          placeholder="Nom de la bière"
-          placeholderTextColor={colors.neutral.muted}
-          style={styles.input}
-          autoCorrect={false}
-          autoCapitalize="words"
-        />
-
-        <Text style={styles.fieldLabel}>Sous-titre</Text>
-        <TextInput
-          accessibilityLabel="Modifier le sous-titre de l’étiquette"
-          value={subtitle}
-          onChangeText={setSubtitle}
-          placeholder="Style / variante"
-          placeholderTextColor={colors.neutral.muted}
-          style={styles.input}
-          autoCorrect={false}
-          autoCapitalize="words"
-        />
-      </Card>
-
-      <Card style={styles.sectionCard}>
-        <Text style={styles.sectionTitle}>Palette</Text>
-        <View style={styles.chipsWrap}>
-          {LABEL_PALETTE_OPTIONS.map((option) => {
-            const isSelected = option.id === selectedPaletteId;
-
-            return (
-              <Pressable
-                key={option.id}
-                accessibilityRole="button"
-                accessibilityLabel={`Sélectionner la palette ${option.label}`}
-                style={[styles.chip, isSelected && styles.chipSelected]}
-                onPress={() => setSelectedPaletteId(option.id)}
-              >
-                <Text
-                  style={[
-                    styles.chipText,
-                    isSelected && styles.chipTextSelected,
-                  ]}
-                >
-                  {option.label}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-
-        <Text style={styles.sectionTitle}>Icône</Text>
-        <View style={styles.chipsWrap}>
-          {LABEL_ICON_OPTIONS.map((option) => {
-            const isSelected = option.id === selectedIconId;
-
-            return (
-              <Pressable
-                key={option.id}
-                accessibilityRole="button"
-                accessibilityLabel={`Sélectionner l’icône ${option.label}`}
-                style={[styles.chip, isSelected && styles.chipSelected]}
-                onPress={() => setSelectedIconId(option.id)}
-              >
-                <Text
-                  style={[
-                    styles.chipText,
-                    isSelected && styles.chipTextSelected,
-                  ]}
-                >
-                  {option.symbol} {option.label}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-      </Card>
-
-      <Card style={styles.sectionCard}>
-        <Text style={styles.sectionTitle}>Modèle</Text>
-
-        <View style={styles.chipsWrap}>
-          {LABEL_BOTTLE_FORMAT_OPTIONS.map((option) => {
-            const isSelected = option.id === selectedBottleFormat;
-
-            return (
-              <Pressable
-                key={option.id}
-                accessibilityRole="button"
-                accessibilityLabel={`Sélectionner le format ${option.label}`}
-                style={[styles.chip, isSelected && styles.chipSelected]}
-                onPress={() => setSelectedBottleFormat(option.id)}
-              >
-                <Text
-                  style={[
-                    styles.chipText,
-                    isSelected && styles.chipTextSelected,
-                  ]}
-                >
-                  {option.label}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-
-        <View style={styles.chipsWrap}>
-          {LABEL_TEMPLATE_OPTIONS.map((option) => {
-            const isSelected = option.id === selectedTemplateId;
-
-            return (
-              <Pressable
-                key={option.id}
-                accessibilityRole="button"
-                accessibilityLabel={`Sélectionner le template ${option.label}`}
-                style={[styles.chip, isSelected && styles.chipSelected]}
-                onPress={() => setSelectedTemplateId(option.id)}
-              >
-                <Text
-                  style={[
-                    styles.chipText,
-                    isSelected && styles.chipTextSelected,
-                  ]}
-                >
-                  {option.label}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-      </Card>
-
-      <Card
-        style={[
-          styles.previewCard,
-          { backgroundColor: selectedPalette.backgroundColor },
+      <ScrollView
+        style={styles.scrollContainer}
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: navigationFooterOffset },
         ]}
+        showsVerticalScrollIndicator={false}
       >
-        <Text
+        <Card style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>Texte</Text>
+
+          <Text style={styles.fieldLabel}>Nom</Text>
+          <TextInput
+            accessibilityLabel="Modifier le nom de l’étiquette"
+            value={name}
+            onChangeText={setName}
+            placeholder="Nom de la bière"
+            placeholderTextColor={colors.neutral.muted}
+            style={styles.input}
+            autoCorrect={false}
+            autoCapitalize="words"
+          />
+
+          <Text style={styles.fieldLabel}>Sous-titre</Text>
+          <TextInput
+            accessibilityLabel="Modifier le sous-titre de l’étiquette"
+            value={subtitle}
+            onChangeText={setSubtitle}
+            placeholder="Style / variante"
+            placeholderTextColor={colors.neutral.muted}
+            style={styles.input}
+            autoCorrect={false}
+            autoCapitalize="words"
+          />
+        </Card>
+
+        <Card style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>Palette</Text>
+          <View style={styles.chipsWrap}>
+            {LABEL_PALETTE_OPTIONS.map((option) => {
+              const isSelected = option.id === selectedPaletteId;
+
+              return (
+                <Pressable
+                  key={option.id}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Sélectionner la palette ${option.label}`}
+                  style={[styles.chip, isSelected && styles.chipSelected]}
+                  onPress={() => setSelectedPaletteId(option.id)}
+                >
+                  <Text
+                    style={[
+                      styles.chipText,
+                      isSelected && styles.chipTextSelected,
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text style={styles.sectionTitle}>Icône</Text>
+          <View style={styles.chipsWrap}>
+            {LABEL_ICON_OPTIONS.map((option) => {
+              const isSelected = option.id === selectedIconId;
+
+              return (
+                <Pressable
+                  key={option.id}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Sélectionner l’icône ${option.label}`}
+                  style={[styles.chip, isSelected && styles.chipSelected]}
+                  onPress={() => setSelectedIconId(option.id)}
+                >
+                  <Text
+                    style={[
+                      styles.chipText,
+                      isSelected && styles.chipTextSelected,
+                    ]}
+                  >
+                    {option.symbol} {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </Card>
+
+        <Card style={styles.sectionCard}>
+          <Text style={styles.sectionTitle}>Modèle</Text>
+
+          <View style={styles.chipsWrap}>
+            {LABEL_BOTTLE_FORMAT_OPTIONS.map((option) => {
+              const isSelected = option.id === selectedBottleFormat;
+
+              return (
+                <Pressable
+                  key={option.id}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Sélectionner le format ${option.label}`}
+                  style={[styles.chip, isSelected && styles.chipSelected]}
+                  onPress={() => setSelectedBottleFormat(option.id)}
+                >
+                  <Text
+                    style={[
+                      styles.chipText,
+                      isSelected && styles.chipTextSelected,
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <View style={styles.chipsWrap}>
+            {LABEL_TEMPLATE_OPTIONS.map((option) => {
+              const isSelected = option.id === selectedTemplateId;
+
+              return (
+                <Pressable
+                  key={option.id}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Sélectionner le template ${option.label}`}
+                  style={[styles.chip, isSelected && styles.chipSelected]}
+                  onPress={() => setSelectedTemplateId(option.id)}
+                >
+                  <Text
+                    style={[
+                      styles.chipText,
+                      isSelected && styles.chipTextSelected,
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </Card>
+
+        <Card
           style={[
-            styles.previewIcon,
-            { color: selectedPalette.foregroundColor },
+            styles.previewCard,
+            { backgroundColor: selectedPalette.backgroundColor },
           ]}
         >
-          {selectedIcon.symbol}
-        </Text>
-        <Text
-          style={[
-            styles.previewTitle,
-            { color: selectedPalette.foregroundColor },
-          ]}
-        >
-          {previewTitle}
-        </Text>
-        <Text
-          style={[
-            styles.previewSubtitle,
-            { color: selectedPalette.foregroundColor },
-          ]}
-        >
-          {previewSubtitle}
-        </Text>
-      </Card>
+          <Text
+            style={[
+              styles.previewIcon,
+              { color: selectedPalette.foregroundColor },
+            ]}
+          >
+            {selectedIcon.symbol}
+          </Text>
+          <Text
+            style={[
+              styles.previewTitle,
+              { color: selectedPalette.foregroundColor },
+            ]}
+          >
+            {previewTitle}
+          </Text>
+          <Text
+            style={[
+              styles.previewSubtitle,
+              { color: selectedPalette.foregroundColor },
+            ]}
+          >
+            {previewSubtitle}
+          </Text>
+        </Card>
 
-      {statusMessage ? (
-        <Text style={styles.statusMessage}>{statusMessage}</Text>
-      ) : null}
+        {statusMessage ? (
+          <Text style={styles.statusMessage}>{statusMessage}</Text>
+        ) : null}
 
-      <View style={styles.actionsRow}>
-        <PrimaryButton
-          accessibilityLabel="Enregistrer le brouillon"
-          label={toButtonLabel(isSaving)}
-          disabled={!draft || isSaving}
-          style={styles.actionButton}
-          onPress={() => {
-            void handleSave();
-          }}
-        />
+        <View style={styles.actionsRow}>
+          <PrimaryButton
+            accessibilityLabel="Enregistrer le brouillon"
+            label={toButtonLabel(isSaving)}
+            disabled={!draft || isSaving}
+            style={styles.actionButton}
+            onPress={() => {
+              void handleSave();
+            }}
+          />
 
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Ouvrir la fiche du brouillon"
-          style={styles.secondaryButton}
-          disabled={!draft || isSaving}
-          onPress={() => {
-            if (!draft) {
-              return;
-            }
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Ouvrir la fiche du brouillon"
+            style={styles.secondaryButton}
+            disabled={!draft || isSaving}
+            onPress={() => {
+              if (!draft) {
+                return;
+              }
 
-            router.push(buildLabelDetailsRoute(draft.id));
-          }}
-        >
-          <Text style={styles.secondaryButtonText}>Voir la fiche</Text>
-        </Pressable>
-      </View>
+              router.push(buildLabelDetailsRoute(draft.id));
+            }}
+          >
+            <Text style={styles.secondaryButtonText}>Voir la fiche</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
     </Screen>
   );
 }
 
 const styles = StyleSheet.create({
+  scrollContainer: {
+    flex: 1,
+  },
+  scrollContent: {
+    gap: spacing.sm,
+  },
   sectionCard: {
     marginBottom: spacing.sm,
     gap: spacing.xs,

--- a/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
@@ -221,6 +221,7 @@ export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
           { paddingBottom: navigationFooterOffset },
         ]}
         showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="handled"
       >
         <Card style={styles.sectionCard}>
           <Text style={styles.sectionTitle}>Texte</Text>
@@ -434,7 +435,6 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
   },
   sectionCard: {
-    marginBottom: spacing.sm,
     gap: spacing.xs,
   },
   sectionTitle: {

--- a/packages/mobile-app/src/features/labels/presentation/LabelSelectBatchScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelSelectBatchScreen.tsx
@@ -20,6 +20,7 @@ import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
+import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
 import { useRouter } from "expo-router";
@@ -51,6 +52,7 @@ export function resolveSelectedBatchId(
 
 export function LabelSelectBatchScreen() {
   const router = useRouter();
+  const navigationFooterOffset = useNavigationFooterOffset();
   const [candidates, setCandidates] = useState<LabelBatchCandidate[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
@@ -231,14 +233,16 @@ export function LabelSelectBatchScreen() {
         />
       )}
 
-      <PrimaryButton
-        accessibilityLabel="Créer un brouillon d’étiquette"
-        label={isCreating ? "Création..." : "Créer le brouillon"}
-        disabled={!selectedBatchId || isCreating}
-        onPress={() => {
-          void handleCreateDraft();
-        }}
-      />
+      <View style={{ marginBottom: navigationFooterOffset }}>
+        <PrimaryButton
+          accessibilityLabel="Créer un brouillon d’étiquette"
+          label={isCreating ? "Création..." : "Créer le brouillon"}
+          disabled={!selectedBatchId || isCreating}
+          onPress={() => {
+            void handleCreateDraft();
+          }}
+        />
+      </View>
     </Screen>
   );
 }


### PR DESCRIPTION
## Summary

Both Labels screens had visible content clipped by the floating `NavigationFooter` tab bar, blocking the primary user action on each:

- **Sélection du brassin** (#596): the "Créer le brouillon" CTA sat below the footer. Users could not validate their batch choice without reaching behind the tab bar.
- **Éditeur d'étiquette** (#597): the live label preview at the bottom was clipped — the single most valuable element on the screen.

## Approach

Applied the existing `useNavigationFooterOffset()` pattern already in use on 10+ screens (BatchesScreen, BatchDetailsScreen, EquipmentScreen, IngredientsScreen, most calculators). No new utilities introduced.

### Select screen (#596)
- Wrap the `PrimaryButton` in a `View` with `marginBottom = navigationFooterOffset`.
- Inline dynamic style matches the established codebase pattern (offset depends on runtime `useSafeAreaInsets`, not static).

### Editor screen (#597)
- Introduce a `ScrollView` wrapping all the editor Cards (Texte / Palette / Icône / Modèle).
- Apply `paddingBottom = navigationFooterOffset` on `contentContainerStyle`.
- Secondary benefit: long Cards (palette + icon + template grids on small devices) are now scrollable.

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format:check)
- [x] `npx jest src/features/labels` green (16/16 tests pass)
- [x] Follows existing `useNavigationFooterOffset()` convention (10+ screens)
- [x] No new design tokens, no hardcoded colors / spacing
- [x] No tests added — pattern is layout-only, existing functional coverage already validates the business logic

## Test plan

- [ ] CI green on this PR
- [ ] On device (or simulator): navigate Dashboard → Voir plus → Mes étiquettes → Créer → Sélection → verify the "Créer le brouillon" CTA sits **above** the tab bar and is tappable without scroll.
- [ ] Continue to Éditeur: verify the preview Card at the bottom of the editor is **fully visible** above the tab bar.

Closes #596
Closes #597