### PR TITLE
feat(scan): mobile data layer for /scan/lookup endpoint (#697)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,8 @@ expo-env.d.ts
 # NestJS / backend
 # ===========================
 /tmp
-data/
-data/*.db
+/packages/api/data/
+/packages/api/data/*.db
 
 # ===========================
 # Tests & coverage

--- a/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
@@ -1,0 +1,157 @@
+import { dataSource } from "@/core/data/data-source";
+import { HttpError } from "@/core/http/http-error";
+import {
+  ScanLookupBeerNotFoundError,
+  ScanLookupInvalidBarcodeError,
+  ScanLookupServiceUnavailableError,
+  lookupBeerByBarcode,
+} from "@/features/scan/application/scan-lookup.use-cases";
+import { lookupBeerByBarcode as fetchLookupFromApi } from "@/features/scan/data/scan-lookup.api";
+
+jest.mock("@/core/data/data-source", () => ({
+  dataSource: { useDemoData: false },
+}));
+
+jest.mock("@/features/scan/data/scan-lookup.api", () => ({
+  lookupBeerByBarcode: jest.fn(),
+}));
+
+const mockFetchLookup = fetchLookupFromApi as jest.MockedFunction<
+  typeof fetchLookupFromApi
+>;
+
+describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
+  beforeEach(() => {
+    mockFetchLookup.mockReset();
+    dataSource.useDemoData = false;
+  });
+
+  describe("input normalisation", () => {
+    it("trims whitespace and strips non-digits before hitting the API", async () => {
+      mockFetchLookup.mockResolvedValueOnce({
+        item: { barcode: "5060277380011" } as never,
+        source: "cache_hit_fresh",
+        rawPayloadAvailable: false,
+      });
+
+      await lookupBeerByBarcode("  5060-277 380011  ");
+
+      expect(mockFetchLookup).toHaveBeenCalledWith("5060277380011");
+    });
+
+    it("throws ScanLookupInvalidBarcodeError when the barcode is empty", async () => {
+      await expect(lookupBeerByBarcode("")).rejects.toBeInstanceOf(
+        ScanLookupInvalidBarcodeError,
+      );
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+    });
+
+    it("throws ScanLookupInvalidBarcodeError when the barcode has no digit", async () => {
+      await expect(lookupBeerByBarcode("   abc---  ")).rejects.toBeInstanceOf(
+        ScanLookupInvalidBarcodeError,
+      );
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("demo mode", () => {
+    beforeEach(() => {
+      dataSource.useDemoData = true;
+    });
+
+    it("returns the matching demo entry without hitting the network", async () => {
+      const result = await lookupBeerByBarcode("5060277380011");
+
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+      expect(result.item.name).toBe("Punk IPA");
+      expect(result.item.brewery).toBe("BrewDog");
+      expect(result.source).toBe("cache_hit_fresh");
+      expect(result.rawPayloadAvailable).toBe(false);
+    });
+
+    it("throws ScanLookupBeerNotFoundError when the demo catalogue has no match", async () => {
+      await expect(lookupBeerByBarcode("0000000000000")).rejects.toBeInstanceOf(
+        ScanLookupBeerNotFoundError,
+      );
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("real API mode — error mapping", () => {
+    it("translates a 404 HttpError to ScanLookupBeerNotFoundError", async () => {
+      mockFetchLookup.mockRejectedValueOnce(
+        new HttpError(404, "Beer not found"),
+      );
+
+      await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
+        ScanLookupBeerNotFoundError,
+      );
+    });
+
+    it("translates a 503 HttpError to ScanLookupServiceUnavailableError", async () => {
+      mockFetchLookup.mockRejectedValueOnce(
+        new HttpError(503, "OFF unreachable"),
+      );
+
+      await expect(lookupBeerByBarcode("5060277380011")).rejects.toBeInstanceOf(
+        ScanLookupServiceUnavailableError,
+      );
+    });
+
+    it("re-throws HttpError for other statuses (401, 429, 500…)", async () => {
+      const rateLimited = new HttpError(429, "Too many requests");
+      mockFetchLookup.mockRejectedValueOnce(rateLimited);
+
+      await expect(lookupBeerByBarcode("5060277380011")).rejects.toBe(
+        rateLimited,
+      );
+    });
+
+    it("re-throws non-HttpError exceptions untouched (network failures)", async () => {
+      const networkError = new Error("Network request failed");
+      mockFetchLookup.mockRejectedValueOnce(networkError);
+
+      await expect(lookupBeerByBarcode("5060277380011")).rejects.toBe(
+        networkError,
+      );
+    });
+
+    it("returns the API result when the call succeeds", async () => {
+      mockFetchLookup.mockResolvedValueOnce({
+        item: {
+          id: "id-1",
+          barcode: "5060277380011",
+          name: "Punk IPA",
+        } as never,
+        source: "cache_miss_fetched",
+        rawPayloadAvailable: true,
+      });
+
+      const result = await lookupBeerByBarcode("5060277380011");
+
+      expect(result.item.name).toBe("Punk IPA");
+      expect(result.source).toBe("cache_miss_fetched");
+      expect(result.rawPayloadAvailable).toBe(true);
+    });
+  });
+
+  describe("custom error classes", () => {
+    it("ScanLookupBeerNotFoundError exposes the queried barcode", () => {
+      const err = new ScanLookupBeerNotFoundError("5060277380011");
+      expect(err.barcode).toBe("5060277380011");
+      expect(err.name).toBe("ScanLookupBeerNotFoundError");
+    });
+
+    it("ScanLookupServiceUnavailableError exposes the queried barcode", () => {
+      const err = new ScanLookupServiceUnavailableError("5060277380011");
+      expect(err.barcode).toBe("5060277380011");
+      expect(err.name).toBe("ScanLookupServiceUnavailableError");
+    });
+
+    it("ScanLookupInvalidBarcodeError truncates very long input in the message", () => {
+      const err = new ScanLookupInvalidBarcodeError("a".repeat(200));
+      expect(err.message.length).toBeLessThan(120);
+      expect(err.name).toBe("ScanLookupInvalidBarcodeError");
+    });
+  });
+});

--- a/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
@@ -52,6 +52,44 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       );
       expect(mockFetchLookup).not.toHaveBeenCalled();
     });
+
+    it("throws ScanLookupInvalidBarcodeError when the barcode is too short (< 8 digits)", async () => {
+      await expect(lookupBeerByBarcode("1234567")).rejects.toBeInstanceOf(
+        ScanLookupInvalidBarcodeError,
+      );
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+    });
+
+    it("throws ScanLookupInvalidBarcodeError when the barcode is too long (> 14 digits)", async () => {
+      await expect(
+        lookupBeerByBarcode("123456789012345"),
+      ).rejects.toBeInstanceOf(ScanLookupInvalidBarcodeError);
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+    });
+
+    it("accepts an 8-digit barcode (lower bound — EAN-8)", async () => {
+      mockFetchLookup.mockResolvedValueOnce({
+        item: { barcode: "12345678" } as never,
+        source: "cache_hit_fresh",
+        rawPayloadAvailable: false,
+      });
+
+      await lookupBeerByBarcode("12345678");
+
+      expect(mockFetchLookup).toHaveBeenCalledWith("12345678");
+    });
+
+    it("accepts a 14-digit barcode (upper bound — GTIN-14)", async () => {
+      mockFetchLookup.mockResolvedValueOnce({
+        item: { barcode: "12345678901234" } as never,
+        source: "cache_hit_fresh",
+        rawPayloadAvailable: false,
+      });
+
+      await lookupBeerByBarcode("12345678901234");
+
+      expect(mockFetchLookup).toHaveBeenCalledWith("12345678901234");
+    });
   });
 
   describe("demo mode", () => {

--- a/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
@@ -1,0 +1,107 @@
+/**
+ * Use-case for the scan lookup flow (Epic #594 chunk #1, mobile
+ * counterpart of backend issue #696).
+ *
+ * Orchestrates:
+ * - The data-source toggle (`dataSource.useDemoData` → return a
+ *   demo entry, otherwise hit the real backend).
+ * - Barcode normalisation (trim + strip non-digits) so a barcode
+ *   coming from a manual entry / paste does not surprise the API.
+ * - Domain-level guard rails (empty input, etc.) before touching
+ *   the network.
+ *
+ * Does NOT handle UI concerns (loading state, toast messages):
+ * those belong to the presentation layer (#698).
+ */
+import { dataSource } from "@/core/data/data-source";
+import { HttpError } from "@/core/http/http-error";
+import { lookupBeerByBarcode as fetchLookupFromApi } from "@/features/scan/data/scan-lookup.api";
+import type { ScanLookupResult } from "@/features/scan/domain/scan.types";
+import { buildDemoLookupResult, demoScanCatalog } from "@/mocks/demo-data";
+
+/**
+ * Error thrown when the caller passes an obviously invalid barcode
+ * (empty string, only whitespace, no digit at all). The data layer
+ * would also reject these, but failing fast at the use-case layer
+ * keeps a useless network round-trip from happening.
+ */
+export class ScanLookupInvalidBarcodeError extends Error {
+  constructor(barcode: string) {
+    super(
+      `Cannot lookup an invalid barcode (received: "${barcode.slice(0, 32)}").`,
+    );
+    this.name = "ScanLookupInvalidBarcodeError";
+  }
+}
+
+/**
+ * Error thrown when the lookup endpoint cannot resolve the barcode
+ * (404 from backend) — barcode unknown to OpenFoodFacts AND absent
+ * from the local catalogue. Distinct from a transport failure.
+ */
+export class ScanLookupBeerNotFoundError extends Error {
+  constructor(public readonly barcode: string) {
+    super(`Beer not found for barcode "${barcode}".`);
+    this.name = "ScanLookupBeerNotFoundError";
+  }
+}
+
+/**
+ * Error thrown when OpenFoodFacts is unreachable AND the local
+ * catalogue is empty (backend 503). The presentation layer should
+ * surface a "try again later" message and keep the camera ready
+ * for a retry.
+ */
+export class ScanLookupServiceUnavailableError extends Error {
+  constructor(public readonly barcode: string) {
+    super(`Scan lookup is temporarily unavailable for barcode "${barcode}".`);
+    this.name = "ScanLookupServiceUnavailableError";
+  }
+}
+
+function normaliseBarcode(input: string): string {
+  return input.trim().replace(/\D/g, "");
+}
+
+/**
+ * Resolves a beer by EAN-13.
+ *
+ * @throws {ScanLookupInvalidBarcodeError} when the barcode is empty
+ *         or contains no digit after normalisation.
+ * @throws {ScanLookupBeerNotFoundError} when the backend reports 404.
+ * @throws {ScanLookupServiceUnavailableError} when the backend
+ *         reports 503 (OFF unreachable + no local cache).
+ * @throws {HttpError} for any other transport / authorisation
+ *         failure (401, 429, 500, etc.) — caller decides how to
+ *         react.
+ */
+export async function lookupBeerByBarcode(
+  rawBarcode: string,
+): Promise<ScanLookupResult> {
+  const barcode = normaliseBarcode(rawBarcode);
+  if (barcode.length === 0) {
+    throw new ScanLookupInvalidBarcodeError(rawBarcode);
+  }
+
+  if (dataSource.useDemoData) {
+    const demoItem = demoScanCatalog[barcode];
+    if (!demoItem) {
+      throw new ScanLookupBeerNotFoundError(barcode);
+    }
+    return buildDemoLookupResult(demoItem);
+  }
+
+  try {
+    return await fetchLookupFromApi(barcode);
+  } catch (error) {
+    if (error instanceof HttpError) {
+      if (error.status === 404) {
+        throw new ScanLookupBeerNotFoundError(barcode);
+      }
+      if (error.status === 503) {
+        throw new ScanLookupServiceUnavailableError(barcode);
+      }
+    }
+    throw error;
+  }
+}

--- a/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
@@ -20,10 +20,22 @@ import type { ScanLookupResult } from "@/features/scan/domain/scan.types";
 import { buildDemoLookupResult, demoScanCatalog } from "@/mocks/demo-data";
 
 /**
- * Error thrown when the caller passes an obviously invalid barcode
- * (empty string, only whitespace, no digit at all). The data layer
- * would also reject these, but failing fast at the use-case layer
- * keeps a useless network round-trip from happening.
+ * Inclusive digit-count window the backend accepts on `/scan/lookup/:ean`
+ * (`^\d{8,14}$` per `ScanDomainService.validateBarcode`). Mirrored here so
+ * the use-case can fail fast on obviously malformed input (empty string,
+ * a few digits typed by mistake, a long alphanumeric paste) before
+ * burning a network round-trip.
+ */
+const BARCODE_MIN_LENGTH = 8;
+const BARCODE_MAX_LENGTH = 14;
+
+/**
+ * Error thrown when the caller passes a barcode that cannot match the
+ * backend contract (empty after normalisation, fewer than 8 digits, or
+ * more than 14). The data layer would also reject these, but failing
+ * fast at the use-case layer keeps a useless network round-trip from
+ * happening and lets the presentation layer surface a precise error
+ * message instead of a generic 4xx from the API.
  */
 export class ScanLookupInvalidBarcodeError extends Error {
   constructor(barcode: string) {
@@ -64,10 +76,12 @@ function normaliseBarcode(input: string): string {
 }
 
 /**
- * Resolves a beer by EAN-13.
+ * Resolves a beer by EAN/UPC barcode.
  *
- * @throws {ScanLookupInvalidBarcodeError} when the barcode is empty
- *         or contains no digit after normalisation.
+ * @throws {ScanLookupInvalidBarcodeError} when the normalised barcode
+ *         contains fewer than 8 digits or more than 14 (the backend
+ *         contract). Empty input and non-digit-only input both fall in
+ *         this case after normalisation.
  * @throws {ScanLookupBeerNotFoundError} when the backend reports 404.
  * @throws {ScanLookupServiceUnavailableError} when the backend
  *         reports 503 (OFF unreachable + no local cache).
@@ -79,7 +93,10 @@ export async function lookupBeerByBarcode(
   rawBarcode: string,
 ): Promise<ScanLookupResult> {
   const barcode = normaliseBarcode(rawBarcode);
-  if (barcode.length === 0) {
+  if (
+    barcode.length < BARCODE_MIN_LENGTH ||
+    barcode.length > BARCODE_MAX_LENGTH
+  ) {
     throw new ScanLookupInvalidBarcodeError(rawBarcode);
   }
 

--- a/packages/mobile-app/src/features/scan/data/__tests__/scan-lookup.api.test.ts
+++ b/packages/mobile-app/src/features/scan/data/__tests__/scan-lookup.api.test.ts
@@ -1,0 +1,171 @@
+import { lookupBeerByBarcode } from "@/features/scan/data/scan-lookup.api";
+
+const mockRequest = jest.fn();
+
+jest.mock("@/core/http/http-client", () => ({
+  request: (...args: unknown[]) => mockRequest(...args),
+}));
+
+describe("scan-lookup.api / lookupBeerByBarcode", () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  describe("happy path", () => {
+    it("calls the backend with the URL-encoded EAN", async () => {
+      mockRequest.mockResolvedValueOnce({
+        item: {
+          id: "id-1",
+          barcode: "5060277380011",
+          name: "Punk IPA",
+          brewery: "BrewDog",
+          style: "IPA",
+          abv: 5.4,
+          ibu: 35,
+          color_ebc: 14,
+          fermentation_type: "ale",
+          aromatic_tags: "tropical, citrus, pine",
+          notes_source: "BrewDog DIY Dog 2019",
+          is_abv_estimated: false,
+          is_ibu_estimated: false,
+          is_color_ebc_estimated: false,
+          is_style_estimated: false,
+          source: "seed",
+          fetched_at: null,
+          created_at: "2026-04-27T00:00:00.000Z",
+          updated_at: "2026-04-27T00:00:00.000Z",
+        },
+        source: "cache_hit_fresh",
+        rawPayloadAvailable: false,
+      });
+
+      const result = await lookupBeerByBarcode("5060277380011");
+
+      expect(mockRequest).toHaveBeenCalledWith("/scan/lookup/5060277380011");
+      expect(result.item.barcode).toBe("5060277380011");
+      expect(result.item.name).toBe("Punk IPA");
+      expect(result.source).toBe("cache_hit_fresh");
+    });
+
+    it("normalises snake_case backend fields to camelCase domain shape", async () => {
+      mockRequest.mockResolvedValueOnce({
+        item: {
+          id: "id-2",
+          barcode: "5410702000132",
+          name: "La Chouffe",
+          brewery: "Brasserie d Achouffe",
+          style: "Belgian Strong Pale Ale",
+          abv: 8.0,
+          ibu: 20,
+          color_ebc: 14,
+          fermentation_type: "ale",
+          aromatic_tags: "banana, clove",
+          notes_source: "datasheet",
+          is_abv_estimated: false,
+          is_ibu_estimated: true,
+          is_color_ebc_estimated: true,
+          is_style_estimated: false,
+          source: "openfoodfacts",
+          fetched_at: "2026-04-27T01:00:00.000Z",
+          created_at: "2026-04-27T00:00:00.000Z",
+          updated_at: "2026-04-27T01:00:00.000Z",
+        },
+        source: "cache_hit_stale",
+        rawPayloadAvailable: true,
+      });
+
+      const result = await lookupBeerByBarcode("5410702000132");
+
+      expect(result.item.colorEbc).toBe(14);
+      expect(result.item.fermentationType).toBe("ale");
+      expect(result.item.aromaticTags).toBe("banana, clove");
+      expect(result.item.notesSource).toBe("datasheet");
+      expect(result.item.isAbvEstimated).toBe(false);
+      expect(result.item.isIbuEstimated).toBe(true);
+      expect(result.item.isColorEbcEstimated).toBe(true);
+      expect(result.item.isStyleEstimated).toBe(false);
+      expect(result.item.origin).toBe("openfoodfacts");
+      expect(result.item.fetchedAt).toBe("2026-04-27T01:00:00.000Z");
+      expect(result.source).toBe("cache_hit_stale");
+      expect(result.rawPayloadAvailable).toBe(true);
+    });
+  });
+
+  describe("sad path — backend returned nullable fields", () => {
+    it("propagates null abv / ibu / colorEbc / aromaticTags / notesSource / fetchedAt", async () => {
+      mockRequest.mockResolvedValueOnce({
+        item: {
+          id: "id-3",
+          barcode: "1234567890123",
+          name: "Mystery Beer",
+          brewery: "Unknown Brewery",
+          style: "Unknown",
+          abv: null,
+          ibu: null,
+          color_ebc: null,
+          fermentation_type: "unknown",
+          aromatic_tags: null,
+          notes_source: null,
+          is_abv_estimated: true,
+          is_ibu_estimated: true,
+          is_color_ebc_estimated: true,
+          is_style_estimated: true,
+          source: "openfoodfacts",
+          fetched_at: null,
+          created_at: "2026-04-27T00:00:00.000Z",
+          updated_at: "2026-04-27T00:00:00.000Z",
+        },
+        source: "cache_miss_fetched",
+        rawPayloadAvailable: true,
+      });
+
+      const result = await lookupBeerByBarcode("1234567890123");
+
+      expect(result.item.abv).toBeNull();
+      expect(result.item.ibu).toBeNull();
+      expect(result.item.colorEbc).toBeNull();
+      expect(result.item.aromaticTags).toBeNull();
+      expect(result.item.notesSource).toBeNull();
+      expect(result.item.fetchedAt).toBeNull();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("URL-encodes a barcode containing path-traversal characters", async () => {
+      mockRequest.mockResolvedValueOnce({
+        item: {
+          id: "id-x",
+          barcode: "weird",
+          name: "x",
+          brewery: "x",
+          style: "x",
+          fermentation_type: "ale",
+          is_abv_estimated: false,
+          is_ibu_estimated: false,
+          is_color_ebc_estimated: false,
+          is_style_estimated: false,
+          source: "manual",
+          created_at: "2026-04-27T00:00:00.000Z",
+          updated_at: "2026-04-27T00:00:00.000Z",
+        },
+        source: "cache_hit_fresh",
+        rawPayloadAvailable: false,
+      });
+
+      await lookupBeerByBarcode("../../etc/passwd");
+
+      const url = mockRequest.mock.calls[0][0] as string;
+      expect(url).not.toContain("/../");
+      expect(url).toContain("..%2F..%2Fetc%2Fpasswd");
+    });
+
+    it("re-throws when the http-client throws (let HttpError bubble up)", async () => {
+      const networkError = new Error("Network request failed");
+      mockRequest.mockRejectedValueOnce(networkError);
+
+      await expect(lookupBeerByBarcode("5060277380011")).rejects.toBe(
+        networkError,
+      );
+    });
+  });
+});

--- a/packages/mobile-app/src/features/scan/data/scan-lookup.api.ts
+++ b/packages/mobile-app/src/features/scan/data/scan-lookup.api.ts
@@ -1,0 +1,109 @@
+/**
+ * Data layer for the backend `GET /scan/lookup/:ean` endpoint
+ * (Epic #594 chunk #1, mobile counterpart of Issue #696).
+ *
+ * Per Clean Architecture, this file contains only the HTTP call and
+ * the snake_case → camelCase mapping. Use-case orchestration (demo
+ * data branching, error handling for the UI, retry logic) lives in
+ * `application/scan-lookup.use-cases.ts`.
+ */
+import { request } from "@/core/http/http-client";
+
+import type {
+  ScanCatalogItem,
+  ScanCatalogItemOrigin,
+  ScanLookupResult,
+  ScanLookupSource,
+} from "../domain/scan.types";
+
+/**
+ * Wire shape returned by the backend. snake_case fields, no nested
+ * camelCase. Keep this `type` private to the module so consumers
+ * always go through `ScanLookupResult` from the domain.
+ */
+type ScanCatalogItemDto = {
+  id: string;
+  barcode: string;
+  name: string;
+  brewery: string;
+  style: string;
+  abv?: number | null;
+  ibu?: number | null;
+  color_ebc?: number | null;
+  fermentation_type: string;
+  aromatic_tags?: string | null;
+  notes_source?: string | null;
+  is_abv_estimated: boolean;
+  is_ibu_estimated: boolean;
+  is_color_ebc_estimated: boolean;
+  is_style_estimated: boolean;
+  source: ScanCatalogItemOrigin;
+  fetched_at?: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type ScanLookupResultDto = {
+  item: ScanCatalogItemDto;
+  source: ScanLookupSource;
+  rawPayloadAvailable: boolean;
+};
+
+function mapItem(dto: ScanCatalogItemDto): ScanCatalogItem {
+  return {
+    id: dto.id,
+    barcode: dto.barcode,
+    name: dto.name,
+    brewery: dto.brewery,
+    style: dto.style,
+    abv: dto.abv ?? null,
+    ibu: dto.ibu ?? null,
+    colorEbc: dto.color_ebc ?? null,
+    fermentationType: dto.fermentation_type,
+    aromaticTags: dto.aromatic_tags ?? null,
+    notesSource: dto.notes_source ?? null,
+    isAbvEstimated: dto.is_abv_estimated,
+    isIbuEstimated: dto.is_ibu_estimated,
+    isColorEbcEstimated: dto.is_color_ebc_estimated,
+    isStyleEstimated: dto.is_style_estimated,
+    origin: dto.source,
+    fetchedAt: dto.fetched_at ?? null,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  };
+}
+
+function mapResult(dto: ScanLookupResultDto): ScanLookupResult {
+  return {
+    item: mapItem(dto.item),
+    source: dto.source,
+    rawPayloadAvailable: dto.rawPayloadAvailable,
+  };
+}
+
+/**
+ * Resolves a beer by EAN-13 against the backend lookup endpoint.
+ *
+ * The backend is cache-first: seed and manual entries never expire,
+ * OpenFoodFacts entries respect a 1-hour TTL. On cache miss the
+ * backend hits OpenFoodFacts, persists the response, and returns
+ * the freshly inserted row. See backend issue #696 / PR #729 for
+ * the full contract.
+ *
+ * Errors surface as `HttpError` from the shared HTTP client:
+ * - 401 — missing or invalid JWT (caller should redirect to auth)
+ * - 404 — barcode unknown to OpenFoodFacts and not in the local
+ *   catalogue (caller can offer manual entry / contribution)
+ * - 503 — OpenFoodFacts unreachable AND no cache row to fall back
+ *   on (caller should ask the user to retry)
+ * - 429 — rate limited (backend caps at 30 req/min/IP); caller
+ *   should back off
+ */
+export async function lookupBeerByBarcode(
+  ean: string,
+): Promise<ScanLookupResult> {
+  const dto = await request<ScanLookupResultDto>(
+    `/scan/lookup/${encodeURIComponent(ean)}`,
+  );
+  return mapResult(dto);
+}

--- a/packages/mobile-app/src/features/scan/domain/scan.types.ts
+++ b/packages/mobile-app/src/features/scan/domain/scan.types.ts
@@ -119,3 +119,60 @@ export interface ScanResultDetailsViewModel {
   result: ScanResolvedResult;
   details: ScanProductDetails | null;
 }
+
+/**
+ * Provenance of the data returned by the backend `GET /scan/lookup/:ean`
+ * endpoint (Epic #594 chunk #1, backend issue #696).
+ */
+export type ScanLookupSource =
+  | "cache_hit_fresh"
+  | "cache_hit_stale"
+  | "cache_miss_fetched";
+
+/**
+ * Source the backend assigned when the row was originally created in
+ * `scan_catalog_items`. `seed` and `manual` rows never expire;
+ * `openfoodfacts` rows respect the 1-hour TTL.
+ */
+export type ScanCatalogItemOrigin = "seed" | "openfoodfacts" | "manual";
+
+/**
+ * Domain shape of a single beer entry returned by the lookup endpoint.
+ * snake_case backend fields are normalised to camelCase here to keep
+ * presentation/use-case code idiomatic React Native.
+ */
+export interface ScanCatalogItem {
+  id: string;
+  barcode: string;
+  name: string;
+  brewery: string;
+  style: string;
+  abv: number | null;
+  ibu: number | null;
+  colorEbc: number | null;
+  fermentationType: string;
+  aromaticTags: string | null;
+  notesSource: string | null;
+  isAbvEstimated: boolean;
+  isIbuEstimated: boolean;
+  isColorEbcEstimated: boolean;
+  isStyleEstimated: boolean;
+  origin: ScanCatalogItemOrigin;
+  fetchedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Response shape for the lookup use-case. Mirrors the backend
+ * `ScanLookupResultDto`: `item` is the resolved beer, `source` tells
+ * the caller where the data came from so the UI can render "from
+ * cache" vs "fetched live" cues, `rawPayloadAvailable` exposes that
+ * the backend has the raw OpenFoodFacts response server-side (the
+ * raw payload itself is never returned to the client).
+ */
+export interface ScanLookupResult {
+  item: ScanCatalogItem;
+  source: ScanLookupSource;
+  rawPayloadAvailable: boolean;
+}

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2504,10 +2504,11 @@ const buildDemoScanCatalogItem = (
   colorEbc: overrides.colorEbc ?? null,
   fermentationType: overrides.fermentationType ?? "ale",
   aromaticTags: overrides.aromaticTags ?? null,
-  notesSource: overrides.notesSource ?? "demo data (mobile-app)",
-  isAbvEstimated: overrides.isAbvEstimated ?? false,
-  isIbuEstimated: overrides.isIbuEstimated ?? true,
-  isColorEbcEstimated: overrides.isColorEbcEstimated ?? true,
+  notesSource: overrides.notesSource ?? null,
+  isAbvEstimated: overrides.isAbvEstimated ?? overrides.abv == null,
+  isIbuEstimated: overrides.isIbuEstimated ?? overrides.ibu == null,
+  isColorEbcEstimated:
+    overrides.isColorEbcEstimated ?? overrides.colorEbc == null,
   isStyleEstimated: overrides.isStyleEstimated ?? false,
   origin: overrides.origin ?? "seed",
   fetchedAt: overrides.fetchedAt ?? null,
@@ -2538,6 +2539,7 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     ibu: 20,
     colorEbc: 14,
     aromaticTags: "banana, clove, coriander",
+    notesSource: "Brasserie d'Achouffe — official datasheet",
   }),
   "5410799000111": buildDemoScanCatalogItem({
     id: "demo-scan-rochefort-10",
@@ -2549,6 +2551,7 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     ibu: 28,
     colorEbc: 70,
     aromaticTags: "dark fruit, port, caramel, raisin",
+    notesSource: "Trappist Rochefort — published brewery profile",
   }),
 };
 

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -9,6 +9,10 @@ import { User } from "@/features/auth/domain/auth.types";
 import { HopProduct } from "@/features/ingredients/domain/hop.types";
 import { Ingredient } from "@/features/ingredients/domain/ingredient.types";
 import { MaltProduct } from "@/features/ingredients/domain/malt.types";
+import type {
+  ScanCatalogItem,
+  ScanLookupResult,
+} from "@/features/scan/domain/scan.types";
 import { YeastProduct } from "@/features/ingredients/domain/yeast.types";
 
 export type Equipment = {
@@ -2479,3 +2483,84 @@ export const demoBatches: Batch[] = [
     })),
   },
 ];
+
+/**
+ * Demo lookup catalogue keyed by EAN-13. Used by `lookupBeerByBarcode`
+ * use-case when `dataSource.useDemoData = true` so the scan flow
+ * works offline and during the soutenance demo. Mirrors the seed
+ * shipped on the backend (see `packages/api/src/database/seeds/scan-catalog.seed.ts`)
+ * but stays independent so the mobile demo can run without a backend.
+ */
+const buildDemoScanCatalogItem = (
+  overrides: Partial<ScanCatalogItem> & { id: string; barcode: string },
+): ScanCatalogItem => ({
+  id: overrides.id,
+  barcode: overrides.barcode,
+  name: overrides.name ?? "Unknown",
+  brewery: overrides.brewery ?? "Unknown",
+  style: overrides.style ?? "Unknown",
+  abv: overrides.abv ?? null,
+  ibu: overrides.ibu ?? null,
+  colorEbc: overrides.colorEbc ?? null,
+  fermentationType: overrides.fermentationType ?? "ale",
+  aromaticTags: overrides.aromaticTags ?? null,
+  notesSource: overrides.notesSource ?? "demo data (mobile-app)",
+  isAbvEstimated: overrides.isAbvEstimated ?? false,
+  isIbuEstimated: overrides.isIbuEstimated ?? true,
+  isColorEbcEstimated: overrides.isColorEbcEstimated ?? true,
+  isStyleEstimated: overrides.isStyleEstimated ?? false,
+  origin: overrides.origin ?? "seed",
+  fetchedAt: overrides.fetchedAt ?? null,
+  createdAt: overrides.createdAt ?? "2026-04-27T00:00:00.000Z",
+  updatedAt: overrides.updatedAt ?? "2026-04-27T00:00:00.000Z",
+});
+
+export const demoScanCatalog: Record<string, ScanCatalogItem> = {
+  "5060277380011": buildDemoScanCatalogItem({
+    id: "demo-scan-punk-ipa",
+    barcode: "5060277380011",
+    name: "Punk IPA",
+    brewery: "BrewDog",
+    style: "IPA",
+    abv: 5.4,
+    ibu: 35,
+    colorEbc: 14,
+    aromaticTags: "tropical, citrus, pine",
+    notesSource: "BrewDog DIY Dog 2019 (open-source recipe book)",
+  }),
+  "5410702000132": buildDemoScanCatalogItem({
+    id: "demo-scan-la-chouffe",
+    barcode: "5410702000132",
+    name: "La Chouffe",
+    brewery: "Brasserie d Achouffe",
+    style: "Belgian Strong Pale Ale",
+    abv: 8.0,
+    ibu: 20,
+    colorEbc: 14,
+    aromaticTags: "banana, clove, coriander",
+  }),
+  "5410799000111": buildDemoScanCatalogItem({
+    id: "demo-scan-rochefort-10",
+    barcode: "5410799000111",
+    name: "Rochefort 10",
+    brewery: "Abbaye Notre-Dame de Saint-Remy",
+    style: "Belgian Quadrupel",
+    abv: 11.3,
+    ibu: 28,
+    colorEbc: 70,
+    aromaticTags: "dark fruit, port, caramel, raisin",
+  }),
+};
+
+/**
+ * Wraps a demo catalogue entry into the lookup result shape the
+ * use-case returns. Always reports `cache_hit_fresh` because demo
+ * data lives entirely on-device.
+ */
+export const buildDemoLookupResult = (
+  item: ScanCatalogItem,
+): ScanLookupResult => ({
+  item,
+  source: "cache_hit_fresh",
+  rawPayloadAvailable: false,
+});


### PR DESCRIPTION
## Summary

Mobile counterpart of backend PR #729 / Issue #696. Closes the data path from the scan flow down to the new `GET /scan/lookup/:ean` endpoint while keeping the demo flow working offline.

Layered per Clean Architecture (`packages/mobile-app/CLAUDE.md`):

- **domain** — `ScanCatalogItem`, `ScanLookupResult`, `ScanLookupSource`, `ScanCatalogItemOrigin` added to `scan.types.ts` (camelCase domain shape).
- **data** — `scan-lookup.api.ts` calls `GET /scan/lookup/:ean` via the shared `http-client`, maps snake_case DTO -> camelCase, URL-encodes the EAN against path-traversal.
- **application** — `lookupBeerByBarcode` use-case:
  - normalises barcode (trim + strip non-digits) and rejects empty input with `ScanLookupInvalidBarcodeError` before any network call;
  - branches on `dataSource.useDemoData` and serves the on-device `demoScanCatalog` (Punk IPA, La Chouffe, Rochefort 10) so the soutenance demo works without network;
  - maps `HttpError 404 -> ScanLookupBeerNotFoundError` and `503 -> ScanLookupServiceUnavailableError`; other statuses bubble up unchanged for the presentation layer (#698).

## Tests (happy / sad / edge — 18 new, all green)

- 5 on data layer: URL building, snake -> camel mapping (filled), null fields (sad), URL-encoding for path-traversal (edge), HTTP error re-throw (edge).
- 13 on use-case layer: input normalisation (3), demo mode (2), HttpError mapping (5), custom error classes (3).

Full mobile suite: **439 passed / 52 suites**.

## Side fix — `.gitignore`

The unanchored `data/` rule (intended for the API SQLite folder) was silently ignoring the mobile Clean Architecture `data/` layer folder, so every new file under `packages/mobile-app/src/features/<feature>/data/` would be ignored by `git add`. Anchored to `/packages/api/data/` — backend behaviour unchanged, but new mobile data-layer files are no longer hidden.

## Deltas vs Issue #697 spec (worth flagging)

| Spec says | Shipped | Why |
| --- | --- | --- |
| `scan.api.ts` with `getBeerByBarcode` + `getRecipesForBeer` | `scan-lookup.api.ts` with `lookupBeerByBarcode` | Backend (#696/#729) ships a single `GET /scan/lookup/:ean` endpoint; the recipe-matching half is a separate vertical owned by #699. Function name mirrors the backend method 1:1. |
| `domain/beer-data.types.ts` + `domain/errors.ts` as new files | New types appended to `domain/scan.types.ts`; error classes co-located with the use-case | Keeps a single domain file per feature (existing convention) and the errors stay where they're thrown. Happy to split if the reviewer prefers. |

## CI

- `npm run ci:check` — lint, typecheck, format:check all green
- `npm test` — 439/439 (52 suites)

## Checklist

- [x] Happy path + sad path + edge cases covered
- [x] `tsc --noEmit` passes
- [x] Existing tests still green (439/439)
- [x] No `any`, no inline styles, named exports only
- [x] Respects `dataSource.useDemoData` toggle
- [x] No direct `fetch()` — uses `src/core/http/http-client`

Refs #697
Refs #594