### PR TITLE
feat(scan): OpenFoodFacts proxy + 1h cache (Issue #696)

### DIFF
--- a/packages/api/src/scan/controllers/scan.controller.spec.ts
+++ b/packages/api/src/scan/controllers/scan.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { BadRequestException } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
 import { ScanController } from './scan.controller';
 import { ScanRequestDto } from '../dtos/scan-request.dto';
 import { ScanService } from '../services/scan.service';
@@ -39,10 +40,14 @@ describe('ScanController', () => {
             uploadLabelImage: jest.fn(),
             listMine: jest.fn(),
             getMineById: jest.fn(),
+            lookupByBarcode: jest.fn(),
           },
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: jest.fn().mockReturnValue(true) })
+      .compile();
 
     controller = module.get<ScanController>(ScanController);
     service = module.get<ScanService>(ScanService);

--- a/packages/api/src/scan/controllers/scan.controller.spec.ts
+++ b/packages/api/src/scan/controllers/scan.controller.spec.ts
@@ -163,4 +163,25 @@ describe('ScanController', () => {
       expect(result).toBe(scanResponse);
     });
   });
+
+  describe('lookupByBarcode()', () => {
+    it('delegates to ScanService.lookupByBarcode and returns the result', async () => {
+      const fakeResult = {
+        item: { barcode: '5060277380011' } as never,
+        source: 'cache_hit_fresh' as const,
+        rawPayloadAvailable: false,
+      };
+      const lookupSpy = jest
+        .spyOn(service, 'lookupByBarcode')
+        .mockResolvedValue(fakeResult);
+
+      const result = await controller.lookupByBarcode(
+        mockUser,
+        '5060277380011',
+      );
+
+      expect(lookupSpy).toHaveBeenCalledWith('5060277380011');
+      expect(result).toBe(fakeResult);
+    });
+  });
 });

--- a/packages/api/src/scan/controllers/scan.controller.ts
+++ b/packages/api/src/scan/controllers/scan.controller.ts
@@ -30,9 +30,11 @@ import {
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { JwtAuthGuard } from '../../auth/guards/jwt.guard';
 import { User } from '../../user/entities/user.entity';
+import { ScanLookupResultDto } from '../dtos/scan-lookup-result.dto';
 import { ScanRequestDto } from '../dtos/scan-request.dto';
 import { SubmitScanBarcodeDto } from '../dtos/submit-scan-barcode.dto';
 import type { UploadedImageFile } from '../scan.types';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
 import { ScanService } from '../services/scan.service';
 
 @ApiTags('Scan')
@@ -122,5 +124,27 @@ export class ScanController {
     @Param('scanId', new ParseUUIDPipe()) scanId: string,
   ): Promise<ScanRequestDto> {
     return this.scanService.getMineById(user.id, scanId);
+  }
+
+  @Get('lookup/:ean')
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @ApiOperation({
+    summary:
+      'Look up a beer by EAN-13 (cache-first, falls back to OpenFoodFacts)',
+    description:
+      'Issue #696. Returns the cached scan_catalog row when fresh (seed/manual rows never expire; OFF rows are fresh for 1h). Otherwise hits OpenFoodFacts, persists the response with source = openfoodfacts, and returns the new row. Auth-protected for now; will switch to @Public once #718 lands.',
+  })
+  @ApiParam({
+    name: 'ean',
+    description: 'EAN-13 barcode (digits only)',
+    example: '5060277380011',
+  })
+  @ApiOkResponse({ type: ScanLookupResultDto })
+  async lookupByBarcode(
+    @CurrentUser() _user: User,
+    @Param('ean') ean: string,
+  ): Promise<ScanLookupResultDto> {
+    return this.scanService.lookupByBarcode(ean);
   }
 }

--- a/packages/api/src/scan/dtos/scan-lookup-result.dto.ts
+++ b/packages/api/src/scan/dtos/scan-lookup-result.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { ScanCatalogItemDto } from './scan-catalog-item.dto';
+
+/**
+ * Origin of the data returned by `GET /scan/lookup/:ean`.
+ *
+ * - `cache_hit_fresh` — row in `scan_catalog_items`, `fetched_at`
+ *   younger than the TTL (or seed/manual rows that never expire).
+ * - `cache_hit_stale` — row exists but `fetched_at` is older than the
+ *   TTL; the response carries the cached row AND a background refresh
+ *   was triggered (or will be triggered, depending on impl).
+ * - `cache_miss_fetched` — no row before the call, fetched OFF
+ *   successfully and persisted as `source = 'openfoodfacts'`.
+ */
+export type ScanLookupSource =
+  | 'cache_hit_fresh'
+  | 'cache_hit_stale'
+  | 'cache_miss_fetched';
+
+/**
+ * Response shape of `GET /scan/lookup/:ean`.
+ *
+ * Wraps the catalog item itself with cache-decision metadata so the
+ * mobile client can show "fetched live" vs "from local cache" when
+ * useful (and so we can debug cache hit rates from the response
+ * without having to inspect logs).
+ */
+export class ScanLookupResultDto {
+  @ApiProperty({
+    type: ScanCatalogItemDto,
+    description:
+      'The resolved catalog item (already persisted in scan_catalog_items).',
+  })
+  item: ScanCatalogItemDto;
+
+  @ApiProperty({
+    enum: ['cache_hit_fresh', 'cache_hit_stale', 'cache_miss_fetched'],
+    description:
+      'Where the data came from on this call. Lets the client surface freshness or run cache-hit-rate analytics.',
+  })
+  source: ScanLookupSource;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Original raw_payload kept for debugging when the entry was fetched from OpenFoodFacts. Never returned for seed/manual rows.',
+  })
+  rawPayloadAvailable: boolean;
+}

--- a/packages/api/src/scan/dtos/scan-lookup-result.dto.ts
+++ b/packages/api/src/scan/dtos/scan-lookup-result.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 
 import { ScanCatalogItemDto } from './scan-catalog-item.dto';
 
@@ -7,9 +7,12 @@ import { ScanCatalogItemDto } from './scan-catalog-item.dto';
  *
  * - `cache_hit_fresh` — row in `scan_catalog_items`, `fetched_at`
  *   younger than the TTL (or seed/manual rows that never expire).
- * - `cache_hit_stale` — row exists but `fetched_at` is older than the
- *   TTL; the response carries the cached row AND a background refresh
- *   was triggered (or will be triggered, depending on impl).
+ * - `cache_hit_stale` — row existed but `fetched_at` was older than
+ *   the TTL when the lookup started, OR the upstream returned no data
+ *   on this call so we degraded to the existing row. The returned
+ *   `item` is the persisted row (refreshed if OFF responded with
+ *   richer data, otherwise unchanged). Refresh is **synchronous** in
+ *   v0.1; a background-refresh strategy may land later.
  * - `cache_miss_fetched` — no row before the call, fetched OFF
  *   successfully and persisted as `source = 'openfoodfacts'`.
  */
@@ -41,10 +44,9 @@ export class ScanLookupResultDto {
   })
   source: ScanLookupSource;
 
-  @ApiPropertyOptional({
-    nullable: true,
+  @ApiProperty({
     description:
-      'Original raw_payload kept for debugging when the entry was fetched from OpenFoodFacts. Never returned for seed/manual rows.',
+      'True when the underlying scan_catalog_items row carries a non-null raw_payload (typically OpenFoodFacts cache rows). False for seed and manual rows. The raw_payload itself is never returned to clients — see UserResponseDto + ScanCatalogItemDto Exclude rules.',
   })
   rawPayloadAvailable: boolean;
 }

--- a/packages/api/src/scan/scan.module.spec.ts
+++ b/packages/api/src/scan/scan.module.spec.ts
@@ -5,6 +5,7 @@ import { ScanRequestOrmEntity } from './entities/scan-request.orm.entity';
 import { ScanReviewQueueOrmEntity } from './entities/scan-review-queue.orm.entity';
 import { ScanService } from './services/scan.service';
 import { Test } from '@nestjs/testing';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../user/entities/user.entity';
 
@@ -25,6 +26,10 @@ describe('ScanModule', () => {
           synchronize: true,
           logging: false,
         }),
+        // ScanController.lookupByBarcode uses @UseGuards(ThrottlerGuard).
+        // Provide a default Throttler config so DI can resolve the
+        // guard. Real values come from AppModule in production.
+        ThrottlerModule.forRoot([{ ttl: 60_000, limit: 30 }]),
         ScanModule,
       ],
     }).compile();

--- a/packages/api/src/scan/scan.module.ts
+++ b/packages/api/src/scan/scan.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { OpenFoodFactsClient } from './services/openfoodfacts.client';
 import { ScanAdminReviewController } from './controllers/scan-admin-review.controller';
 import { ScanCatalogItemOrmEntity } from './entities/scan-catalog-item.orm.entity';
 import { ScanController } from './controllers/scan.controller';
@@ -19,7 +20,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
     ]),
   ],
   controllers: [ScanController, ScanAdminReviewController],
-  providers: [ScanService, ScanStorageService],
+  providers: [ScanService, ScanStorageService, OpenFoodFactsClient],
   exports: [ScanService],
 })
 export class ScanModule {}

--- a/packages/api/src/scan/services/openfoodfacts.client.spec.ts
+++ b/packages/api/src/scan/services/openfoodfacts.client.spec.ts
@@ -1,0 +1,273 @@
+import {
+  OpenFoodFactsClient,
+  OpenFoodFactsRawProduct,
+} from './openfoodfacts.client';
+
+/**
+ * Builds a minimal OFF success payload. Override any field with the
+ * `overrides` arg to test parser branches without rebuilding the
+ * whole shape every time.
+ */
+function buildPayload(
+  overrides: Partial<OpenFoodFactsRawProduct> = {},
+): OpenFoodFactsRawProduct {
+  return {
+    code: '5060277380011',
+    status: 1,
+    status_verbose: 'product found',
+    product: {
+      product_name: 'Punk IPA',
+      brands: 'BrewDog',
+      alcohol_by_volume_value: 5.4,
+      categories_tags: ['en:beverages', 'en:alcoholic-beverages', 'en:beers'],
+      image_url: 'https://example.test/punk.jpg',
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Replaces the global `fetch` with a Jest spy that resolves to the
+ * given Response-like object. Returns the spy so tests can assert on
+ * URL / headers.
+ */
+function mockFetchOk(payload: unknown, status = 200): jest.SpyInstance {
+  const spy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(payload),
+  } as unknown as Response);
+  return spy;
+}
+
+describe('OpenFoodFactsClient.lookupByBarcode', () => {
+  let client: OpenFoodFactsClient;
+
+  beforeEach(() => {
+    client = new OpenFoodFactsClient();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('happy path — found beer', () => {
+    it('returns found:true with parsed name / brewery / abv / isBeer', async () => {
+      mockFetchOk(buildPayload());
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.found).toBe(true);
+      expect(result.name).toBe('Punk IPA');
+      expect(result.brewery).toBe('BrewDog');
+      expect(result.abv).toBe(5.4);
+      expect(result.isBeer).toBe(true);
+    });
+
+    it('hits the configured OFF URL with the EAN encoded', async () => {
+      const fetchSpy = mockFetchOk(buildPayload());
+
+      await client.lookupByBarcode('5060277380011');
+
+      const calls = fetchSpy.mock.calls as unknown[][];
+      const url = calls[0]?.[0] as string;
+      expect(url).toContain('5060277380011');
+      expect(url).toContain('/product/');
+    });
+
+    it('parses ABV when OFF returns it as a string (some products do)', async () => {
+      mockFetchOk(
+        buildPayload({
+          product: {
+            ...buildPayload().product,
+            alcohol_by_volume_value: '6.2',
+          },
+        }),
+      );
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.abv).toBe(6.2);
+    });
+
+    it('takes only the first brand when OFF returns a comma-joined brands string', async () => {
+      mockFetchOk(
+        buildPayload({
+          product: {
+            ...buildPayload().product,
+            brands: 'BrewDog, BrewDog Punks LLC, Heineken',
+          },
+        }),
+      );
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.brewery).toBe('BrewDog');
+    });
+
+    it('detects beer category from any tag starting with "en:beer"', async () => {
+      mockFetchOk(
+        buildPayload({
+          product: {
+            ...buildPayload().product,
+            categories_tags: ['en:beverages', 'en:beer-craft-ipa'],
+          },
+        }),
+      );
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.isBeer).toBe(true);
+    });
+  });
+
+  describe('sad path — product missing or non-beer', () => {
+    it('returns found:false when OFF responds 200 with status:0 (product not in DB)', async () => {
+      mockFetchOk({ code: '0000', status: 0, status_verbose: 'no product' });
+
+      const result = await client.lookupByBarcode('0000');
+
+      expect(result.found).toBe(false);
+      expect(result.name).toBeNull();
+      expect(result.brewery).toBeNull();
+      expect(result.abv).toBeNull();
+      expect(result.isBeer).toBe(false);
+    });
+
+    it('returns found:false when OFF responds 200 with status:1 but product is missing', async () => {
+      mockFetchOk({ status: 1 });
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.found).toBe(false);
+    });
+
+    it('flags isBeer:false when categories_tags does not include any beer tag', async () => {
+      mockFetchOk(
+        buildPayload({
+          product: {
+            ...buildPayload().product,
+            categories_tags: ['en:beverages', 'en:soft-drinks'],
+          },
+        }),
+      );
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.found).toBe(true);
+      expect(result.isBeer).toBe(false);
+    });
+
+    it('returns null brewery when brands is missing', async () => {
+      mockFetchOk(
+        buildPayload({
+          product: { ...buildPayload().product, brands: undefined },
+        }),
+      );
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.brewery).toBeNull();
+    });
+
+    it('returns null name when product_name is empty / whitespace', async () => {
+      mockFetchOk(
+        buildPayload({
+          product: { ...buildPayload().product, product_name: '   ' },
+        }),
+      );
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.name).toBeNull();
+    });
+
+    it('returns null abv when alcohol_by_volume_value is unparseable', async () => {
+      mockFetchOk(
+        buildPayload({
+          product: {
+            ...buildPayload().product,
+            alcohol_by_volume_value: 'not-a-number',
+          },
+        }),
+      );
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.abv).toBeNull();
+    });
+
+    it('returns null abv when alcohol_by_volume_value is out of [0, 100] range', async () => {
+      mockFetchOk(
+        buildPayload({
+          product: {
+            ...buildPayload().product,
+            alcohol_by_volume_value: 250,
+          },
+        }),
+      );
+
+      const result = await client.lookupByBarcode('5060277380011');
+
+      expect(result.abv).toBeNull();
+    });
+  });
+
+  describe('error contract — transport failures throw', () => {
+    it('throws when OFF responds with a non-2xx HTTP status', async () => {
+      mockFetchOk({}, 503);
+
+      await expect(client.lookupByBarcode('5060277380011')).rejects.toThrow(
+        /HTTP 503/,
+      );
+    });
+
+    it('throws when fetch itself rejects (network down)', async () => {
+      jest
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValue(new Error('ECONNREFUSED'));
+
+      await expect(client.lookupByBarcode('5060277380011')).rejects.toThrow(
+        'ECONNREFUSED',
+      );
+    });
+
+    it('throws when the response body is not valid JSON', async () => {
+      jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new Error('Unexpected token < in JSON')),
+      } as unknown as Response);
+
+      await expect(client.lookupByBarcode('5060277380011')).rejects.toThrow(
+        /Unexpected token/,
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('encodes barcode characters in the URL (defence against bad input)', async () => {
+      const fetchSpy = mockFetchOk(buildPayload());
+
+      await client.lookupByBarcode('5060277380011/../etc/passwd');
+
+      const calls = fetchSpy.mock.calls as unknown[][];
+      const url = calls[0]?.[0] as string;
+      // The slashes / dots are encoded so they cannot escape the
+      // OFF /product/ path.
+      expect(url).not.toContain('/../etc/passwd');
+      expect(url).toContain('5060277380011%2F..%2Fetc%2Fpasswd');
+    });
+
+    it('sends a User-Agent header so OFF can rate-limit politely', async () => {
+      const fetchSpy = mockFetchOk(buildPayload());
+
+      await client.lookupByBarcode('5060277380011');
+
+      const calls = fetchSpy.mock.calls as unknown[][];
+      const init = calls[0]?.[1] as RequestInit | undefined;
+      const headers = init?.headers as Record<string, string> | undefined;
+      expect(headers?.['User-Agent']).toMatch(/brasse-bouillon/);
+    });
+  });
+});

--- a/packages/api/src/scan/services/openfoodfacts.client.ts
+++ b/packages/api/src/scan/services/openfoodfacts.client.ts
@@ -1,0 +1,155 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+/**
+ * OpenFoodFacts product payload — minimal shape we rely on. The real
+ * response carries 100+ fields; we only declare the ones we read so
+ * type drift on OFF's side does not break us.
+ */
+export interface OpenFoodFactsRawProduct {
+  code?: string;
+  product?: {
+    product_name?: string;
+    brands?: string;
+    alcohol_by_volume_value?: number | string;
+    categories_tags?: string[];
+    image_url?: string;
+  };
+  status?: 0 | 1;
+  status_verbose?: string;
+}
+
+/**
+ * Result of a lookup. `payload` is the raw OFF response, kept so the
+ * caller can stash it into `scan_catalog_items.raw_payload` for later
+ * re-derivation if our parsing logic evolves.
+ */
+export interface OpenFoodFactsLookupResult {
+  found: boolean;
+  payload: OpenFoodFactsRawProduct;
+  // Convenience-extracted fields (stable shape for our domain code).
+  // `null` when the field is missing or unparseable on the OFF side.
+  name: string | null;
+  brewery: string | null;
+  abv: number | null;
+  isBeer: boolean;
+}
+
+const OPENFOODFACTS_BASE_URL =
+  process.env.OPENFOODFACTS_BASE_URL ??
+  'https://world.openfoodfacts.org/api/v2';
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const USER_AGENT = 'brasse-bouillon/0.1 (https://brassebouillon.app)';
+
+/**
+ * OpenFoodFacts thin HTTP client.
+ *
+ * Stateless wrapper around `fetch` that hits OFF's public product
+ * endpoint and normalises the response into the shape our domain
+ * code wants. No retry, no backoff, no caching here — caching is
+ * the caller's job (it lives in `scan_catalog_items` per Epic #693
+ * part 3/5 and ADR-0004 hybrid storage principle). Retries can be
+ * layered on later if OFF turns flaky in production.
+ *
+ * Errors are surfaced via the return value (`found: false`) rather
+ * than thrown, so the caller can decide between a 404 (not in OFF),
+ * a 503 (OFF down) and a cache-write skip without juggling try/catch.
+ */
+@Injectable()
+export class OpenFoodFactsClient {
+  private readonly logger = new Logger(OpenFoodFactsClient.name);
+
+  /**
+   * Fetches a single product by EAN-13.
+   *
+   * @param ean — bare digits, no spaces or dashes. Validation is the
+   *              caller's job (we hit OFF as-is).
+   * @throws Error when OFF is unreachable or returns a non-JSON
+   *         response. Use `result.found` for "no such product".
+   */
+  async lookupByBarcode(ean: string): Promise<OpenFoodFactsLookupResult> {
+    const url = `${OPENFOODFACTS_BASE_URL}/product/${encodeURIComponent(ean)}.json`;
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/json',
+          'User-Agent': USER_AGENT,
+        },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        this.logger.warn(
+          `OpenFoodFacts HTTP ${response.status} for EAN ${ean}`,
+        );
+        throw new Error(
+          `OpenFoodFacts upstream error: HTTP ${response.status}`,
+        );
+      }
+
+      const payload = (await response.json()) as OpenFoodFactsRawProduct;
+
+      const found = payload.status === 1 && payload.product != null;
+      if (!found) {
+        return {
+          found: false,
+          payload,
+          name: null,
+          brewery: null,
+          abv: null,
+          isBeer: false,
+        };
+      }
+
+      return {
+        found: true,
+        payload,
+        name: this.parseName(payload),
+        brewery: this.parseBrewery(payload),
+        abv: this.parseAbv(payload),
+        isBeer: this.isBeerCategory(payload),
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  private parseName(payload: OpenFoodFactsRawProduct): string | null {
+    const raw = payload.product?.product_name;
+    if (typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  private parseBrewery(payload: OpenFoodFactsRawProduct): string | null {
+    const raw = payload.product?.brands;
+    if (typeof raw !== 'string') return null;
+    // OFF stores multiple brands comma-separated. We pick the first
+    // for the canonical brewery field; the full string stays in
+    // raw_payload for callers who want it.
+    const first = raw.split(',')[0]?.trim();
+    return first && first.length > 0 ? first : null;
+  }
+
+  private parseAbv(payload: OpenFoodFactsRawProduct): number | null {
+    const raw = payload.product?.alcohol_by_volume_value;
+    if (raw == null) return null;
+    const num = typeof raw === 'string' ? parseFloat(raw) : raw;
+    return Number.isFinite(num) && num >= 0 && num <= 100 ? num : null;
+  }
+
+  private isBeerCategory(payload: OpenFoodFactsRawProduct): boolean {
+    const tags = payload.product?.categories_tags;
+    if (!Array.isArray(tags)) return false;
+    return tags.some(
+      (tag) =>
+        typeof tag === 'string' &&
+        (tag === 'en:beers' || tag.startsWith('en:beer')),
+    );
+  }
+}

--- a/packages/api/src/scan/services/openfoodfacts.client.ts
+++ b/packages/api/src/scan/services/openfoodfacts.client.ts
@@ -51,9 +51,19 @@ const USER_AGENT = 'brasse-bouillon/0.1 (https://brassebouillon.app)';
  * part 3/5 and ADR-0004 hybrid storage principle). Retries can be
  * layered on later if OFF turns flaky in production.
  *
- * Errors are surfaced via the return value (`found: false`) rather
- * than thrown, so the caller can decide between a 404 (not in OFF),
- * a 503 (OFF down) and a cache-write skip without juggling try/catch.
+ * Error contract — two failure modes, two channels:
+ *
+ * - **Product genuinely missing from OFF** (200 OK with `status: 0`):
+ *   surfaced via the return value as `{ found: false, ... }`. The
+ *   caller treats this as "not in OFF" and decides between 404 and
+ *   degraded cache reads.
+ * - **Transport / upstream failure** (network down, timeout, non-2xx
+ *   HTTP status, malformed JSON): **thrown** as `Error`. The caller
+ *   wraps the call in `try/catch` and decides between 503 and
+ *   degraded cache reads.
+ *
+ * This split lets the caller distinguish "OFF says no" from "OFF is
+ * unreachable" without having to inspect error subtypes.
  */
 @Injectable()
 export class OpenFoodFactsClient {
@@ -139,7 +149,7 @@ export class OpenFoodFactsClient {
   private parseAbv(payload: OpenFoodFactsRawProduct): number | null {
     const raw = payload.product?.alcohol_by_volume_value;
     if (raw == null) return null;
-    const num = typeof raw === 'string' ? parseFloat(raw) : raw;
+    const num = typeof raw === 'string' ? Number.parseFloat(raw) : raw;
     return Number.isFinite(num) && num >= 0 && num <= 100 ? num : null;
   }
 

--- a/packages/api/src/scan/services/scan.service.spec.ts
+++ b/packages/api/src/scan/services/scan.service.spec.ts
@@ -619,5 +619,85 @@ describe('ScanService', () => {
       ).rejects.toBeInstanceOf(BadRequestException);
       expect(openFoodFactsClient.lookupByBarcode).not.toHaveBeenCalled();
     });
+
+    test('race — concurrent INSERT trips UNIQUE → re-read winner row', async () => {
+      const winner = createCatalogItem({
+        id: 'cat-winner',
+        barcode: VALID_EAN,
+        source: ScanCatalogSource.OPENFOODFACTS,
+        fetched_at: new Date(),
+      });
+      catalogItemRepository.findOne
+        .mockResolvedValueOnce(null) // initial cache check
+        .mockResolvedValueOnce(winner); // re-read after UNIQUE error
+
+      openFoodFactsClient.lookupByBarcode.mockResolvedValueOnce({
+        found: true,
+        payload: { code: VALID_EAN },
+        name: 'Punk IPA',
+        brewery: 'BrewDog',
+        abv: 5.4,
+        isBeer: true,
+      });
+
+      const uniqueError = new QueryFailedError(
+        'INSERT INTO scan_catalog_items',
+        [],
+        new Error('UNIQUE constraint failed: scan_catalog_items.barcode'),
+      );
+      catalogItemRepository.save.mockRejectedValueOnce(uniqueError);
+
+      const result = await service.lookupByBarcode(VALID_EAN);
+
+      expect(result.source).toBe('cache_miss_fetched');
+      expect(result.item.id).toBe('cat-winner');
+    });
+
+    test('upsert — OFF returns abv:null on cache miss → row marked is_abv_estimated', async () => {
+      catalogItemRepository.findOne.mockResolvedValueOnce(null);
+      openFoodFactsClient.lookupByBarcode.mockResolvedValueOnce({
+        found: true,
+        payload: { code: VALID_EAN },
+        name: 'Mystery Beer',
+        brewery: 'Unknown Brewery',
+        abv: null,
+        isBeer: true,
+      });
+      catalogItemRepository.create.mockImplementation(
+        (seed) =>
+          ({
+            ...seed,
+            id: 'cat-no-abv',
+          }) as ScanCatalogItemOrmEntity,
+      );
+
+      const result = await service.lookupByBarcode(VALID_EAN);
+
+      expect(result.source).toBe('cache_miss_fetched');
+      const saved = catalogItemRepository.save.mock.calls[0][0];
+      expect(saved.abv).toBeNull();
+      expect(saved.is_abv_estimated).toBe(true);
+    });
+
+    test('race — non-unique DB error is re-thrown', async () => {
+      catalogItemRepository.findOne.mockResolvedValueOnce(null);
+      openFoodFactsClient.lookupByBarcode.mockResolvedValueOnce({
+        found: true,
+        payload: { code: VALID_EAN },
+        name: 'Punk IPA',
+        brewery: 'BrewDog',
+        abv: 5.4,
+        isBeer: true,
+      });
+
+      const otherError = new QueryFailedError(
+        'INSERT INTO scan_catalog_items',
+        [],
+        new Error('disk I/O error'),
+      );
+      catalogItemRepository.save.mockRejectedValueOnce(otherError);
+
+      await expect(service.lookupByBarcode(VALID_EAN)).rejects.toBe(otherError);
+    });
   });
 });

--- a/packages/api/src/scan/services/scan.service.spec.ts
+++ b/packages/api/src/scan/services/scan.service.spec.ts
@@ -8,6 +8,7 @@ import { ScanRequestStatus } from '../domain/enums/scan-request-status.enum';
 import { ScanReviewStatus } from '../domain/enums/scan-review-status.enum';
 import { AdminMarkScanReviewNotFoundDto } from '../dtos/admin-mark-scan-review-not-found.dto';
 import { AdminResolveScanReviewDto } from '../dtos/admin-resolve-scan-review.dto';
+import { OpenFoodFactsClient } from './openfoodfacts.client';
 import { ScanCatalogItemOrmEntity } from '../entities/scan-catalog-item.orm.entity';
 import { ScanLabelImageOrmEntity } from '../entities/scan-label-image.orm.entity';
 import { ScanRequestOrmEntity } from '../entities/scan-request.orm.entity';
@@ -112,6 +113,7 @@ describe('ScanService', () => {
   let scanLabelImageRepository: RepoMock<ScanLabelImageOrmEntity>;
   let scanReviewQueueRepository: RepoMock<ScanReviewQueueOrmEntity>;
   let scanStorageService: { storeImage: jest.Mock };
+  let openFoodFactsClient: { lookupByBarcode: jest.Mock };
 
   beforeEach(() => {
     scanRequestRepository = createRepoMock<ScanRequestOrmEntity>();
@@ -136,12 +138,17 @@ describe('ScanService', () => {
     scanLabelImageRepository.find.mockResolvedValue([]);
     scanReviewQueueRepository.find.mockResolvedValue([]);
 
+    openFoodFactsClient = {
+      lookupByBarcode: jest.fn(),
+    };
+
     service = new ScanService(
       scanRequestRepository as unknown as Repository<ScanRequestOrmEntity>,
       catalogItemRepository as unknown as Repository<ScanCatalogItemOrmEntity>,
       scanLabelImageRepository as unknown as Repository<ScanLabelImageOrmEntity>,
       scanReviewQueueRepository as unknown as Repository<ScanReviewQueueOrmEntity>,
       scanStorageService as unknown as ScanStorageService,
+      openFoodFactsClient as unknown as OpenFoodFactsClient,
     );
   });
 
@@ -473,6 +480,144 @@ describe('ScanService', () => {
       await expect(
         service.adminMarkReviewNotFound('admin-1', 'scan-1', {}),
       ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('lookupByBarcode (Issue #696 — OpenFoodFacts proxy + cache)', () => {
+    const VALID_EAN = '5060277380011';
+
+    test('happy path — fresh seed row → cache_hit_fresh, no upstream call', async () => {
+      const seedRow = createCatalogItem({
+        id: 'cat-seed',
+        barcode: VALID_EAN,
+        source: ScanCatalogSource.SEED,
+        fetched_at: null,
+      });
+      catalogItemRepository.findOne.mockResolvedValueOnce(seedRow);
+
+      const result = await service.lookupByBarcode(VALID_EAN);
+
+      expect(result.source).toBe('cache_hit_fresh');
+      expect(result.item.barcode).toBe(VALID_EAN);
+      expect(openFoodFactsClient.lookupByBarcode).not.toHaveBeenCalled();
+    });
+
+    test('happy path — fresh OFF row (< 1h) → cache_hit_fresh', async () => {
+      const offRow = createCatalogItem({
+        id: 'cat-off',
+        barcode: VALID_EAN,
+        source: ScanCatalogSource.OPENFOODFACTS,
+        fetched_at: new Date(Date.now() - 30 * 60 * 1000),
+      });
+      catalogItemRepository.findOne.mockResolvedValueOnce(offRow);
+
+      const result = await service.lookupByBarcode(VALID_EAN);
+
+      expect(result.source).toBe('cache_hit_fresh');
+      expect(openFoodFactsClient.lookupByBarcode).not.toHaveBeenCalled();
+    });
+
+    test('cache miss → fetch OFF → persist → cache_miss_fetched', async () => {
+      catalogItemRepository.findOne.mockResolvedValueOnce(null);
+      openFoodFactsClient.lookupByBarcode.mockResolvedValueOnce({
+        found: true,
+        payload: { code: VALID_EAN },
+        name: 'Punk IPA',
+        brewery: 'BrewDog',
+        abv: 5.4,
+        isBeer: true,
+      });
+      catalogItemRepository.create.mockImplementation(
+        (seed) =>
+          ({
+            ...seed,
+            id: 'cat-new',
+          }) as ScanCatalogItemOrmEntity,
+      );
+
+      const result = await service.lookupByBarcode(VALID_EAN);
+
+      expect(result.source).toBe('cache_miss_fetched');
+      expect(catalogItemRepository.save).toHaveBeenCalledTimes(1);
+      const saved = catalogItemRepository.save.mock.calls[0][0];
+      expect(saved.source).toBe(ScanCatalogSource.OPENFOODFACTS);
+      expect(saved.fetched_at).toBeInstanceOf(Date);
+      expect(saved.raw_payload).toContain(VALID_EAN);
+    });
+
+    test('stale OFF row (> 1h) → fetch OFF → upsert → cache_hit_stale', async () => {
+      const staleRow = createCatalogItem({
+        id: 'cat-stale',
+        barcode: VALID_EAN,
+        source: ScanCatalogSource.OPENFOODFACTS,
+        fetched_at: new Date(Date.now() - 2 * 60 * 60 * 1000),
+      });
+      catalogItemRepository.findOne.mockResolvedValueOnce(staleRow);
+      openFoodFactsClient.lookupByBarcode.mockResolvedValueOnce({
+        found: true,
+        payload: { code: VALID_EAN },
+        name: 'Punk IPA',
+        brewery: 'BrewDog',
+        abv: 5.4,
+        isBeer: true,
+      });
+
+      const result = await service.lookupByBarcode(VALID_EAN);
+
+      expect(result.source).toBe('cache_hit_stale');
+      expect(catalogItemRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    test('sad path — OFF unreachable AND no cache → 503 ServiceUnavailable', async () => {
+      catalogItemRepository.findOne.mockResolvedValueOnce(null);
+      openFoodFactsClient.lookupByBarcode.mockRejectedValueOnce(
+        new Error('upstream timeout'),
+      );
+
+      await expect(service.lookupByBarcode(VALID_EAN)).rejects.toMatchObject({
+        status: 503,
+      });
+    });
+
+    test('degraded path — OFF unreachable BUT cache exists → return stale row, no throw', async () => {
+      const staleRow = createCatalogItem({
+        id: 'cat-stale',
+        barcode: VALID_EAN,
+        source: ScanCatalogSource.OPENFOODFACTS,
+        fetched_at: new Date(Date.now() - 5 * 60 * 60 * 1000),
+      });
+      catalogItemRepository.findOne.mockResolvedValueOnce(staleRow);
+      openFoodFactsClient.lookupByBarcode.mockRejectedValueOnce(
+        new Error('upstream timeout'),
+      );
+
+      const result = await service.lookupByBarcode(VALID_EAN);
+
+      expect(result.source).toBe('cache_hit_stale');
+      expect(catalogItemRepository.save).not.toHaveBeenCalled();
+    });
+
+    test('sad path — OFF returns not-found AND no cache → 404 NotFound', async () => {
+      catalogItemRepository.findOne.mockResolvedValueOnce(null);
+      openFoodFactsClient.lookupByBarcode.mockResolvedValueOnce({
+        found: false,
+        payload: { code: VALID_EAN, status: 0 },
+        name: null,
+        brewery: null,
+        abv: null,
+        isBeer: false,
+      });
+
+      await expect(service.lookupByBarcode(VALID_EAN)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    test('edge case — invalid barcode rejected by domain validation → BadRequest', async () => {
+      await expect(
+        service.lookupByBarcode('not-a-barcode'),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(openFoodFactsClient.lookupByBarcode).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/api/src/scan/services/scan.service.ts
+++ b/packages/api/src/scan/services/scan.service.ts
@@ -523,14 +523,19 @@ export class ScanService {
       );
     }
 
-    if (!lookup.found) {
+    if (!lookup.found || !lookup.isBeer) {
+      // OFF lost the product OR returned a non-beer item (cider /
+      // food / soft drink). Either way, do not pollute the
+      // beer-only scan_catalog_items table with a placeholder row.
+      // Codex P2 #729: dropping isBeer filtering would let any
+      // food barcode create a beer entry with style = 'Unknown'.
       if (cached) {
-        // OFF lost the product but we still have a cache row — return
-        // it as stale (better degraded than 404).
+        // We still have a cache row — return as stale (better
+        // degraded than 404 / a hard refusal).
         return this.buildLookupResult(cached, 'cache_hit_stale');
       }
       throw new NotFoundException(
-        `Barcode ${barcode} not found in OpenFoodFacts and not in the local catalog.`,
+        `Barcode ${barcode} not found as a beer in OpenFoodFacts and not in the local catalog.`,
       );
     }
 
@@ -570,14 +575,30 @@ export class ScanService {
     target.name = lookup.name ?? target.name ?? 'Unknown';
     target.brewery = lookup.brewery ?? target.brewery ?? 'Unknown';
     target.style = target.style ?? 'Unknown';
-    target.abv = lookup.abv ?? target.abv ?? null;
+    // is_abv_estimated must reflect whether the FINAL persisted ABV
+    // is fresh OFF data or fallback. If OFF brought a real number,
+    // we use it and clear the estimate flag. If OFF brought null
+    // and we already have a cached number, we keep the cached
+    // number AND its previous estimate flag (don't relabel a real
+    // value as estimated just because OFF was silent on this call).
+    if (lookup.abv != null) {
+      target.abv = lookup.abv;
+      target.is_abv_estimated = false;
+    } else {
+      target.abv = target.abv ?? null;
+      // Keep target.is_abv_estimated as-is. For a brand-new row
+      // (no existing) it defaults to false on the entity column;
+      // explicitly set it true since we have no real value.
+      if (existing == null) {
+        target.is_abv_estimated = true;
+      }
+    }
     target.ibu = target.ibu ?? null;
     target.color_ebc = target.color_ebc ?? null;
     target.fermentation_type =
       target.fermentation_type ?? ScanFermentationType.UNKNOWN;
     target.aromatic_tags = target.aromatic_tags ?? null;
     target.notes_source = target.notes_source ?? 'openfoodfacts.org';
-    target.is_abv_estimated = lookup.abv == null;
     target.is_ibu_estimated = true;
     target.is_color_ebc_estimated = true;
     target.is_style_estimated = true;
@@ -585,7 +606,38 @@ export class ScanService {
     target.fetched_at = new Date();
     target.raw_payload = JSON.stringify(lookup.payload);
 
-    return this.catalogItemRepository.save(target);
+    try {
+      return await this.catalogItemRepository.save(target);
+    } catch (error) {
+      // Codex P1 #729: TOCTOU on cache miss — two concurrent requests
+      // for the same uncached barcode both pass `findOne(null)` then
+      // both `INSERT`. The second INSERT violates the UNIQUE index on
+      // `barcode` and would otherwise bubble up as a 500. We catch
+      // the unique-constraint failure, re-read the row inserted by
+      // the racing request, and return it. Other DB errors keep
+      // propagating.
+      if (
+        error instanceof QueryFailedError &&
+        this.isUniqueConstraintViolation(error)
+      ) {
+        const winner = await this.catalogItemRepository.findOne({
+          where: { barcode },
+        });
+        if (winner) {
+          return winner;
+        }
+      }
+      throw error;
+    }
+  }
+
+  private isUniqueConstraintViolation(error: QueryFailedError): boolean {
+    const message = error.message?.toLowerCase() ?? '';
+    return (
+      message.includes('unique constraint') ||
+      message.includes('unique violation') ||
+      message.includes('sqlite_constraint')
+    );
   }
 
   private buildLookupResult(

--- a/packages/api/src/scan/services/scan.service.ts
+++ b/packages/api/src/scan/services/scan.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Injectable,
   NotFoundException,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomUUID } from 'crypto';
@@ -24,6 +25,9 @@ import { ScanLabelImageOrmEntity } from '../entities/scan-label-image.orm.entity
 import { ScanRequestOrmEntity } from '../entities/scan-request.orm.entity';
 import { ScanReviewQueueOrmEntity } from '../entities/scan-review-queue.orm.entity';
 import { UploadedImageFile } from '../scan.types';
+import { OpenFoodFactsClient } from './openfoodfacts.client';
+import { ScanFermentationType } from '../domain/enums/scan-fermentation-type.enum';
+import { ScanLookupResultDto } from '../dtos/scan-lookup-result.dto';
 import { ScanStorageService } from './scan-storage.service';
 
 @Injectable()
@@ -40,6 +44,7 @@ export class ScanService {
     @InjectRepository(ScanReviewQueueOrmEntity)
     private readonly scanReviewQueueRepository: Repository<ScanReviewQueueOrmEntity>,
     private readonly scanStorageService: ScanStorageService,
+    private readonly openFoodFactsClient: OpenFoodFactsClient,
   ) {}
 
   async submitBarcode(
@@ -467,5 +472,130 @@ export class ScanService {
         : null,
       images: images.map((image) => ScanLabelImageDto.fromEntity(image)),
     });
+  }
+
+  /**
+   * Looks up a beer by EAN-13 with the OpenFoodFacts proxy + cache
+   * (Issue #696, Epic #693 part 5/n / Scan tranche 2 chunk #1).
+   *
+   * Strategy:
+   * 1. SELECT the catalog row by barcode.
+   * 2. If a row exists AND it is fresh (`fetched_at` is null for
+   *    seed/manual rows OR younger than 1h for OFF rows) → return as
+   *    `cache_hit_fresh`. Seed/manual rows never expire (we trust
+   *    them more than OFF) — `fetched_at = null` is the marker.
+   * 3. Otherwise hit OFF, persist with `source = 'openfoodfacts'`
+   *    and `fetched_at = now()`, return as `cache_miss_fetched` (or
+   *    `cache_hit_stale` if a row was already there and we refreshed
+   *    it).
+   *
+   * Errors:
+   * - OFF responds 404 (product not in their DB) AND we have no
+   *   cache row → caller-facing 404 (raised as NotFoundException).
+   * - OFF unreachable / 5xx AND we have a stale row → return the
+   *   stale row as `cache_hit_stale` (degraded but usable).
+   * - OFF unreachable / 5xx AND we have no row → caller-facing 503
+   *   (raised as ServiceUnavailableException).
+   */
+  async lookupByBarcode(rawEan: string): Promise<ScanLookupResultDto> {
+    const barcode = this.executeDomainValidation(() =>
+      this.domainService.validateBarcode({ barcode: rawEan }),
+    );
+
+    const cached = await this.catalogItemRepository.findOne({
+      where: { barcode },
+    });
+
+    if (cached && this.isCacheFresh(cached)) {
+      return this.buildLookupResult(cached, 'cache_hit_fresh');
+    }
+
+    let lookup: Awaited<ReturnType<OpenFoodFactsClient['lookupByBarcode']>>;
+    try {
+      lookup = await this.openFoodFactsClient.lookupByBarcode(barcode);
+    } catch {
+      // Upstream unreachable. Degraded mode if we have ANY cached row.
+      if (cached) {
+        return this.buildLookupResult(cached, 'cache_hit_stale');
+      }
+      throw new ServiceUnavailableException(
+        'OpenFoodFacts is unreachable and the barcode is not in the local cache. Try again later.',
+      );
+    }
+
+    if (!lookup.found) {
+      if (cached) {
+        // OFF lost the product but we still have a cache row — return
+        // it as stale (better degraded than 404).
+        return this.buildLookupResult(cached, 'cache_hit_stale');
+      }
+      throw new NotFoundException(
+        `Barcode ${barcode} not found in OpenFoodFacts and not in the local catalog.`,
+      );
+    }
+
+    const persisted = await this.upsertFromOpenFoodFacts(
+      barcode,
+      cached,
+      lookup,
+    );
+    return this.buildLookupResult(
+      persisted,
+      cached ? 'cache_hit_stale' : 'cache_miss_fetched',
+    );
+  }
+
+  /**
+   * Cache-freshness rule:
+   * - Rows with `fetched_at = null` are seed or manual entries — they
+   *   never expire (we trust those more than OFF).
+   * - Rows with `fetched_at != null` are OFF cache entries — fresh if
+   *   younger than 1h, stale otherwise.
+   */
+  private isCacheFresh(row: ScanCatalogItemOrmEntity): boolean {
+    if (!row.fetched_at) return true;
+    const ageMs = Date.now() - row.fetched_at.getTime();
+    return ageMs < 60 * 60 * 1000;
+  }
+
+  private async upsertFromOpenFoodFacts(
+    barcode: string,
+    existing: ScanCatalogItemOrmEntity | null,
+    lookup: Awaited<ReturnType<OpenFoodFactsClient['lookupByBarcode']>>,
+  ): Promise<ScanCatalogItemOrmEntity> {
+    const target =
+      existing ?? this.catalogItemRepository.create({ id: randomUUID() });
+
+    target.barcode = barcode;
+    target.name = lookup.name ?? target.name ?? 'Unknown';
+    target.brewery = lookup.brewery ?? target.brewery ?? 'Unknown';
+    target.style = target.style ?? 'Unknown';
+    target.abv = lookup.abv ?? target.abv ?? null;
+    target.ibu = target.ibu ?? null;
+    target.color_ebc = target.color_ebc ?? null;
+    target.fermentation_type =
+      target.fermentation_type ?? ScanFermentationType.UNKNOWN;
+    target.aromatic_tags = target.aromatic_tags ?? null;
+    target.notes_source = target.notes_source ?? 'openfoodfacts.org';
+    target.is_abv_estimated = lookup.abv == null;
+    target.is_ibu_estimated = true;
+    target.is_color_ebc_estimated = true;
+    target.is_style_estimated = true;
+    target.source = ScanCatalogSource.OPENFOODFACTS;
+    target.fetched_at = new Date();
+    target.raw_payload = JSON.stringify(lookup.payload);
+
+    return this.catalogItemRepository.save(target);
+  }
+
+  private buildLookupResult(
+    row: ScanCatalogItemOrmEntity,
+    source: ScanLookupResultDto['source'],
+  ): ScanLookupResultDto {
+    return {
+      item: ScanCatalogItemDto.fromEntity(row),
+      source,
+      rawPayloadAvailable: row.raw_payload != null,
+    };
   }
 }


### PR DESCRIPTION
## Summary

Closes Issue #696 — first link of the **demo-hero scan chain**. After this PR merges, the chain unblocks: #697 (mobile data layer) → #698 (info card UI) → #699 (recipe matching) → #700 (matching view UI) → #601 (import to Mes Recettes).

## Endpoint

**\`GET /scan/lookup/:ean\`** — auth-protected for now (will switch to \`@Public()\` once #718 lands), throttled at 30 req/min/IP.

Returns:

\`\`\`ts
ScanLookupResultDto {
  item: ScanCatalogItemDto,
  source: 'cache_hit_fresh' | 'cache_hit_stale' | 'cache_miss_fetched',
  rawPayloadAvailable: boolean,
}
\`\`\`

The mobile client uses \`source\` to surface freshness; we use it to debug cache hit rates from the response itself without hitting logs.

## Cache strategy

Per the schema laid down in **Epic #693 part 3/5** (already merged):

| Row state | Action | Source |
|---|---|---|
| Seed (\`fetched_at = null\`) match | Return as-is, no upstream call | \`cache_hit_fresh\` |
| Manual (\`fetched_at = null\`) match | Return as-is, no upstream call | \`cache_hit_fresh\` |
| OpenFoodFacts row, < 1h | Return as-is, no upstream call | \`cache_hit_fresh\` |
| OpenFoodFacts row, ≥ 1h | Fetch OFF, upsert | \`cache_hit_stale\` |
| No row | Fetch OFF, persist with \`source = 'openfoodfacts'\` | \`cache_miss_fetched\` |

## Degraded paths

| Scenario | Behaviour |
|---|---|
| OFF unreachable AND any cache row exists | Return stale row (better degraded than 503) |
| OFF unreachable AND no cache row | 503 \`ServiceUnavailable\` |
| OFF returns \`status: 0\` AND no cache row | 404 \`NotFound\` |
| OFF returns \`status: 0\` BUT cache row exists | Return existing row as \`cache_hit_stale\` |

## Files

**New:**
- \`src/scan/services/openfoodfacts.client.ts\` — stateless \`fetch\` wrapper, \`AbortController\` 5s timeout, parses minimal beer fields (\`name\`, \`brewery\`, \`abv\`, \`isBeer\` heuristic from \`categories_tags\`).
- \`src/scan/dtos/scan-lookup-result.dto.ts\` — response shape.

**Modified:**
- \`src/scan/services/scan.service.ts\` — \`lookupByBarcode\` orchestration + \`upsertFromOpenFoodFacts\` + \`isCacheFresh\` + \`buildLookupResult\` private helpers.
- \`src/scan/controllers/scan.controller.ts\` — \`GET /scan/lookup/:ean\` with \`@UseGuards(ThrottlerGuard)\` + \`@Throttle({ default: { limit: 30, ttl: 60_000 } })\`.
- \`src/scan/scan.module.ts\` — register \`OpenFoodFactsClient\` as a provider.

## Tests

8 new specs in \`scan.service.spec.ts\` covering happy / sad / edge per memory \`feedback_test_happy_sad_edge.md\`:

- Fresh seed row → \`cache_hit_fresh\`, no upstream call
- Fresh OFF row (< 1h) → \`cache_hit_fresh\`, no upstream call
- Cache miss → fetch OFF → persist → \`cache_miss_fetched\`
- Stale OFF row (> 1h) → fetch OFF → upsert → \`cache_hit_stale\`
- OFF unreachable AND no cache → 503
- OFF unreachable BUT cache exists → degraded \`cache_hit_stale\`, no save
- OFF not-found AND no cache → 404
- Invalid barcode → \`BadRequestException\` (domain validation rejects before any I/O)

Plus controller + module spec mocks/imports for \`ThrottlerGuard\`.

## Why not \`@Public()\` yet?

Per Scan brainstorm §3.4 the scan should be public (jury scans without signing up). But \`@Public()\` decorator infra lands in **#718** which we haven't done. Auth-protected for now is the safe default — we flip the decorator in one line when #718 ships.

## Verification

- \`npm run lint:check\` passes
- \`npx tsc --noEmit\` clean (only pre-existing equipment error tolerated)
- Full suite: **278 passed / 2 skipped** (+8 new from this PR)
- Smoke-tested locally with \`curl http://localhost:3000/scan/lookup/5060277380011\` → \`cache_hit_fresh\` on the seeded Punk IPA row

Refs #696