### PR TITLE
fix(android): wire usesCleartextTraffic via expo-build-properties plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9402,6 +9402,38 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-build-properties": {
+      "version": "55.0.13",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-55.0.13.tgz",
+      "integrity": "sha512-UYZhUKyh7YQhbJdkBvo68WUQ7fOtZeSV7F8kfYkjEiN/ADRHG0WfEIiddvGfi9cH/5iwpptv/+Lu5cx6uvfegA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^55.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/@expo/schema-utils": {
+      "version": "55.0.3",
+      "resolved": "https://registry.npmjs.org/@expo/schema-utils/-/schema-utils-55.0.3.tgz",
+      "integrity": "sha512-l9KHVjTo6MvoeyvwNr6AjckGJm8NIcqZ3QSAh51cWozXW9v2AUjyCyqYtFtyntLWRZ0x/ByYJishpQo4ZQq45Q==",
+      "license": "MIT"
+    },
+    "node_modules/expo-build-properties/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "18.0.13",
       "license": "MIT",
@@ -20070,7 +20102,7 @@
     },
     "packages/api": {
       "name": "brasse-bouillon-backend",
-      "version": "0.0.1",
+      "version": "0.1.10-alpha1",
       "license": "UNLICENSED",
       "dependencies": {
         "@nestjs/common": "^11.0.1",
@@ -20130,11 +20162,11 @@
     },
     "packages/beer-encyclopedia": {
       "name": "@brasse-bouillon/beer-encyclopedia",
-      "version": "0.2.0"
+      "version": "0.2.3"
     },
     "packages/mobile-app": {
       "name": "@brasse-bouillon/mobile-app",
-      "version": "1.0.0",
+      "version": "0.1.10-alpha1",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -20142,6 +20174,7 @@
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.90.21",
         "expo": "~54.0.33",
+        "expo-build-properties": "^55.0.13",
         "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
@@ -21207,7 +21240,7 @@
     },
     "packages/website": {
       "name": "@brasse-bouillon/website",
-      "version": "0.1.0"
+      "version": "0.1.1"
     }
   }
 }

--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -24,7 +24,6 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
-      "usesCleartextTraffic": true,
       "runtimeVersion": {
         "policy": "appVersion"
       }
@@ -35,7 +34,15 @@
       "favicon": "./assets/images/favicon.png"
     },
     "plugins": [
-      "expo-router"
+      "expo-router",
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "usesCleartextTraffic": true
+          }
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true
@@ -49,6 +56,9 @@
     "owner": "beniot",
     "updates": {
       "url": "https://u.expo.dev/a527c490-36e1-49f2-a91b-5866a2823b5f"
+    },
+    "runtimeVersion": {
+      "policy": "appVersion"
     }
   }
 }

--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -56,9 +56,6 @@
     "owner": "beniot",
     "updates": {
       "url": "https://u.expo.dev/a527c490-36e1-49f2-a91b-5866a2823b5f"
-    },
-    "runtimeVersion": {
-      "policy": "appVersion"
     }
   }
 }

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -24,6 +24,7 @@
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.90.21",
     "expo": "~54.0.33",
+    "expo-build-properties": "^55.0.13",
     "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",


### PR DESCRIPTION
## Symptom

Real-device backend-mode test of APK #4 (built from `mobile-app-v0.1.10-alpha1`) failed with **'Network request failed' instantly** on every signup attempt, despite:

- Backend running on PC, listening on `*:3000` ✅
- Tailscale mesh between PC (`100.67.85.126`) and phone working ✅
- Chrome on phone successfully reaching `http://100.67.85.126:3000/auth/register` (returned a 404 'Cannot GET' — correct response for GET on a POST-only endpoint) ✅
- The JS bundle in the installed APK contains the correct Tailscale URL ✅
- `EXPO_PUBLIC_USE_DEMO_DATA=false` correctly baked (no demo button visible)

The instant fail (sub-second) indicated the request was blocked **before any network connection attempt** — at the Android OS level.

## Root cause — verified empirically

PR #759 added `'usesCleartextTraffic': true` to `app.json -> android`. **Expo SDK 54 silently ignores that shorthand at prebuild time.** The property never reaches the generated `AndroidManifest.xml`.

Verified by decoding the actual installed APK using `pyaxmlparser`:

```
python3 -c \"from pyaxmlparser import APK; print(APK('current.apk').get_attribute_value('application', 'usesCleartextTraffic'))\"
# → None  (should have been 'true')
```

Without the explicit attribute, Android API 28+ defaults to **blocking cleartext HTTP**. Chrome works because it has its own permissive network policy; the APK is constrained by the manifest.

## Fix

Expo SDK 50+ moved native build config like `usesCleartextTraffic` to a dedicated plugin: `expo-build-properties`. The supported syntax:

```json
{
  \"plugins\": [
    \"expo-router\",
    [
      \"expo-build-properties\",
      {
        \"android\": {
          \"usesCleartextTraffic\": true
        }
      }
    ]
  ]
}
```

This generates the correct `<application android:usesCleartextTraffic=\"true\"/>` in `AndroidManifest.xml`.

## What changes

| File | Change |
|---|---|
| `packages/mobile-app/package.json` | Adds `expo-build-properties` dependency (`^55.0.13`, maintained by Expo) |
| `packages/mobile-app/app.json` | Removes the no-op `android.usesCleartextTraffic` flag introduced by PR #759, adds the plugin entry under `plugins` |
| `package-lock.json` | Lockfile sync |

## Verification

Local:
- `tsc --noEmit` ✅ (no code changes)
- `npm run ci:check` ✅ (lint + typecheck + format)

Post-merge — to be done by user when the next APK build completes:

```
# Download the new APK build artifact, then:
python3 -c \"from pyaxmlparser import APK; print(APK('build5.apk').get_attribute_value('application', 'usesCleartextTraffic'))\"
# → expected: 'true'
```

If `'true'` → install on phone, test signup, expect SQL queries to appear in the backend `nest start --watch` terminal.

## Security note (still relevant)

This flag is **global** across all build profiles. Issue #760 (scope to dev/preview only via `app.config.js` conditional or `NetworkSecurityConfig`) still applies as a post-soutenance hardening item. This PR doesn't change the security posture — it just makes the flag actually take effect.

## Checklist

- [x] Single targeted change to address PR #759's silent no-op
- [x] Plugin choice (`expo-build-properties`) is the official Expo-recommended path for SDK 50+
- [x] Verified the broken APK had `None` for `usesCleartextTraffic` before the fix
- [x] Tests not affected (config-only)
- [x] No `tsc` / `lint` impact

Closes the J-30 sprint blocker on real-device backend testing.