### PR TITLE
feat(scan): add La Goudale as a 4th demo bottle for live testing

### DIFF
--- a/packages/api/src/database/seeds/scan-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/scan-catalog.seed.spec.ts
@@ -20,7 +20,7 @@ function buildRepoMock(): RepoMock {
 
 describe('seedScanCatalog (Epic #693 part 5/5)', () => {
   describe('happy path', () => {
-    it('inserts all 6 demo beers when the table is empty', async () => {
+    it('inserts all 7 demo beers when the table is empty', async () => {
       const repo = buildRepoMock();
       repo.findOne.mockResolvedValue(null);
 
@@ -28,9 +28,9 @@ describe('seedScanCatalog (Epic #693 part 5/5)', () => {
         repo as unknown as Repository<ScanCatalogItemOrmEntity>,
       );
 
-      expect(result).toEqual({ inserted: 6, updated: 0, total: 6 });
-      expect(repo.create).toHaveBeenCalledTimes(6);
-      expect(repo.save).toHaveBeenCalledTimes(6);
+      expect(result).toEqual({ inserted: 7, updated: 0, total: 7 });
+      expect(repo.create).toHaveBeenCalledTimes(7);
+      expect(repo.save).toHaveBeenCalledTimes(7);
     });
 
     it('tags every inserted row with source = seed and clears cache fields', async () => {
@@ -66,9 +66,9 @@ describe('seedScanCatalog (Epic #693 part 5/5)', () => {
         repo as unknown as Repository<ScanCatalogItemOrmEntity>,
       );
 
-      expect(result).toEqual({ inserted: 0, updated: 6, total: 6 });
+      expect(result).toEqual({ inserted: 0, updated: 7, total: 7 });
       expect(repo.create).not.toHaveBeenCalled();
-      expect(repo.save).toHaveBeenCalledTimes(6);
+      expect(repo.save).toHaveBeenCalledTimes(7);
     });
 
     it('forces source back to seed when overwriting an existing row that drifted', async () => {
@@ -97,7 +97,7 @@ describe('seedScanCatalog (Epic #693 part 5/5)', () => {
   describe('edge cases', () => {
     it('mixes inserts and updates when only some barcodes already exist', async () => {
       const repo = buildRepoMock();
-      // First three barcodes exist, last three do not.
+      // First three barcodes exist, last four do not.
       let counter = 0;
       repo.findOne.mockImplementation(() => {
         counter += 1;
@@ -112,7 +112,7 @@ describe('seedScanCatalog (Epic #693 part 5/5)', () => {
         repo as unknown as Repository<ScanCatalogItemOrmEntity>,
       );
 
-      expect(result).toEqual({ inserted: 3, updated: 3, total: 6 });
+      expect(result).toEqual({ inserted: 4, updated: 3, total: 7 });
     });
 
     it('respects an explicit override list (e.g. tests, alternate demo data)', async () => {
@@ -129,13 +129,14 @@ describe('seedScanCatalog (Epic #693 part 5/5)', () => {
       expect(result).toEqual({ inserted: 2, updated: 0, total: 2 });
     });
 
-    it('exposes 6 demo beers covering Punk IPA + 5 Belgian classics', () => {
-      expect(SCAN_CATALOG_SEED_BEERS).toHaveLength(6);
+    it('exposes 7 demo beers covering Punk IPA + 5 Belgian classics + La Goudale (FR)', () => {
+      expect(SCAN_CATALOG_SEED_BEERS).toHaveLength(7);
       const names = SCAN_CATALOG_SEED_BEERS.map((b) => b.name);
       expect(names).toContain('Punk IPA');
       expect(names).toContain('La Chouffe');
       expect(names).toContain('Rochefort 10');
       expect(names).toContain('Karmeliet Tripel');
+      expect(names).toContain('La Goudale');
     });
   });
 });

--- a/packages/api/src/database/seeds/scan-catalog.seed.ts
+++ b/packages/api/src/database/seeds/scan-catalog.seed.ts
@@ -122,6 +122,18 @@ export const SCAN_CATALOG_SEED_BEERS: readonly ScanCatalogSeedBeer[] = [
     aromatic_tags: 'pear, apple, dry finish, light hop',
     notes_source: 'Brouwerij Duvel Moortgat public datasheet',
   },
+  {
+    barcode: '3261570000044',
+    name: 'La Goudale',
+    brewery: 'Brasserie Goudale',
+    style: 'Bière Blonde à l Ancienne',
+    abv: 7.2,
+    ibu: 22,
+    color_ebc: 16,
+    fermentation_type: ScanFermentationType.ALE,
+    aromatic_tags: 'malt biscuit, honey, floral hops, soft bitterness',
+    notes_source: 'Brasserie Goudale public datasheet (62510 Arques, France)',
+  },
 ];
 
 /**

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2564,7 +2564,8 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     ibu: 22,
     colorEbc: 16,
     aromaticTags: "malt biscuit, honey, floral hops, soft bitterness",
-    notesSource: "Brasserie Goudale (62510 Arques, France) — official datasheet",
+    notesSource:
+      "Brasserie Goudale (62510 Arques, France) — official datasheet",
   }),
 };
 

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2554,6 +2554,18 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     aromaticTags: "dark fruit, port, caramel, raisin",
     notesSource: "Trappist Rochefort — published brewery profile",
   }),
+  "3261570000044": buildDemoScanCatalogItem({
+    id: "demo-scan-la-goudale",
+    barcode: "3261570000044",
+    name: "La Goudale",
+    brewery: "Brasserie Goudale",
+    style: "Bière Blonde à l'Ancienne",
+    abv: 7.2,
+    ibu: 22,
+    colorEbc: 16,
+    aromaticTags: "malt biscuit, honey, floral hops, soft bitterness",
+    notesSource: "Brasserie Goudale (62510 Arques, France) — official datasheet",
+  }),
 };
 
 /**
@@ -2665,6 +2677,34 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
       score: 0.81,
     },
   ],
+  // La Goudale — French Bière de Garde / blonde, 7.2% ABV. Closest
+  // matches by ABV + style (strong blondes / saisons).
+  "3261570000044": [
+    {
+      recipeId: "r-demo-6",
+      name: "Belgian Tripel",
+      brewer: "Caroline",
+      rating: 4.8,
+      brewedCount: 31,
+      score: 0.92,
+    },
+    {
+      recipeId: "r-demo-9",
+      name: "Saison Farmhouse",
+      brewer: "Hugo",
+      rating: 4.6,
+      brewedCount: 19,
+      score: 0.85,
+    },
+    {
+      recipeId: "r-demo-8",
+      name: "Kölsch Tradition",
+      brewer: "Antoine",
+      rating: 4.4,
+      brewedCount: 15,
+      score: 0.76,
+    },
+  ],
 };
 
 /**
@@ -2685,6 +2725,8 @@ export const demoBreweryStories: Record<string, string> = {
     "Au pied des Ardennes belges, depuis 1982. La légende veut que des elfes (les chouffes) habitent la vallée de la Wartet. Pierre Gobron et Christian Bauweraerts ont créé La Chouffe pour partager leur amour de la bière belge — la mascotte rouge du gnome est devenue une icône.",
   "Abbaye Notre-Dame de Saint-Remy":
     "Trappiste authentique depuis 1595, près de Rochefort en Belgique. Les moines ne brassent que pour subvenir aux besoins de l'abbaye — la production reste délibérément limitée. Rochefort 10 est leur quadruple emblématique, régulièrement classée parmi les meilleures bières du monde.",
+  "Brasserie Goudale":
+    "Brassée à Arques dans le Nord de la France depuis 1996, La Goudale rend hommage aux bières médiévales appelées 'Goudale' ou 'Good Ale' que l'on vendait deux deniers le pot. Bière blonde de haute fermentation, malt d'orge et froment de blé, houblons des Flandres — un style traditionnel français à part dans le paysage des bières de garde du Nord.",
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds **La Goudale** (Brasserie Goudale, 62510 Arques, France) as a 4th seeded demo bottle so the live demo path can be tested with a **real physical bottle** in hand, without printed barcode labels.

The existing 3 demo beers (Punk IPA, La Chouffe, Rochefort 10) are imports — either you stop at a specialty beer shop, or you fall back to printed barcode labels. La Goudale is widely distributed in French supermarkets, so any user testing the app in France can grab one and scan it directly.

## Beer details

| Field | Value |
|---|---|
| EAN | `3261570000044` (valid EAN-13 verified) |
| Name | La Goudale |
| Brewery | Brasserie Goudale (62510 Arques) |
| Style | Bière Blonde à l'Ancienne, haute fermentation |
| ABV | 7.2% |
| IBU | 22 (estimated from style) |
| EBC | 16 (estimated, blonde range) |
| Aromatic tags | malt biscuit, honey, floral hops, soft bitterness |

EAN-13 validation:
```
Odd  (1,3,5,7,9,11):  3+6+5+0+0+0 = 14
Even (2,4,6,8,10,12): 2+1+7+0+0+4 = 14
Total = 14 + (14*3) = 56
Check = (10 - 56%10) % 10 = 4 ✓
```

## Files modified

- `packages/api/src/database/seeds/scan-catalog.seed.ts` — 7th entry in `SCAN_CATALOG_SEED_BEERS`
- `packages/mobile-app/src/mocks/demo-data.ts`:
  - `demoScanCatalog`: 4th entry keyed by `3261570000044`
  - `demoEquivalentRecipes`: 3 stylistically close existing demoRecipes (Belgian Tripel, Saison Farmhouse, Kölsch Tradition) — same shape as the future #699 API output
  - `demoBreweryStories`: short curated story for Brasserie Goudale (history + style)

## Tests

- Mobile scan suite: 134/134 green
- API scan suite: 65/65 green

## Manual verification

Local DB reseeded: `scan_catalog_items` now has 7 rows including La Goudale at `3261570000044`. Verified via `sqlite3 packages/api/data/brasse-bouillon.db "SELECT barcode, name FROM scan_catalog_items;"`.

## Demo impact

Once this PR merges + a new release tag cuts + a new APK is built, the soutenance / oral blanc demo can run end-to-end on a real bottle bought at any French supermarket — much stronger story than printed labels.

## Checklist

- [x] EAN-13 check digit verified mathematically
- [x] Mobile + API tests still green (134 + 65)
- [x] `tsc --noEmit` passes
- [x] Local DB reseeded successfully (7 rows)
- [x] No `any`, no inline styles introduced