### PR TITLE
docs(architecture): accept ADR-0001, ADR-0002, ADR-0003

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,3 +169,28 @@ This project maintains a [PROJECT_LOG.md](PROJECT_LOG.md) — a chronological, a
 | Sprint structure | [docs/project-management/sprint-definition.md](docs/project-management/sprint-definition.md) |
 | API docs | [docs/api/](docs/api/) |
 | Architecture | [docs/architecture/](docs/architecture/) |
+| Architecture Decision Records | [docs/architecture/decisions/](docs/architecture/decisions/) |
+
+---
+
+## Architecture Decision Records — mandatory context for every PR review
+
+Every agent (Copilot, Codex, and any human reviewer) MUST read the
+accepted ADRs under [docs/architecture/decisions/](docs/architecture/decisions/)
+before reviewing code. These documents define the structural rules of
+this project.
+
+**Active accepted ADRs** (as of 2026-04-24):
+
+- [ADR-0001 — Build for today, design for tomorrow](docs/architecture/decisions/0001-build-for-today-design-for-tomorrow.md)
+  — Five-clause rule, four forbidden anti-patterns, three tolerated
+  exceptions. Applies to every new piece of code.
+- [ADR-0002 — Centralized NestJS backend for all external data sources](docs/architecture/decisions/0002-centralized-nestjs-backend.md)
+  — Mobile talks only to our NestJS API; no direct third-party calls
+  from the mobile bundle.
+- [ADR-0003 — Consent as a single source of truth](docs/architecture/decisions/0003-consent-single-source-of-truth.md)
+  — One canonical consent store on the mobile app; feature-namespaced,
+  append-only, GDPR-compliant by construction.
+
+When reviewing a PR, flag any diff that violates these ADRs. Cite the
+ADR number and clause in the review comment.

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,46 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-04-24
 
+### Architecture session — three ADRs accepted
+
+Morning session continuation (third of four brainstorms scheduled for
+the day) — structured Q&A to formalize three architectural decisions
+that already governed the code informally and needed a written
+contract. All three land as accepted ADRs under a new folder
+[`docs/architecture/decisions/`](docs/architecture/decisions/) with a
+README explaining the template (Michael Nygard format) and the
+mutability policy (append-only once accepted, supersession via a new
+ADR).
+
+- **ADR-0001 — Build for today, design for tomorrow.** Five-clause
+  rule (minimal implementation, shapes anticipate evolution, `501 Not
+  Implemented` stubs for deferred endpoints, components extensible by
+  default, one ADR per structural choice), four forbidden anti-patterns
+  (feature flags for non-existent features, phantom lifecycle hooks,
+  premature abstraction without the rule of three, `TODO v2` without
+  a trace), three tolerated exceptions (kill switches on demo-critical
+  paths, abstractions imposed by Clean Architecture, dated transient
+  TODO markers). Enforcement at PR-review time via the AI reviewers
+  (Copilot, Codex) reading the ADR through `CLAUDE.md`.
+- **ADR-0002 — Centralized NestJS backend.** Mobile talks only to
+  our NestJS API; the backend proxies OpenFoodFacts today and
+  Wikipedia / Untappd / RateBeer / brewery scrapers tomorrow.
+  Response normalisation, server-side caching, and credentials
+  management all live server-side. Aligned with ADR-0001 on the
+  `source` discriminant and the `501` stubs.
+- **ADR-0003 — Consent as a single source of truth.** One canonical
+  append-only consent store on the mobile app, feature-namespaced
+  axes (`scan.barcode`, `scan.photos`, `scan.metadata`, `ml.training`,
+  `telemetry`, …), two writers in v0.1 (Scan onboarding, Settings
+  privacy). Resolves the Scan / Settings consent overlap flagged in
+  the two earlier brainstorms. GDPR-compliant by construction.
+
+Root `CLAUDE.md` now carries a mandatory "Architecture Decision
+Records" section linking the three ADRs, so every agent starting a
+session reads them before reviewing code. Violations should be
+flagged at PR-review time with an explicit ADR number + clause
+citation.
+
 ### Log entry enrichment for PR #688 ([PR #689](https://github.com/benoit-bremaud/brasse-bouillon/pull/689))
 
 Small follow-up PR to bring the `Compte` & settings entry (above) in

--- a/docs/architecture/decisions/0001-build-for-today-design-for-tomorrow.md
+++ b/docs/architecture/decisions/0001-build-for-today-design-for-tomorrow.md
@@ -1,0 +1,168 @@
+# ADR-0001 — Build for today, design for tomorrow
+
+**Status**  Accepted
+**Date**    2026-04-24
+**Owners**  @benoit-bremaud
+
+---
+
+## Context
+
+The 2026-05-27 defense leaves five weeks of working runway. Two failure
+modes threaten this budget:
+
+- **Coding cheaply "for the demo"** — shortcuts that ship in v0.1 and must
+  be thrown away in v0.2, creating known-to-be-wasted effort.
+- **Over-designing every component** — infrastructure for needs that do not
+  exist yet, burning the runway on speculative work that the demo never
+  touches.
+
+Independently of the defense context, the owner's product philosophy is to
+**write just enough code to solve today's problem, but name and shape it
+so tomorrow's feature lands without a refactor**. The morning brainstorms
+on the Scan feature (2026-04-24) and the merged `Compte` screen both
+cited this principle as their structuring rule. This ADR formalises it as
+a project-wide convention, readable by both future-us and the AI agents
+(Copilot, Codex) that review every PR on this repository.
+
+---
+
+## Decision
+
+We commit to a five-clause rule that applies to every new piece of code
+on the Brasse-Bouillon monorepo.
+
+### The rule — five clauses
+
+1. **Minimal implementation for the immediate need.** No feature flag for
+   a feature that does not exist. No lifecycle hook added "in case we
+   need it". Ship the code the current user story asks for, not one line
+   more.
+2. **Naming, types, and contracts anticipate evolution.** Where the
+   shape of the domain is already known (source of data, user
+   provenance, consent axes), encode it in the type system from day one,
+   even if only one variant is used today. Example: `BeerData.source:
+   'openfoodfacts' | 'internal' | 'community'` exists at v0.1 even
+   though only `'openfoodfacts'` is populated.
+3. **Backend endpoints stubbed with `501 Not Implemented`** for deferred
+   functions, instead of missing endpoints. The mobile client knows the
+   API surface today and keeps working unchanged when the server-side
+   body lands.
+4. **Components extensible by default.** Stable signature, optional
+   props, no fragile private contract. `<SuggestCorrectionLink />` is a
+   `mailto:` link in v0.1 and a `<Modal>` form in v0.2 — the call site
+   does not change.
+5. **One ADR per structural choice**, linked to a migration roadmap
+   when the v0.2 shape is known. The ADR becomes the contract between
+   v0.1 and v0.2.
+
+### Anti-patterns forbidden
+
+The rule is negatively reinforced by four explicit anti-patterns:
+
+- **Feature flags for non-existent features.** A flag is only legitimate
+  when it controls a feature that actually ships. "Just in case" flags
+  create dead branches and confusion.
+- **Phantom lifecycle hooks.** `onBeforeX` / `onAfterY` callbacks added
+  without a real consumer. They widen the API surface without usage.
+- **Premature abstraction.** Factoring two similar usages into a generic
+  helper. Apply the **rule of three** — three concrete occurrences
+  before we consider an abstraction. Two is a coincidence; three is a
+  pattern.
+- **`TODO v2` comments without a structured trace.** Any deferred work
+  must point at a GitHub issue or a dedicated ADR. A bare `// TODO v2`
+  comment makes the debt invisible.
+
+### Exceptions tolerated
+
+Three narrowly-scoped exceptions are explicitly tolerated. They exist
+because the rule, applied absolutely, would create larger problems than
+the ones it solves.
+
+- **Kill switches on demo-critical paths.** The Scan flow can switch to
+  a hardcoded mock if the OpenFoodFacts API degrades on defense day.
+  The kill switch is a legitimate feature flag because it ships with a
+  running feature and its removal is dated.
+- **Abstractions imposed by the architecture.** The Clean Architecture
+  layering (`domain/` / `data/` / `application/` / `presentation/`)
+  does not need per-feature justification. It is a project-wide
+  invariant; applying it is not premature abstraction.
+- **Dated transient `TODO` markers** in the form
+  `// TODO @<initials> <YYYY-MM-DD>: <text>`. The deadline is the
+  safety net. A transient TODO without a date or an assignee is
+  forbidden.
+
+---
+
+## Consequences
+
+### Positive
+
+- **v0.1 → v0.2 upgrades become linear.** Shapes are already in place;
+  the work is to fill them, not to rewrite them.
+- **The AI reviewer workflow becomes predictable.** Both Copilot and
+  Codex read `CLAUDE.md` (which references this ADR) and flag
+  violations — feature flags without a running feature, TODO without a
+  trace, generic helpers at the second usage.
+- **ADRs accumulate as the contract between milestones.** Each
+  structural decision becomes a document a future reader (or agent)
+  can grep for instead of reverse-engineering intent from the code.
+
+### Negative
+
+- **Upfront cost on naming and types.** Encoding future variants in
+  type unions at v0.1 requires a judgement call the author would not
+  otherwise make. Getting it wrong costs a later rename.
+- **Discipline required on scope.** The rule can be used to justify
+  speculative work ("let's build the community backend now because the
+  `source: 'community'` variant is in the type"). The anti-patterns
+  and exceptions above are the guard rails.
+- **Enforcement depends on reviewer vigilance.** No linter catches
+  "premature abstraction" or "TODO without issue link". We rely on
+  Copilot / Codex + the human reviewer at PR time.
+
+---
+
+## Enforcement
+
+Enforcement is done at PR-review time, via the AI reviewers already
+active on every PR in this repository.
+
+- **Reference in `CLAUDE.md`** — the file already loaded by every agent
+  at session start — links this ADR. Copilot and Codex therefore read
+  the rule before reviewing each PR.
+- **Every PR review** cross-checks the diff against the five clauses,
+  the four anti-patterns, and the three exceptions.
+- **Disagreements** are resolved inline by the human owner using the
+  Must / Should / Nice / Disagree triage documented in the global
+  `CLAUDE.md`.
+
+No automated linting rule is added. The anti-patterns are mostly
+qualitative (premature abstraction, phantom hooks) and poorly expressed
+in AST rules. The cost of a custom ESLint rule set would exceed the
+value at project stage v0.1.
+
+---
+
+## Roadmap
+
+- **v0.1 (pre-defense)** — this ADR is the current working rule.
+- **v0.2** — when the community backend lands, revisit the `source:
+  'community'` variant and the `contributedBy` / `contributedAt` /
+  `approvedAt` fields to confirm they still match the actual shape.
+- **v0.3+** — if automated linting becomes cost-effective (e.g. via a
+  shared AI-review ruleset published by a third party), write an ADR
+  that supersedes the "Enforcement" section of this one.
+
+---
+
+## References
+
+- `docs/product/brainstorms/scan-2026-04-24.md` § 4 — cites this
+  principle as the structural rule for the Scan feature.
+- `docs/product/brainstorms/compte-parametres-2026-04-24.md` § 15 —
+  cites this principle as the structural rule for the merged `Compte`
+  screen.
+- `CLAUDE.md` (root) — where this ADR is referenced for AI-agent
+  consumption.
+- Michael Nygard, *Documenting Architecture Decisions* (2011) — template.

--- a/docs/architecture/decisions/0002-centralized-nestjs-backend.md
+++ b/docs/architecture/decisions/0002-centralized-nestjs-backend.md
@@ -82,9 +82,10 @@ Concretely:
   TTL on the Scan responses in v0.1).
 - **Backend becomes a single point of failure.** If our NestJS API is
   down, mobile cannot scan even if OpenFoodFacts is up. Mitigated
-  short-term by bundling six demo beers in the app (see `scan-2026-04-24.md`
-  § 4.3) and by the 1-hour memory cache; long-term by health-check
-  monitoring and autoscaling.
+  short-term by bundling six demo beers in the app (see
+  `docs/product/brainstorms/scan-2026-04-24.md` § 4.3) and by the
+  1-hour memory cache; long-term by health-check monitoring and
+  autoscaling.
 - **Server cost.** Proxying every call means we pay compute and
   bandwidth for traffic that could have gone peer-to-peer with OFF.
   Acceptable at v0.1 volumes; revisit if the scan volume crosses
@@ -101,9 +102,12 @@ Concretely:
 - **v0.2** — add Wikipedia enrichment + a real beer DB for
   hand-curated official recipes (BrewDog DIY Dog, Chouffe, Rochefort,
   Karmeliet). Redis cache replaces in-memory.
-- **v0.3+** — Untappd / RateBeer integrations (paid APIs) flipped on
-  with a feature flag that actually gates a running feature (per
-  ADR-0001 anti-pattern #1 exception).
+- **v0.3+** — Untappd / RateBeer integrations (paid APIs) ship behind
+  a feature flag that **actually gates a running feature**, not a
+  speculative one — so the flag complies with ADR-0001's
+  "Feature flags for non-existent features" anti-pattern (the
+  feature exists and the flag controls its exposure, which is a
+  legitimate usage, not an exception).
 
 ---
 

--- a/docs/architecture/decisions/0002-centralized-nestjs-backend.md
+++ b/docs/architecture/decisions/0002-centralized-nestjs-backend.md
@@ -1,0 +1,116 @@
+# ADR-0002 — Centralized NestJS backend for all external data sources
+
+**Status**  Accepted
+**Date**    2026-04-24
+**Owners**  @benoit-bremaud
+
+---
+
+## Context
+
+The Scan feature needs data about a bottle after a barcode is captured.
+In v0.1 the only source is OpenFoodFacts. In v0.2 and beyond we
+anticipate adding Wikipedia (for brewery stories), Untappd and RateBeer
+(for community ratings), brewery websites (for official published
+recipes), and a private database (for recipes submitted by our own
+community). Similar cross-source needs exist for the Ingredients and
+Equipment catalogues when they graduate from seed data to live data.
+
+Two architectures compete:
+
+- **Mobile talks directly to each external API.** Short-term speed; the
+  mobile team wires an HTTP client per provider.
+- **Mobile talks only to our NestJS backend, which proxies every
+  external source.** One integration surface for the mobile app, one
+  place to manage keys, caches, and retries.
+
+---
+
+## Decision
+
+The mobile app talks **only** to our NestJS backend. The backend proxies
+every external data source.
+
+```
+┌─────────────┐         ┌──────────────────┐
+│ Mobile app  │ ──────▶ │  NestJS backend  │
+└─────────────┘         └──────────────────┘
+                              │    │    │
+                              ▼    ▼    ▼
+                           ┌────┐ ┌──┐ ┌──┐
+                           │ OFF│ │WP│ │DB│
+                           └────┘ └──┘ └──┘
+```
+
+Concretely:
+
+- The mobile app's **sole HTTP client** points at the NestJS base URL.
+- Every external API integration (OpenFoodFacts today; Wikipedia /
+  Untappd / RateBeer / brewery scrapers tomorrow) lives server-side.
+- The backend owns **caching** (in-memory now, Redis when justified),
+  **retry / timeout** policies, and **response shape normalisation**
+  (mobile sees a single canonical `BeerData` regardless of the source
+  chain that produced it).
+- External API **credentials** (keys, tokens, OAuth secrets) are held
+  server-side. None ever ships in a mobile bundle.
+
+---
+
+## Consequences
+
+### Positive
+
+- **No key leakage on mobile.** API credentials for paid or
+  rate-limited sources never reach the device.
+- **One mobile surface.** Adding a new data source is a server-side
+  task. No mobile deployment, no App Store / Play Store wait, no
+  forced client-side update.
+- **Central caching and rate-limiting.** A cache hit on the server
+  serves every mobile client. OpenFoodFacts free-tier rate limits do
+  not leak into UX flakiness per user.
+- **Response normalisation.** Mobile consumes a stable `BeerData`
+  shape. Source substitution (OFF → brewery API for a given SKU) is
+  invisible to the mobile code.
+- **Aligned with ADR-0001.** The `source` discriminant on `BeerData`
+  exists from day one even though only `'openfoodfacts'` is populated
+  in v0.1.
+
+### Negative
+
+- **Extra hop on every request.** Mobile → backend → external source
+  adds network latency. Mitigated by the server-side cache (1-hour
+  TTL on the Scan responses in v0.1).
+- **Backend becomes a single point of failure.** If our NestJS API is
+  down, mobile cannot scan even if OpenFoodFacts is up. Mitigated
+  short-term by bundling six demo beers in the app (see `scan-2026-04-24.md`
+  § 4.3) and by the 1-hour memory cache; long-term by health-check
+  monitoring and autoscaling.
+- **Server cost.** Proxying every call means we pay compute and
+  bandwidth for traffic that could have gone peer-to-peer with OFF.
+  Acceptable at v0.1 volumes; revisit if the scan volume crosses
+  paying-tier thresholds.
+
+---
+
+## Roadmap
+
+- **v0.1 (pre-defense)** — single endpoint `GET /beers/:barcode`
+  proxying OpenFoodFacts, with a 1-hour in-memory cache. 501 stubs
+  for `POST /beer-contributions` and community endpoints (per
+  ADR-0001 clause 3).
+- **v0.2** — add Wikipedia enrichment + a real beer DB for
+  hand-curated official recipes (BrewDog DIY Dog, Chouffe, Rochefort,
+  Karmeliet). Redis cache replaces in-memory.
+- **v0.3+** — Untappd / RateBeer integrations (paid APIs) flipped on
+  with a feature flag that actually gates a running feature (per
+  ADR-0001 anti-pattern #1 exception).
+
+---
+
+## References
+
+- `docs/product/brainstorms/scan-2026-04-24.md` § 4 — original
+  architecture decision captured during the Scan Q&A.
+- ADR-0001 — "Build for today, design for tomorrow" — dictates that
+  the `source` discriminant and the 501-stub endpoints exist from day
+  one.

--- a/docs/architecture/decisions/0003-consent-single-source-of-truth.md
+++ b/docs/architecture/decisions/0003-consent-single-source-of-truth.md
@@ -46,10 +46,25 @@ interface ConsentDecision {
 }
 ```
 
-- **Axis** is a stable identifier, namespaced by feature prefix when
-  the axis is feature-local (`scan.barcode`, `scan.photos`,
-  `scan.metadata`) and un-prefixed when it crosses features
-  (`ml.training`, `telemetry`).
+- **Axis** is a stable identifier, namespaced by feature prefix
+  when the axis is feature-local and un-prefixed when it crosses
+  features. The canonical axes for v0.1 are:
+  - `scan.barcode` — feature-local, barcode value storage.
+  - `scan.photos` — feature-local, front/back label photo storage.
+  - `scan.metadata` — feature-local, capture timestamps and device
+    info.
+  - `scan.training` — feature-local, opt-in for ML training on
+    scan data specifically (captured inline during the scan
+    onboarding modal because that is the first context where the
+    user is asked).
+  - `ml.training` — global, opt-in for any ML training on user
+    data (captured in the `Compte` privacy section). Supersedes
+    `scan.training` when more recent — see the read contract below.
+  - `telemetry` — global, opt-in for anonymous usage telemetry
+    (captured in the `Compte` privacy section).
+
+  New axes — both feature-local and global — are added with a new
+  ADR or a documented entry in the ADR roadmap.
 - **Source** records *where* the decision was taken, for audit
   purposes (the user flipped telemetry off from the Settings screen;
   the user granted scan.training from the onboarding modal).
@@ -60,19 +75,33 @@ interface ConsentDecision {
   future surface) **must** go through the `consent.use-cases.ts`
   use-case. Direct writes to `AsyncStorage` / `SQLite` are forbidden.
 - **Readers** query the use-case for the latest decision per axis.
-  If a feature needs both a feature-local axis and the global axis,
-  it reads both (e.g. ML training in Scan reads `scan.training` OR
-  `ml.training`, falling back to `false`).
+  When a feature depends on an axis that has both a feature-local
+  form and a global form (e.g. ML training exists as both
+  `scan.training` and `ml.training`), the **most recent decision
+  across both axes wins** — never an `OR` or a per-axis fallback.
+  Rationale: a global opt-out entered yesterday must supersede a
+  feature-local opt-in entered last month, and vice-versa. Encoded
+  as a single helper `canUseForTraining()` that scans the log for
+  any record matching either axis and returns the most-recent
+  `value`.
 - A decision is **never overwritten silently**. Every new write
-  appends a new `ConsentDecision` record. The current value is the
-  latest record per axis. This gives us a free consent log for GDPR.
+  appends a new `ConsentDecision` record. The current value for a
+  given axis is derived by querying the log for the latest record
+  carrying that axis. This gives us a free consent log for GDPR.
 
 ### Storage
 
-- v0.1 — local `AsyncStorage` JSON blob keyed by axis.
-- v0.2 — when auth lands (see ADR-0002's roadmap), the consent log
+- v0.1 — a single `AsyncStorage` key (`brasse.consent.log`) holding
+  a JSON array of `ConsentDecision` records, **append-only**. Each
+  write reads the current array, appends the new record, and writes
+  the array back. The shape is never a map keyed by axis — a
+  per-axis key would overwrite prior decisions and break the
+  GDPR audit trail the append-only clause above guarantees.
+- v0.2 — when auth lands (see ADR-0002's roadmap), the same log
   syncs to the backend and becomes downloadable / deletable on
-  request.
+  request. The v0.1 array shape maps 1-to-1 onto the v0.2 backend
+  table (one row per `ConsentDecision`), so there is no migration
+  semantics beyond a first-sync upload.
 
 ---
 
@@ -86,7 +115,7 @@ interface ConsentDecision {
 - **Free GDPR consent log.** The append-only store IS the consent
   history the regulator expects. Per the `Compte` brainstorm (Axis
   D, conservative cuts), the v0.1 MVP collects the log silently; v0.2
-  adds the browseable UI, but no data backfill is needed because the
+  adds the browsable UI, but no data backfill is needed because the
   v0.1 store is already the right shape.
 - **Testability.** A single use-case to mock in unit tests for Scan,
   for Settings, and for any future consent-touching feature.
@@ -97,10 +126,14 @@ interface ConsentDecision {
 
 ### Negative
 
-- **Two-axis reads.** A feature that cares about "ML training
-  allowed?" has to read both `scan.training` and `ml.training`. We
-  encapsulate this in a small helper (`canUseForTraining()`) so the
-  two-axis logic does not leak into presentation code.
+- **Two-axis reads with most-recent-wins semantics.** A feature
+  that cares about "ML training allowed?" has to scan the log for
+  the most-recent record across both `scan.training` and
+  `ml.training`. We encapsulate this in a small helper
+  (`canUseForTraining()`) so the two-axis logic does not leak into
+  presentation code. The helper never `OR`s axis values — doing so
+  would let a stale feature-local opt-in survive a more recent
+  global opt-out, which is a GDPR compliance failure.
 - **Append-only store grows.** A very chatty user could accumulate
   hundreds of records over time. Acceptable at v0.1 volumes. v0.2
   compaction (keep only the last N records per axis for display,
@@ -114,7 +147,7 @@ interface ConsentDecision {
 - **v0.1 (pre-defense)** — single `AsyncStorage` store, two writers
   (Scan onboarding, Settings privacy), namespaced axes.
 - **v0.2** — backend sync when auth is wired (B-13 bis resolved),
-  browseable consent log UI in the Settings screen, real GDPR
+  browsable consent log UI in the Settings screen, real GDPR
   export.
 - **v0.3+** — compaction policy for old records; export format
   negotiation with any external regulator reporting requirement.

--- a/docs/architecture/decisions/0003-consent-single-source-of-truth.md
+++ b/docs/architecture/decisions/0003-consent-single-source-of-truth.md
@@ -1,0 +1,134 @@
+# ADR-0003 — Consent as a single source of truth
+
+**Status**  Accepted
+**Date**    2026-04-24
+**Owners**  @benoit-bremaud
+
+---
+
+## Context
+
+Two independent features both collect user consent decisions:
+
+- **Scan** — at the moment the user first uses the scanner, four
+  consent axes are gathered (barcode value storage, photo storage,
+  metadata collection, ML-training opt-in). Each axis is stored with
+  the pending scan and can be revoked by purging local scan data.
+- **`Compte` screen (Axis C, "Privacy" section)** — the future
+  account / settings screen exposes two global toggles: telemetry
+  opt-in / opt-out and ML-training opt-in / opt-out. The second
+  overlaps directly with the Scan `training` axis.
+
+If these two surfaces each write to their own storage, the user
+experiences contradictions: toggling ML training off in the settings
+screen may leave the Scan store still recording training data, or
+vice-versa. That is a GDPR consistency failure.
+
+---
+
+## Decision
+
+We commit to **one canonical consent store** on the mobile app. Every
+feature that reads or writes a consent decision uses this store.
+
+### Canonical shape
+
+```ts
+// domain/consent/consent.types.ts
+interface ConsentDecision {
+  axis: ConsentAxis;           // 'scan.barcode' | 'scan.photos' |
+                                //  'scan.metadata' | 'ml.training' |
+                                //  'telemetry' | …
+  value: boolean;
+  decidedAt: string;            // ISO timestamp
+  source: ConsentSource;        // 'scan.onboarding' | 'settings.privacy'
+                                //  | 'scan.purge' | …
+}
+```
+
+- **Axis** is a stable identifier, namespaced by feature prefix when
+  the axis is feature-local (`scan.barcode`, `scan.photos`,
+  `scan.metadata`) and un-prefixed when it crosses features
+  (`ml.training`, `telemetry`).
+- **Source** records *where* the decision was taken, for audit
+  purposes (the user flipped telemetry off from the Settings screen;
+  the user granted scan.training from the onboarding modal).
+
+### Write and read contracts
+
+- **Writers** (Scan onboarding modal, Settings privacy toggles, any
+  future surface) **must** go through the `consent.use-cases.ts`
+  use-case. Direct writes to `AsyncStorage` / `SQLite` are forbidden.
+- **Readers** query the use-case for the latest decision per axis.
+  If a feature needs both a feature-local axis and the global axis,
+  it reads both (e.g. ML training in Scan reads `scan.training` OR
+  `ml.training`, falling back to `false`).
+- A decision is **never overwritten silently**. Every new write
+  appends a new `ConsentDecision` record. The current value is the
+  latest record per axis. This gives us a free consent log for GDPR.
+
+### Storage
+
+- v0.1 — local `AsyncStorage` JSON blob keyed by axis.
+- v0.2 — when auth lands (see ADR-0002's roadmap), the consent log
+  syncs to the backend and becomes downloadable / deletable on
+  request.
+
+---
+
+## Consequences
+
+### Positive
+
+- **No cross-surface contradictions.** Toggling ML training off in
+  the Settings privacy section immediately hides training data from
+  the Scan flow, and vice-versa.
+- **Free GDPR consent log.** The append-only store IS the consent
+  history the regulator expects. Per the `Compte` brainstorm (Axis
+  D, conservative cuts), the v0.1 MVP collects the log silently; v0.2
+  adds the browseable UI, but no data backfill is needed because the
+  v0.1 store is already the right shape.
+- **Testability.** A single use-case to mock in unit tests for Scan,
+  for Settings, and for any future consent-touching feature.
+- **Aligned with ADR-0001.** The axis namespace (`scan.*`, `ml.*`,
+  `telemetry`) is wider than what v0.1 uses, but that is intentional
+  — the shape anticipates v0.2 axes (push notifications, social
+  sharing) without needing a store migration.
+
+### Negative
+
+- **Two-axis reads.** A feature that cares about "ML training
+  allowed?" has to read both `scan.training` and `ml.training`. We
+  encapsulate this in a small helper (`canUseForTraining()`) so the
+  two-axis logic does not leak into presentation code.
+- **Append-only store grows.** A very chatty user could accumulate
+  hundreds of records over time. Acceptable at v0.1 volumes. v0.2
+  compaction (keep only the last N records per axis for display,
+  full log for regulator export) is a known migration, documented
+  in the roadmap.
+
+---
+
+## Roadmap
+
+- **v0.1 (pre-defense)** — single `AsyncStorage` store, two writers
+  (Scan onboarding, Settings privacy), namespaced axes.
+- **v0.2** — backend sync when auth is wired (B-13 bis resolved),
+  browseable consent log UI in the Settings screen, real GDPR
+  export.
+- **v0.3+** — compaction policy for old records; export format
+  negotiation with any external regulator reporting requirement.
+
+---
+
+## References
+
+- `docs/product/brainstorms/scan-2026-04-24.md` § 2 — Scan consent
+  axes decided.
+- `docs/product/brainstorms/compte-parametres-2026-04-24.md` § 6 —
+  `Compte` screen Axis D (GDPR) decided to plumb consent into the
+  same store as Scan.
+- ADR-0001 — "Build for today, design for tomorrow" — dictates that
+  the v0.1 store shape carries the v0.2 axes already.
+- ADR-0002 — "Centralized NestJS backend" — sets the contract for
+  the v0.2 backend sync.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -1,0 +1,54 @@
+# Architecture Decision Records (ADRs)
+
+This folder collects the **structural decisions** made on the Brasse-Bouillon
+project. Each ADR is a self-contained document that captures:
+
+- The **context** that forced the decision.
+- The **decision** itself (what we commit to, and what we explicitly rule out).
+- The **consequences** (positive and negative) we accept.
+- Optionally, the **migration roadmap** to the next state.
+
+---
+
+## Format
+
+Every ADR follows the same skeleton (inspired by Michael Nygard's template):
+
+```
+# ADR-NNNN — Title
+
+**Status**  Proposed / Accepted / Deprecated / Superseded by ADR-MMMM
+**Date**    YYYY-MM-DD
+**Owners**  @handle(s)
+
+## Context
+## Decision
+## Consequences
+## Roadmap (optional)
+## References (optional)
+```
+
+- **Filename**: `NNNN-kebab-case-title.md`, zero-padded four-digit index.
+- **Language**: English (per `docs/CONVENTIONS.md` §1). French labels are
+  kept in code spans when they refer to the in-app UI.
+- **Mutability**: an ADR is append-only once **Accepted**. To change a
+  decision, write a new ADR that **supersedes** the old one and flip the
+  old one's status to `Superseded by ADR-MMMM`.
+
+---
+
+## Index
+
+| # | Title | Status | Date |
+|---|-------|--------|------|
+| [0001](0001-build-for-today-design-for-tomorrow.md) | Build for today, design for tomorrow | Accepted | 2026-04-24 |
+| [0002](0002-centralized-nestjs-backend.md) | Centralized NestJS backend for all external data sources | Accepted | 2026-04-24 |
+| [0003](0003-consent-single-source-of-truth.md) | Consent as a single source of truth | Accepted | 2026-04-24 |
+
+---
+
+## Related documents
+
+- `CLAUDE.md` (root) — project conventions that AI agents apply.
+- `docs/CONVENTIONS.md` — naming, language, structure rules.
+- `docs/product/brainstorms/` — product Q&A sessions that feed the ADRs.


### PR DESCRIPTION
## Summary

Formalises three architectural decisions that governed the Brasse-Bouillon code informally and needed a written contract. All three are accepted, dated 2026-04-24, and indexed under a new `docs/architecture/decisions/` folder.

- **[ADR-0001 — Build for today, design for tomorrow](docs/architecture/decisions/0001-build-for-today-design-for-tomorrow.md)** — five-clause rule (minimal implementation, shapes anticipate evolution, `501 Not Implemented` stubs, components extensible by default, one ADR per structural choice), four forbidden anti-patterns (feature flags for non-existent features, phantom lifecycle hooks, premature abstraction, `TODO v2` without trace), three tolerated exceptions (kill switches, imposed architecture, dated transient TODO markers). Enforcement at PR-review time via AI reviewers reading the ADR through `CLAUDE.md`.
- **[ADR-0002 — Centralized NestJS backend for all external data sources](docs/architecture/decisions/0002-centralized-nestjs-backend.md)** — mobile talks only to our NestJS API; backend proxies OpenFoodFacts today and Wikipedia / Untappd / RateBeer / brewery scrapers tomorrow. Credentials and caching server-side. Captures the decision taken in the Scan brainstorm (PR #686).
- **[ADR-0003 — Consent as a single source of truth](docs/architecture/decisions/0003-consent-single-source-of-truth.md)** — one canonical append-only consent store on the mobile app, feature-namespaced axes (`scan.barcode`, `scan.photos`, `scan.metadata`, `ml.training`, `telemetry`, …). Resolves the overlap between Scan consent (4 axes) and the privacy toggles on the merged `Compte` screen (PR #688, Axis D).

Also ships:
- A new `docs/architecture/decisions/README.md` documenting the ADR template, mutability policy (append-only once accepted), and an index table.
- Root `CLAUDE.md` updated with a mandatory "Architecture Decision Records" section linking the three ADRs, so every agent starting a session reads them before reviewing code.
- `PROJECT_LOG.md` entry for this session.

## Checklist

- [x] Happy path + sad path + edge cases covered — N/A (documentation PR)
- [x] `tsc --noEmit` passes — N/A (no code)
- [x] Build passes — N/A (no code)
- [x] Existing tests still green — N/A (no code)
- [x] No `any`, no inline styles introduced — N/A (no code)
- [x] `PROJECT_LOG.md` updated

## Files

- `docs/architecture/decisions/0001-build-for-today-design-for-tomorrow.md` — new
- `docs/architecture/decisions/0002-centralized-nestjs-backend.md` — new
- `docs/architecture/decisions/0003-consent-single-source-of-truth.md` — new
- `docs/architecture/decisions/README.md` — new (folder index + template + policy)
- `CLAUDE.md` — adds ADR section + index at the bottom
- `PROJECT_LOG.md` — session entry

## Related

- Formalises decisions taken in [PR #686](https://github.com/benoit-bremaud/brasse-bouillon/pull/686) (Scan brainstorm) and [PR #688](https://github.com/benoit-bremaud/brasse-bouillon/pull/688) (Compte & settings brainstorm).
- Third of four brainstorms scheduled for 2026-04-24 morning session (Personas + journey debrief is the fourth).