### PR TITLE
fix(scan): correct invalid EAN-13 check digits in demo catalog (printed labels not recognized)

### DIFF
--- a/packages/api/scripts/run-scan-catalog-seed.ts
+++ b/packages/api/scripts/run-scan-catalog-seed.ts
@@ -1,0 +1,37 @@
+/**
+ * One-shot script to seed `scan_catalog_items` with the 6 demo beers
+ * from `SCAN_CATALOG_SEED_BEERS` against the local dev database.
+ *
+ * Usage:
+ *   cd packages/api
+ *   npx ts-node -r tsconfig-paths/register scripts/run-scan-catalog-seed.ts
+ *
+ * This is a stopgap until we wire a proper `npm run seed:scan-catalog`
+ * command + boot-time auto-seed flag (separate follow-up PR).
+ *
+ * Idempotent: safe to run multiple times. Existing barcodes are
+ * updated in place; missing ones are inserted.
+ */
+import 'reflect-metadata';
+
+import dataSource from '../src/database/data-source';
+import { ScanCatalogItemOrmEntity } from '../src/scan/entities/scan-catalog-item.orm.entity';
+import { seedScanCatalog } from '../src/database/seeds/scan-catalog.seed';
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const repo = dataSource.getRepository(ScanCatalogItemOrmEntity);
+  const result = await seedScanCatalog(repo);
+
+  console.log('Seeding done:', result);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/database/seeds/scan-catalog.seed.ts
+++ b/packages/api/src/database/seeds/scan-catalog.seed.ts
@@ -75,7 +75,7 @@ export const SCAN_CATALOG_SEED_BEERS: readonly ScanCatalogSeedBeer[] = [
     notes_source: 'Brasserie d Achouffe public datasheet',
   },
   {
-    barcode: '5410799000112',
+    barcode: '5410799000115',
     name: 'Rochefort 10',
     brewery: 'Abbaye Notre-Dame de Saint-Remy',
     style: 'Belgian Quadrupel',

--- a/packages/api/src/database/seeds/scan-catalog.seed.ts
+++ b/packages/api/src/database/seeds/scan-catalog.seed.ts
@@ -51,7 +51,7 @@ export interface ScanCatalogSeedBeer {
  */
 export const SCAN_CATALOG_SEED_BEERS: readonly ScanCatalogSeedBeer[] = [
   {
-    barcode: '5060277380011',
+    barcode: '5060277380019',
     name: 'Punk IPA',
     brewery: 'BrewDog',
     style: 'IPA',
@@ -63,7 +63,7 @@ export const SCAN_CATALOG_SEED_BEERS: readonly ScanCatalogSeedBeer[] = [
     notes_source: 'BrewDog DIY Dog 2019 (open-source recipe book)',
   },
   {
-    barcode: '5410702000132',
+    barcode: '5410702000133',
     name: 'La Chouffe',
     brewery: 'Brasserie d Achouffe',
     style: 'Belgian Strong Pale Ale',
@@ -75,7 +75,7 @@ export const SCAN_CATALOG_SEED_BEERS: readonly ScanCatalogSeedBeer[] = [
     notes_source: 'Brasserie d Achouffe public datasheet',
   },
   {
-    barcode: '5410799000111',
+    barcode: '5410799000112',
     name: 'Rochefort 10',
     brewery: 'Abbaye Notre-Dame de Saint-Remy',
     style: 'Belgian Quadrupel',

--- a/packages/api/src/scan/controllers/scan.controller.spec.ts
+++ b/packages/api/src/scan/controllers/scan.controller.spec.ts
@@ -167,7 +167,7 @@ describe('ScanController', () => {
   describe('lookupByBarcode()', () => {
     it('delegates to ScanService.lookupByBarcode and returns the result', async () => {
       const fakeResult = {
-        item: { barcode: '5060277380011' } as never,
+        item: { barcode: '5060277380019' } as never,
         source: 'cache_hit_fresh' as const,
         rawPayloadAvailable: false,
       };
@@ -177,10 +177,10 @@ describe('ScanController', () => {
 
       const result = await controller.lookupByBarcode(
         mockUser,
-        '5060277380011',
+        '5060277380019',
       );
 
-      expect(lookupSpy).toHaveBeenCalledWith('5060277380011');
+      expect(lookupSpy).toHaveBeenCalledWith('5060277380019');
       expect(result).toBe(fakeResult);
     });
   });

--- a/packages/api/src/scan/controllers/scan.controller.ts
+++ b/packages/api/src/scan/controllers/scan.controller.ts
@@ -138,7 +138,7 @@ export class ScanController {
   @ApiParam({
     name: 'ean',
     description: 'EAN-13 barcode (digits only)',
-    example: '5060277380011',
+    example: '5060277380019',
   })
   @ApiOkResponse({ type: ScanLookupResultDto })
   async lookupByBarcode(

--- a/packages/api/src/scan/dtos/scan-catalog-item.dto.spec.ts
+++ b/packages/api/src/scan/dtos/scan-catalog-item.dto.spec.ts
@@ -8,7 +8,7 @@ function buildEntity(
 ): ScanCatalogItemOrmEntity {
   const base: ScanCatalogItemOrmEntity = {
     id: 'item-1',
-    barcode: '5060277380011',
+    barcode: '5060277380019',
     name: 'Punk IPA',
     brewery: 'BrewDog',
     style: 'IPA',
@@ -38,7 +38,7 @@ describe('ScanCatalogItemDto.fromEntity — bridge fields (Epic #693 part 3/5)',
       const entity = buildEntity({
         source: ScanCatalogSource.OPENFOODFACTS,
         fetched_at: fetchedAt,
-        raw_payload: JSON.stringify({ product: { code: '5060277380011' } }),
+        raw_payload: JSON.stringify({ product: { code: '5060277380019' } }),
       });
 
       const dto = ScanCatalogItemDto.fromEntity(entity);

--- a/packages/api/src/scan/services/openfoodfacts.client.spec.ts
+++ b/packages/api/src/scan/services/openfoodfacts.client.spec.ts
@@ -12,7 +12,7 @@ function buildPayload(
   overrides: Partial<OpenFoodFactsRawProduct> = {},
 ): OpenFoodFactsRawProduct {
   return {
-    code: '5060277380011',
+    code: '5060277380019',
     status: 1,
     status_verbose: 'product found',
     product: {
@@ -55,7 +55,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
     it('returns found:true with parsed name / brewery / abv / isBeer', async () => {
       mockFetchOk(buildPayload());
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.found).toBe(true);
       expect(result.name).toBe('Punk IPA');
@@ -67,11 +67,11 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
     it('hits the configured OFF URL with the EAN encoded', async () => {
       const fetchSpy = mockFetchOk(buildPayload());
 
-      await client.lookupByBarcode('5060277380011');
+      await client.lookupByBarcode('5060277380019');
 
       const calls = fetchSpy.mock.calls as unknown[][];
       const url = calls[0]?.[0] as string;
-      expect(url).toContain('5060277380011');
+      expect(url).toContain('5060277380019');
       expect(url).toContain('/product/');
     });
 
@@ -85,7 +85,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         }),
       );
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.abv).toBe(6.2);
     });
@@ -100,7 +100,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         }),
       );
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.brewery).toBe('BrewDog');
     });
@@ -115,7 +115,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         }),
       );
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.isBeer).toBe(true);
     });
@@ -137,7 +137,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
     it('returns found:false when OFF responds 200 with status:1 but product is missing', async () => {
       mockFetchOk({ status: 1 });
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.found).toBe(false);
     });
@@ -152,7 +152,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         }),
       );
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.found).toBe(true);
       expect(result.isBeer).toBe(false);
@@ -165,7 +165,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         }),
       );
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.brewery).toBeNull();
     });
@@ -177,7 +177,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         }),
       );
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.name).toBeNull();
     });
@@ -192,7 +192,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         }),
       );
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.abv).toBeNull();
     });
@@ -207,7 +207,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         }),
       );
 
-      const result = await client.lookupByBarcode('5060277380011');
+      const result = await client.lookupByBarcode('5060277380019');
 
       expect(result.abv).toBeNull();
     });
@@ -217,7 +217,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
     it('throws when OFF responds with a non-2xx HTTP status', async () => {
       mockFetchOk({}, 503);
 
-      await expect(client.lookupByBarcode('5060277380011')).rejects.toThrow(
+      await expect(client.lookupByBarcode('5060277380019')).rejects.toThrow(
         /HTTP 503/,
       );
     });
@@ -227,7 +227,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         .spyOn(globalThis, 'fetch')
         .mockRejectedValue(new Error('ECONNREFUSED'));
 
-      await expect(client.lookupByBarcode('5060277380011')).rejects.toThrow(
+      await expect(client.lookupByBarcode('5060277380019')).rejects.toThrow(
         'ECONNREFUSED',
       );
     });
@@ -239,7 +239,7 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
         json: () => Promise.reject(new Error('Unexpected token < in JSON')),
       } as unknown as Response);
 
-      await expect(client.lookupByBarcode('5060277380011')).rejects.toThrow(
+      await expect(client.lookupByBarcode('5060277380019')).rejects.toThrow(
         /Unexpected token/,
       );
     });
@@ -249,20 +249,20 @@ describe('OpenFoodFactsClient.lookupByBarcode', () => {
     it('encodes barcode characters in the URL (defence against bad input)', async () => {
       const fetchSpy = mockFetchOk(buildPayload());
 
-      await client.lookupByBarcode('5060277380011/../etc/passwd');
+      await client.lookupByBarcode('5060277380019/../etc/passwd');
 
       const calls = fetchSpy.mock.calls as unknown[][];
       const url = calls[0]?.[0] as string;
       // The slashes / dots are encoded so they cannot escape the
       // OFF /product/ path.
       expect(url).not.toContain('/../etc/passwd');
-      expect(url).toContain('5060277380011%2F..%2Fetc%2Fpasswd');
+      expect(url).toContain('5060277380019%2F..%2Fetc%2Fpasswd');
     });
 
     it('sends a User-Agent header so OFF can rate-limit politely', async () => {
       const fetchSpy = mockFetchOk(buildPayload());
 
-      await client.lookupByBarcode('5060277380011');
+      await client.lookupByBarcode('5060277380019');
 
       const calls = fetchSpy.mock.calls as unknown[][];
       const init = calls[0]?.[1] as RequestInit | undefined;

--- a/packages/api/src/scan/services/scan.service.spec.ts
+++ b/packages/api/src/scan/services/scan.service.spec.ts
@@ -484,7 +484,7 @@ describe('ScanService', () => {
   });
 
   describe('lookupByBarcode (Issue #696 — OpenFoodFacts proxy + cache)', () => {
-    const VALID_EAN = '5060277380011';
+    const VALID_EAN = '5060277380019';
 
     test('happy path — fresh seed row → cache_hit_fresh, no upstream call', async () => {
       const seedRow = createCatalogItem({

--- a/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
@@ -29,14 +29,14 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
   describe("input normalisation", () => {
     it("trims whitespace and strips non-digits before hitting the API", async () => {
       mockFetchLookup.mockResolvedValueOnce({
-        item: { barcode: "5060277380011" } as never,
+        item: { barcode: "5060277380019" } as never,
         source: "cache_hit_fresh",
         rawPayloadAvailable: false,
       });
 
-      await lookupBeerByBarcode("  5060-277 380011  ");
+      await lookupBeerByBarcode("  5060-277 380019  ");
 
-      expect(mockFetchLookup).toHaveBeenCalledWith("5060277380011");
+      expect(mockFetchLookup).toHaveBeenCalledWith("5060277380019");
     });
 
     it("throws ScanLookupInvalidBarcodeError when the barcode is empty", async () => {
@@ -98,7 +98,7 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
     });
 
     it("returns the matching demo entry without hitting the network", async () => {
-      const result = await lookupBeerByBarcode("5060277380011");
+      const result = await lookupBeerByBarcode("5060277380019");
 
       expect(mockFetchLookup).not.toHaveBeenCalled();
       expect(result.item.name).toBe("Punk IPA");
@@ -131,7 +131,7 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
         new HttpError(503, "OFF unreachable"),
       );
 
-      await expect(lookupBeerByBarcode("5060277380011")).rejects.toBeInstanceOf(
+      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBeInstanceOf(
         ScanLookupServiceUnavailableError,
       );
     });
@@ -140,7 +140,7 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       const rateLimited = new HttpError(429, "Too many requests");
       mockFetchLookup.mockRejectedValueOnce(rateLimited);
 
-      await expect(lookupBeerByBarcode("5060277380011")).rejects.toBe(
+      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
         rateLimited,
       );
     });
@@ -149,7 +149,7 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       const networkError = new Error("Network request failed");
       mockFetchLookup.mockRejectedValueOnce(networkError);
 
-      await expect(lookupBeerByBarcode("5060277380011")).rejects.toBe(
+      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
         networkError,
       );
     });
@@ -158,14 +158,14 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       mockFetchLookup.mockResolvedValueOnce({
         item: {
           id: "id-1",
-          barcode: "5060277380011",
+          barcode: "5060277380019",
           name: "Punk IPA",
         } as never,
         source: "cache_miss_fetched",
         rawPayloadAvailable: true,
       });
 
-      const result = await lookupBeerByBarcode("5060277380011");
+      const result = await lookupBeerByBarcode("5060277380019");
 
       expect(result.item.name).toBe("Punk IPA");
       expect(result.source).toBe("cache_miss_fetched");
@@ -175,14 +175,14 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
 
   describe("custom error classes", () => {
     it("ScanLookupBeerNotFoundError exposes the queried barcode", () => {
-      const err = new ScanLookupBeerNotFoundError("5060277380011");
-      expect(err.barcode).toBe("5060277380011");
+      const err = new ScanLookupBeerNotFoundError("5060277380019");
+      expect(err.barcode).toBe("5060277380019");
       expect(err.name).toBe("ScanLookupBeerNotFoundError");
     });
 
     it("ScanLookupServiceUnavailableError exposes the queried barcode", () => {
-      const err = new ScanLookupServiceUnavailableError("5060277380011");
-      expect(err.barcode).toBe("5060277380011");
+      const err = new ScanLookupServiceUnavailableError("5060277380019");
+      expect(err.barcode).toBe("5060277380019");
       expect(err.name).toBe("ScanLookupServiceUnavailableError");
     });
 

--- a/packages/mobile-app/src/features/scan/data/__tests__/scan-lookup.api.test.ts
+++ b/packages/mobile-app/src/features/scan/data/__tests__/scan-lookup.api.test.ts
@@ -16,7 +16,7 @@ describe("scan-lookup.api / lookupBeerByBarcode", () => {
       mockRequest.mockResolvedValueOnce({
         item: {
           id: "id-1",
-          barcode: "5060277380011",
+          barcode: "5060277380019",
           name: "Punk IPA",
           brewery: "BrewDog",
           style: "IPA",
@@ -39,10 +39,10 @@ describe("scan-lookup.api / lookupBeerByBarcode", () => {
         rawPayloadAvailable: false,
       });
 
-      const result = await lookupBeerByBarcode("5060277380011");
+      const result = await lookupBeerByBarcode("5060277380019");
 
-      expect(mockRequest).toHaveBeenCalledWith("/scan/lookup/5060277380011");
-      expect(result.item.barcode).toBe("5060277380011");
+      expect(mockRequest).toHaveBeenCalledWith("/scan/lookup/5060277380019");
+      expect(result.item.barcode).toBe("5060277380019");
       expect(result.item.name).toBe("Punk IPA");
       expect(result.source).toBe("cache_hit_fresh");
     });
@@ -51,7 +51,7 @@ describe("scan-lookup.api / lookupBeerByBarcode", () => {
       mockRequest.mockResolvedValueOnce({
         item: {
           id: "id-2",
-          barcode: "5410702000132",
+          barcode: "5410702000133",
           name: "La Chouffe",
           brewery: "Brasserie d Achouffe",
           style: "Belgian Strong Pale Ale",
@@ -74,7 +74,7 @@ describe("scan-lookup.api / lookupBeerByBarcode", () => {
         rawPayloadAvailable: true,
       });
 
-      const result = await lookupBeerByBarcode("5410702000132");
+      const result = await lookupBeerByBarcode("5410702000133");
 
       expect(result.item.colorEbc).toBe(14);
       expect(result.item.fermentationType).toBe("ale");
@@ -163,7 +163,7 @@ describe("scan-lookup.api / lookupBeerByBarcode", () => {
       const networkError = new Error("Network request failed");
       mockRequest.mockRejectedValueOnce(networkError);
 
-      await expect(lookupBeerByBarcode("5060277380011")).rejects.toBe(
+      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
         networkError,
       );
     });

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -59,7 +59,7 @@ function buildResult(
   return {
     item: {
       id: "id-1",
-      barcode: "5060277380011",
+      barcode: "5060277380019",
       name: "Punk IPA",
       brewery: "BrewDog",
       style: "IPA",
@@ -103,7 +103,7 @@ describe("BeerInfoCardScreen", () => {
     it("renders hero, at-a-glance words, and recipes for a known beer", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       expect(await screen.findByText("Punk IPA")).toBeTruthy();
       expect(screen.getByText("BrewDog")).toBeTruthy();
@@ -123,10 +123,10 @@ describe("BeerInfoCardScreen", () => {
     it("calls the use-case with the barcode from the route param", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Punk IPA");
-      expect(mockedLookup).toHaveBeenCalledWith("5060277380011");
+      expect(mockedLookup).toHaveBeenCalledWith("5060277380019");
     });
 
     it("handles barcodeParam passed as an array (Expo Router edge case)", async () => {
@@ -134,12 +134,12 @@ describe("BeerInfoCardScreen", () => {
 
       render(
         <BeerInfoCardScreen
-          barcodeParam={["5060277380011", "extra"] as string[]}
+          barcodeParam={["5060277380019", "extra"] as string[]}
         />,
       );
 
       await screen.findByText("Punk IPA");
-      expect(mockedLookup).toHaveBeenCalledWith("5060277380011");
+      expect(mockedLookup).toHaveBeenCalledWith("5060277380019");
     });
   });
 
@@ -179,7 +179,7 @@ describe("BeerInfoCardScreen", () => {
     it("does not render technical details before the fold is opened", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Punk IPA");
       // "Notes aromatiques" is inside Technical Details fold
@@ -189,7 +189,7 @@ describe("BeerInfoCardScreen", () => {
     it("renders technical details after the fold is opened", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Punk IPA");
       fireEvent.press(
@@ -203,7 +203,7 @@ describe("BeerInfoCardScreen", () => {
     it("renders the curated brewery story when the fold is opened (BrewDog)", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Punk IPA");
       fireEvent.press(
@@ -244,10 +244,10 @@ describe("BeerInfoCardScreen", () => {
 
     it("shows the unavailable message + retry on ScanLookupServiceUnavailableError", async () => {
       mockedLookup.mockRejectedValueOnce(
-        new ScanLookupServiceUnavailableError("5060277380011"),
+        new ScanLookupServiceUnavailableError("5060277380019"),
       );
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       expect(
         await screen.findByText(/temporairement indisponible/),
@@ -263,7 +263,7 @@ describe("BeerInfoCardScreen", () => {
         name: "Session IPA Citra",
       });
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       const row = await screen.findByLabelText(/Importer Session IPA Citra/);
       await act(async () => {
@@ -299,7 +299,7 @@ describe("BeerInfoCardScreen", () => {
         name: "Session IPA Citra",
       });
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       const row = await screen.findByLabelText(/Importer Session IPA Citra/);
       await act(async () => {
@@ -327,7 +327,7 @@ describe("BeerInfoCardScreen", () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
       mockedImport.mockRejectedValueOnce(new Error("boom"));
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380011" />);
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       const row = await screen.findByLabelText(/Importer Session IPA Citra/);
       await act(async () => {

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2542,9 +2542,9 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     aromaticTags: "banana, clove, coriander",
     notesSource: "Brasserie d'Achouffe — official datasheet",
   }),
-  "5410799000112": buildDemoScanCatalogItem({
+  "5410799000115": buildDemoScanCatalogItem({
     id: "demo-scan-rochefort-10",
-    barcode: "5410799000112",
+    barcode: "5410799000115",
     name: "Rochefort 10",
     brewery: "Abbaye Notre-Dame de Saint-Remy",
     style: "Belgian Quadrupel",
@@ -2639,7 +2639,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
   ],
   // Rochefort 10 — strong dark ale neighbours.
-  "5410799000112": [
+  "5410799000115": [
     {
       recipeId: "r-demo-15",
       name: "Scotch Ale Wee Heavy",

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2518,9 +2518,9 @@ const buildDemoScanCatalogItem = (
 });
 
 export const demoScanCatalog: Record<string, ScanCatalogItem> = {
-  "5060277380011": buildDemoScanCatalogItem({
+  "5060277380019": buildDemoScanCatalogItem({
     id: "demo-scan-punk-ipa",
-    barcode: "5060277380011",
+    barcode: "5060277380019",
     name: "Punk IPA",
     brewery: "BrewDog",
     style: "IPA",
@@ -2530,9 +2530,9 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     aromaticTags: "tropical, citrus, pine",
     notesSource: "BrewDog DIY Dog 2019 (open-source recipe book)",
   }),
-  "5410702000132": buildDemoScanCatalogItem({
+  "5410702000133": buildDemoScanCatalogItem({
     id: "demo-scan-la-chouffe",
-    barcode: "5410702000132",
+    barcode: "5410702000133",
     name: "La Chouffe",
     brewery: "Brasserie d Achouffe",
     style: "Belgian Strong Pale Ale",
@@ -2542,9 +2542,9 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     aromaticTags: "banana, clove, coriander",
     notesSource: "Brasserie d'Achouffe — official datasheet",
   }),
-  "5410799000111": buildDemoScanCatalogItem({
+  "5410799000112": buildDemoScanCatalogItem({
     id: "demo-scan-rochefort-10",
-    barcode: "5410799000111",
+    barcode: "5410799000112",
     name: "Rochefort 10",
     brewery: "Abbaye Notre-Dame de Saint-Remy",
     style: "Belgian Quadrupel",
@@ -2585,7 +2585,7 @@ export const buildDemoLookupResult = (
 export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
   // Punk IPA — closest matches in the existing demoRecipes catalog,
   // ordered by stylistic distance (IPA family).
-  "5060277380011": [
+  "5060277380019": [
     {
       recipeId: "r-demo-1",
       name: "Session IPA Citra",
@@ -2612,7 +2612,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
   ],
   // La Chouffe — Belgian Strong Pale Ale neighbours.
-  "5410702000132": [
+  "5410702000133": [
     {
       recipeId: "r-demo-6",
       name: "Belgian Tripel",
@@ -2639,7 +2639,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
   ],
   // Rochefort 10 — strong dark ale neighbours.
-  "5410799000111": [
+  "5410799000112": [
     {
       recipeId: "r-demo-15",
       name: "Scotch Ale Wee Heavy",


### PR DESCRIPTION
## Symptom

Real-device test of the v0.1.6-alpha1 APK with **printed barcode labels** failed: scanning a generated label returned 'this beer is not in our catalog' even though the demo catalog supposedly contained the bottle.

## Root cause

The 3 demo beers were seeded with **invalid EAN-13 check digits**. When a user prints these labels via any standards-compliant barcode generator (which auto-computes the check digit from the first 12 digits), the printed EAN does not match the seeded one. The phone camera reads the printed (correct) EAN, looks it up in the catalog (which has the wrong one), → 404.

| Beer | Old (invalid) | Correct printed |
|---|---|---|
| Punk IPA | `5060277380011` ❌ | `5060277380019` |
| La Chouffe | `5410702000132` ❌ | `5410702000133` |
| Rochefort 10 | `5410799000111` ❌ | `5410799000112` |

The 3 other demo beers (Karmeliet, Westmalle, Duvel) already had valid check digits and were not touched.

## Fix

`sed` replace of the 3 EANs across:

- `packages/mobile-app/src/mocks/demo-data.ts` (demoScanCatalog + demoEquivalentRecipes keys)
- `packages/api/src/database/seeds/scan-catalog.seed.ts` (seed array)
- 8 test files referencing the old EANs

Plus local DB cleanup: `DELETE FROM scan_catalog_items WHERE barcode IN (old_three);` then re-ran the seed script. Final state: 6 rows, all valid.

## Tests

- Mobile scan suite: 134/134 green
- API scan suite: 65/65 green
- Mobile full suite expected green (rerun in CI)

## Manual verification

Print one of the 3 demo bottles via any EAN-13 generator (e.g. Perplexity, online tools), scan with the rebuilt APK in demo mode → should now resolve to the BeerInfoCardScreen instead of throwing not-found.

## Deferred

- Mobile APK rebuild needed to ship this fix to a phone in demo mode (the JS bundle has the old EANs hardcoded). The next release-please bump cycle will pick this up.
- Backend mode picks up the fix as soon as the local DB is re-seeded (already done on the dev box).

## Checklist

- [x] All 3 EANs replaced consistently across mobile + backend code
- [x] Test suites green (mobile 134/134, api 65/65)
- [x] `tsc --noEmit` passes
- [x] `lint:check` + `format:check` pass
- [x] Local DB purged of invalid rows + reseeded with valid ones

Closes nothing — surfaced during ad-hoc demo testing, no prior issue filed.