### PR TITLE
docs(product): add docs/product/references/ folder for external PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,12 @@ tree.txt
 Guide_Complet_Calculs_Brassage_*.md
 Chapitre*_*.md
 
+# External reference PDFs — tracked as local copies only, never versioned.
+# Reference material we consult for product / encyclopedia / scan work but
+# that we do not own (copyright stays with the original publisher).
+# Examples: BrewDog's DIY DOG recipe book, brewery recipe decks, etc.
+docs/product/references/*.pdf
+
 # Misc
 .cache/
 .temp

--- a/.gitignore
+++ b/.gitignore
@@ -124,11 +124,19 @@ tree.txt
 Guide_Complet_Calculs_Brassage_*.md
 Chapitre*_*.md
 
-# External reference PDFs — tracked as local copies only, never versioned.
-# Reference material we consult for product / encyclopedia / scan work but
+# External reference material — tracked as local copies only, never
+# versioned. Files we consult for product / encyclopedia / scan work but
 # that we do not own (copyright stays with the original publisher).
-# Examples: BrewDog's DIY DOG recipe book, brewery recipe decks, etc.
-docs/product/references/*.pdf
+# Examples: BrewDog's DIY DOG recipe book, brewery decks, datasheets,
+# images, archives, etc.
+#
+# Ignore everything in the folder by default, then re-include only the
+# tracked metadata files (README). This is broader than a `*.pdf` rule
+# and covers the full "PDFs and assets" scope described in the README:
+# zip archives, images, mp4 walkthroughs, anything a contributor might
+# legitimately drop in for reference.
+docs/product/references/*
+!docs/product/references/README.md
 
 # Misc
 .cache/

--- a/docs/product/references/README.md
+++ b/docs/product/references/README.md
@@ -13,7 +13,7 @@ is the only file tracked in this folder.
 
 | File | Source | Purpose |
 |---|---|---|
-| `diy-dog-brewdog-2019-v8.pdf` | [BrewDog — DIY DOG](https://www.brewdog.com/uk/community/culture/diy-dog) | Open-source recipe book from BrewDog. ~27 MB. Used as a reference for (a) the Scan Tranche 2 demo (Punk IPA official recipe matching), (b) the beer encyclopedia seed data, and (c) product decisions about how to present official vs community recipes (pharmacy metaphor, ADR-0001 roadmap). |
+| `brewdog-diy-dog-2019-v8.pdf` | [BrewDog — DIY DOG](https://www.brewdog.com/uk/community/culture/diy-dog) | Open-source recipe book from BrewDog. ~27 MB. Used as a reference for (a) the Scan Tranche 2 demo (Punk IPA official recipe matching), (b) the beer encyclopedia seed data, and (c) product decisions about how to present official vs community recipes (pharmacy metaphor, ADR-0001 roadmap). |
 
 ## How to add a new reference
 

--- a/docs/product/references/README.md
+++ b/docs/product/references/README.md
@@ -1,0 +1,49 @@
+# External Reference Material
+
+This folder hosts **external reference PDFs and assets** consulted during
+product, encyclopedia, and scan feature work. **None of these files are
+versioned in git** — they are copyright of their original publishers and
+kept only as local working copies.
+
+The `.gitignore` at the repo root has an explicit rule excluding
+`docs/product/references/*.pdf` from version control. This `README.md`
+is the only file tracked in this folder.
+
+## Current local references
+
+| File | Source | Purpose |
+|---|---|---|
+| `diy-dog-brewdog-2019-v8.pdf` | [BrewDog — DIY DOG](https://www.brewdog.com/uk/community/culture/diy-dog) | Open-source recipe book from BrewDog. ~27 MB. Used as a reference for (a) the Scan Tranche 2 demo (Punk IPA official recipe matching), (b) the beer encyclopedia seed data, and (c) product decisions about how to present official vs community recipes (pharmacy metaphor, ADR-0001 roadmap). |
+
+## How to add a new reference
+
+1. Drop the PDF (or other binary) in this folder. Name it with the
+   pattern `<source>-<topic>-<year>-<version>.<ext>` for clarity:
+   - `brewdog-diy-dog-2019-v8.pdf`
+   - `saveurbiere-catalogue-2024.pdf`
+   - `microbrasseur-rapport-2023.pdf`
+2. Verify `.gitignore` still protects it: `git check-ignore <path>`
+   should print the file path.
+3. Add one row in the **Current local references** table above with:
+   - The filename.
+   - A public URL to the source (if any).
+   - A one-line purpose.
+4. Commit the README update (the binary itself stays local).
+
+## Policy — why we don't commit these
+
+- **Copyright** — we do not own these documents; versioning them in a
+  repo (even private) would make redistribution easier, which is not
+  our right.
+- **Size** — most references are tens of MB (DIY DOG is 27 MB).
+  Committing them would bloat the repo history permanently and slow
+  `git clone` for every contributor.
+- **Stability** — references change over time (annual editions, new
+  versions). We pin in the table above the version we consulted for
+  each piece of work, without carrying the binary.
+
+## If you need to share a reference
+
+Send the original public URL to the recipient. If the document is no
+longer publicly available, archive.org is usually the right channel —
+do not re-upload to GitHub / Slack / etc.


### PR DESCRIPTION
## Summary

Sets up a dedicated location for **external reference material** (recipe decks, catalogues, brewery PDFs, etc.) that we consult during product / encyclopedia / scan feature work but that we do **not own** and must not version.

Triggered today by the BrewDog DIY DOG 2019 v8 PDF (27 MB) landing in \`/home/vev/Downloads/\` — we want that reference accessible in the repo root for local work without committing it.

## Change

- **New folder** \`docs/product/references/\` with a \`README.md\` documenting:
  - The policy (copyright + size + stability rationale for not versioning).
  - A naming convention for added references.
  - A table of currently-tracked local references (starts with DIY DOG).
- **New \`.gitignore\` rule** \`docs/product/references/*.pdf\` so any PDF dropped in the folder stays local-only by default. The README is the only file tracked in the folder.

## Policy enforced

1. **Copyright** — we do not own these documents; versioning them (even in a private repo) would make redistribution trivially easy, which isn't our right.
2. **Size** — references are tens of MB (DIY DOG is 27 MB). Committing them would bloat git history forever.
3. **Stability** — references change (annual editions). We pin the version we consulted in the README table without carrying the binary.

## Verification

\`\`\`bash
git check-ignore docs/product/references/diy-dog-brewdog-2019-v8.pdf
# -> prints the file path, confirming it's ignored
\`\`\`

## Checklist

- [x] Happy path + sad path + edge cases covered — N/A (docs + gitignore rule only)
- [x] \`tsc --noEmit\` passes — N/A
- [x] Build passes — N/A
- [x] Existing tests still green — N/A (no code)
- [x] No \`any\`, no inline styles introduced — N/A
- [ ] \`PROJECT_LOG.md\` updated — bundled with the next substantive PR

## Files

- \`docs/product/references/README.md\` — new, 49 lines (policy + naming + reference table)
- \`.gitignore\` — +6 lines (rule for \`docs/product/references/*.pdf\`)

## Related

- Triggered by today's DIY DOG PDF drop for the Scan Tranche 2 demo (Punk IPA official recipe) and the encyclopedia recipe ingestion work.
- Follow-up epic to come: **DB schema audit + recipe-ingestion brainstorm** (the DIY DOG data needs a richer schema than we have today).