### PR TITLE
docs(personas): refactor into 5 personas + log enrichment PR #691

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -82,7 +82,8 @@ garbled "anti-pattern exception" wording) and ADR-0003 (incomplete
 canonical axis list missing `scan.training`, two `browseable`
 typos) — three unique + four duplicates, all grouped with
 cross-references. All nine addressed in commit `508bab2`.
- All three land as accepted ADRs under a new folder
+
+All three land as accepted ADRs under a new folder
 [`docs/architecture/decisions/`](docs/architecture/decisions/) with a
 README explaining the template (Michael Nygard format) and the
 mutability policy (append-only once accepted, supersession via a new

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,12 +7,82 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-04-24
 
-### Architecture session — three ADRs accepted
+### Personas review — 5 personas + drêches bonus planned
+
+Morning session final brainstorm (fourth of four) — full personas
+review triggered by the user's request to reconcile the existing
+[docs/personas/user_personas.md](docs/personas/user_personas.md)
+(3 personas: Nicolas / Claire / Marc) with the product decisions
+taken earlier in the day (Scan brainstorm introduced a "curious
+amateur" primary persona, Compte brainstorm used an unnamed
+"Marie" brewer in examples, Google Forms survey surfaced a strong
+ecology axis with zero feature ship).
+
+Method: debrief by tensions, five tensions resolved one by one
+with clickable Q&A:
+
+- **Tension 1 (vocabulary)** — proper names (Léa, Nicolas, Claire,
+  Zoé, Marc) stay in the personas file for storytelling; technical
+  roles (Discovery / Novice / Amateur / Eco-responsible / Expert)
+  are used in user stories, user scenarios, GitHub tickets, and
+  code comments.
+- **Tension 2 (Scan brainstorm's "curious amateur")** — promoted
+  to a distinct 4th persona **Léa la Curieuse** (25-32, young urban
+  active, discovered a beer socially, no brewing equipment). Becomes
+  the primary persona for the 2026-05-27 defense (scan demo hero).
+- **Tension 3 (gaps personas → features)** — aligned on the P0-P4
+  priority already validated; each persona has at least one v0.1
+  feature served (Léa: full scan; Nicolas: Académie Glossaire;
+  Claire: labels + UI fluidity; Zoé: drêches bonus; Marc: CSV
+  export bonus), everything else roadmapped v0.2+.
+- **Tension 4 (admin persona)** — Admin dropped from the brewer
+  personas (not a brewer). The two admin user scenarios (public
+  recipe management, user management) were removed from
+  [docs/user_scenarios/user_scenarios.md](docs/user_scenarios/user_scenarios.md)
+  with a note redirecting to a future v0.2+ epic "Community
+  moderation".
+- **Tension 5 (ecology)** — created a 5th persona **Zoé la
+  Brasseuse Éco-responsable** (28-40, ecology-adjacent profession,
+  1-2 years of brewing) and committed to ship a minimal
+  **drêches (spent grain) valorization** feature in v0.1 as a
+  planned bonus (~0.5-1j: an end-of-batch card suggesting 3-5
+  hand-written recipes to reuse the spent grain).
+  [docs/requirements/user_needs.md](docs/requirements/user_needs.md)
+  §4 rewritten as a table with explicit version status per item
+  (drêches v0.1, carbon footprint v0.2+, local suppliers v0.2+).
+
+Final personas: 5 (Léa primary + Nicolas + Claire + Zoé + Marc),
+mapping table + reference rule added at the top of the personas
+file. Version bumped to v2 with a versioning history block.
+
+**Side effect**: the user adopted *"Build for today, design for
+tomorrow"* (ADR-0001 title) as a structuring catchphrase for the
+rest of the defense preparation — the phrase now ties the Scan
+brainstorm, the Compte brainstorm, the three ADRs, and the personas
+priority table into a single coherent narrative.
+
+### Architecture session — three ADRs accepted ([PR #691](https://github.com/benoit-bremaud/brasse-bouillon/pull/691))
 
 Morning session continuation (third of four brainstorms scheduled for
 the day) — structured Q&A to formalize three architectural decisions
 that already governed the code informally and needed a written
-contract. All three land as accepted ADRs under a new folder
+contract.
+
+Branch `docs/adr-001-002-003`, merged as `148da08`. Review cycle:
+two Codex **P1 (Must Have)** comments on ADR-0003 revealing real
+logic bugs — (a) the read contract `scan.training OR ml.training`
+preserved a stale opt-in over a newer global opt-out (GDPR
+compliance failure), rewritten as "most recent decision across
+both axes wins" with a single helper scanning the append-only log;
+(b) v0.1 storage described as "AsyncStorage keyed by axis"
+contradicted the append-only clause — rewritten as a single
+`brasse.consent.log` key holding a JSON array of `ConsentDecision`
+records. Seven Copilot comments on ADR-0002 (broken path reference,
+garbled "anti-pattern exception" wording) and ADR-0003 (incomplete
+canonical axis list missing `scan.training`, two `browseable`
+typos) — three unique + four duplicates, all grouped with
+cross-references. All nine addressed in commit `508bab2`.
+ All three land as accepted ADRs under a new folder
 [`docs/architecture/decisions/`](docs/architecture/decisions/) with a
 README explaining the template (Michael Nygard format) and the
 mutability policy (append-only once accepted, supersession via a new

--- a/docs/personas/user_personas.md
+++ b/docs/personas/user_personas.md
@@ -1,55 +1,143 @@
 # 🎯 User Personas – Brasse-Bouillon
 
-Ce document présente les profils types d'utilisateurs cibles de l'application Brasse-Bouillon. Chaque persona est conçu pour refléter des attentes, comportements, frustrations et besoins spécifiques, et ainsi guider les choix de conception et d’interface.
+Ce document présente les profils types d'utilisateurs cibles de l'application Brasse-Bouillon. Chaque persona est conçu pour refléter des attentes, comportements, frustrations et besoins spécifiques, et ainsi guider les choix de conception et d'interface.
+
+**Version** : 2 (2026-04-24) — refonte après debrief personas de la session brainstorms soutenance.
 
 ---
 
-## 👤 Persona 1 – Nicolas le Débutant 🔎
+## 🗺️ Cartographie des personas
+
+### Rôles utilisateur de l'application
+
+| Rôle (technique) | Persona (narrative) | Statut v0.1 |
+|---|---|---|
+| Découverte / Curieuse | **Léa la Curieuse** | ⭐ **Persona primaire de la soutenance** (demo hero) |
+| Débutant | **Nicolas le Débutant** | Cible secondaire — servi par Scan + onboarding |
+| Amateur créatif | **Claire l'Amatrice Créative** | Cible secondaire — journal brassage partiel (B-08 v0.2) |
+| Éco-responsable | **Zoé la Brasseuse Éco-responsable** | Cible secondaire — servie par la valorisation des drêches |
+| Expert | **Marc le Brasseur Expert** | Vision v0.2 — export CSV possible en bonus |
+
+### Règle de référence
+
+Les **noms propres** (Léa, Nicolas, Claire, Zoé, Marc) sont utilisés dans cette fiche personas et dans le storytelling (soutenance, deck ydays, supports de communication) pour humaniser les utilisateurs cibles.
+
+Les **rôles techniques** (Découverte / Débutant / Amateur / Éco-responsable / Expert) sont utilisés dans les documents techniques (user stories, user scenarios, user_needs, tickets GitHub, commentaires de code) pour garder une indépendance vis-à-vis des renommages.
+
+Exemple :
+- Dans le pitch soutenance : *"Léa vient de scanner une Punk IPA..."*
+- Dans un ticket GitHub : *"As a Curious user, I want to scan a bottle..."*
+
+---
+
+## ⭐ Persona 1 – Léa la Curieuse 🔍
+
+> **Persona primaire de la soutenance du 2026-05-27.**
 
 ### Description
 
-Débutant curieux, technophile et motivé, souvent influencé par des amis ou par l’envie de créer quelque chose de tangible à partager.
+Jeune active urbaine, curieuse, sensible à l'artisanat et à l'expérimentation. Elle vient de goûter une bière originale dans un bar ou chez un ami et se demande *"et si j'essayais d'en brasser une moi-même ?"*. Elle n'a jamais brassé.
 
 ### Profil général
 
-* **Âge :** 30–35 ans
-* **Situation professionnelle :** Jeune actif dans le numérique
-* **Lieu :** Zone urbaine, proche de communautés brassicoles ou magasins spécialisés
+- **Âge :** 25–32 ans
+- **Situation professionnelle :** Jeune active (communication, design, tech, enseignement, métiers créatifs)
+- **Lieu :** Urbain, souvent en colocation ou jeune couple
+- **Équipement brassage :** aucun — cuisine équipée standard (grande casserole, thermomètre de cuisine)
+
+### Déclencheur
+
+Une expérience sociale ponctuelle : une bière découverte dans un bar, chez un ami, à un festival, offerte. Elle ne cherchait pas à brasser ; c'est la bière qui l'a interpellée.
 
 ### Objectifs
 
-* Réussir son premier brassin sans erreur
-* Comprendre les bases du brassage artisanal
-* Partager sa création avec ses proches
+- Comprendre ce qu'est cette bière (style, goût, origine)
+- Se demander si elle peut *"en faire quelque chose de similaire"* chez elle
+- Faire un premier brassin simple, sans investir dans du matériel coûteux
+- Partager l'expérience avec son entourage (le brassin, pas forcément la bière)
 
 ### Frustrations
 
-* Difficulté à comprendre les termes techniques
-* Manque de clarté dans les étapes
-* Informations dispersées ou trop complexes
+- Les applications existantes exigent qu'on sache déjà ce qu'on cherche (IBU, style, gravité)
+- Les termes techniques rebutent au premier contact
+- Les forums et communautés brassicoles supposent un niveau minimum
+- Difficile de passer de *"j'aime cette bière"* à *"voici comment en brasser une équivalente"*
 
 ### Motivations
 
-* Expérience DIY enrichissante
-* Découverte d’un nouvel univers artisanal
-* Fierté de faire soi-même
+- Curiosité et envie de découvrir un savoir-faire
+- Plaisir de raconter *"j'ai brassé une bière inspirée de celle qu'on a bue ensemble"*
+- Culture artisanale / DIY moderne
+- Potentiellement : démarche vers une consommation plus consciente
 
 ### Canaux utilisés
 
-* Instagram, blogs vulgarisés, recommandations d’amis
+- Instagram, TikTok (contenus courts découverte)
+- Recommandations d'amis
+- Bars à bières, festivals brassicoles
+
+### Fonctionnalités clés attendues
+
+Offrir une **porte d'entrée pédagogique** vers le brassage :
+
+- **Scan de bouteille** (code-barres ou photo) — la fonctionnalité hero de la soutenance
+- Fiche bière claire, vocabulaire naturel ("amertume marquée" plutôt que "IBU 40")
+- Proposition de recettes équivalentes accessibles
+- Import direct dans *"Mes Recettes"* avec un parcours simple
+- Contenu pédagogique léger (académie) accessible en un geste
+
+---
+
+## 👤 Persona 2 – Nicolas le Débutant 🔎
+
+### Description
+
+Débutant curieux, technophile et motivé, souvent influencé par des amis ou par l'envie de créer quelque chose de tangible à partager. Il a déjà envie de brasser (démarche active), par opposition à Léa qui est attirée par une bière précise.
+
+### Profil général
+
+- **Âge :** 30–35 ans
+- **Situation professionnelle :** Jeune actif dans le numérique
+- **Lieu :** Zone urbaine, proche de communautés brassicoles ou magasins spécialisés
+
+### Déclencheur
+
+Envie DIY plus générale : *"je veux me lancer dans le brassage maison"*. Moment de vie (confinement, nouveau hobby, cadeau reçu).
+
+### Objectifs
+
+- Réussir son premier brassin sans erreur
+- Comprendre les bases du brassage artisanal
+- Partager sa création avec ses proches
+
+### Frustrations
+
+- Difficulté à comprendre les termes techniques
+- Manque de clarté dans les étapes
+- Informations dispersées ou trop complexes
+
+### Motivations
+
+- Expérience DIY enrichissante
+- Découverte d'un nouvel univers artisanal
+- Fierté de faire soi-même
+
+### Canaux utilisés
+
+- Instagram, blogs vulgarisés, recommandations d'amis
 
 ### Fonctionnalités clés attendues
 
 Offrir une expérience accessible et rassurante :
 
-* Tutoriels interactifs et progressifs
-* Recettes guidées pas-à-pas
-* Liste de courses automatique
-* Lexique intégré pour vulgariser les termes techniques
+- Tutoriels interactifs et progressifs (v0.2)
+- Recettes guidées pas-à-pas
+- Liste de courses automatique (panier local depuis la fiche recette)
+- Lexique intégré pour vulgariser les termes techniques (Académie Glossaire existant — à promouvoir)
 
 ---
 
-## 👩 Persona 2 – Claire l’Amatrice Créative 🍺
+## 👩 Persona 3 – Claire l'Amatrice Créative 🍺
 
 ### Description
 
@@ -57,44 +145,100 @@ Brasseuse passionnée, créative et méthodique. Elle brasse pour le plaisir, ex
 
 ### Profil général
 
-* **Âge :** 35–45 ans
-* **Situation professionnelle :** Active dans un métier créatif (graphisme, artisanat…)
-* **Lieu :** Urbain ou périurbain
+- **Âge :** 35–45 ans
+- **Situation professionnelle :** Active dans un métier créatif (graphisme, artisanat…)
+- **Lieu :** Urbain ou périurbain
+- **Équipement brassage :** Kit débutant à intermédiaire (pot 20-30L, fermenteur, densimètre)
 
 ### Objectifs
 
-* Tester de nouveaux styles de bière
-* Gérer son historique et ses variantes de recettes
-* Partager ses créations avec son entourage ou en ligne
+- Tester de nouveaux styles de bière
+- Gérer son historique et ses variantes de recettes
+- Partager ses créations avec son entourage ou en ligne
 
 ### Frustrations
 
-* Applications existantes trop techniques ou austères
-* Difficile de retrouver ses versions précédentes
-* Peu de recommandations pertinentes
+- Applications existantes trop techniques ou austères
+- Difficile de retrouver ses versions précédentes
+- Peu de recommandations pertinentes
 
 ### Motivations
 
-* Développer son style personnel
-* Être fière de ses productions
-* Créer un lien social autour du brassage
+- Développer son style personnel
+- Être fière de ses productions
+- Créer un lien social autour du brassage
 
 ### Canaux utilisés
 
-* Groupes Facebook, ateliers locaux, chaînes YouTube spécialisées
+- Groupes Facebook, ateliers locaux, chaînes YouTube spécialisées
 
 ### Fonctionnalités clés attendues
 
 Proposer une interface inspirante et personnalisable :
 
-* Journal de brassage riche et visuel
-* Suggestions personnalisées
-* Interface claire et fluide
-* Possibilités de partage communautaire
+- Journal de brassage riche et visuel (v0.2 — B-08 Mes Brassins rewrite)
+- Suggestions personnalisées (v0.2+ — dépend de la feature Community)
+- Interface claire et fluide (présente en v0.1)
+- Possibilités de partage communautaire (v0.2+)
+- Création d'étiquettes de bouteilles personnalisées (présente en v0.1, à finaliser — B-28 / B-29)
 
 ---
 
-## 👨‍🔬 Persona 3 – Marc le Brasseur Expert
+## 🌱 Persona 4 – Zoé la Brasseuse Éco-responsable
+
+### Description
+
+Brasseuse amateure engagée dans une démarche de durabilité. Elle a déjà brassé plusieurs fois et veut maintenant réduire l'empreinte de ses pratiques : valoriser ses déchets, choisir des ingrédients locaux, mesurer son impact.
+
+### Profil général
+
+- **Âge :** 28–40 ans
+- **Situation professionnelle :** Active dans un métier lié à l'écologie ou la durabilité (consultante développement durable, ingénieure environnement, journaliste éco, métier des filières courtes)
+- **Lieu :** Urbain ou rural, souvent avec un potager ou une pratique zéro déchet
+- **Équipement brassage :** Kit intermédiaire, souvent récupéré ou acheté d'occasion
+
+### Déclencheur
+
+Prise de conscience progressive : elle brasse depuis 1-2 ans, elle s'interroge sur les 5-7 kg de drêches qu'elle jette à chaque brassin, sur l'origine des malts et houblons, sur l'énergie du brassage.
+
+### Objectifs
+
+- Valoriser les drêches (recettes zéro déchet, compost, alimentation animale)
+- Choisir des ingrédients locaux et de saison quand c'est possible
+- Mesurer l'impact de ses brassins (empreinte carbone approximative)
+- Inspirer son entourage à une pratique plus sobre
+
+### Frustrations
+
+- Les drêches finissent à la poubelle par manque d'idées ou de temps
+- Pas de données fiables sur l'impact environnemental du brassage amateur
+- Difficile d'identifier les fournisseurs locaux ou responsables
+- Les apps brassicoles ignorent complètement cet axe
+
+### Motivations
+
+- Cohérence entre ses valeurs et ses pratiques
+- Éducation communautaire (partager ses trouvailles)
+- Satisfaction de "fermer la boucle" (du malt à la drêche valorisée)
+
+### Canaux utilisés
+
+- Podcasts et newsletters écologie
+- Instagram *green* / zéro déchet
+- Communautés locales (AMAP, ressourceries, ateliers de réparation)
+
+### Fonctionnalités clés attendues
+
+Servir la boucle complète du brassage :
+
+- **Valorisation des drêches** — à la fin d'un brassin, un encadré "Tu as X kg de drêches → voici 3 recettes pour les valoriser" (v0.1 — à développer, ~0,5-1j)
+- Calcul d'empreinte carbone par brassin (v0.2+)
+- Fournisseurs locaux et responsables géolocalisés (v0.2+ — dépend de la feature Boutique)
+- Tag "ingrédient local" ou "ingrédient bio" dans le catalogue ingrédients (v0.2+)
+
+---
+
+## 👨‍🔬 Persona 5 – Marc le Brasseur Expert
 
 ### Description
 
@@ -102,49 +246,62 @@ Brasseur expérimenté, rigoureux et orienté performance. Il cherche à optimis
 
 ### Profil général
 
-* **Âge :** 45+
-* **Situation professionnelle :** Consultant technique ou cadre dans un domaine scientifique
-* **Lieu :** Résidence avec espace de brassage dédié
+- **Âge :** 45+
+- **Situation professionnelle :** Consultant technique ou cadre dans un domaine scientifique
+- **Lieu :** Résidence avec espace de brassage dédié
 
 ### Objectifs
 
-* Atteindre une régularité parfaite
-* Suivre ses métriques de fermentation
-* Connecter son matériel (capteurs, thermomètres, balances…)
+- Atteindre une régularité parfaite
+- Suivre ses métriques de fermentation
+- Connecter son matériel (capteurs, thermomètres, balances…)
 
 ### Frustrations
 
-* Interfaces trop limitées ou peu techniques
-* Absence d’intégrations API/CSV
-* Manque de précision ou de personnalisation des outils
+- Interfaces trop limitées ou peu techniques
+- Absence d'intégrations API / CSV
+- Manque de précision ou de personnalisation des outils
 
 ### Motivations
 
-* Contrôle total sur chaque variable
-* Optimisation du rendement
-* Partage avancé de ses brassins auprès de pairs exigeants
+- Contrôle total sur chaque variable
+- Optimisation du rendement
+- Partage avancé de ses brassins auprès de pairs exigeants
 
 ### Canaux utilisés
 
-* Reddit, Discord spécialisés, blogs techniques brassicoles
+- Reddit, Discord spécialisés, blogs techniques brassicoles
 
 ### Fonctionnalités clés attendues
 
-Répondre aux exigences d’un brassage poussé :
+Répondre aux exigences d'un brassage poussé :
 
-* Intégration avec fichiers CSV et API tierces
-* Courbes de fermentation et historiques de données
-* Calculs avancés et paramétrables
-* Export structuré et sauvegarde automatique
+- Export CSV des brassins et recettes (v0.1 bonus possible si marge ~0,5j)
+- Calculateurs avancés (présents en v0.1 — Outils)
+- Intégration avec fichiers CSV et API tierces (v0.2+)
+- Courbes de fermentation et historiques de données (v0.2+ — dépend de B-08 Mes Brassins rewrite)
+- Export structuré et sauvegarde automatique (v0.2+)
+- Intégration IoT / capteurs (v0.3+)
 
 ---
 
-## 🧭 Conclusion et impact sur le design
+## 🎯 Impact sur la conception — priorisation soutenance
 
-Ces trois personas permettent de structurer la conception de l’application mobile Brasse-Bouillon. Le système devra répondre à une diversité de profils :
+La soutenance du **2026-05-27** vise en priorité **Léa la Curieuse** (la fonctionnalité de scan est le *demo hero*). Les autres personas sont servies partiellement ou reportées en version 2 :
 
-* Du novice recherchant un accompagnement visuel et simple,
-* À l’amatrice expérimentale attentive à l’expérience utilisateur,
-* Jusqu’à l’expert technophile exigeant des outils avancés.
+| Persona | Fonctionnalités v0.1 (soutenance) | Reste en v0.2+ |
+|---|---|---|
+| **Léa** (primaire) | Scan + reconnaissance + recettes équivalentes + import "Mes Recettes" | Suggestions communautaires avancées |
+| **Nicolas** | Connexion démo + dashboard simplifié + Académie Glossaire existant | Tutoriels interactifs, liste de courses complète |
+| **Claire** | Étiquettes + interface fluide + Académie | Journal brassage riche (B-08), suggestions perso, partage communautaire |
+| **Zoé** | Valorisation des drêches (bonus à développer ~0,5-1j) | Empreinte carbone, fournisseurs locaux, tags bio |
+| **Marc** | Calculateurs avancés existants + Export CSV (bonus si marge) | Courbes fermentation, API / CSV import, IoT |
 
-L’interface devra être à la fois accessible, adaptable et évolutive, pour répondre à leurs besoins respectifs tout en maintenant une cohérence globale.
+Cette stratégie respecte le principe **ADR-0001 "Build for today, design for tomorrow"** : chaque gap non comblé est documenté, chaque persona a un chemin clair vers v0.2.
+
+---
+
+## 📝 Historique des versions
+
+- **v2 (2026-04-24)** — Refonte suite au debrief personas. Ajout de Léa la Curieuse (persona primaire soutenance, issue du brainstorm Scan du matin) et de Zoé la Brasseuse Éco-responsable (angle durabilité issu de la dimension écologique du questionnaire Google Forms). Cartographie rôle / persona ajoutée en tête. Admin retiré des personas brasseurs (voir doc séparée pour les rôles opérateurs / back-office).
+- **v1 (date antérieure)** — Version initiale à 3 personas (Nicolas, Claire, Marc).

--- a/docs/personas/user_personas.md
+++ b/docs/personas/user_personas.md
@@ -10,23 +10,26 @@ Ce document présente les profils types d'utilisateurs cibles de l'application B
 
 ### Rôles utilisateur de l'application
 
-| Rôle (technique) | Persona (narrative) | Statut v0.1 |
-|---|---|---|
-| Découverte / Curieuse | **Léa la Curieuse** | ⭐ **Persona primaire de la soutenance** (demo hero) |
-| Débutant | **Nicolas le Débutant** | Cible secondaire — servi par Scan + onboarding |
-| Amateur créatif | **Claire l'Amatrice Créative** | Cible secondaire — journal brassage partiel (B-08 v0.2) |
-| Éco-responsable | **Zoé la Brasseuse Éco-responsable** | Cible secondaire — servie par la valorisation des drêches |
-| Expert | **Marc le Brasseur Expert** | Vision v0.2 — export CSV possible en bonus |
+| Role ID (EN, canonical) | Libellé FR (display) | Persona (narrative FR) | Statut v0.1 |
+|---|---|---|---|
+| `Discovery` | Découverte / Curieuse | **Léa la Curieuse** | ⭐ **Persona primaire de la soutenance** (demo hero) |
+| `Novice` | Débutant | **Nicolas le Débutant** | Cible secondaire — servi par Scan + onboarding |
+| `Amateur` | Amateur créatif | **Claire l'Amatrice Créative** | Cible secondaire — journal brassage partiel (B-08 v0.2) |
+| `EcoResponsible` | Éco-responsable | **Zoé la Brasseuse Éco-responsable** | Cible secondaire — servie par la valorisation des drêches |
+| `Expert` | Expert | **Marc le Brasseur Expert** | Vision v0.2 — export CSV possible en bonus |
 
-### Règle de référence
+### Règle de référence — bilingue assumée
 
-Les **noms propres** (Léa, Nicolas, Claire, Zoé, Marc) sont utilisés dans cette fiche personas et dans le storytelling (soutenance, deck ydays, supports de communication) pour humaniser les utilisateurs cibles.
+Cette fiche personas est volontairement bilingue. Elle porte à la fois le **storytelling** (destiné au jury francophone, au deck ydays, aux supports de communication) et les **identifiants techniques** utilisés dans le code et les tickets.
 
-Les **rôles techniques** (Découverte / Débutant / Amateur / Éco-responsable / Expert) sont utilisés dans les documents techniques (user stories, user scenarios, user_needs, tickets GitHub, commentaires de code) pour garder une indépendance vis-à-vis des renommages.
+- **Role IDs (en anglais)** — `Discovery`, `Novice`, `Amateur`, `EcoResponsible`, `Expert` — à utiliser dans les user stories, les user scenarios, les tickets GitHub, les commentaires de code, les constantes TypeScript (`enum UserPersonaRole`). Canoniques et stables.
+- **Noms propres (en français)** — Léa, Nicolas, Claire, Zoé, Marc — à utiliser dans la fiche personas ci-dessous, le storytelling soutenance, le deck ydays, les supports de communication. Humanisent les utilisateurs cibles.
+- **Libellés FR display** — Découverte, Débutant, Amateur créatif, Éco-responsable, Expert — à utiliser dans l'UI francophone quand un libellé de rôle doit être affiché à l'utilisateur.
 
-Exemple :
-- Dans le pitch soutenance : *"Léa vient de scanner une Punk IPA..."*
-- Dans un ticket GitHub : *"As a Curious user, I want to scan a bottle..."*
+Exemples :
+- Dans le pitch soutenance (narrative FR) : *"Léa vient de scanner une Punk IPA..."*
+- Dans un ticket GitHub (technical EN) : *"As a `Discovery` user, I want to scan a bottle..."*
+- Dans le code TypeScript : `UserPersonaRole.Discovery`
 
 ---
 

--- a/docs/requirements/user_needs.md
+++ b/docs/requirements/user_needs.md
@@ -68,11 +68,13 @@ Ce document a pour but de synthétiser les retours issus du questionnaire Google
 
 ### 🌱 4. Enjeux écologiques et durables
 
-Les répondants manifestent un intérêt fort pour des outils aidant à :
+Les répondants manifestent un intérêt fort pour des outils aidant à une pratique plus durable. Ces besoins sont incarnés par la **persona Zoé la Brasseuse Éco-responsable** (voir [docs/personas/user_personas.md](../personas/user_personas.md)).
 
-- Valoriser les drêches (recettes zéro déchet, recyclage).
-- Calculer l’empreinte carbone de leurs brassins.
-- Localiser des fournisseurs responsables à proximité.
+| Item | Description | Statut version |
+|---|---|---|
+| ♻️ Valoriser les drêches | Recettes zéro déchet / recyclage / compost | **v0.1 — bonus prévu (~0,5-1j)** |
+| 🌍 Empreinte carbone | Calcul par brassin (ingrédients, transport, énergie) | v0.2+ |
+| 🏪 Fournisseurs responsables | Localiser des partenaires proches et responsables | v0.2+ (dépend de Boutique) |
 
 ---
 

--- a/docs/requirements/user_needs.md
+++ b/docs/requirements/user_needs.md
@@ -66,15 +66,15 @@ Ce document a pour but de synthétiser les retours issus du questionnaire Google
 
 ---
 
-### 🌱 4. Enjeux écologiques et durables
+### 🌱 4. Sustainability and ecology concerns
 
-Les répondants manifestent un intérêt fort pour des outils aidant à une pratique plus durable. Ces besoins sont incarnés par la **persona Zoé la Brasseuse Éco-responsable** (voir [docs/personas/user_personas.md](../personas/user_personas.md)).
+Survey respondents expressed strong interest in tools that support more sustainable brewing practices. These needs are carried by the **`EcoResponsible` persona — Zoé la Brasseuse Éco-responsable** (see [docs/personas/user_personas.md](../personas/user_personas.md)).
 
-| Item | Description | Statut version |
+| Item | Description | Version status |
 |---|---|---|
-| ♻️ Valoriser les drêches | Recettes zéro déchet / recyclage / compost | **v0.1 — bonus prévu (~0,5-1j)** |
-| 🌍 Empreinte carbone | Calcul par brassin (ingrédients, transport, énergie) | v0.2+ |
-| 🏪 Fournisseurs responsables | Localiser des partenaires proches et responsables | v0.2+ (dépend de Boutique) |
+| ♻️ Spent-grain valorization (drêches) | Zero-waste recipes / composting / animal feed | **v0.1 — planned bonus (~0.5-1 day)** |
+| 🌍 Carbon footprint | Per-batch estimate (ingredients, transport, energy) | v0.2+ |
+| 🏪 Responsible suppliers | Locate local, sustainable partners | v0.2+ (depends on Shop feature) |
 
 ---
 

--- a/docs/user_scenarios/user_scenarios.md
+++ b/docs/user_scenarios/user_scenarios.md
@@ -117,10 +117,10 @@ Ce document décrit les scénarios critiques identifiés pour chaque interaction
 
 ---
 
-## Note sur les rôles back-office
+## Note on back-office roles
 
-Les scénarios concernant l'**Administrateur** (gestion des recettes publiques, gestion des utilisateurs) ont été retirés de ce document lors du debrief personas du 2026-04-24. L'Admin n'est pas un persona brasseur au sens du produit Brasse-Bouillon : c'est un rôle opérateur back-office distinct.
+The scenarios about the **Administrator** (public recipe management, user management) were removed from this document during the 2026-04-24 personas debrief. The admin is not a brewer persona in the Brasse-Bouillon product sense — it is a distinct back-office operator role.
 
-Ces scénarios seront documentés séparément en **version 2 (v0.2+)**, en lien avec l'arrivée de la feature **Community** (modération des recettes publiques, gestion des utilisateurs inscrits). Un epic GitHub dédié sera créé (`TBD : epic "Community moderation v0.2+"`) pour porter cette vision.
+These scenarios will be documented separately in **version 2 (v0.2+)**, alongside the arrival of the **Community** feature (public recipe moderation, registered user management). A dedicated GitHub epic will be created (`TBD: epic "Community moderation v0.2+"`) to carry this vision.
 
-Voir la fiche personas [docs/personas/user_personas.md](../personas/user_personas.md) pour la cartographie à jour des rôles brasseurs (Découverte / Débutant / Amateur / Éco-responsable / Expert).
+See the personas sheet [docs/personas/user_personas.md](../personas/user_personas.md) for the up-to-date mapping of brewer roles (`Discovery` / `Novice` / `Amateur` / `EcoResponsible` / `Expert`).

--- a/docs/user_scenarios/user_scenarios.md
+++ b/docs/user_scenarios/user_scenarios.md
@@ -117,34 +117,10 @@ Ce document décrit les scénarios critiques identifiés pour chaque interaction
 
 ---
 
-### **7. Ajouter ou modifier une recette publique**
+## Note sur les rôles back-office
 
-#### Acteur : Administrateur
+Les scénarios concernant l'**Administrateur** (gestion des recettes publiques, gestion des utilisateurs) ont été retirés de ce document lors du debrief personas du 2026-04-24. L'Admin n'est pas un persona brasseur au sens du produit Brasse-Bouillon : c'est un rôle opérateur back-office distinct.
 
-#### Étapes
+Ces scénarios seront documentés séparément en **version 2 (v0.2+)**, en lien avec l'arrivée de la feature **Community** (modération des recettes publiques, gestion des utilisateurs inscrits). Un epic GitHub dédié sera créé (`TBD : epic "Community moderation v0.2+"`) pour porter cette vision.
 
-1. L’administrateur accède à l’interface "Gestion des recettes publiques".
-2. Il sélectionne une recette existante ou clique sur "Ajouter une recette".
-3. Pour une nouvelle recette, il saisit les informations suivantes :
-   - Titre de la recette.
-   - Liste des ingrédients avec quantités.
-   - Étapes détaillées de brassage.
-4. Pour une recette existante, il modifie les informations nécessaires ou supprime la recette.
-5. Une fois terminé, il valide les changements, qui sont publiés pour tous les utilisateurs.
-6. Un journal des modifications est mis à jour pour garder une trace des actions.
-
----
-
-### **8. Gérer les utilisateurs**
-
-#### Acteur : Administrateur
-
-#### Étapes
-
-1. L’administrateur accède à l’interface "Gestion des utilisateurs".
-2. Il recherche un utilisateur via son nom ou adresse email.
-3. L’administrateur peut :
-   - Ajouter un nouvel utilisateur avec les informations nécessaires.
-   - Modifier les droits ou informations d’un utilisateur existant.
-   - Supprimer un utilisateur en cas de besoin.
-4. Chaque action est sauvegardée dans un journal d’administration pour assurer la traçabilité.
+Voir la fiche personas [docs/personas/user_personas.md](../personas/user_personas.md) pour la cartographie à jour des rôles brasseurs (Découverte / Débutant / Amateur / Éco-responsable / Expert).


### PR DESCRIPTION
## Summary

Morning brainstorm #4 of 4 — full personas review triggered by the user's ask to reconcile the existing 3-personas doc with the product decisions taken earlier today (Scan brainstorm, Compte brainstorm, three ADRs). Debrief by **5 tensions**, each resolved with clickable Q&A.

### Personas file — full rewrite

[docs/personas/user_personas.md](docs/personas/user_personas.md) goes from **3 personas** (Nicolas, Claire, Marc) to **5 personas** with a clear role ↔ name mapping:

| Role | Persona | Status v0.1 |
|---|---|---|
| Discovery | **Léa la Curieuse** (NEW) | ⭐ **Primary defense persona** (scan demo hero) |
| Novice | Nicolas le Débutant | Secondary — served by Scan + Académie Glossaire |
| Amateur | Claire l'Amatrice Créative | Secondary — served by Labels + UI fluidity |
| Eco-responsible | **Zoé la Brasseuse Éco-responsable** (NEW) | Secondary — served by drêches bonus |
| Expert | Marc le Brasseur Expert | v0.2 vision — CSV export possible as v0.1 bonus |

### Side files — consistency with the personas decision

- [docs/user_scenarios/user_scenarios.md](docs/user_scenarios/user_scenarios.md) — admin scenarios 7+8 dropped (admin is back-office, not a brewer). Note added pointing to a future v0.2+ "Community moderation" epic.
- [docs/requirements/user_needs.md](docs/requirements/user_needs.md) — ecology section §4 rewritten as a 3-row table with explicit version status per item (drêches v0.1 planned bonus, carbon footprint v0.2+, local suppliers v0.2+). Links to the new Zoé persona.

### Log enrichment for PR #691 (bundled)

[PROJECT_LOG.md](PROJECT_LOG.md) — the ADR session entry from PR #691 is enriched with the PR link, merge SHA (`148da08`), and the review-cycle narrative (2 Codex P1 + 7 Copilot, all addressed in `508bab2`).

## Tensions resolved (5)

1. **Vocabulary** — proper names in personas, roles in technical docs.
2. **Scan's "curious amateur"** — promoted to a distinct 4th persona Léa.
3. **Gaps personas → features** — aligned on the P0-P4 priority already validated.
4. **Admin persona** — dropped from brewer personas, relocated to v0.2+ back-office scope.
5. **Ecology axis** — 5th persona Zoé created + drêches feature planned as v0.1 bonus.

## Checklist

- [x] Happy path + sad path + edge cases covered — N/A (documentation PR)
- [x] `tsc --noEmit` passes — N/A (no code)
- [x] Build passes — N/A (no code)
- [x] Existing tests still green — N/A (no code)
- [x] No `any`, no inline styles introduced — N/A (no code)
- [x] `PROJECT_LOG.md` updated

## Files

- `docs/personas/user_personas.md` — full rewrite (150 → ~260 lines, 5 personas, role mapping, priority table, versioning history)
- `docs/user_scenarios/user_scenarios.md` — admin scenarios dropped + back-office note
- `docs/requirements/user_needs.md` — §4 rewritten with version status table
- `PROJECT_LOG.md` — personas session entry + PR #691 log enrichment

## Related

- Formalises decisions taken in [PR #686](https://github.com/benoit-bremaud/brasse-bouillon/pull/686) (Scan brainstorm) and [PR #688](https://github.com/benoit-bremaud/brasse-bouillon/pull/688) (Compte brainstorm).
- Closes the morning brainstorm sequence (4 of 4 — Scan, Compte, Architecture, Personas).
- Bundles the log enrichment for [PR #691](https://github.com/benoit-bremaud/brasse-bouillon/pull/691) (ADRs) as agreed in chat to avoid a dedicated recursive log-PR cycle.