### PR TITLE
docs(contributing): document AI auto-review convention

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -437,6 +437,32 @@ The list of people to mention should be suggested based on the PR context (scope
 - At least one reviewer must approve
 - Address review comments before merging
 
+#### AI reviewers — auto-review by default (no manual request needed)
+
+Two AI reviewers are wired on this repository. Both are GitHub Apps,
+not collaborators, so they cannot be added via the
+`requested_reviewers` API (it returns HTTP 422). They review every PR
+automatically on push:
+
+| Reviewer | Bot account | Status |
+|---|---|---|
+| Codex | `chatgpt-codex-connector[bot]` | Always active |
+| Copilot | `copilot-pull-request-reviewer[bot]` | OFF until 2026-05-01 (premium-request quota exhausted), then back on |
+
+What this means in practice:
+
+- **Do not** call `gh api ... requested_reviewers -X POST` for either
+  bot — the call fails with 422 and the bot reviews anyway.
+- **Do** wait for the review to be **posted** (not just "requested")
+  before considering the PR ready, per the PR review procedure in
+  global `~/.claude/CLAUDE.md`. Verify with:
+  `gh api repos/OWNER/REPO/pulls/PR/reviews --jq '.[].state'`.
+- **Do** address every inline comment per the Must Have / Should
+  Have / Nice to Have / Disagree taxonomy, exactly the same way as
+  for a human reviewer.
+- Human reviewers are **never** tagged as PR reviewers on this
+  project (solo dev — AI-only review policy).
+
 ---
 
 ## Code Style


### PR DESCRIPTION
## Summary

Documents the discovered behavior of the two AI reviewer GitHub Apps wired on this repo (Codex + Copilot):

- Both are Apps, not collaborators
- API requests via `requested_reviewers` return HTTP 422 (Apps cannot be requested)
- They auto-review every PR on push regardless (webhook-driven at the App level)

## Why

Discovered empirically on PR #743: tried to add Codex via the standard `gh pr create --reviewer` and `gh api ... requested_reviewers` paths, both returned 422, but Codex still posted a P1 review minutes later.

Without this documentation, future contributors (human or AI agent) waste cycles building auto-retry workflows for an unfixable error, or believe the AI review skipped because they don't see "Requested by" in the sidebar.

## What changes

One new section in `CONTRIBUTING.md` § "Wait for review" → "AI reviewers — auto-review by default (no manual request needed)" with the table of bots, the practical rules, and the cross-link to the global PR procedure.

## Checklist

- [x] No code changes — docs only
- [x] No CI impact

Closes nothing — this is pure documentation hygiene from the PR #743 cycle.