### PR TITLE
chore(ci): wire release-please to a fine-grained PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,9 +20,21 @@ jobs:
     name: Release Please
     runs-on: ubuntu-latest
     steps:
+      # Use a fine-grained PAT stored as RELEASE_PLEASE_TOKEN. The default
+      # GITHUB_TOKEN cannot be used here because GitHub deliberately refuses
+      # to trigger `pull_request` workflows on events created by its own
+      # internal token (to prevent infinite loops). Consequence with the
+      # default token: every release-please PR gets stuck `BLOCKED` because
+      # the required CI checks (changes / mobile-app / api / SonarCloud)
+      # never start. With a user PAT, the PR is seen as created by a real
+      # user and the CI runs normally.
+      #
+      # Rotation: the PAT expires on 2027-04-24. See issue #703 and
+      # CONTRIBUTING.md §Release workflow for the rotation procedure.
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,8 @@ jobs:
       # to trigger `pull_request` workflows on events created by its own
       # internal token (to prevent infinite loops). Consequence with the
       # default token: every release-please PR gets stuck `BLOCKED` because
-      # the required CI checks (changes / mobile-app / api / SonarCloud)
+      # the required CI checks (changes / mobile-app / api /
+      # SonarCloud Scan / SonarCloud Code Analysis / security-audit)
       # never start. With a user PAT, the PR is seen as created by a real
       # user and the CI runs normally.
       #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,38 @@ in `release-please-config.json` and manifest in
    - Merge the release PR
    - release-please automatically tags + creates the GitHub Release
 
+### Authentication — fine-grained PAT
+
+release-please uses a **fine-grained Personal Access Token** stored as the
+`RELEASE_PLEASE_TOKEN` secret, not the default `GITHUB_TOKEN`. GitHub
+deliberately refuses to trigger `pull_request` workflows on events created
+by its own internal `GITHUB_TOKEN` (to prevent infinite loops). Without a
+user PAT, every release-please PR would get stuck `BLOCKED` by branch
+protection because the required CI checks (`changes`, `mobile-app`, `api`,
+`SonarCloud Scan`) never start.
+
+The current PAT is scoped to this repository only with the following
+permissions:
+
+- `Contents: Read and write`
+- `Pull requests: Read and write`
+- `Issues: Read and write`
+- `Metadata: Read-only` (auto-required)
+
+**Rotation** — the PAT expires on **2027-04-24**. Before that date:
+
+1. Open [GitHub → Settings → Personal access tokens → Fine-grained tokens](https://github.com/settings/personal-access-tokens).
+2. Regenerate the `Brasse-Bouillon release-please` token with the same
+   permissions above and a new expiration date (recommended: 1 year).
+3. Copy the new token, go to [Repo Settings → Secrets and variables → Actions](https://github.com/benoit-bremaud/brasse-bouillon/settings/secrets/actions)
+   and update the `RELEASE_PLEASE_TOKEN` secret value.
+4. Update the expiration date in this document and in the inline comment
+   of `.github/workflows/release-please.yml`.
+
+Missing the rotation means release-please workflows fail silently on the
+next release cycle until the PAT is renewed. Set a calendar reminder for
+`2027-03-24` (one month before expiration).
+
 ### What NOT to do
 
 - **Never `git tag` manually.** All tags are created by release-please.


### PR DESCRIPTION
## Summary

Fixes the recurrent blocker that hit us on [PR #695](https://github.com/benoit-bremaud/brasse-bouillon/pull/695) (first release after B-70 About footer): release-please PRs get stuck BLOCKED because the CI checks never start. Root cause is a GitHub security feature — events created by the default \`GITHUB_TOKEN\` deliberately do not trigger \`pull_request\` workflows (to prevent infinite loops).

## Change

- \`.github/workflows/release-please.yml\`: the action now reads \`secrets.RELEASE_PLEASE_TOKEN\` (a fine-grained PAT scoped to this repo only). PRs created under this token are seen by GitHub as human-initiated and trigger CI normally.
- Inline comment in the workflow documents the reason and the PAT expiration date (2027-04-24).
- \`CONTRIBUTING.md\` §Release Workflow gains an \"Authentication — fine-grained PAT\" subsection with the rotation procedure.

## PAT configuration (already done before this PR)

- Token name: \`Brasse-Bouillon release-please\`
- Repository access: \`Only select repositories\` → \`brasse-bouillon\`
- Permissions: \`Contents: R/W\`, \`Pull requests: R/W\`, \`Issues: R/W\`, \`Metadata: Read-only\`
- Expiration: \`2027-04-24\`
- Stored as repository secret \`RELEASE_PLEASE_TOKEN\`

## Checklist

- [x] Happy path + sad path + edge cases covered — N/A (CI config)
- [x] \`tsc --noEmit\` passes — N/A (no code)
- [x] Build passes — N/A (no code)
- [x] Existing tests still green — N/A (no code)
- [x] No \`any\`, no inline styles introduced — N/A (no code)
- [ ] \`PROJECT_LOG.md\` updated — deferred to the next substantive PR per the log-bundling agreement

## Verification after merge

- Trigger a noop merge to main (e.g. the next feature PR).
- Observe the resulting release-please PR: it should now have the full CI suite attached (\`changes\`, \`mobile-app\`, \`api\`, \`SonarCloud Scan\`, \`security-audit\`) within 30 s of creation, without any manual close + reopen.

## Known limitation — does NOT unstick #695

This PR alone does not create the missing \`mobile-app-v0.1.4-alpha1\` and \`api-v0.1.4-alpha1\` tags — PR #695 is in an inconsistent \`autorelease: pending\` state that release-please refuses to resolve on its own. Phase B (manual tag creation + label flip) will follow in a small follow-up PR or direct commit once this lands.

## Related

- Closes #703 once merged.
- Unblocks the next release-please cycle (v0.1.5-alpha1 when the next feature PR merges).