### PR TITLE
docs(product): Scan brainstorm decisions (2026-04-24)

### DIFF
--- a/docs/product/brainstorms/scan-2026-04-24.md
+++ b/docs/product/brainstorms/scan-2026-04-24.md
@@ -1,0 +1,274 @@
+# Brainstorm — Scan ⭐ (2026-04-24)
+
+**Session** : 60 min Q&A structuré avec le product owner.
+**Statut** : 18 décisions prises et validées.
+**Prochaine étape** : traduction en sub-issues GitHub pour la Tranche 2 Scan (demo hero de la soutenance 2026-05-27).
+
+---
+
+## Contexte produit
+
+Le Scan est **la feature démo hero** de la soutenance. Aujourd'hui la capture barcode et bouteille existent mais le flux s'arrête à la sauvegarde locale du scan pending. Cette session a pour but de cadrer **tout ce qui se passe après la capture** : reconnaissance, affichage, matching recettes, import dans Mes Recettes.
+
+L'objectif n'est pas de spécifier toute la feature à la ligne près, mais d'**arrêter les choix structurants** pour que le code qui arrive ensuite soit cohérent avec le produit.
+
+---
+
+## 1. Identité produit
+
+### Persona primaire — Amateur curieux
+
+Un amateur qui vient de découvrir une bière au bar ou chez un ami, et qui se demande *"est-ce que je pourrais brasser quelque chose de similaire chez moi ?"*. Brasse-Bouillon lui sert de **porte d'entrée pédagogique vers le brassage**.
+
+**Impact sur les décisions** :
+- L'UI privilégie les mots (amertume "marquée") sur les chiffres (IBU 40)
+- Les recettes proposées sont accessibles, pas seulement précises
+- Le langage reste simple, explicatif
+
+### Métaphore produit — Pharmacie
+
+Le modèle mental qui guide tout le design :
+
+| Pharmacie | Brasse-Bouillon |
+|---|---|
+| 💊 Médicament de marque (Doliprane) | 🏆 Recette de la brasserie (Punk IPA par BrewDog) |
+| 🧾 Générique (Paracétamol Biogaran) | 🧪 Recette équivalente communauté |
+| Pharmacien présente les deux | App affiche les deux, distincts visuellement |
+| Patient choisit selon préférence | Utilisateur choisit selon ce qu'il veut brasser |
+
+Cette analogie **structure le vocabulaire, les visuels, et la pédagogie intégrée**.
+
+---
+
+## 2. UX de l'écran résultat scan
+
+### Structure — Hero + Essentiel + Recettes + folds
+
+```
+┌────────────────────────────────┐
+│   [photo héro de la bière]     │  ~40% écran
+├────────────────────────────────┤
+│ En bref : nom, brasserie, ABV  │
+│ Style · Couleur · Amertume     │  (mots, pas chiffres)
+├────────────────────────────────┤
+│ 🏆 Recette de la brasserie     │  si existe
+│    [carte recette officielle]  │
+├────────────────────────────────┤
+│ 🧪 Recettes équivalentes       │
+│    [top 3 cartes communauté]   │
+│    [Voir plus] →               │
+├────────────────────────────────┤
+│ ▶ Détails techniques           │  fold, lazy loaded
+│ ▶ Story de la brasserie        │  fold, lazy loaded
+└────────────────────────────────┘
+```
+
+### Principe technique — Lazy loading (Lazy Initialization pattern)
+
+Les folds techniques et story ne chargent leur contenu que lorsqu'ils sont ouverts. Bénéfices :
+- Premier rendu <500ms (infos critiques uniquement)
+- Économie d'appels API pour les 70% d'utilisateurs qui ne déploient pas les folds
+- Robuste en réseau faible (les folds peuvent timeout sans bloquer)
+
+### Gestion des sections vides
+
+Si une section n'a pas assez de data (< 3 champs remplis), elle est **masquée entièrement** — pas d'écran avec "—" partout.
+
+### Bières peu connues — Vision hybride (build for today, design for tomorrow)
+
+Quand OpenFoodFacts retourne peu d'infos :
+- Affichage lecture seule de ce qu'on a
+- Lien discret "💡 Tu connais cette bière ? Suggérer une correction" → ouvre un `mailto:feedback@brasse-bouillon.app`
+- Pas de backend de contribution en MVP
+- **Préparation Vision 2** (contribution communautaire complète) :
+  - Type `BeerData` inclut déjà `source: 'openfoodfacts' | 'internal' | 'community'`, `contributedBy`, `contributedAt`, `approvedAt` (null en MVP)
+  - Endpoints backend `POST /beer-contributions` etc. existent mais retournent `501 Not Implemented`
+  - Composant `<SuggestCorrectionLink />` extensible (mailto aujourd'hui, form Modal plus tard)
+
+---
+
+## 3. Algorithme de matching recettes
+
+### Formule globale
+
+```
+Pour chaque recette candidate :
+
+  SIMILARITÉ = Si recette officielle pour cette bière → 100%
+             Sinon → Style × 50 + ABV × 25 + Amertume × 15 + Couleur × 10
+             (poids renormalisés si critère manquant)
+
+  QUALITÉ    = NoteMoyenne × 60 + Brassins_log × 30 + Récence × 10
+
+  SCORE FINAL = SIMILARITÉ × 70% + QUALITÉ × 30%
+```
+
+### Détails — Composantes du score Similarité
+
+| Critère | Poids | Calcul |
+|---|---|---|
+| Style | 50% | Match exact = 100, famille proche (IPA vs NEIPA) = 70, différent = 0 |
+| ABV | 25% | Distance normalisée : écart 0% → 100, écart 2% → 50, écart 4% → 0 |
+| Amertume | 15% | Match catégoriel (douce / marquée / très marquée) |
+| Couleur | 10% | Match catégoriel (claire / ambrée / brune / noire) |
+
+**Si un critère manque** : redistribution proportionnelle des poids sur les critères présents.
+
+**Recette officielle** : similarité = 100% par définition, pas de calcul. Seule la qualité varie.
+
+### Détails — Composantes du score Qualité
+
+| Composante | Poids | Calcul |
+|---|---|---|
+| NoteMoyenne | 60% | ★ 1.0 → 20, ★ 5.0 → 100 (linéaire) |
+| Confiance_brassins | 30% | Logarithmique : 0 brassin → 0, 1 → 30, 5 → 60, 20 → 80, 100 → 95, 500+ → 100 |
+| Récence | 10% | Décroissance : <30j → 100, <90j → 80, <1an → 60, <2ans → 40, 2ans+ → 20 |
+
+Le log sur la confiance évite qu'une recette récente excellente soit injustement rétrogradée face à des vieilles recettes avec beaucoup de brassins.
+
+### Affichage
+
+- Section "🏆 Recette de la brasserie" en premier (masquée si aucune recette officielle pour cette bière)
+- Section "🧪 Recettes équivalentes" avec **top 3**
+- Bouton "Voir plus" → écran liste complète
+- Si meilleur match < 40% : avertissement discret *"Aucune recette très similaire en base. Voici les plus proches."*
+
+---
+
+## 4. Architecture technique
+
+### Principe projet validé — **Build for today, design for tomorrow**
+
+À formaliser en **ADR-001** lors de la session Architecture de ce matin. Application concrète :
+- Code minimal pour le besoin immédiat
+- Nommage + types + contrats prévoient l'évolution
+- Endpoints backend stubs en `501 Not Implemented` pour les fonctions différées
+- Composants extensibles (signatures stables, props optionnelles)
+- ADRs documentant les choix + la roadmap migration
+
+### Architecture API — Backend centralisé
+
+```
+┌─────────────┐         ┌──────────────────┐
+│ Mobile app  │ ──────▶ │ NestJS API nous  │
+└─────────────┘         └──────────────────┘
+                               │   │   │
+                               ▼   ▼   ▼
+                          ┌────┐ ┌──┐ ┌──┐
+                          │OFF │ │WP│ │DB│
+                          └────┘ └──┘ └──┘
+```
+
+Le mobile parle **uniquement** à notre NestJS. Le backend proxifie OpenFoodFacts, et plus tard Wikipedia, Untappd, RateBeer, etc. Mobile n'a qu'une seule API à connaître.
+
+**Bénéfices** :
+- Clés API externes dans le backend, jamais exposées dans le bundle mobile
+- Cache server-side (Redis plus tard)
+- Changement d'API externe → modif backend seulement, pas de déploiement mobile
+- Gestion centralisée des erreurs, timeouts, retries
+- Ajout de nouvelles sources = zéro impact mobile
+
+### Stratégie cache / fallback démo — Stratégie A
+
+Pour garantir la démo du 27 mai quoi qu'il arrive :
+- **6 bières pré-seedées en dur** dans l'app (fichier JSON statique)
+- Scan de l'une de ces 6 → tout marche même en mode avion
+- Pour toutes les autres bières → appel live OpenFoodFacts via notre backend, cache mémoire 1h
+
+Les 6 bières suggérées : Punk IPA (BrewDog), Chouffe, Rochefort 10, Karmeliet Tripel, Heineken, + une bière artisanale locale.
+
+---
+
+## 5. Stratégie démo — Soutenance 2026-05-27
+
+### Script original (90 secondes)
+
+```
+[0:00 → 0:15]  INTRO — setup narratif amateur
+   Pose la Punk IPA sur la table, présente l'utilisateur curieux.
+
+[0:15 → 0:35]  SCAN — geste + reconnaissance
+   Vérification 5/5, résultat affiché (photo + nom + brasserie + ABV).
+
+[0:35 → 1:00]  DÉCOUVERTE — scroll sections
+   "Amateur voit Style / Couleur / Amertume en mots. Le brasseur
+    trouve IBU / OG / FG en dessous. L'app s'adapte."
+
+[1:00 → 1:20]  MATCH — recettes pharmacie
+   "BrewDog DIY Dog comme marque, trois communautaires comme
+    génériques."
+
+[1:20 → 1:30]  IMPORT — point final
+   Un clic, recette dans Mes Recettes, prête à brasser.
+```
+
+### Variante enrichie — "Jury beer"
+
+Le product owner demandera au jury d'apporter des bouteilles vides le jour J pour tester en conditions réelles. Notre stratégie couvre les 4 scénarios possibles :
+
+| Scénario | Comportement app | Narratif adaptatif |
+|---|---|---|
+| **A** — Bière connue (dans seed ou OFF) | Flow complet, matching recettes | *"Voici le flow nominal."* (script original) |
+| **B** — Bière inconnue | Lecture seule + "Suggérer correction" | *"Voici exactement ce qu'on a prévu — la communauté grandit."* |
+| **C** — Barcode illisible | Fallback mode photo (bottle scan) | *"On pivote sur le mode photo."* |
+| **D** — Pas une bière (cidre, vin) | Catégorie détectée, redirection | Humour + pivot |
+
+L'avantage : **chaque échec apparent devient une démonstration de robustesse produit**.
+
+### Plan de secours technique
+
+- **Fallback 1** : mode avion + les 6 bières du bundle → scan marche hors-ligne
+- **Fallback 2** : screencast vidéo 90s pré-enregistré, jouable en cas de panne totale
+
+---
+
+## 6. Décomposition en chunks codables
+
+Pour la traduction en sub-issues GitHub (session planification de cet après-midi) :
+
+| # | Chunk | Effort | Ordre suggéré |
+|---|---|---|---|
+| 1 | **Backend NestJS** — proxy OpenFoodFacts + endpoints recettes + cache | 3-4j | 1 (débloque le reste) |
+| 2 | **Mobile** — data layer Scan (API client interne) | 1j | 2 |
+| 3 | **Mobile** — UI info card avec hero + folds lazy loaded | 2j | 3 |
+| 4 | **Mobile** — algo matching score-based | 1-2j | 4 (parallèle à 3) |
+| 5 | **Mobile** — UI matching avec section officielle + top 3 | 1j | 5 |
+| 6 | **Seed** — 6 bières démo enrichies + recettes équivalentes + recette officielle BrewDog | 0.5j | Parallèle |
+| 7 | **Script démo + screencast fallback** | 0.5j | Fin |
+
+**Total estimé** : 10-12 jours de dev focus sur la Tranche 2 Scan.
+
+---
+
+## 7. Décisions complètes — Synthèse tableau
+
+| # | Catégorie | Décision |
+|---|---|---|
+| 1 | Persona | Amateur curieux qui veut apprendre à brasser |
+| 2 | UX structure | Hero + Essentiel + Recettes + folds repliables |
+| 3 | Bières peu connues | Lecture seule + mailto correction (Vision hybride, préparée pour V2) |
+| 4 | Matching approche | Score multi-critères (pas de filtre strict) |
+| 5 | Pondération similarité | Style 50 / ABV 25 / Amertume 15 / Couleur 10 |
+| 6 | UI recette officielle | Section dédiée au-dessus, visuellement distincte |
+| 7 | Data manquante | Renormaliser les poids sur les critères présents |
+| 8 | Ajout Score Qualité | Note + Brassins + Récence |
+| 9 | Officielle similarité | = 100% par définition |
+| 10 | Principe projet | Build for today, design for tomorrow (ADR-001) |
+| 11 | Score final | Similarité × 70 + Qualité × 30 |
+| 12 | Nombre affiché | Top 3 + "Voir plus" |
+| 13 | Métaphore produit | Pharmacie (marque vs génériques) |
+| 14 | Seuil minimum | Afficher avec avertissement si meilleur < 40% |
+| 15 | Cache/fallback | Bundle 6 bières en dur + cache mémoire 1h |
+| 16 | Script démo | 90s scripted, 5 phases |
+| 17 | Architecture API | Backend NestJS centralisé, mobile → une seule API |
+| 18 | Variante démo | Jury beer — 4 scénarios adaptatifs |
+
+---
+
+## 8. À faire suite de la session
+
+- [ ] Rédiger **ADR-001 — Build for today, design for tomorrow** (session Architecture du matin)
+- [ ] Décomposer en sub-issues GitHub avec les 7 chunks (session planification)
+- [ ] Lister les 6 bières démo précises + source des recettes équivalentes (seed task)
+- [ ] Préparer la demande formelle au jury d'apporter des bouteilles (courrier coach ou mention en intro pitch)
+- [ ] Enregistrer le screencast fallback la semaine du 20 mai

--- a/docs/product/brainstorms/scan-2026-04-24.md
+++ b/docs/product/brainstorms/scan-2026-04-24.md
@@ -1,156 +1,161 @@
 # Brainstorm — Scan ⭐ (2026-04-24)
 
-**Session** : 60 min Q&A structuré avec le product owner.
-**Statut** : 18 décisions prises et validées.
-**Prochaine étape** : traduction en sub-issues GitHub pour la Tranche 2 Scan (demo hero de la soutenance 2026-05-27).
+**Session** : 60 min structured Q&A with the product owner.
+**Status** : 18 decisions taken and validated.
+**Next step** : translate into GitHub sub-issues for the Scan Tranche 2 (demo hero of the 2026-05-27 defense).
 
 ---
 
-## Contexte produit
+## Product context
 
-Le Scan est **la feature démo hero** de la soutenance. Aujourd'hui la capture barcode et bouteille existent mais le flux s'arrête à la sauvegarde locale du scan pending. Cette session a pour but de cadrer **tout ce qui se passe après la capture** : reconnaissance, affichage, matching recettes, import dans Mes Recettes.
+The Scan is the **demo hero** of the defense. Today, barcode and bottle capture work, but the flow stops at saving the pending scan locally. This session scopes **everything that happens after the capture** : recognition, display, recipe matching, import into My Recipes.
 
-L'objectif n'est pas de spécifier toute la feature à la ligne près, mais d'**arrêter les choix structurants** pour que le code qui arrive ensuite soit cohérent avec le produit.
+The goal is not to specify the entire feature line by line, but to **lock in the structural choices** so the code that follows is coherent with the product vision.
 
 ---
 
-## 1. Identité produit
+## 1. Product identity
 
-### Persona primaire — Amateur curieux
+### Primary persona — Curious amateur
 
-Un amateur qui vient de découvrir une bière au bar ou chez un ami, et qui se demande *"est-ce que je pourrais brasser quelque chose de similaire chez moi ?"*. Brasse-Bouillon lui sert de **porte d'entrée pédagogique vers le brassage**.
+An amateur who just discovered a beer at a bar or at a friend's place, and wonders *"could I brew something similar at home?"*. Brasse-Bouillon is their **pedagogical gateway to brewing**.
 
-**Impact sur les décisions** :
-- L'UI privilégie les mots (amertume "marquée") sur les chiffres (IBU 40)
-- Les recettes proposées sont accessibles, pas seulement précises
-- Le langage reste simple, explicatif
+**Impact on decisions** :
 
-### Métaphore produit — Pharmacie
+- The UI favors words ("marked" bitterness) over numbers ("IBU 40")
+- Proposed recipes are accessible, not just precise
+- Language stays simple and explanatory
 
-Le modèle mental qui guide tout le design :
+### Product metaphor — Pharmacy
 
-| Pharmacie | Brasse-Bouillon |
+The mental model guiding the whole design :
+
+| Pharmacy | Brasse-Bouillon |
 |---|---|
-| 💊 Médicament de marque (Doliprane) | 🏆 Recette de la brasserie (Punk IPA par BrewDog) |
-| 🧾 Générique (Paracétamol Biogaran) | 🧪 Recette équivalente communauté |
-| Pharmacien présente les deux | App affiche les deux, distincts visuellement |
-| Patient choisit selon préférence | Utilisateur choisit selon ce qu'il veut brasser |
+| 💊 Brand-name medicine (Doliprane) | 🏆 Brewery recipe (Punk IPA by BrewDog) |
+| 🧾 Generic (Paracetamol Biogaran) | 🧪 Community equivalent recipe |
+| Pharmacist presents both | App displays both, visually distinct |
+| Patient chooses by preference | User chooses depending on what they want to brew |
 
-Cette analogie **structure le vocabulaire, les visuels, et la pédagogie intégrée**.
+This analogy **structures vocabulary, visuals, and embedded pedagogy**.
 
 ---
 
-## 2. UX de l'écran résultat scan
+## 2. UX of the scan result screen
 
-### Structure — Hero + Essentiel + Recettes + folds
+### Structure — Hero + Essentials + Recipes + folds
 
 ```
 ┌────────────────────────────────┐
-│   [photo héro de la bière]     │  ~40% écran
+│   [beer hero photo]            │  ~40% screen
 ├────────────────────────────────┤
-│ En bref : nom, brasserie, ABV  │
-│ Style · Couleur · Amertume     │  (mots, pas chiffres)
+│ At a glance : name, brewery,   │
+│ ABV                            │
+│ Style · Color · Bitterness     │  (words, not numbers)
 ├────────────────────────────────┤
-│ 🏆 Recette de la brasserie     │  si existe
-│    [carte recette officielle]  │
+│ 🏆 Brewery recipe              │  if available
+│    [official recipe card]      │
 ├────────────────────────────────┤
-│ 🧪 Recettes équivalentes       │
-│    [top 3 cartes communauté]   │
-│    [Voir plus] →               │
+│ 🧪 Equivalent recipes          │
+│    [top 3 community cards]     │
+│    [See more] →                │
 ├────────────────────────────────┤
-│ ▶ Détails techniques           │  fold, lazy loaded
-│ ▶ Story de la brasserie        │  fold, lazy loaded
+│ ▶ Technical details            │  fold, lazy loaded
+│ ▶ Brewery story                │  fold, lazy loaded
 └────────────────────────────────┘
 ```
 
-### Principe technique — Lazy loading (Lazy Initialization pattern)
+### Technical principle — Lazy loading (Lazy Initialization pattern)
 
-Les folds techniques et story ne chargent leur contenu que lorsqu'ils sont ouverts. Bénéfices :
-- Premier rendu <500ms (infos critiques uniquement)
-- Économie d'appels API pour les 70% d'utilisateurs qui ne déploient pas les folds
-- Robuste en réseau faible (les folds peuvent timeout sans bloquer)
+The "technical details" and "brewery story" folds only load their content when opened. Benefits :
 
-### Gestion des sections vides
+- First render under 500 ms (critical info only)
+- API call savings for the 70% of users who never expand the folds
+- Robust on weak networks (folds can time out without blocking the primary render)
 
-Si une section n'a pas assez de data (< 3 champs remplis), elle est **masquée entièrement** — pas d'écran avec "—" partout.
+### Empty section handling
 
-### Bières peu connues — Vision hybride (build for today, design for tomorrow)
+If a section has fewer than 3 filled fields, it is **hidden entirely** — no screen with "—" everywhere.
 
-Quand OpenFoodFacts retourne peu d'infos :
-- Affichage lecture seule de ce qu'on a
-- Lien discret "💡 Tu connais cette bière ? Suggérer une correction" → ouvre un `mailto:feedback@brasse-bouillon.app`
-- Pas de backend de contribution en MVP
-- **Préparation Vision 2** (contribution communautaire complète) :
-  - Type `BeerData` inclut déjà `source: 'openfoodfacts' | 'internal' | 'community'`, `contributedBy`, `contributedAt`, `approvedAt` (null en MVP)
-  - Endpoints backend `POST /beer-contributions` etc. existent mais retournent `501 Not Implemented`
-  - Composant `<SuggestCorrectionLink />` extensible (mailto aujourd'hui, form Modal plus tard)
+### Little-known beers — Hybrid vision (build for today, design for tomorrow)
 
----
+When OpenFoodFacts returns little information :
 
-## 3. Algorithme de matching recettes
-
-### Formule globale
-
-```
-Pour chaque recette candidate :
-
-  SIMILARITÉ = Si recette officielle pour cette bière → 100%
-             Sinon → Style × 50 + ABV × 25 + Amertume × 15 + Couleur × 10
-             (poids renormalisés si critère manquant)
-
-  QUALITÉ    = NoteMoyenne × 60 + Brassins_log × 30 + Récence × 10
-
-  SCORE FINAL = SIMILARITÉ × 70% + QUALITÉ × 30%
-```
-
-### Détails — Composantes du score Similarité
-
-| Critère | Poids | Calcul |
-|---|---|---|
-| Style | 50% | Match exact = 100, famille proche (IPA vs NEIPA) = 70, différent = 0 |
-| ABV | 25% | Distance normalisée : écart 0% → 100, écart 2% → 50, écart 4% → 0 |
-| Amertume | 15% | Match catégoriel (douce / marquée / très marquée) |
-| Couleur | 10% | Match catégoriel (claire / ambrée / brune / noire) |
-
-**Si un critère manque** : redistribution proportionnelle des poids sur les critères présents.
-
-**Recette officielle** : similarité = 100% par définition, pas de calcul. Seule la qualité varie.
-
-### Détails — Composantes du score Qualité
-
-| Composante | Poids | Calcul |
-|---|---|---|
-| NoteMoyenne | 60% | ★ 1.0 → 20, ★ 5.0 → 100 (linéaire) |
-| Confiance_brassins | 30% | Logarithmique : 0 brassin → 0, 1 → 30, 5 → 60, 20 → 80, 100 → 95, 500+ → 100 |
-| Récence | 10% | Décroissance : <30j → 100, <90j → 80, <1an → 60, <2ans → 40, 2ans+ → 20 |
-
-Le log sur la confiance évite qu'une recette récente excellente soit injustement rétrogradée face à des vieilles recettes avec beaucoup de brassins.
-
-### Affichage
-
-- Section "🏆 Recette de la brasserie" en premier (masquée si aucune recette officielle pour cette bière)
-- Section "🧪 Recettes équivalentes" avec **top 3**
-- Bouton "Voir plus" → écran liste complète
-- Si meilleur match < 40% : avertissement discret *"Aucune recette très similaire en base. Voici les plus proches."*
+- Read-only display of what we have
+- Discreet link *"💡 Do you know this beer? Suggest a correction"* opens a `mailto:feedback@brasse-bouillon.app`
+- No contribution backend in MVP
+- **Vision 2 preparation** (full community contribution) :
+  - `BeerData` type already includes `source: 'openfoodfacts' | 'internal' | 'community'`, `contributedBy`, `contributedAt`, `approvedAt` (null in MVP)
+  - Backend endpoints `POST /beer-contributions` etc. exist but return `501 Not Implemented`
+  - `<SuggestCorrectionLink />` component is extensible (mailto today, Modal form later)
 
 ---
 
-## 4. Architecture technique
+## 3. Recipe matching algorithm
 
-### Principe projet validé — **Build for today, design for tomorrow**
+### Global formula
 
-À formaliser en **ADR-001** lors de la session Architecture de ce matin. Application concrète :
-- Code minimal pour le besoin immédiat
-- Nommage + types + contrats prévoient l'évolution
-- Endpoints backend stubs en `501 Not Implemented` pour les fonctions différées
-- Composants extensibles (signatures stables, props optionnelles)
-- ADRs documentant les choix + la roadmap migration
+```
+For each candidate recipe :
 
-### Architecture API — Backend centralisé
+  SIMILARITY = If official recipe for this beer → 100%
+             Otherwise → Style × 50 + ABV × 25 + Bitterness × 15 + Color × 10
+             (weights renormalized if a criterion is missing)
+
+  QUALITY    = AvgRating × 60 + BrewCount_confidence × 30 + Recency × 10
+
+  FINAL SCORE = SIMILARITY × 70% + QUALITY × 30%
+```
+
+### Details — Similarity score components
+
+| Criterion | Weight | Computation |
+|---|---|---|
+| Style | 50% | Exact match = 100, close family (IPA vs NEIPA) = 70, different = 0 |
+| ABV | 25% | Normalized distance : 0% gap → 100, 2% gap → 50, 4% gap → 0 |
+| Bitterness | 15% | Categorical match (soft / marked / very marked) |
+| Color | 10% | Categorical match (pale / amber / brown / black) |
+
+**When a criterion is missing** : proportional redistribution of weights across the present criteria.
+
+**Official recipe** : similarity = 100% by definition, no computation. Only quality varies.
+
+### Details — Quality score components
+
+| Component | Weight | Computation |
+|---|---|---|
+| AvgRating | 60% | ★ 1.0 → 20, ★ 5.0 → 100 (linear) |
+| BrewCount_confidence | 30% | Logarithmic : 0 brews → 0, 1 → 30, 5 → 60, 20 → 80, 100 → 95, 500+ → 100 |
+| Recency | 10% | Decay : <30d → 100, <90d → 80, <1yr → 60, <2yr → 40, 2yr+ → 20 |
+
+The log on confidence prevents a recent excellent recipe from being unfairly downgraded compared to old recipes with many brews.
+
+### Display
+
+- "🏆 Brewery recipe" section first (hidden if no official recipe exists for this beer)
+- "🧪 Equivalent recipes" section with **top 3**
+- "See more" button → full list screen
+- If best match < 40% : discreet warning *"No very similar recipe in the database. Here are the closest ones."*
+
+---
+
+## 4. Technical architecture
+
+### Validated project principle — **Build for today, design for tomorrow**
+
+To be formalized as **ADR-001** during this morning's Architecture session. Concrete application :
+
+- Minimal code for the immediate need
+- Naming + types + contracts anticipate evolution
+- Backend endpoints stubbed as `501 Not Implemented` for deferred functions
+- Extensible components (stable signatures, optional props)
+- ADRs documenting choices + migration roadmap
+
+### API architecture — Centralized backend
 
 ```
 ┌─────────────┐         ┌──────────────────┐
-│ Mobile app  │ ──────▶ │ NestJS API nous  │
+│ Mobile app  │ ──────▶ │ Our NestJS API   │
 └─────────────┘         └──────────────────┘
                                │   │   │
                                ▼   ▼   ▼
@@ -159,116 +164,118 @@ Le log sur la confiance évite qu'une recette récente excellente soit injusteme
                           └────┘ └──┘ └──┘
 ```
 
-Le mobile parle **uniquement** à notre NestJS. Le backend proxifie OpenFoodFacts, et plus tard Wikipedia, Untappd, RateBeer, etc. Mobile n'a qu'une seule API à connaître.
+The mobile app talks **only** to our NestJS backend. The backend proxies OpenFoodFacts, and later Wikipedia, Untappd, RateBeer, etc. Mobile knows a single API.
 
-**Bénéfices** :
-- Clés API externes dans le backend, jamais exposées dans le bundle mobile
-- Cache server-side (Redis plus tard)
-- Changement d'API externe → modif backend seulement, pas de déploiement mobile
-- Gestion centralisée des erreurs, timeouts, retries
-- Ajout de nouvelles sources = zéro impact mobile
+**Benefits** :
 
-### Stratégie cache / fallback démo — Stratégie A
+- External API keys in the backend, never exposed in the mobile bundle
+- Server-side cache (Redis later)
+- External API change → backend modification only, no mobile deployment
+- Centralized error handling, timeouts, retries
+- New source additions = zero mobile impact
 
-Pour garantir la démo du 27 mai quoi qu'il arrive :
-- **6 bières pré-seedées en dur** dans l'app (fichier JSON statique)
-- Scan de l'une de ces 6 → tout marche même en mode avion
-- Pour toutes les autres bières → appel live OpenFoodFacts via notre backend, cache mémoire 1h
+### Demo cache / fallback strategy — Strategy A
 
-Les 6 bières suggérées : Punk IPA (BrewDog), Chouffe, Rochefort 10, Karmeliet Tripel, Heineken, + une bière artisanale locale.
+To guarantee the 2026-05-27 demo whatever happens :
+
+- **6 hard-coded seed beers** in the app (static JSON file)
+- Scanning one of these 6 → everything works even in airplane mode
+- For any other beer → live OpenFoodFacts call via our backend, 1-hour memory cache
+
+Suggested 6 beers : Punk IPA (BrewDog), Chouffe, Rochefort 10, Karmeliet Tripel, Heineken, + a local artisanal beer.
 
 ---
 
-## 5. Stratégie démo — Soutenance 2026-05-27
+## 5. Demo strategy — 2026-05-27 defense
 
-### Script original (90 secondes)
+### Original script (90 seconds)
 
 ```
-[0:00 → 0:15]  INTRO — setup narratif amateur
-   Pose la Punk IPA sur la table, présente l'utilisateur curieux.
+[0:00 → 0:15]  INTRO — amateur narrative setup
+   Place Punk IPA on the table, introduce the curious user.
 
-[0:15 → 0:35]  SCAN — geste + reconnaissance
-   Vérification 5/5, résultat affiché (photo + nom + brasserie + ABV).
+[0:15 → 0:35]  SCAN — gesture + recognition
+   5/5 verification, result shown (photo + name + brewery + ABV).
 
-[0:35 → 1:00]  DÉCOUVERTE — scroll sections
-   "Amateur voit Style / Couleur / Amertume en mots. Le brasseur
-    trouve IBU / OG / FG en dessous. L'app s'adapte."
+[0:35 → 1:00]  DISCOVERY — scroll sections
+   "Amateur sees Style / Color / Bitterness in words. The
+    experienced brewer finds IBU / OG / FG below. The app adapts."
 
-[1:00 → 1:20]  MATCH — recettes pharmacie
-   "BrewDog DIY Dog comme marque, trois communautaires comme
-    génériques."
+[1:00 → 1:20]  MATCH — pharmacy recipes
+   "BrewDog DIY Dog as the brand, three community alternatives
+    as generics."
 
-[1:20 → 1:30]  IMPORT — point final
-   Un clic, recette dans Mes Recettes, prête à brasser.
+[1:20 → 1:30]  IMPORT — closing
+   One tap, recipe lands in My Recipes, ready to brew.
 ```
 
-### Variante enrichie — "Jury beer"
+### Enriched variant — "Jury beer"
 
-Le product owner demandera au jury d'apporter des bouteilles vides le jour J pour tester en conditions réelles. Notre stratégie couvre les 4 scénarios possibles :
+The product owner will ask the jury to bring empty bottles on defense day to test in real conditions. Our strategy covers the 4 possible scenarios :
 
-| Scénario | Comportement app | Narratif adaptatif |
+| Scenario | App behavior | Adaptive narrative |
 |---|---|---|
-| **A** — Bière connue (dans seed ou OFF) | Flow complet, matching recettes | *"Voici le flow nominal."* (script original) |
-| **B** — Bière inconnue | Lecture seule + "Suggérer correction" | *"Voici exactement ce qu'on a prévu — la communauté grandit."* |
-| **C** — Barcode illisible | Fallback mode photo (bottle scan) | *"On pivote sur le mode photo."* |
-| **D** — Pas une bière (cidre, vin) | Catégorie détectée, redirection | Humour + pivot |
+| **A** — Known beer (in seed or OFF) | Full flow, recipe matching | *"Here is the nominal flow."* (original script) |
+| **B** — Unknown beer | Read-only + "Suggest correction" | *"Here is exactly what we anticipated — the community grows."* |
+| **C** — Unreadable barcode | Fallback to photo mode (bottle scan) | *"We pivot to photo mode."* |
+| **D** — Not a beer (cider, wine) | Category detected, redirection | Humor + pivot |
 
-L'avantage : **chaque échec apparent devient une démonstration de robustesse produit**.
+The benefit : **each apparent failure becomes a demonstration of product robustness**.
 
-### Plan de secours technique
+### Technical backup plan
 
-- **Fallback 1** : mode avion + les 6 bières du bundle → scan marche hors-ligne
-- **Fallback 2** : screencast vidéo 90s pré-enregistré, jouable en cas de panne totale
+- **Fallback 1** : airplane mode + the 6 bundled beers → scan works offline
+- **Fallback 2** : pre-recorded 90s screencast, playable in case of total outage
 
 ---
 
-## 6. Décomposition en chunks codables
+## 6. Decomposition into codable chunks
 
-Pour la traduction en sub-issues GitHub (session planification de cet après-midi) :
+For the translation to GitHub sub-issues (afternoon planning session) :
 
-| # | Chunk | Effort | Ordre suggéré |
+| # | Chunk | Effort | Suggested order |
 |---|---|---|---|
-| 1 | **Backend NestJS** — proxy OpenFoodFacts + endpoints recettes + cache | 3-4j | 1 (débloque le reste) |
-| 2 | **Mobile** — data layer Scan (API client interne) | 1j | 2 |
-| 3 | **Mobile** — UI info card avec hero + folds lazy loaded | 2j | 3 |
-| 4 | **Mobile** — algo matching score-based | 1-2j | 4 (parallèle à 3) |
-| 5 | **Mobile** — UI matching avec section officielle + top 3 | 1j | 5 |
-| 6 | **Seed** — 6 bières démo enrichies + recettes équivalentes + recette officielle BrewDog | 0.5j | Parallèle |
-| 7 | **Script démo + screencast fallback** | 0.5j | Fin |
+| 1 | **NestJS backend** — OpenFoodFacts proxy + recipe endpoints + cache | 3-4 days | 1 (unblocks the rest) |
+| 2 | **Mobile** — Scan data layer (internal API client) | 1 day | 2 |
+| 3 | **Mobile** — info card UI with hero + lazy-loaded folds | 2 days | 3 |
+| 4 | **Mobile** — score-based matching algo | 1-2 days | 4 (parallel to 3) |
+| 5 | **Mobile** — matching UI with official section + top 3 | 1 day | 5 |
+| 6 | **Seed** — 6 demo beers enriched + equivalent recipes + BrewDog official recipe | 0.5 day | Parallel |
+| 7 | **Demo script + screencast fallback** | 0.5 day | End |
 
-**Total estimé** : 10-12 jours de dev focus sur la Tranche 2 Scan.
+**Total estimate** : 10-12 focused dev days on Scan Tranche 2.
 
 ---
 
-## 7. Décisions complètes — Synthèse tableau
+## 7. Complete decisions — Summary table
 
-| # | Catégorie | Décision |
+| # | Category | Decision |
 |---|---|---|
-| 1 | Persona | Amateur curieux qui veut apprendre à brasser |
-| 2 | UX structure | Hero + Essentiel + Recettes + folds repliables |
-| 3 | Bières peu connues | Lecture seule + mailto correction (Vision hybride, préparée pour V2) |
-| 4 | Matching approche | Score multi-critères (pas de filtre strict) |
-| 5 | Pondération similarité | Style 50 / ABV 25 / Amertume 15 / Couleur 10 |
-| 6 | UI recette officielle | Section dédiée au-dessus, visuellement distincte |
-| 7 | Data manquante | Renormaliser les poids sur les critères présents |
-| 8 | Ajout Score Qualité | Note + Brassins + Récence |
-| 9 | Officielle similarité | = 100% par définition |
-| 10 | Principe projet | Build for today, design for tomorrow (ADR-001) |
-| 11 | Score final | Similarité × 70 + Qualité × 30 |
-| 12 | Nombre affiché | Top 3 + "Voir plus" |
-| 13 | Métaphore produit | Pharmacie (marque vs génériques) |
-| 14 | Seuil minimum | Afficher avec avertissement si meilleur < 40% |
-| 15 | Cache/fallback | Bundle 6 bières en dur + cache mémoire 1h |
-| 16 | Script démo | 90s scripted, 5 phases |
-| 17 | Architecture API | Backend NestJS centralisé, mobile → une seule API |
-| 18 | Variante démo | Jury beer — 4 scénarios adaptatifs |
+| 1 | Persona | Curious amateur who wants to learn to brew |
+| 2 | UX structure | Hero + Essentials + Recipes + collapsible folds |
+| 3 | Little-known beers | Read-only + mailto correction (hybrid vision, prepared for V2) |
+| 4 | Matching approach | Multi-criteria score (no strict filter) |
+| 5 | Similarity weighting | Style 50 / ABV 25 / Bitterness 15 / Color 10 |
+| 6 | Official recipe UI | Dedicated section on top, visually distinct |
+| 7 | Missing data | Renormalize weights across present criteria |
+| 8 | Quality score addition | Rating + BrewCount + Recency |
+| 9 | Official recipe similarity | = 100% by definition |
+| 10 | Project principle | Build for today, design for tomorrow (ADR-001) |
+| 11 | Final score | Similarity × 70 + Quality × 30 |
+| 12 | Number displayed | Top 3 + "See more" |
+| 13 | Product metaphor | Pharmacy (brand vs generic) |
+| 14 | Minimum threshold | Display with warning if best < 40% |
+| 15 | Cache / fallback | Bundle 6 beers hard-coded + 1h memory cache |
+| 16 | Demo script | 90s scripted, 5 phases |
+| 17 | API architecture | Centralized NestJS backend, mobile → single API |
+| 18 | Demo variant | Jury beer — 4 adaptive scenarios |
 
 ---
 
-## 8. À faire suite de la session
+## 8. Session follow-up actions
 
-- [ ] Rédiger **ADR-001 — Build for today, design for tomorrow** (session Architecture du matin)
-- [ ] Décomposer en sub-issues GitHub avec les 7 chunks (session planification)
-- [ ] Lister les 6 bières démo précises + source des recettes équivalentes (seed task)
-- [ ] Préparer la demande formelle au jury d'apporter des bouteilles (courrier coach ou mention en intro pitch)
-- [ ] Enregistrer le screencast fallback la semaine du 20 mai
+- [ ] Draft **ADR-001 — Build for today, design for tomorrow** (morning Architecture session)
+- [ ] Decompose into GitHub sub-issues with the 7 chunks (planning session)
+- [ ] List the precise 6 demo beers + source of equivalent recipes (seed task)
+- [ ] Prepare the formal request to the jury for bringing bottles (coach email or mention in pitch intro)
+- [ ] Record the screencast fallback during the week of 2026-05-20


### PR DESCRIPTION
## Summary

Saves the 18 decisions taken during the 60-min Scan brainstorm session on 2026-04-24 morning.

The Scan feature is the **demo hero** for the 2026-05-27 defense — this document is the reference that will guide the Tranche 2 Scan implementation starting this afternoon.

## What's inside

- **Identity product** : persona (amateur curieux), product metaphor (pharmacy — brand vs generic recipes)
- **UX** : Hero + Essentiel + Recettes + folds, lazy loading, missing-data handling, V2 preparation (community contribution)
- **Matching algorithm** : score multi-criteria Similarity × 70% + Quality × 30%, formulas detailed
- **Architecture** : build for today + design for tomorrow principle (ADR-001), backend-centric API, bundle 6 demo beers + 1h memory cache
- **Demo strategy** : 90s script + "jury beer" variant with 4 adaptive scenarios
- **Decomposition** : 7 coding chunks identified for Tranche 2 (~10-12 days)

## Checklist

- [x] Decisions table complete (18 items)
- [x] All critical paths documented (happy + sad + edge)
- [x] "Build for today, design for tomorrow" principle explicit
- [x] No ambiguity on matching algorithm (all formulas present)

## Test plan

- [ ] Review this document during the Architecture session (next brainstorm this morning) — check if any decision needs an ADR
- [ ] Use this document as reference during the ticket-decomposition session this afternoon
- [ ] Validate the jury-beer variant with the coach before 2026-05-27

Ready to merge. No code impact, documentation only.