### PR TITLE
chore(ci): address late Copilot review from PR #704

### DIFF
--- a/.github/tag-protection.md
+++ b/.github/tag-protection.md
@@ -24,24 +24,37 @@ Per the hybrid monorepo release strategy (see [CONTRIBUTING.md](../CONTRIBUTING.
 
 ### Why `creation` is not blocked
 
-release-please runs inside GitHub Actions as `github-actions[bot]` and
-uses the default `GITHUB_TOKEN`. That token is **not** an admin and
-cannot bypass an admin-only creation rule. Blocking creation while
-still wanting automated release tags creates a deadlock.
+As of 2026-04-24, release-please authenticates with a **fine-grained
+Personal Access Token** stored as the `RELEASE_PLEASE_TOKEN` secret
+(see `CONTRIBUTING.md` §Release Workflow → Authentication). The PRs
+and tags it creates are therefore attributed to the **PAT owner**
+(`@benoit-bremaud`, an admin), not to `github-actions[bot]`.
 
-Two possible resolutions were considered:
+The PAT owner is an admin with `always` bypass on this ruleset, so
+they could cross an admin-only creation rule. We still keep `creation`
+unblocked to preserve two properties:
 
-1. **Allow creation for everyone** (chosen for v0) — creation rule
-   removed from the ruleset. Tags become immutable once created
-   (`update` + `deletion` still blocked), which preserves the audit
-   integrity goal. The small risk of rogue tag creation is
-   acceptable for a private solo-dev repo.
-2. **Use a PAT with Integration bypass** (future option) — generate
-   a PAT with `contents: write` + `workflows: write`, store as
-   `secrets.RELEASE_PLEASE_TOKEN`, pass to the release-please action
-   via `token:`. Add the PAT owner as a bypass actor. More secure
-   but adds setup complexity. Track as tech-debt if the repo goes
-   public.
+1. **Determinism** — tags always appear promptly without any admin
+   bypass step at release time.
+2. **No infrastructure deadlock** — should the PAT ever be swapped for
+   a GitHub App (e.g. if the repo goes public and we want automation
+   that does not depend on a personal credential), the creation rule
+   would already be compatible.
+
+Tags remain **immutable once created** (`update` + `deletion` still
+blocked with admin-only bypass), which preserves the audit integrity
+goal. The small risk of rogue tag creation is acceptable for a
+private solo-dev repo.
+
+### Historical note
+
+The previous setup (before 2026-04-24) used the default `GITHUB_TOKEN`
+with release-please running as `github-actions[bot]`. That setup
+worked for tags, but had a separate side-effect: CI workflows did not
+trigger on release-please PRs (GitHub refuses to trigger
+`pull_request` workflows from events created by its own internal
+token, to prevent infinite loops). The PAT switch fixes both concerns
+in one change.
 
 ## Apply (one-time, by owner)
 

--- a/.github/workflows/release-please-metadata.yml
+++ b/.github/workflows/release-please-metadata.yml
@@ -24,14 +24,16 @@ jobs:
   apply-metadata:
     name: Apply metadata to release-please PR
     # Guard on three conditions:
-    # 1. PR authored by release-please
-    # 2. PR has the autorelease: pending marker
+    # 1. PR branch follows the release-please naming convention (stable
+    #    regardless of the author — GITHUB_TOKEN would author as
+    #    `github-actions[bot]`, a PAT authors as the PAT owner).
+    # 2. PR has the autorelease: pending marker.
     # 3. When triggered by the `labeled` action, only react to the marker
     #    label itself — otherwise the workflow would re-trigger on every
     #    label it adds (type:chore, scope:*, priority:medium), wasting
     #    runs and API calls.
     if: >
-      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'release-please--') &&
       contains(github.event.pull_request.labels.*.name, 'autorelease: pending') &&
       (github.event.action != 'labeled' || github.event.label.name == 'autorelease: pending')
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please-metadata.yml
+++ b/.github/workflows/release-please-metadata.yml
@@ -25,8 +25,9 @@ jobs:
     name: Apply metadata to release-please PR
     # Guard on three conditions:
     # 1. PR branch follows the release-please naming convention (stable
-    #    regardless of the author — GITHUB_TOKEN would author as
-    #    `github-actions[bot]`, a PAT authors as the PAT owner).
+    #    regardless of the author — with GITHUB_TOKEN, PRs are authored
+    #    by `github-actions[bot]`; with a PAT, PRs are authored by the
+    #    PAT owner).
     # 2. PR has the autorelease: pending marker.
     # 3. When triggered by the `labeled` action, only react to the marker
     #    label itself — otherwise the workflow would re-trigger on every

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,16 @@ deliberately refuses to trigger `pull_request` workflows on events created
 by its own internal `GITHUB_TOKEN` (to prevent infinite loops). Without a
 user PAT, every release-please PR would get stuck `BLOCKED` by branch
 protection because the required CI checks (`changes`, `mobile-app`, `api`,
-`SonarCloud Scan`) never start.
+`security-audit`, `SonarCloud Scan`, `SonarCloud Code Analysis`) never
+start.
+
+Because the workflow uses `RELEASE_PLEASE_TOKEN`, the resulting PRs,
+tags, and releases are attributed to the **PAT owner** (not to
+`github-actions[bot]`). Downstream workflows that detect release-please
+PRs must therefore guard on the branch name pattern
+`release-please--*` + the `autorelease: pending` label, not on
+`user.login == 'github-actions[bot]'`. See
+`.github/workflows/release-please-metadata.yml` for the canonical guard.
 
 The current PAT is scoped to this repository only with the following
 permissions:
@@ -167,8 +176,11 @@ permissions:
 4. Update the expiration date in this document and in the inline comment
    of `.github/workflows/release-please.yml`.
 
-Missing the rotation means release-please workflows fail silently on the
-next release cycle until the PAT is renewed. Set a calendar reminder for
+Missing the rotation means the `Release Please` workflow will fail with
+an **authentication error** on the next release cycle until the PAT is
+renewed. The error is visible as a failed run on the Actions tab, but
+can go unnoticed if no one checks — the usual symptom is that no
+release PR appears after a merge. Set a calendar reminder for
 `2027-03-24` (one month before expiration).
 
 ### What NOT to do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,9 +236,13 @@ committing.
 Ruleset `refs/tags/v*` + scoped component tags (`mobile-app-v*`,
 `api-v*`, `website-v*`, `encyclopedia-v*`) block **`update`** and
 **`deletion`** for everyone except admins. Creation is **not blocked**
-so that release-please (running as `github-actions[bot]`) can cut the
-release tags automatically on merge of the release PR. The trade-off
-and future tightening path (PAT with Integration bypass) are
+so that release-please can cut the release tags automatically on merge
+of the release PR.
+
+As of 2026-04-24, release-please authenticates via the
+`RELEASE_PLEASE_TOKEN` PAT (owner `@benoit-bremaud`, an admin), so
+tags it creates are attributed to the PAT owner rather than to
+`github-actions[bot]`. Full rationale and the transition history are
 documented in [.github/tag-protection.md](.github/tag-protection.md).
 
 Result: tags are **immutable once created** (no rewrite, no delete


### PR DESCRIPTION
## Context

Four Copilot comments landed **11 seconds after PR #704 was merged** — timing mismatch rather than missed review. This follow-up addresses all four per the usual protocol.

## Fixes

### 1. 🔴 MUST HAVE — `release-please-metadata.yml` guard regression

With the PAT switch (PR #704), release-please PRs are now authored by the PAT owner (`@benoit-bremaud`), **not** `github-actions[bot]`. The old guard `user.login == 'github-actions[bot]'` would have silently stopped matching → the metadata workflow (labels / assignee / project) would no longer apply to release PRs.

Fixed: switched to guarding on branch name pattern `release-please--*` + the existing `autorelease: pending` label — both stable regardless of which actor authors the PR.

### 2. `CONTRIBUTING.md` — missing CI checks in the list

Added `security-audit` + `SonarCloud Code Analysis` to the list of required CI checks in the §Release Workflow → Authentication section (previously listed only 4 out of 6).

### 3. `CONTRIBUTING.md` — PAT-ownership implications

Added a paragraph documenting that the PAT ownership means release PRs are attributed to the PAT owner and that downstream workflows must guard on branch-name patterns, not on `github-actions[bot]`. References the canonical guard.

### 4. `CONTRIBUTING.md` — rotation warning precision

"Fail silently" was inaccurate. Rewrote to clarify that the workflow will actually **error with an authentication error** (visible on the Actions tab). The real risk is the run being **overlooked**, not silent success.

### 5. `.github/tag-protection.md` — documentation drift

The "Why creation is not blocked" section still described the old GITHUB_TOKEN + bot setup — now conflicting with the PAT reality. Rewrote the section to reflect the current authentication model + added a "Historical note" explaining the transition so future readers understand both patterns.

## Checklist

- [x] Happy path + sad path + edge cases covered — N/A (workflow + docs only)
- [x] `tsc --noEmit` passes — N/A
- [x] Build passes — N/A
- [x] Existing tests still green — N/A
- [x] No `any`, no inline styles introduced — N/A
- [ ] `PROJECT_LOG.md` updated — bundled with the next substantive PR

## Related

- Follow-up to [PR #704](https://github.com/benoit-bremaud/brasse-bouillon/pull/704) (PAT config for release-please).
- Resolves the 4 Copilot comments posted after #704's merge.