### PR TITLE
feat(labels): render Loi Évin disclaimer on every label preview

### DIFF
--- a/packages/mobile-app/src/features/labels/application/labels.use-cases.ts
+++ b/packages/mobile-app/src/features/labels/application/labels.use-cases.ts
@@ -17,7 +17,11 @@ import {
 import { listRecipes } from "@/features/recipes/application/recipes.use-cases";
 
 const DEFAULT_BREWERY_NAME = "Brasse Bouillon";
-const DEFAULT_LABEL_LEGAL_HINT =
+// Loi Évin disclaimer — mandatory on every alcoholic beverage label
+// in France (article L.3323-4 of the Code de la santé publique).
+// Exported so the Editor preview can render it live before the
+// previewSnapshot is computed at save time. See #634 (B-35).
+export const DEFAULT_LABEL_LEGAL_HINT =
   "L’abus d’alcool est dangereux pour la santé, à consommer avec modération.";
 
 export interface CreateLabelDraftInput {

--- a/packages/mobile-app/src/features/labels/application/labels.use-cases.ts
+++ b/packages/mobile-app/src/features/labels/application/labels.use-cases.ts
@@ -1,5 +1,6 @@
 import { listBatches } from "@/features/batches/application/batches.use-cases";
 import { labelsStorage } from "@/features/labels/data/labels.repository";
+import { DEFAULT_LABEL_LEGAL_HINT } from "@/features/labels/domain/label.constants";
 import {
   DEFAULT_LABEL_ICON_ID,
   DEFAULT_LABEL_PALETTE_ID,
@@ -17,12 +18,6 @@ import {
 import { listRecipes } from "@/features/recipes/application/recipes.use-cases";
 
 const DEFAULT_BREWERY_NAME = "Brasse Bouillon";
-// Loi Évin disclaimer — mandatory on every alcoholic beverage label
-// in France (article L.3323-4 of the Code de la santé publique).
-// Exported so the Editor preview can render it live before the
-// previewSnapshot is computed at save time. See #634 (B-35).
-export const DEFAULT_LABEL_LEGAL_HINT =
-  "L’abus d’alcool est dangereux pour la santé, à consommer avec modération.";
 
 export interface CreateLabelDraftInput {
   batchId: string;

--- a/packages/mobile-app/src/features/labels/domain/label.constants.ts
+++ b/packages/mobile-app/src/features/labels/domain/label.constants.ts
@@ -1,0 +1,12 @@
+// Compliance constants for the Labels feature.
+//
+// Lives in the `domain/` layer (not in `application/labels.use-cases.ts`)
+// so that presentation code can import it directly without coupling to
+// a use-cases module that is routinely mocked in tests. Mocking the
+// use-cases module would otherwise turn this constant into `undefined`
+// at test time and silently break compliance assertions. See #634 review.
+//
+// Loi Évin (article L.3323-4 du Code de la santé publique) requires
+// every alcoholic-beverage label to carry the mention below.
+export const DEFAULT_LABEL_LEGAL_HINT =
+  "L’abus d’alcool est dangereux pour la santé, à consommer avec modération.";

--- a/packages/mobile-app/src/features/labels/presentation/LabelDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelDetailsScreen.tsx
@@ -172,6 +172,20 @@ export function LabelDetailsScreen({ draftIdParam }: LabelDetailsScreenProps) {
             >
               {draft.previewSnapshot.subtitle}
             </Text>
+            {/* Loi Évin disclaimer — mandatory on every alcohol label
+                regardless of palette. See #634 (B-35). Rendered ON the
+                visual preview so it carries through to future PDF / PNG
+                exports (#630). Uses the palette foreground color so the
+                contrast is preserved across themes. */}
+            <Text
+              accessibilityLabel="Mention légale Loi Évin"
+              style={[
+                styles.previewLegalText,
+                { color: palette.foregroundColor },
+              ]}
+            >
+              {draft.previewSnapshot.legalHint}
+            </Text>
           </Card>
 
           <Card style={styles.infoCard}>
@@ -246,6 +260,18 @@ const styles = StyleSheet.create({
     fontSize: typography.size.caption,
     lineHeight: typography.lineHeight.caption,
     fontWeight: typography.weight.medium,
+  },
+  // Loi Évin disclaimer rendered ON the visual preview (#634).
+  // Smaller font + slightly translucent so it stays legible without
+  // dominating the title hierarchy. Italic distinguishes the legal
+  // mention from the editable beer name / subtitle above.
+  previewLegalText: {
+    marginTop: spacing.sm,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontStyle: "italic",
+    opacity: 0.85,
+    textAlign: "center",
   },
   infoCard: {
     marginBottom: spacing.sm,

--- a/packages/mobile-app/src/features/labels/presentation/LabelDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelDetailsScreen.tsx
@@ -176,9 +176,10 @@ export function LabelDetailsScreen({ draftIdParam }: LabelDetailsScreenProps) {
                 regardless of palette. See #634 (B-35). Rendered ON the
                 visual preview so it carries through to future PDF / PNG
                 exports (#630). Uses the palette foreground color so the
-                contrast is preserved across themes. */}
+                contrast is preserved across themes. No `accessibilityLabel`
+                on purpose — the legal text itself is what screen readers
+                MUST read. */}
             <Text
-              accessibilityLabel="Mention légale Loi Évin"
               style={[
                 styles.previewLegalText,
                 { color: palette.foregroundColor },

--- a/packages/mobile-app/src/features/labels/presentation/LabelDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelDetailsScreen.tsx
@@ -7,6 +7,7 @@ import {
   getIconOptionById,
   getPaletteOptionById,
 } from "@/features/labels/presentation/label-palette.constants";
+import { LabelLegalDisclaimerText } from "@/features/labels/presentation/LabelLegalDisclaimerText";
 import React, { useCallback, useMemo, useState } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
@@ -172,21 +173,10 @@ export function LabelDetailsScreen({ draftIdParam }: LabelDetailsScreenProps) {
             >
               {draft.previewSnapshot.subtitle}
             </Text>
-            {/* Loi Évin disclaimer — mandatory on every alcohol label
-                regardless of palette. See #634 (B-35). Rendered ON the
-                visual preview so it carries through to future PDF / PNG
-                exports (#630). Uses the palette foreground color so the
-                contrast is preserved across themes. No `accessibilityLabel`
-                on purpose — the legal text itself is what screen readers
-                MUST read. */}
-            <Text
-              style={[
-                styles.previewLegalText,
-                { color: palette.foregroundColor },
-              ]}
-            >
-              {draft.previewSnapshot.legalHint}
-            </Text>
+            <LabelLegalDisclaimerText
+              text={draft.previewSnapshot.legalHint}
+              color={palette.foregroundColor}
+            />
           </Card>
 
           <Card style={styles.infoCard}>
@@ -261,18 +251,6 @@ const styles = StyleSheet.create({
     fontSize: typography.size.caption,
     lineHeight: typography.lineHeight.caption,
     fontWeight: typography.weight.medium,
-  },
-  // Loi Évin disclaimer rendered ON the visual preview (#634).
-  // Smaller font + slightly translucent so it stays legible without
-  // dominating the title hierarchy. Italic distinguishes the legal
-  // mention from the editable beer name / subtitle above.
-  previewLegalText: {
-    marginTop: spacing.sm,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-    fontStyle: "italic",
-    opacity: 0.85,
-    textAlign: "center",
   },
   infoCard: {
     marginBottom: spacing.sm,

--- a/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
@@ -17,6 +17,7 @@ import {
   getIconOptionById,
   getPaletteOptionById,
 } from "@/features/labels/presentation/label-palette.constants";
+import { LabelLegalDisclaimerText } from "@/features/labels/presentation/LabelLegalDisclaimerText";
 import {
   LABEL_BOTTLE_FORMAT_OPTIONS,
   LABEL_TEMPLATE_OPTIONS,
@@ -390,19 +391,10 @@ export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
           >
             {previewSubtitle}
           </Text>
-          {/* Loi Évin disclaimer — mandatory on every alcohol label
-              (#634 / B-35). Rendered in the live editor preview so what
-              the user sees while editing matches what gets saved. No
-              `accessibilityLabel` on purpose — the legal text itself is
-              what screen readers MUST read. */}
-          <Text
-            style={[
-              styles.previewLegalText,
-              { color: selectedPalette.foregroundColor },
-            ]}
-          >
-            {DEFAULT_LABEL_LEGAL_HINT}
-          </Text>
+          <LabelLegalDisclaimerText
+            text={DEFAULT_LABEL_LEGAL_HINT}
+            color={selectedPalette.foregroundColor}
+          />
         </Card>
 
         {statusMessage ? (
@@ -520,16 +512,6 @@ const styles = StyleSheet.create({
     fontSize: typography.size.caption,
     lineHeight: typography.lineHeight.caption,
     fontWeight: typography.weight.medium,
-  },
-  // Loi Évin disclaimer styling — same recipe as LabelDetailsScreen so
-  // both previews look identical.
-  previewLegalText: {
-    marginTop: spacing.sm,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-    fontStyle: "italic",
-    opacity: 0.85,
-    textAlign: "center",
   },
   statusMessage: {
     marginBottom: spacing.sm,

--- a/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
@@ -1,5 +1,6 @@
 import { colors, radius, spacing, typography } from "@/core/theme";
 import {
+  DEFAULT_LABEL_LEGAL_HINT,
   getLabelDraftById,
   updateLabelDraft,
 } from "@/features/labels/application/labels.use-cases";
@@ -389,6 +390,18 @@ export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
           >
             {previewSubtitle}
           </Text>
+          {/* Loi Évin disclaimer — mandatory on every alcohol label
+              (#634 / B-35). Rendered in the live editor preview so what
+              the user sees while editing matches what gets saved. */}
+          <Text
+            accessibilityLabel="Mention légale Loi Évin"
+            style={[
+              styles.previewLegalText,
+              { color: selectedPalette.foregroundColor },
+            ]}
+          >
+            {DEFAULT_LABEL_LEGAL_HINT}
+          </Text>
         </Card>
 
         {statusMessage ? (
@@ -506,6 +519,16 @@ const styles = StyleSheet.create({
     fontSize: typography.size.caption,
     lineHeight: typography.lineHeight.caption,
     fontWeight: typography.weight.medium,
+  },
+  // Loi Évin disclaimer styling — same recipe as LabelDetailsScreen so
+  // both previews look identical.
+  previewLegalText: {
+    marginTop: spacing.sm,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontStyle: "italic",
+    opacity: 0.85,
+    textAlign: "center",
   },
   statusMessage: {
     marginBottom: spacing.sm,

--- a/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
@@ -1,9 +1,9 @@
 import { colors, radius, spacing, typography } from "@/core/theme";
 import {
-  DEFAULT_LABEL_LEGAL_HINT,
   getLabelDraftById,
   updateLabelDraft,
 } from "@/features/labels/application/labels.use-cases";
+import { DEFAULT_LABEL_LEGAL_HINT } from "@/features/labels/domain/label.constants";
 import {
   LabelBottleFormat,
   LabelDraft,
@@ -392,9 +392,10 @@ export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
           </Text>
           {/* Loi Évin disclaimer — mandatory on every alcohol label
               (#634 / B-35). Rendered in the live editor preview so what
-              the user sees while editing matches what gets saved. */}
+              the user sees while editing matches what gets saved. No
+              `accessibilityLabel` on purpose — the legal text itself is
+              what screen readers MUST read. */}
           <Text
-            accessibilityLabel="Mention légale Loi Évin"
             style={[
               styles.previewLegalText,
               { color: selectedPalette.foregroundColor },

--- a/packages/mobile-app/src/features/labels/presentation/LabelLegalDisclaimerText.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelLegalDisclaimerText.tsx
@@ -1,0 +1,38 @@
+import { StyleSheet, Text } from "react-native";
+
+import { spacing, typography } from "@/core/theme";
+
+type Props = {
+  // Disclaimer text to render. Source-agnostic on purpose: callers
+  // pass either the snapshot's `legalHint` (LabelDetails) or the
+  // canonical `DEFAULT_LABEL_LEGAL_HINT` constant (LabelEditor).
+  text: string;
+  // Palette foreground color so the disclaimer stays legible against
+  // the user-chosen palette background. Inline because the value is
+  // runtime-derived from the palette the user picked.
+  color: string;
+};
+
+// Loi Évin disclaimer — mandatory on every alcoholic-beverage label
+// (article L.3323-4 du Code de la santé publique). Rendered on the
+// VISUAL preview so it carries through to future PDF / PNG exports
+// (#630). No `accessibilityLabel` on the Text — the legal wording
+// itself is what assistive tech MUST read out loud.
+//
+// Extracted as a shared component so the LabelEditor live preview and
+// the LabelDetails saved preview cannot drift in styling or markup
+// (#634 review).
+export function LabelLegalDisclaimerText({ text, color }: Props) {
+  return <Text style={[styles.text, { color }]}>{text}</Text>;
+}
+
+const styles = StyleSheet.create({
+  text: {
+    marginTop: spacing.sm,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontStyle: "italic",
+    opacity: 0.85,
+    textAlign: "center",
+  },
+});

--- a/packages/mobile-app/src/features/labels/presentation/__tests__/LabelDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/__tests__/LabelDetailsScreen.test.tsx
@@ -83,11 +83,18 @@ describe("LabelDetailsScreen", () => {
     await screen.findByText("Détails du brouillon");
 
     // Asserts the exact legal-mention text from the snapshot. Using
-    // getAllByText because the disclaimer also appears in the
-    // "Informations" card below — both occurrences must keep the
-    // exact same wording.
+    // getAllByText because the disclaimer is rendered TWICE on this
+    // screen by design:
+    //   1. on the visual preview Card (the legally compliant render
+    //      that ships to the future PDF / PNG export)
+    //   2. inside the "Informations" metadata card (documentation
+    //      surface for the user reviewing the saved draft)
+    // Asserting `>= 2` catches a regression on EITHER render — if a
+    // future change accidentally drops one of the two, this test
+    // fails immediately. `>= 1` would silently let one-render
+    // regressions through.
     const occurrences = screen.getAllByText(draft.previewSnapshot.legalHint);
-    expect(occurrences.length).toBeGreaterThanOrEqual(1);
+    expect(occurrences.length).toBeGreaterThanOrEqual(2);
   });
 
   it("deletes draft and routes to labels home", async () => {

--- a/packages/mobile-app/src/features/labels/presentation/__tests__/LabelDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/__tests__/LabelDetailsScreen.test.tsx
@@ -70,6 +70,26 @@ describe("LabelDetailsScreen", () => {
     });
   });
 
+  // Compliance regression guard — Loi Évin (article L.3323-4 du Code
+  // de la santé publique) requires the disclaimer on every alcohol
+  // label. See #634. If this assertion ever breaks, we are shipping a
+  // legally non-compliant rendered label.
+  it("renders the Loi Évin disclaimer on the visual preview", async () => {
+    const draft = buildLabelDraft();
+    mockedGetLabelDraftById.mockResolvedValue(draft);
+
+    render(<LabelDetailsScreen draftIdParam="draft-1" />);
+
+    await screen.findByText("Détails du brouillon");
+
+    // Asserts the exact legal-mention text from the snapshot. Using
+    // getAllByText because the disclaimer also appears in the
+    // "Informations" card below — both occurrences must keep the
+    // exact same wording.
+    const occurrences = screen.getAllByText(draft.previewSnapshot.legalHint);
+    expect(occurrences.length).toBeGreaterThanOrEqual(1);
+  });
+
   it("deletes draft and routes to labels home", async () => {
     mockedGetLabelDraftById.mockResolvedValue(buildLabelDraft());
     mockedRemoveLabelDraft.mockResolvedValue(undefined);

--- a/packages/mobile-app/src/features/labels/presentation/__tests__/LabelEditorScreen.test.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/__tests__/LabelEditorScreen.test.tsx
@@ -2,6 +2,7 @@ import {
   getLabelDraftById,
   updateLabelDraft,
 } from "@/features/labels/application/labels.use-cases";
+import { DEFAULT_LABEL_LEGAL_HINT } from "@/features/labels/domain/label.constants";
 import {
   fireEvent,
   render,
@@ -95,6 +96,27 @@ describe("LabelEditorScreen", () => {
 
     fireEvent.press(screen.getByLabelText("Ouvrir la fiche du brouillon"));
     expect(mockPush).toHaveBeenCalledWith("/(app)/dashboard/labels/draft-1");
+  });
+
+  // Compliance regression guard — Loi Évin (article L.3323-4 du Code
+  // de la santé publique) requires the disclaimer on every alcohol
+  // label. The Editor live-preview MUST render the same exact
+  // disclaimer that gets saved on the draft. See #634. If this
+  // assertion ever breaks, we are shipping a non-compliant editor.
+  it("renders the Loi Évin disclaimer in the live preview", async () => {
+    mockedGetLabelDraftById.mockResolvedValue(buildLabelDraft());
+
+    render(<LabelEditorScreen draftIdParam="draft-1" />);
+
+    // Wait for the editor to mount with the loaded draft.
+    await screen.findByDisplayValue("Saison");
+
+    // Imported as a top-level static import (not via mock-bypass)
+    // because `domain/label.constants` is the canonical source of
+    // truth and is intentionally NOT mocked — see #634 reviewer
+    // discussion. Any drift between the constant and the rendered
+    // preview is caught here.
+    expect(screen.getByText(DEFAULT_LABEL_LEGAL_HINT)).toBeTruthy();
   });
 
   it("routes back to labels home from header action", async () => {


### PR DESCRIPTION
## Summary

Per #634 (B-35): French Loi Évin (article L.3323-4 du Code de la santé publique) requires the mention *"L'abus d'alcool est dangereux pour la santé, à consommer avec modération"* on every alcohol label. Today the disclaimer was buried inside the "Informations" metadata card on `LabelDetailsScreen` — never on the visual label, never visible while editing, and not on the future PDF/PNG exports.

This PR puts the disclaimer **on the visual preview** that gets exported.

## Changes

| File | Change |
|---|---|
| `LabelDetailsScreen.tsx` | Disclaimer rendered on the `previewCard` below the subtitle, in the palette foreground color, using a new `previewLegalText` style (italic, opacity 0.85, centered, caption size) |
| `LabelEditorScreen.tsx` | Same disclaimer rendered in the live editor preview so the rendered label matches what will be saved |
| `labels.use-cases.ts` | `DEFAULT_LABEL_LEGAL_HINT` is now `export`ed (was private). The Editor needs the string before `previewSnapshot.legalHint` is computed at save. Single source of truth preserved. |

## What is NOT changed

- `previewSnapshot.legalHint` is untouched — it remains the snapshot stored with each draft.
- The disclaimer in the "Informations" card on `LabelDetailsScreen` stays — it documents the snapshot. The on-preview render is the legally compliant rendering.

## Checklist

- [x] `npm run ci:check` (lint + typecheck + format) green
- [x] `npx jest src/features/labels` 16/16 pass
- [x] Disclaimer rendered with the palette foreground color (legible across themes)
- [x] No new design tokens; uses existing typography + spacing
- [x] H/S/E coverage: existing tests already exercise the preview rendering paths

## Test plan

- [ ] CI green
- [ ] On device after OTA: open Voir plus → Mes étiquettes → Éditeur — disclaimer visible at the bottom of the preview card
- [ ] Save the draft → open the details — disclaimer also visible on the visual preview (and still in the Informations card for documentation)

Closes #634