### PR TITLE
docs(project-log): log PR #689 merge + end-of-review convention

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,9 +7,9 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-04-24
 
-### PROJECT_LOG enrichment for PR #688 ([PR #689](https://github.com/benoit-bremaud/brasse-bouillon/pull/689))
+### Log entry enrichment for PR #688 ([PR #689](https://github.com/benoit-bremaud/brasse-bouillon/pull/689))
 
-Small follow-up PR to bring the Compte & settings entry (above) in
+Small follow-up PR to bring the `Compte` & settings entry (above) in
 line with the per-merge logging convention: adds the PR #688 link,
 the merge SHA `6a518b0`, the branch name, and the review-cycle
 narrative (1 Codex P2 on a contradictory MVP estimate, 5 Copilot
@@ -27,7 +27,7 @@ phrase" in commit `4e2d558`; the English referents (`GDPR`,
 Also introduces a new repeatable process rule on this project: an
 **end-of-review summary comment** is now posted on every PR before
 the user merges (CI state, reviews received, resolution commit SHAs,
-explicit "prêt à merger" line). Stored as a durable convention in
+explicit "ready to merge" line). Stored as a durable convention in
 the agent's memory so all future PRs follow the pattern.
 
 ### `Compte` & settings brainstorm + MVP conservative cuts ([PR #688](https://github.com/benoit-bremaud/brasse-bouillon/pull/688))

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,29 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-04-24
 
+### PROJECT_LOG enrichment for PR #688 ([PR #689](https://github.com/benoit-bremaud/brasse-bouillon/pull/689))
+
+Small follow-up PR to bring the Compte & settings entry (above) in
+line with the per-merge logging convention: adds the PR #688 link,
+the merge SHA `6a518b0`, the branch name, and the review-cycle
+narrative (1 Codex P2 on a contradictory MVP estimate, 5 Copilot
+comments on `docs/CONVENTIONS.md` compliance, all addressed in
+commit `761f4d8`).
+
+Branch `docs/project-log-pr-688`, merged as `56a861d`. Review
+cycle: one Copilot comment flagging that even the meta-commentary
+naming the flagged French terms (by quoting them verbatim) itself
+violates `docs/CONVENTIONS.md` §1. Paraphrased as "a French quote
+in a heading / a French data-privacy acronym / a French legal-notice
+phrase" in commit `4e2d558`; the English referents (`GDPR`,
+`packages/mobile-app/CHANGELOG.md`) stay as code spans.
+
+Also introduces a new repeatable process rule on this project: an
+**end-of-review summary comment** is now posted on every PR before
+the user merges (CI state, reviews received, resolution commit SHAs,
+explicit "prêt à merger" line). Stored as a durable convention in
+the agent's memory so all future PRs follow the pattern.
+
 ### `Compte` & settings brainstorm + MVP conservative cuts ([PR #688](https://github.com/benoit-bremaud/brasse-bouillon/pull/688))
 
 Morning session continuation — 45-minute structured Q&A on the


### PR DESCRIPTION
## Summary

Logs the merge of [PR #689](https://github.com/benoit-bremaud/brasse-bouillon/pull/689) and records the new repeatable process rule introduced today.

- Adds a log entry for PR #689 (merge SHA `56a861d`), with the review-cycle narrative (1 Copilot comment on `docs/CONVENTIONS.md` §1 — paraphrased French term names in `4e2d558`).
- Documents the new convention: **every PR now gets a concise end-of-review summary comment** (CI state + reviews + resolution commit SHAs + explicit "prêt à merger" line) before the user merges. Stored as a durable memory for the agent so it applies to every future PR.

## Checklist

- [x] Happy path + sad path + edge cases covered — N/A (log entry)
- [x] `tsc --noEmit` passes — N/A (no code)
- [x] Build passes — N/A (no code)
- [x] Existing tests still green — N/A (no code)
- [x] No `any`, no inline styles introduced — N/A (no code)
- [x] `PROJECT_LOG.md` updated — this PR IS the log update

## Files

- `PROJECT_LOG.md` — new entry above the Compte & settings entry

## Related

- Logs the merge of [PR #689](https://github.com/benoit-bremaud/brasse-bouillon/pull/689)
- Same per-merge logging pattern as [PR #687](https://github.com/benoit-bremaud/brasse-bouillon/pull/687) did for the Scan brainstorm entry