### PR TITLE
fix(android): allow cleartext HTTP traffic for LAN backend testing

### DIFF
--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -24,6 +24,7 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
+      "usesCleartextTraffic": true,
       "runtimeVersion": {
         "policy": "appVersion"
       }


### PR DESCRIPTION
## Symptom

Real-device test of the v0.1.9-alpha1 backend-mode APK failed: signup form (and any auth/scan request) returned **'Network request failed'**, even though:

- Backend was healthy on the dev PC (`nest start --watch` running)
- Backend bound on all interfaces (`*:3000`)
- `curl http://192.168.1.244:3000/...` from the PC returned the expected HTTP responses
- Phone was on the same WiFi as the PC

## Root cause

Android API 28+ **blocks cleartext (HTTP) traffic by default** for security. The Expo `app.json` android section had no opt-in, so the AndroidManifest generated by EAS had `android:usesCleartextTraffic="false"` (default). Any non-HTTPS request from the app — including `http://192.168.1.244:3000` — was silently rejected at the network layer.

## Fix

Set `'usesCleartextTraffic': true` in `app.json` android section. Expo prebuild propagates this to AndroidManifest at build time.

## Security note — temporary

This flag opens the app to MITM on any HTTP endpoint it talks to. Acceptable for the J-30 demo phase because:

- Internal LAN traffic on the dev WiFi is the only HTTP target
- Backend has no public deployment yet
- The risk window closes once the backend ships over HTTPS

**To revisit post-soutenance**: replace this blanket flag with a `NetworkSecurityConfig` file that allows HTTP only for `192.168.0.0/16` + `localhost`, or switch the backend to HTTPS.

## Verification

- After this PR merges + new release-please tag + APK rebuild, signup + login + scan against the local backend should work end-to-end.
- The 'Network request failed' message disappears in backend mode.
- Demo mode (current behaviour) is unchanged.

## Checklist

- [x] Single-line additive change to `app.json`
- [x] No code logic touched
- [x] No `tsc` / `lint` impact (config only)
- [x] Existing tests still green (no test executes mobile app config)
- [x] Documented as temporary in commit body + PR body