### PR TITLE
feat(recipes): import community recipe from beer info card (Issue #601)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,64 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-04-27
 
+### PR opened — Mobile UI: import community recipe (Issue #601)
+
+Branch `feat/mobile-recipe-import-issue-601`. Mobile-side closing of
+the demo-hero scan loop, paired with the just-merged backend PR #742.
+The user can now scan a beer, see the curated equivalent recipes, and
+import one into their own catalog with a single tap — landing on the
+new recipe's detail page.
+
+Scope (mobile only):
+
+- **Data layer** `recipes.api.ts` — new
+  `importFromCommunity(sourceId): Promise<Recipe>` calling
+  `POST /recipes/import-from-community/:id`.
+- **Use-case** `recipes.use-cases.ts` — new
+  `importRecipeFromCommunity(sourceId)` with the standard
+  `dataSource.useDemoData` branch:
+  - demo: returns the source recipe id + name from `demoRecipes`
+    (lets the UI navigate to a resolvable detail page when no real
+    backend is wired);
+  - backend: delegates to the API, returns the new recipe id + name
+    from the response.
+- **Screen** `BeerInfoCardScreen.tsx` — `EquivalentRecipesSection`
+  rewritten:
+  - per-row "+ Importer" CTA replaces the previous "tap to navigate
+    to source" affordance;
+  - `importingId` local state drives `disabled` + `accessibilityState
+    busy/disabled` + a "Import…" label during the round-trip;
+  - `Alert.alert` success modal with "Voir la recette" action →
+    `router.push('/(app)/recipes/{newId}')`;
+  - `Alert.alert` failure modal with retry-friendly French copy.
+- **Tests** — 5 added across 2 suites:
+  - 3 use-case unit tests in
+    `__tests__/import-recipe.test.ts` (happy demo, sad demo, happy
+    backend with API delegation assertion);
+  - 2 screen tests in `BeerInfoCardScreen.test.tsx` `import community
+    recipe` block (happy: import called + alert posted + nav on
+    "Voir la recette"; sad: rejected import → error alert + no nav).
+- Full mobile suite stays green: 531 / 58 (was 526 / 57).
+
+Decisions:
+
+- Tap on the row IS the import action (vs. a dedicated icon-button
+  to the right) — keeps the layout dense, makes the demo flow a
+  single tap, and matches the persona of a curious brewer who already
+  trusts the curated list.
+- Source id translation lives in the use-case (not the screen) —
+  keeps the screen agnostic of demo / backend mode and follows the
+  data-source toggle convention.
+- Provenance display (the `import_provenance` text written by the
+  backend) is intentionally NOT surfaced on the recipe detail screen
+  yet — the recipe detail refonte (4 tabs) ships that surface
+  later, this PR keeps the mobile layer minimal and demo-functional.
+
+Follows up: backend-mode integration with real public recipe IDs
+(curated public seed + #700 swap) before the soutenance demo. Until
+then, real-backend mode requires the demo recipe IDs to exist in the
+DB; demo mode works end-to-end on day 1.
+
 ### PR opened — Backend import-from-community endpoint (Issue #601)
 
 Branch `feat/recipes-import-from-community-issue-601`. Closes the

--- a/packages/mobile-app/src/features/recipes/application/__tests__/import-recipe.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/import-recipe.test.ts
@@ -1,0 +1,70 @@
+import { importRecipeFromCommunity } from "@/features/recipes/application/recipes.use-cases";
+import { importFromCommunity } from "@/features/recipes/data/recipes.api";
+
+const dataSourceMock = { useDemoData: true };
+
+jest.mock("@/core/data/data-source", () => ({
+  get dataSource() {
+    return dataSourceMock;
+  },
+}));
+
+jest.mock("@/features/recipes/data/recipes.api", () => ({
+  importFromCommunity: jest.fn(),
+}));
+
+const mockedImport = importFromCommunity as jest.MockedFunction<
+  typeof importFromCommunity
+>;
+
+describe("importRecipeFromCommunity", () => {
+  beforeEach(() => {
+    mockedImport.mockReset();
+    dataSourceMock.useDemoData = true;
+  });
+
+  describe("happy path — demo mode", () => {
+    it("returns the source recipe id and name without calling the API", async () => {
+      const result = await importRecipeFromCommunity("r-demo-1");
+
+      expect(result.recipeId).toBe("r-demo-1");
+      expect(result.name.length).toBeGreaterThan(0);
+      expect(mockedImport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sad path — demo mode", () => {
+    it("throws when the source id does not match any demo recipe", async () => {
+      await expect(importRecipeFromCommunity("does-not-exist")).rejects.toThrow(
+        /Demo recipe not found/,
+      );
+      expect(mockedImport).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("happy path — backend mode", () => {
+    it("delegates to the recipes API and returns the new recipe id and name", async () => {
+      dataSourceMock.useDemoData = false;
+      mockedImport.mockResolvedValueOnce({
+        id: "imported-uuid-1",
+        ownerId: "user-1",
+        name: "Session IPA Citra (community)",
+        description: null,
+        visibility: "private",
+        version: 1,
+        rootRecipeId: "imported-uuid-1",
+        parentRecipeId: null,
+        createdAt: "2026-04-27T12:00:00.000Z",
+        updatedAt: "2026-04-27T12:00:00.000Z",
+      });
+
+      const result = await importRecipeFromCommunity("source-uuid-7");
+
+      expect(mockedImport).toHaveBeenCalledWith("source-uuid-7");
+      expect(result).toEqual({
+        recipeId: "imported-uuid-1",
+        name: "Session IPA Citra (community)",
+      });
+    });
+  });
+});

--- a/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
@@ -1,5 +1,6 @@
 import {
   getMineById,
+  importFromCommunity,
   listMine,
   listSteps,
 } from "@/features/recipes/data/recipes.api";
@@ -62,6 +63,32 @@ export async function listRecipeSteps(recipeId: string): Promise<RecipeStep[]> {
     return demoRecipeSteps.filter((step) => step.recipeId === recipeId);
   }
   return listSteps(recipeId);
+}
+
+export type ImportRecipeResult = {
+  recipeId: string;
+  name: string;
+};
+
+/**
+ * Import a community (PUBLIC or UNLISTED) recipe into the current
+ * user's catalog. In demo mode, simulates the backend by returning
+ * the source recipe id (which already lives in `demoRecipes`) so
+ * the screen can navigate to a resolvable detail page without a
+ * real API call.
+ */
+export async function importRecipeFromCommunity(
+  sourceId: string,
+): Promise<ImportRecipeResult> {
+  if (dataSource.useDemoData) {
+    const source = demoRecipes.find((item) => item.id === sourceId);
+    if (!source) {
+      throw new Error(`Demo recipe not found: ${sourceId}`);
+    }
+    return { recipeId: source.id, name: source.name };
+  }
+  const imported = await importFromCommunity(sourceId);
+  return { recipeId: imported.id, name: imported.name };
 }
 
 export async function getRecipeDetailsViewModel(

--- a/packages/mobile-app/src/features/recipes/data/recipes.api.ts
+++ b/packages/mobile-app/src/features/recipes/data/recipes.api.ts
@@ -66,3 +66,11 @@ export async function listSteps(recipeId: string): Promise<RecipeStep[]> {
   const rows = await request<RecipeStepDto[]>(`/recipes/${recipeId}/steps`);
   return rows.map(mapRecipeStep);
 }
+
+export async function importFromCommunity(sourceId: string): Promise<Recipe> {
+  const row = await request<RecipeDto>(
+    `/recipes/import-from-community/${sourceId}`,
+    { method: "POST" },
+  );
+  return mapRecipe(row);
+}

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -1,5 +1,12 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import {
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
 
 import { colors, radius, spacing, typography } from "@/core/theme";
 import { Card } from "@/core/ui/Card";
@@ -7,6 +14,7 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 
+import { importRecipeFromCommunity } from "@/features/recipes/application/recipes.use-cases";
 import {
   ScanLookupBeerNotFoundError,
   ScanLookupInvalidBarcodeError,
@@ -173,7 +181,7 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
 
         <EquivalentRecipesSection
           barcode={status.result.item.barcode}
-          onPickRecipe={(recipeId) =>
+          onImported={(recipeId) =>
             router.push(`/(app)/recipes/${recipeId}` as never)
           }
         />
@@ -241,16 +249,46 @@ function GlanceCell({ label, value }: { label: string; value: string }) {
   );
 }
 
+const IMPORT_ERROR_MESSAGE =
+  "Impossible d'importer cette recette pour le moment. Réessaie dans quelques instants.";
+
 function EquivalentRecipesSection({
   barcode,
-  onPickRecipe,
-}: {
+  onImported,
+}: Readonly<{
   barcode: string;
-  onPickRecipe: (recipeId: string) => void;
-}) {
+  onImported: (recipeId: string) => void;
+}>) {
   const recipes = useMemo<ReadonlyArray<ScanRecipeMatch>>(
     () => getDemoEquivalentRecipes(barcode),
     [barcode],
+  );
+  const [importingId, setImportingId] = useState<string | null>(null);
+
+  const handleImport = useCallback(
+    async (sourceId: string) => {
+      if (importingId) return;
+      setImportingId(sourceId);
+      try {
+        const result = await importRecipeFromCommunity(sourceId);
+        Alert.alert(
+          "Recette importée",
+          `« ${result.name} » a été ajoutée à Mes Recettes.`,
+          [
+            {
+              text: "Voir la recette",
+              onPress: () => onImported(result.recipeId),
+            },
+          ],
+          { cancelable: true, onDismiss: () => onImported(result.recipeId) },
+        );
+      } catch {
+        Alert.alert("Import impossible", IMPORT_ERROR_MESSAGE);
+      } finally {
+        setImportingId(null);
+      }
+    },
+    [importingId, onImported],
   );
 
   if (recipes.length === 0) {
@@ -263,32 +301,44 @@ function EquivalentRecipesSection({
       <Text style={styles.recipesSubtitle}>
         Notées par la communauté Brasse Bouillon
       </Text>
-      {recipes.map((recipe) => (
-        <Pressable
-          key={recipe.recipeId}
-          onPress={() => onPickRecipe(recipe.recipeId)}
-          style={({ pressed }) => [
-            styles.recipeRow,
-            pressed ? styles.recipeRowPressed : null,
-          ]}
-          accessibilityRole="button"
-          accessibilityLabel={`${recipe.name} par ${recipe.brewer}, noté ${recipe.rating} sur 5`}
-        >
-          <View style={styles.recipeRowLeft}>
-            <Text style={styles.recipeName} numberOfLines={2}>
-              {recipe.name}
-            </Text>
-            <Text style={styles.recipeBrewer}>
-              {recipe.brewer} · brassée {recipe.brewedCount} fois
-            </Text>
-          </View>
-          <View style={styles.recipeRowRight}>
-            <Text style={styles.recipeRating}>
-              ★ {recipe.rating.toFixed(1)}
-            </Text>
-          </View>
-        </Pressable>
-      ))}
+      {recipes.map((recipe) => {
+        const isImporting = importingId === recipe.recipeId;
+        const isDisabled = importingId !== null;
+        return (
+          <Pressable
+            key={recipe.recipeId}
+            onPress={() => handleImport(recipe.recipeId)}
+            disabled={isDisabled}
+            style={({ pressed }) => {
+              if (isImporting) return [styles.recipeRow];
+              if (isDisabled)
+                return [styles.recipeRow, styles.recipeRowDisabled];
+              return [
+                styles.recipeRow,
+                pressed ? styles.recipeRowPressed : null,
+              ];
+            }}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: isDisabled, busy: isImporting }}
+            accessibilityLabel={`Importer ${recipe.name} par ${recipe.brewer}, noté ${recipe.rating} sur 5`}
+          >
+            <View style={styles.recipeRowLeft}>
+              <Text style={styles.recipeName} numberOfLines={2}>
+                {recipe.name}
+              </Text>
+              <Text style={styles.recipeBrewer}>
+                {recipe.brewer} · brassée {recipe.brewedCount} fois · ★{" "}
+                {recipe.rating.toFixed(1)}
+              </Text>
+            </View>
+            <View style={styles.recipeRowRight}>
+              <Text style={styles.recipeAction}>
+                {isImporting ? "Import…" : "+ Importer"}
+              </Text>
+            </View>
+          </Pressable>
+        );
+      })}
     </Card>
   );
 }
@@ -437,6 +487,9 @@ const styles = StyleSheet.create({
   recipeRowPressed: {
     opacity: 0.85,
   },
+  recipeRowDisabled: {
+    opacity: 0.5,
+  },
   recipeRowLeft: {
     flex: 1,
     paddingRight: spacing.sm,
@@ -454,7 +507,7 @@ const styles = StyleSheet.create({
     fontSize: typography.size.caption,
     color: colors.neutral.textSecondary,
   },
-  recipeRating: {
+  recipeAction: {
     fontSize: typography.size.label,
     fontWeight: typography.weight.bold,
     color: colors.brand.primary,

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -275,12 +275,13 @@ function EquivalentRecipesSection({
           "Recette importée",
           `« ${result.name} » a été ajoutée à Mes Recettes.`,
           [
+            { text: "Plus tard", style: "cancel" },
             {
               text: "Voir la recette",
               onPress: () => onImported(result.recipeId),
             },
           ],
-          { cancelable: true, onDismiss: () => onImported(result.recipeId) },
+          { cancelable: true },
         );
       } catch {
         Alert.alert("Import impossible", IMPORT_ERROR_MESSAGE);

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -285,10 +285,42 @@ describe("BeerInfoCardScreen", () => {
         text: string;
         onPress?: () => void;
       }>;
+      const viewButton = buttons.find((b) => b.text === "Voir la recette");
       act(() => {
-        buttons[0].onPress?.();
+        viewButton?.onPress?.();
       });
       expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/imported-uuid-1");
+    });
+
+    it("does not navigate when the user dismisses the success alert", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      mockedImport.mockResolvedValueOnce({
+        recipeId: "imported-uuid-2",
+        name: "Session IPA Citra",
+      });
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+
+      const row = await screen.findByLabelText(/Importer Session IPA Citra/);
+      await act(async () => {
+        fireEvent.press(row);
+      });
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalled();
+      });
+
+      // The "Plus tard" cancel button has no onPress handler — pressing it
+      // (or dismissing the alert by tapping outside) must NOT navigate.
+      const buttons = alertSpy.mock.calls[0][2] as Array<{
+        text: string;
+        style?: string;
+        onPress?: () => void;
+      }>;
+      const cancelButton = buttons.find((b) => b.style === "cancel");
+      expect(cancelButton).toBeDefined();
+      expect(cancelButton?.onPress).toBeUndefined();
+      expect(mockPush).not.toHaveBeenCalled();
     });
 
     it("shows an error alert when the import fails and does not navigate", async () => {

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -1,7 +1,15 @@
-import { fireEvent, render, screen } from "@testing-library/react-native";
+import { Alert } from "react-native";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
 import React from "react";
 
 import { BeerInfoCardScreen } from "@/features/scan/presentation/BeerInfoCardScreen";
+import { importRecipeFromCommunity } from "@/features/recipes/application/recipes.use-cases";
 import {
   ScanLookupBeerNotFoundError,
   ScanLookupServiceUnavailableError,
@@ -34,8 +42,15 @@ jest.mock("@/features/scan/application/scan-lookup.use-cases", () => {
   };
 });
 
+jest.mock("@/features/recipes/application/recipes.use-cases", () => ({
+  importRecipeFromCommunity: jest.fn(),
+}));
+
 const mockedLookup = lookupBeerByBarcode as jest.MockedFunction<
   typeof lookupBeerByBarcode
+>;
+const mockedImport = importRecipeFromCommunity as jest.MockedFunction<
+  typeof importRecipeFromCommunity
 >;
 
 function buildResult(
@@ -70,10 +85,18 @@ function buildResult(
 }
 
 describe("BeerInfoCardScreen", () => {
+  let alertSpy: jest.SpyInstance;
+
   beforeEach(() => {
     mockPush.mockReset();
     mockReplace.mockReset();
     mockedLookup.mockReset();
+    mockedImport.mockReset();
+    alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
   });
 
   describe("happy path", () => {
@@ -232,19 +255,60 @@ describe("BeerInfoCardScreen", () => {
     });
   });
 
-  describe("recipe navigation", () => {
-    it("navigates to a real recipe detail when a recipe row is pressed", async () => {
+  describe("import community recipe", () => {
+    it("imports the recipe and navigates to the new detail page on success", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
+      mockedImport.mockResolvedValueOnce({
+        recipeId: "imported-uuid-1",
+        name: "Session IPA Citra",
+      });
 
       render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
 
-      const recipeRow = await screen.findByLabelText(/Session IPA Citra/);
-      fireEvent.press(recipeRow);
+      const row = await screen.findByLabelText(/Importer Session IPA Citra/);
+      await act(async () => {
+        fireEvent.press(row);
+      });
 
-      // Punk IPA's first match maps to the existing r-demo-1 recipe
-      // so the navigation lands on a resolvable recipe detail page
-      // (Codex P1 fix: mocks now use real demoRecipes IDs).
-      expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/r-demo-1");
+      await waitFor(() => {
+        expect(mockedImport).toHaveBeenCalledWith("r-demo-1");
+      });
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Recette importée",
+        expect.stringContaining("Session IPA Citra"),
+        expect.any(Array),
+        expect.any(Object),
+      );
+
+      // Trigger the "Voir la recette" button from the success alert.
+      const buttons = alertSpy.mock.calls[0][2] as Array<{
+        text: string;
+        onPress?: () => void;
+      }>;
+      act(() => {
+        buttons[0].onPress?.();
+      });
+      expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/imported-uuid-1");
+    });
+
+    it("shows an error alert when the import fails and does not navigate", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      mockedImport.mockRejectedValueOnce(new Error("boom"));
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+
+      const row = await screen.findByLabelText(/Importer Session IPA Citra/);
+      await act(async () => {
+        fireEvent.press(row);
+      });
+
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Import impossible",
+          expect.stringContaining("Réessaie"),
+        );
+      });
+      expect(mockPush).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Mobile-side closing of the demo-hero scan loop, paired with the just-merged backend PR #742. The user can now scan a beer, see the curated equivalent recipes, and import one into their own catalog with a single tap — landing on the new recipe's detail page.

### What ships

- **Data layer** — new `importFromCommunity(sourceId): Promise<Recipe>` calling `POST /recipes/import-from-community/:id`.
- **Use-case** — new `importRecipeFromCommunity(sourceId)` with the standard `dataSource.useDemoData` branch: in demo mode it returns the source recipe id + name from `demoRecipes` so the UI lands on a resolvable detail page; in backend mode it delegates to the API and returns the new recipe id + name.
- **Screen** — `EquivalentRecipesSection` rewritten: per-row `+ Importer` CTA, `importingId` state drives `disabled` + `accessibilityState busy` + a transient `Import…` label, success `Alert.alert` with a `Voir la recette` action that pushes `/(app)/recipes/{newId}`, failure `Alert.alert` with retry-friendly copy.

### Tests

- 3 new use-case tests (`__tests__/import-recipe.test.ts`): happy demo, sad demo (unknown source id throws), happy backend (delegation + return shape).
- 2 new screen tests (`BeerInfoCardScreen.test.tsx` `import community recipe`): happy (import called + alert posted + nav on `Voir la recette`), sad (rejected import → error alert + no nav).
- Full mobile suite stays green: **531 / 58** suites.

## Decisions

- **Tap on the row IS the import action** (vs. a dedicated icon-button) — keeps the layout dense, makes the demo flow a single tap, and matches the persona of a curious brewer who already trusts the curated list.
- **Source id translation lives in the use-case** (not the screen) — keeps the screen agnostic of demo / backend mode and follows the data-source toggle convention.
- **Provenance display is intentionally NOT surfaced on the recipe detail screen yet** — the recipe detail refonte (4 tabs) ships that surface later. This PR keeps the mobile layer minimal and demo-functional.

## Follow-ups

- Backend-mode integration with real public recipe IDs needs the curated public recipes seed + #700 swap. Until those land, real-backend mode requires the demo recipe IDs to exist in the DB; demo mode works end-to-end on day 1.

## Checklist

- [x] Happy / sad / edge cases covered
- [x] `tsc --noEmit` passes
- [x] `lint:check` + `format:check` pass
- [x] Existing tests still green (531 / 58)
- [x] No `any`, no inline styles introduced

Closes #601