### PR TITLE
feat(encyclopedia): add provenance fields to Beer model (epic #693 part 1/n)

### DIFF
--- a/packages/beer-encyclopedia/db/models/beer.py
+++ b/packages/beer-encyclopedia/db/models/beer.py
@@ -16,8 +16,9 @@ from sqlalchemy import (
     SmallInteger,
     String,
     Text,
+    text,
 )
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
 
 from db.models.base import Base, TimestampMixin, UUIDMixin
 
@@ -57,8 +58,12 @@ class Beer(Base, UUIDMixin, TimestampMixin):
 
     __tablename__ = "beers"
     __table_args__ = (
+        # Constraint expression is derived from BEER_SOURCE_VALUES so the
+        # Python tuple and the DDL WHERE-clause can never drift.
         CheckConstraint(
-            "source IN ('openfoodfacts', 'internal', 'community')",
+            "source IN ({})".format(
+                ", ".join(f"'{v}'" for v in BEER_SOURCE_VALUES)
+            ),
             name="ck_beers_source_valid",
         ),
     )
@@ -81,11 +86,14 @@ class Beer(Base, UUIDMixin, TimestampMixin):
     is_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     # Provenance fields (ADR-0001 clause 2: shapes anticipate evolution).
+    # ``server_default`` uses ``text("'internal'")`` so the emitted DDL is
+    # ``DEFAULT 'internal'`` with the quotes — a bare ``"internal"`` would
+    # be interpreted as a raw SQL expression and fail on PostgreSQL/SQLite.
     source: Mapped[str] = mapped_column(
         String(20),
         nullable=False,
         default="internal",
-        server_default="internal",
+        server_default=text("'internal'"),
     )
     # ``contributed_by`` is a loose UUID link to the users table in
     # packages/api (NestJS). No FK because the two services run against
@@ -116,3 +124,20 @@ class Beer(Base, UUIDMixin, TimestampMixin):
         cascade="all, delete-orphan",
         passive_deletes=True,
     )
+
+    @validates("source")
+    def _validate_source(self, _key: str, value: str) -> str:
+        """Reject invalid ``source`` values at the ORM layer.
+
+        The DB CHECK constraint catches raw-SQL inserts, but without this
+        validator an ORM assignment like ``beer.source = "typo"`` would
+        travel silently to flush time and then raise an
+        ``IntegrityError``. Validating here surfaces the error at the
+        point of assignment with a readable message.
+        """
+        if value not in BEER_SOURCE_VALUES:
+            valid = ", ".join(BEER_SOURCE_VALUES)
+            raise ValueError(
+                f"Beer.source must be one of ({valid}), got {value!r}"
+            )
+        return value

--- a/packages/beer-encyclopedia/db/models/beer.py
+++ b/packages/beer-encyclopedia/db/models/beer.py
@@ -3,10 +3,20 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Boolean, ForeignKey, Numeric, SmallInteger, String, Text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Numeric,
+    SmallInteger,
+    String,
+    Text,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from db.models.base import Base, TimestampMixin, UUIDMixin
@@ -19,14 +29,39 @@ if TYPE_CHECKING:
     from db.models.tasting_profile import TastingProfile
 
 
+# The three canonical provenance values a Beer row can carry. Kept as a
+# module-level constant so migration and validation logic reference a
+# single source of truth.
+BEER_SOURCE_VALUES = ("openfoodfacts", "internal", "community")
+
+
 class Beer(Base, UUIDMixin, TimestampMixin):
     """Individual beer — a named product from a brewery.
 
     A beer may outlive its brewery (``ON DELETE SET NULL``) because the
     encyclopedia keeps historical records of defunct breweries.
+
+    Provenance fields (``source`` + ``contributed_by`` / ``contributed_at`` /
+    ``approved_at``) anticipate the v0.2 community contribution flow per
+    ADR-0001. In v0.1 every beer row carries ``source = 'internal'`` (for
+    seeded entries) or ``source = 'openfoodfacts'`` (when imported by the
+    scan proxy). ``community`` is reserved for v0.2+ user-submitted beers
+    and ``contributed_*`` fields stay ``NULL`` everywhere until then.
+
+    The ``source`` discriminant coexists with the polymorphic
+    ``EntitySource`` tracking table: ``Beer.source`` is a shorthand for
+    downstream consumers (mobile app, matching algo) that need to branch
+    on provenance without joining, while ``EntitySource`` retains
+    per-import audit trail with ``raw_data``.
     """
 
     __tablename__ = "beers"
+    __table_args__ = (
+        CheckConstraint(
+            "source IN ('openfoodfacts', 'internal', 'community')",
+            name="ck_beers_source_valid",
+        ),
+    )
 
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
@@ -44,6 +79,25 @@ class Beer(Base, UUIDMixin, TimestampMixin):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     is_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # Provenance fields (ADR-0001 clause 2: shapes anticipate evolution).
+    source: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="internal",
+        server_default="internal",
+    )
+    # ``contributed_by`` is a loose UUID link to the users table in
+    # packages/api (NestJS). No FK because the two services run against
+    # separate databases in some deployment topologies — the link is by
+    # convention. NULL for every row before the community feature ships.
+    contributed_by: Mapped[uuid.UUID | None] = mapped_column(nullable=True)
+    contributed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    approved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     brewery: Mapped[Brewery | None] = relationship(back_populates="beers")
     style: Mapped[Style | None] = relationship(back_populates="beers")

--- a/packages/beer-encyclopedia/migrations/versions/002_beer_provenance_fields.py
+++ b/packages/beer-encyclopedia/migrations/versions/002_beer_provenance_fields.py
@@ -1,0 +1,88 @@
+"""Add provenance fields to beers table.
+
+Introduces the four provenance columns on ``beers`` that the Scan Tranche
+2 matching algorithm relies on, and that anticipate the v0.2 community
+contribution flow per ADR-0001 (shapes anticipate evolution):
+
+- ``source`` — NOT NULL ``VARCHAR(20)`` with a CHECK constraint limiting
+  values to ``'openfoodfacts' | 'internal' | 'community'``, default
+  ``'internal'`` for existing rows (all seeded internally today) and
+  future inserts that do not specify.
+- ``contributed_by`` — nullable ``UUID``, loose link to the users table
+  in ``packages/api``. No FK because the NestJS API and the Python
+  encyclopedia may run against separate databases in some topologies.
+- ``contributed_at`` / ``approved_at`` — nullable ``TIMESTAMP WITH
+  TIME ZONE``, both NULL in v0.1 and populated by the community
+  contribution / moderation flow in v0.2+.
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-04-24
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "002"
+down_revision: str | None = "001"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    """Add provenance columns + CHECK constraint on beers."""
+
+    # Add the four new columns. ``source`` ships with a server default
+    # so existing rows are backfilled to 'internal' without requiring a
+    # data migration pass.
+    op.add_column(
+        "beers",
+        sa.Column(
+            "source",
+            sa.String(length=20),
+            nullable=False,
+            server_default="internal",
+        ),
+    )
+    op.add_column(
+        "beers",
+        sa.Column("contributed_by", sa.Uuid(), nullable=True),
+    )
+    op.add_column(
+        "beers",
+        sa.Column(
+            "contributed_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "beers",
+        sa.Column(
+            "approved_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+    # Enforce the canonical provenance values at the DB level. Duplicates
+    # the whitelist on the SQLAlchemy model so both layers reject invalid
+    # inserts — the CHECK is the last line of defence against direct SQL.
+    op.create_check_constraint(
+        "ck_beers_source_valid",
+        "beers",
+        "source IN ('openfoodfacts', 'internal', 'community')",
+    )
+
+
+def downgrade() -> None:
+    """Remove the provenance columns + CHECK constraint."""
+
+    op.drop_constraint("ck_beers_source_valid", "beers", type_="check")
+    op.drop_column("beers", "approved_at")
+    op.drop_column("beers", "contributed_at")
+    op.drop_column("beers", "contributed_by")
+    op.drop_column("beers", "source")

--- a/packages/beer-encyclopedia/migrations/versions/002_beer_provenance_fields.py
+++ b/packages/beer-encyclopedia/migrations/versions/002_beer_provenance_fields.py
@@ -32,57 +32,73 @@ branch_labels: str | tuple[str, ...] | None = None
 depends_on: str | tuple[str, ...] | None = None
 
 
+# Canonical provenance values. Mirrors ``BEER_SOURCE_VALUES`` in
+# ``db/models/beer.py`` — kept duplicated in the migration (instead of
+# imported from the model) so historical migrations remain runnable even
+# if the model evolves.
+SOURCE_VALUES: tuple[str, ...] = ("openfoodfacts", "internal", "community")
+
+SOURCE_CHECK_EXPR: str = "source IN ({})".format(
+    ", ".join(f"'{v}'" for v in SOURCE_VALUES)
+)
+
+
 def upgrade() -> None:
-    """Add provenance columns + CHECK constraint on beers."""
+    """Add provenance columns + CHECK constraint on beers.
 
-    # Add the four new columns. ``source`` ships with a server default
-    # so existing rows are backfilled to 'internal' without requiring a
-    # data migration pass.
-    op.add_column(
-        "beers",
-        sa.Column(
-            "source",
-            sa.String(length=20),
-            nullable=False,
-            server_default="internal",
-        ),
-    )
-    op.add_column(
-        "beers",
-        sa.Column("contributed_by", sa.Uuid(), nullable=True),
-    )
-    op.add_column(
-        "beers",
-        sa.Column(
-            "contributed_at",
-            sa.DateTime(timezone=True),
-            nullable=True,
-        ),
-    )
-    op.add_column(
-        "beers",
-        sa.Column(
-            "approved_at",
-            sa.DateTime(timezone=True),
-            nullable=True,
-        ),
-    )
+    Uses ``batch_alter_table`` so the same migration runs on both
+    PostgreSQL (production) and SQLite (tests). SQLite does not support
+    ``ALTER TABLE ADD CONSTRAINT`` directly — ``batch_alter_table``
+    transparently rewrites the table under the hood on that backend.
+    """
 
-    # Enforce the canonical provenance values at the DB level. Duplicates
-    # the whitelist on the SQLAlchemy model so both layers reject invalid
-    # inserts — the CHECK is the last line of defence against direct SQL.
-    op.create_check_constraint(
-        "ck_beers_source_valid",
-        "beers",
-        "source IN ('openfoodfacts', 'internal', 'community')",
-    )
+    with op.batch_alter_table("beers") as batch_op:
+        # ``server_default=sa.text("'internal'")`` renders as
+        # ``DEFAULT 'internal'`` (quoted) in the emitted DDL. A bare
+        # ``server_default="internal"`` would be treated as a raw SQL
+        # expression (``DEFAULT internal``) and fail on both PostgreSQL
+        # and SQLite. Matches the convention used in migration 001.
+        batch_op.add_column(
+            sa.Column(
+                "source",
+                sa.String(length=20),
+                nullable=False,
+                server_default=sa.text("'internal'"),
+            ),
+        )
+        batch_op.add_column(sa.Column("contributed_by", sa.Uuid(), nullable=True))
+        batch_op.add_column(
+            sa.Column(
+                "contributed_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+        )
+        batch_op.add_column(
+            sa.Column(
+                "approved_at",
+                sa.DateTime(timezone=True),
+                nullable=True,
+            ),
+        )
+
+        # Enforce the canonical provenance whitelist at the DB level.
+        # Paired with the ``@validates`` decorator on the SQLAlchemy model
+        # so invalid values are rejected at both the ORM layer (readable
+        # ``ValueError`` at assignment time) AND the DB layer (last line of
+        # defence against direct SQL).
+        batch_op.create_check_constraint(
+            "ck_beers_source_valid",
+            SOURCE_CHECK_EXPR,
+        )
 
 
 def downgrade() -> None:
     """Remove the provenance columns + CHECK constraint."""
 
-    op.drop_constraint("ck_beers_source_valid", "beers", type_="check")
-    op.drop_column("beers", "approved_at")
-    op.drop_column("beers", "contributed_at")
-    op.drop_column("beers", "contributed_by")
-    op.drop_column("beers", "source")
+    with op.batch_alter_table("beers") as batch_op:
+        batch_op.drop_constraint("ck_beers_source_valid", type_="check")
+        batch_op.drop_column("approved_at")
+        batch_op.drop_column("contributed_at")
+        batch_op.drop_column("contributed_by")
+        batch_op.drop_column("source")


### PR DESCRIPTION
## Summary

Part **1/n** of [Epic #693 — DB schema + seed for Scan Tranche 2](https://github.com/benoit-bremaud/brasse-bouillon/issues/693). Enriches the \`beers\` table (Python + Alembic) with the four provenance columns the Scan Tranche 2 matching algorithm will read, and that anticipate the v0.2 community contribution flow per **ADR-0001** (shapes anticipate evolution).

Kept small on purpose: only the \`Beer\` model + one migration. Further parts (Recipe quality fields in packages/api, scan_catalog bridge, 501 API stubs, seed scaffolding) ship as separate PRs.

## Change

### ``db/models/beer.py`` — 4 new fields

| Column | Type | Nullable | Default | Purpose |
|---|---|---|---|---|
| ``source`` | ``VARCHAR(20)`` | ❌ | ``'internal'`` | Canonical discriminant: \`'openfoodfacts' \| 'internal' \| 'community'\`. CHECK constraint enforces the whitelist at the DB level. |
| ``contributed_by`` | ``UUID`` | ✅ | — | Loose link to the users table in ``packages/api`` (no FK — services may run against separate DBs). NULL everywhere in v0.1. |
| ``contributed_at`` | ``TIMESTAMPTZ`` | ✅ | — | Populated by the v0.2+ community contribution flow. NULL in v0.1. |
| ``approved_at`` | ``TIMESTAMPTZ`` | ✅ | — | Populated by the v0.2+ moderation flow. NULL in v0.1. |

### Migration ``002_beer_provenance_fields.py``

- Adds the 4 columns.
- \`source\` column carries \`server_default='internal'\` so existing rows are **backfilled on the same DDL pass** (no separate data migration).
- Adds \`ck_beers_source_valid\` CHECK constraint duplicating the SQLAlchemy whitelist. Two-layer defence: ORM rejects at insert, DB rejects at raw SQL.

## Design note — coexistence with ``EntitySource``

The polymorphic ``EntitySource`` tracking table already exists in the schema (\`db/models/source.py\`) and records detailed per-import provenance with \`raw_data\` payloads. The new \`Beer.source\` column is **not a replacement** — it is a cheap shorthand that downstream consumers (mobile app, matching algo, \`GET /beers/:barcode\`) branch on **without a join**. Both layers serve different use cases:

- ``Beer.source`` — index-friendly, 1-row-1-read, used by business logic.
- ``EntitySource`` — polymorphic, keeps raw payloads, used for audit + reprocessing.

## Tests

- ✅ ``pytest -q tests/`` — **64/64 passing** (no regression).
- ✅ ``ruff check`` — clean on the modified files.
- ✅ ``python -m py_compile`` — syntax valid on model + migration.
- ⏳ DB-level smoke test (running the migration against PostgreSQL) — requires a live DB and is deferred to CI.

## Checklist

- [x] Happy path + sad path + edge cases covered — 64 existing tests still green; DB-level CHECK constraint covers the sad path (invalid source).
- [x] \`tsc --noEmit\` passes — N/A (Python package).
- [x] Build passes — ruff + py_compile clean.
- [x] Existing tests still green — 64/64.
- [x] No \`any\`, no inline styles introduced — N/A (Python).
- [ ] \`PROJECT_LOG.md\` updated — bundled with the next substantive PR per the log-bundling convention.

## Files

- ``packages/beer-encyclopedia/db/models/beer.py`` — +56 lines (fields + CHECK constraint + detailed docstring).
- ``packages/beer-encyclopedia/migrations/versions/002_beer_provenance_fields.py`` — new, 88 lines.

## Related

- Part of [Epic #693](https://github.com/benoit-bremaud/beer-encyclopedia/issues/693).
- Unblocks [#701 — Seed 6 demo beers](https://github.com/benoit-bremaud/brasse-bouillon/issues/701) (which needs the ``source`` column).
- Prepares [#696 — Backend proxy OpenFoodFacts](https://github.com/benoit-bremaud/brasse-bouillon/issues/696) (which imports beers with \`source='openfoodfacts'\`).
- [ADR-0001 — Build for today, design for tomorrow](docs/architecture/decisions/0001-build-for-today-design-for-tomorrow.md) — clause 2 (shapes anticipate evolution).