### PR TITLE
fix(shop): category-aware price unit instead of hardcoded €/kg

### DIFF
--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -48,6 +48,9 @@
     "owner": "beniot",
     "updates": {
       "url": "https://u.expo.dev/a527c490-36e1-49f2-a91b-5866a2823b5f"
+    },
+    "runtimeVersion": {
+      "policy": "appVersion"
     }
   }
 }

--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -48,9 +48,6 @@
     "owner": "beniot",
     "updates": {
       "url": "https://u.expo.dev/a527c490-36e1-49f2-a91b-5866a2823b5f"
-    },
-    "runtimeVersion": {
-      "policy": "appVersion"
     }
   }
 }

--- a/packages/mobile-app/src/features/shop/domain/__tests__/shop.types.test.ts
+++ b/packages/mobile-app/src/features/shop/domain/__tests__/shop.types.test.ts
@@ -1,0 +1,61 @@
+import {
+  DEFAULT_PRICE_UNIT_BY_CATEGORY,
+  Product,
+  getProductPriceUnit,
+} from "@/features/shop/domain/shop.types";
+
+function buildProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: "p1",
+    name: "Test product",
+    description: "Test",
+    price: 1,
+    category: "malts",
+    inStock: false,
+    ...overrides,
+  };
+}
+
+describe("getProductPriceUnit", () => {
+  // Happy path — explicit priceUnit on the product wins over the default.
+  it("returns the explicit priceUnit when set on the product", () => {
+    const product = buildProduct({ priceUnit: "€/100g", category: "houblons" });
+    expect(getProductPriceUnit(product)).toBe("€/100g");
+  });
+
+  // Sad path — priceUnit missing for a hop product would have shown
+  // the wrong "€/kg" string before #649. Now it must fall back to the
+  // category default "€/100g".
+  it("falls back to the category default when priceUnit is omitted", () => {
+    expect(getProductPriceUnit(buildProduct({ category: "houblons" }))).toBe(
+      "€/100g",
+    );
+    expect(getProductPriceUnit(buildProduct({ category: "levures" }))).toBe(
+      "€/sachet",
+    );
+    expect(getProductPriceUnit(buildProduct({ category: "materiel" }))).toBe(
+      "€/pièce",
+    );
+    expect(getProductPriceUnit(buildProduct({ category: "kits" }))).toBe(
+      "€/pièce",
+    );
+  });
+
+  // Edge case — every category in the type union has a default mapping
+  // (regression guard so adding a new category to ShopCategory without
+  // updating DEFAULT_PRICE_UNIT_BY_CATEGORY trips a TS error AND this
+  // test if it slips through).
+  it("has a default unit registered for every shop category", () => {
+    const categories: Array<keyof typeof DEFAULT_PRICE_UNIT_BY_CATEGORY> = [
+      "malts",
+      "houblons",
+      "levures",
+      "materiel",
+      "accessoires",
+      "kits",
+    ];
+    for (const category of categories) {
+      expect(DEFAULT_PRICE_UNIT_BY_CATEGORY[category]).toMatch(/^€\//);
+    }
+  });
+});

--- a/packages/mobile-app/src/features/shop/domain/__tests__/shop.types.test.ts
+++ b/packages/mobile-app/src/features/shop/domain/__tests__/shop.types.test.ts
@@ -1,8 +1,8 @@
 import {
   DEFAULT_PRICE_UNIT_BY_CATEGORY,
-  Product,
   getProductPriceUnit,
 } from "@/features/shop/domain/shop.types";
+import type { Product } from "@/features/shop/domain/shop.types";
 
 function buildProduct(overrides: Partial<Product> = {}): Product {
   return {

--- a/packages/mobile-app/src/features/shop/domain/__tests__/shop.types.test.ts
+++ b/packages/mobile-app/src/features/shop/domain/__tests__/shop.types.test.ts
@@ -41,19 +41,19 @@ describe("getProductPriceUnit", () => {
     );
   });
 
-  // Edge case — every category in the type union has a default mapping
-  // (regression guard so adding a new category to ShopCategory without
-  // updating DEFAULT_PRICE_UNIT_BY_CATEGORY trips a TS error AND this
-  // test if it slips through).
-  it("has a default unit registered for every shop category", () => {
-    const categories: Array<keyof typeof DEFAULT_PRICE_UNIT_BY_CATEGORY> = [
-      "malts",
-      "houblons",
-      "levures",
-      "materiel",
-      "accessoires",
-      "kits",
-    ];
+  // Edge case — every key actually present in
+  // DEFAULT_PRICE_UNIT_BY_CATEGORY maps to a valid €-prefixed unit.
+  // Iterating from Object.keys (instead of a hardcoded list) keeps
+  // this assertion honest as a regression guard: adding a category
+  // to the map without giving it a real €-prefixed unit will trip
+  // here automatically. The Record<ShopCategory, PriceUnit> typing
+  // already gives us a TS-level guarantee that every ShopCategory
+  // member has SOME entry; this test guards the value shape.
+  it("has a valid €-prefixed unit registered for every entry of the map", () => {
+    const categories = Object.keys(DEFAULT_PRICE_UNIT_BY_CATEGORY) as Array<
+      keyof typeof DEFAULT_PRICE_UNIT_BY_CATEGORY
+    >;
+    expect(categories.length).toBeGreaterThan(0);
     for (const category of categories) {
       expect(DEFAULT_PRICE_UNIT_BY_CATEGORY[category]).toMatch(/^€\//);
     }

--- a/packages/mobile-app/src/features/shop/domain/shop.types.ts
+++ b/packages/mobile-app/src/features/shop/domain/shop.types.ts
@@ -6,12 +6,33 @@ export type ShopCategory =
   | "accessoires"
   | "kits";
 
+// Pricing units actually used in the brewing trade — see #649 (B-48):
+// malts ship by the kilo (sometimes by sack), hops + yeasts by sachet,
+// equipment + accessoires by piece, kits by piece.
+export type PriceUnit = "€/kg" | "€/100g" | "€/sachet" | "€/pièce";
+
+export const DEFAULT_PRICE_UNIT_BY_CATEGORY: Record<ShopCategory, PriceUnit> = {
+  malts: "€/kg",
+  houblons: "€/100g",
+  levures: "€/sachet",
+  materiel: "€/pièce",
+  accessoires: "€/pièce",
+  kits: "€/pièce",
+};
+
 export type Product = {
   id: string;
   name: string;
   description: string;
   price: number;
+  // Pricing unit. When omitted, falls back to the category default
+  // via DEFAULT_PRICE_UNIT_BY_CATEGORY so old seed data keeps working.
+  priceUnit?: PriceUnit;
   category: ShopCategory;
   image?: string;
   inStock: boolean;
 };
+
+export function getProductPriceUnit(product: Product): PriceUnit {
+  return product.priceUnit ?? DEFAULT_PRICE_UNIT_BY_CATEGORY[product.category];
+}

--- a/packages/mobile-app/src/features/shop/domain/shop.types.ts
+++ b/packages/mobile-app/src/features/shop/domain/shop.types.ts
@@ -20,7 +20,9 @@ export const DEFAULT_PRICE_UNIT_BY_CATEGORY: Record<ShopCategory, PriceUnit> = {
   kits: "€/pièce",
 };
 
-export type Product = {
+// `interface` for object shapes per the repo convention (CLAUDE.md
+// §TypeScript). `type` stays for unions like ShopCategory / PriceUnit.
+export interface Product {
   id: string;
   name: string;
   description: string;
@@ -31,7 +33,7 @@ export type Product = {
   category: ShopCategory;
   image?: string;
   inStock: boolean;
-};
+}
 
 export function getProductPriceUnit(product: Product): PriceUnit {
   return product.priceUnit ?? DEFAULT_PRICE_UNIT_BY_CATEGORY[product.category];

--- a/packages/mobile-app/src/features/shop/presentation/ShopCategoryScreen.tsx
+++ b/packages/mobile-app/src/features/shop/presentation/ShopCategoryScreen.tsx
@@ -7,6 +7,7 @@ import {
   shopCategoryDescriptions,
   shopCategoryLabels,
 } from "@/features/shop/presentation/shop.constants";
+import { getProductPriceUnit } from "@/features/shop/domain/shop.types";
 
 import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
@@ -115,7 +116,7 @@ export function ShopCategoryScreen({ categoryParam }: Props) {
                 <Text style={styles.productDesc}>{item.description}</Text>
                 <View style={styles.productMeta}>
                   <Text style={styles.productPrice}>
-                    ~{item.price.toFixed(2)} €/kg
+                    ~{item.price.toFixed(2)} {getProductPriceUnit(item)}
                   </Text>
                   <Badge label="À venir" variant="info" />
                 </View>


### PR DESCRIPTION
## Summary

Per #649 (B-48): every Shop product card showed `~X.XX €/kg`, but that unit is only correct for malts. Result: hops, yeasts, equipment and kits all looked priced "per kilo" — a Densimètre at "15.00 €/kg" and a yeast sachet at "3.80 €/kg" were obvious tells of the data bug.

## Approach

Backwards-compatible: add an optional `priceUnit` on `Product` + a category-default fallback so existing seed data keeps working without a migration.

| Category | Default unit |
|---|---|
| Malts | €/kg |
| Houblons | €/100g |
| Levures | €/sachet |
| Matériel | €/pièce |
| Accessoires | €/pièce |
| Kits | €/pièce |

`ShopCategoryScreen` renders via `getProductPriceUnit(product)` which returns the explicit `priceUnit` if set, else the category default.

## Tests

New `shop.types.test.ts` with the H/S/E pattern:
- **Happy**: explicit `priceUnit` on the product wins over the default
- **Sad**: missing `priceUnit` for a hop falls back to `€/100g` (the regression that #649 catches)
- **Edge**: every `ShopCategory` has a default registered (regression guard against future taxonomy additions)

## Checklist

- [x] `npm run ci:check` (lint + typecheck + format) green
- [x] `npx jest src/features/shop` 18/18 green
- [x] No new design tokens, no hardcoded colors / spacing
- [x] H/S/E convention applied to the new helper test

## Test plan

- [ ] CI green
- [ ] On device after OTA: open Boutique → tap each category — units now read `€/100g` for hops, `€/sachet` for yeasts, `€/pièce` for equipment / accessoires / kits, `€/kg` only for malts.

Closes #649