### PR TITLE
feat(scan): seed 10 curated public recipes + dual-id helper for community import (Issue #701)

### DIFF
--- a/packages/api/scripts/run-public-recipes-seed.ts
+++ b/packages/api/scripts/run-public-recipes-seed.ts
@@ -1,0 +1,46 @@
+/**
+ * One-shot script to seed `recipes` with the 10 curated PUBLIC recipes
+ * from `PUBLIC_RECIPES_SEED` against the local dev database (Issue #701).
+ *
+ * Usage:
+ *   cd packages/api
+ *   npx ts-node -r tsconfig-paths/register scripts/run-public-recipes-seed.ts
+ *
+ * Idempotent: safe to run multiple times. Existing recipe IDs are
+ * updated in place; missing ones are inserted.
+ *
+ * Mirror of run-scan-catalog-seed.ts. This is a stopgap until we wire
+ * a proper `npm run seed:public-recipes` command + boot-time auto-seed
+ * flag (separate follow-up PR).
+ */
+import 'reflect-metadata';
+
+import dataSource from '../src/database/data-source';
+import { RecipeOrmEntity } from '../src/recipe/entities/recipe.orm.entity';
+import { User } from '../src/user/entities/user.entity';
+import { seedPublicRecipes } from '../src/database/seeds/public-recipes.seed';
+import { seedSystemUser } from '../src/database/seeds/system-user.seed';
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  // Step 1 — system user must exist before recipes are inserted
+  // (FK constraint recipes.owner_id -> users.id).
+  const userRepo = dataSource.getRepository(User);
+  const userResult = await seedSystemUser(userRepo);
+  console.log('System user seed:', userResult);
+
+  // Step 2 — public recipes owned by the system user.
+  const recipeRepo = dataSource.getRepository(RecipeOrmEntity);
+  const recipeResult = await seedPublicRecipes(recipeRepo);
+  console.log('Public recipes seed:', recipeResult);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -1,0 +1,153 @@
+import { Repository } from 'typeorm';
+
+import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
+import { RecipeVisibility } from '../../recipe/domain/enums/recipe-visibility.enum';
+import {
+  PUBLIC_RECIPES_SEED,
+  PUBLIC_RECIPES_SYSTEM_OWNER_ID,
+  seedPublicRecipes,
+} from './public-recipes.seed';
+
+type RepoMock = {
+  findOne: jest.Mock;
+  create: jest.Mock;
+  save: jest.Mock;
+};
+
+function buildRepoMock(): RepoMock {
+  return {
+    findOne: jest.fn(),
+    create: jest.fn((input: unknown) => input),
+    save: jest.fn((input: unknown) => Promise.resolve(input)),
+  };
+}
+
+describe('seedPublicRecipes (Issue #701)', () => {
+  describe('happy path', () => {
+    it('inserts all 10 curated recipes when the table is empty', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await seedPublicRecipes(
+        repo as unknown as Repository<RecipeOrmEntity>,
+      );
+
+      expect(result).toEqual({ inserted: 10, updated: 0, total: 10 });
+      expect(repo.create).toHaveBeenCalledTimes(10);
+      expect(repo.save).toHaveBeenCalledTimes(10);
+    });
+
+    it('tags every inserted row as PUBLIC + is_official + system owner', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      await seedPublicRecipes(repo as unknown as Repository<RecipeOrmEntity>);
+
+      for (const call of repo.create.mock.calls as unknown[][]) {
+        const arg = call[0] as Record<string, unknown>;
+        expect(arg.visibility).toBe(RecipeVisibility.PUBLIC);
+        expect(arg.is_official).toBe(true);
+        expect(arg.owner_id).toBe(PUBLIC_RECIPES_SYSTEM_OWNER_ID);
+        expect(arg.imported_from_recipe_id).toBeNull();
+        expect(arg.import_provenance).toBeNull();
+        expect(arg.parent_recipe_id).toBeNull();
+        // Each recipe is its own root (no fork lineage on seed).
+        expect(arg.root_recipe_id).toBe(arg.id);
+        expect(arg.version).toBe(1);
+      }
+    });
+  });
+
+  describe('idempotency (sad path)', () => {
+    it('updates existing rows in place rather than duplicating them', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockImplementation(() =>
+        Promise.resolve({
+          id: 'will-be-overwritten',
+          name: 'old-name',
+          visibility: RecipeVisibility.PRIVATE,
+        }),
+      );
+
+      const result = await seedPublicRecipes(
+        repo as unknown as Repository<RecipeOrmEntity>,
+      );
+
+      expect(result).toEqual({ inserted: 0, updated: 10, total: 10 });
+      expect(repo.create).not.toHaveBeenCalled();
+      expect(repo.save).toHaveBeenCalledTimes(10);
+    });
+
+    it('forces visibility back to PUBLIC when overwriting a row that drifted', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockImplementation(() =>
+        Promise.resolve({
+          id: 'drifted',
+          visibility: RecipeVisibility.PRIVATE,
+          is_official: false,
+        }),
+      );
+
+      await seedPublicRecipes(repo as unknown as Repository<RecipeOrmEntity>);
+
+      const firstSavedCall = repo.save.mock.calls[0] as unknown[];
+      const savedCall = firstSavedCall[0] as Record<string, unknown>;
+      expect(savedCall.visibility).toBe(RecipeVisibility.PUBLIC);
+      expect(savedCall.is_official).toBe(true);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('mixes inserts and updates when only some IDs already exist', async () => {
+      const repo = buildRepoMock();
+      // First three IDs exist, last seven do not.
+      let counter = 0;
+      repo.findOne.mockImplementation(() => {
+        counter += 1;
+        return Promise.resolve(
+          counter <= 3 ? { id: `existing-${counter}` } : null,
+        );
+      });
+
+      const result = await seedPublicRecipes(
+        repo as unknown as Repository<RecipeOrmEntity>,
+      );
+
+      expect(result).toEqual({ inserted: 7, updated: 3, total: 10 });
+    });
+
+    it('respects an explicit override list (e.g. tests, alternate demo data)', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      const customRecipes = PUBLIC_RECIPES_SEED.slice(0, 2);
+
+      const result = await seedPublicRecipes(
+        repo as unknown as Repository<RecipeOrmEntity>,
+        customRecipes,
+      );
+
+      expect(result).toEqual({ inserted: 2, updated: 0, total: 2 });
+    });
+
+    it('exposes 10 curated recipes covering IPA / Belgian / Strong / Lager families', () => {
+      expect(PUBLIC_RECIPES_SEED).toHaveLength(10);
+      const names = PUBLIC_RECIPES_SEED.map((r) => r.name);
+      expect(names).toContain('Session IPA Citra');
+      expect(names).toContain('Belgian Tripel');
+      expect(names).toContain('Saison Farmhouse');
+      expect(names).toContain('Imperial Stout');
+      expect(names).toContain('Kölsch Tradition');
+    });
+
+    it('uses deterministic UUIDs (sequential v4-shaped) so mobile mocks can hardcode references', () => {
+      const ids = PUBLIC_RECIPES_SEED.map((r) => r.id);
+      // All IDs share the system prefix; only the last segment differs.
+      for (const id of ids) {
+        expect(id).toMatch(/^00000000-0000-4000-8000-00000000000[0-9a-f]$/);
+      }
+      // No duplicates.
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+});

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -1,0 +1,317 @@
+import { Repository } from 'typeorm';
+
+import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
+import { RecipeVisibility } from '../../recipe/domain/enums/recipe-visibility.enum';
+import { SYSTEM_USER_ID } from './system-user.seed';
+
+/**
+ * Seed for `recipes` table — 10 PUBLIC curated recipes (Issue #701).
+ *
+ * Provides the canonical pool of community-style recipes that the
+ * BeerInfoCardScreen `Recettes équivalentes` section can offer for
+ * import. Each demo bottle (Punk IPA / La Chouffe / Rochefort 10 /
+ * La Goudale) maps to 3 of these recipes via the mobile
+ * `demoEquivalentRecipes` table; this seed makes the underlying
+ * `POST /recipes/import-from-community/:id` happy path resolvable
+ * in backend mode (without these rows, the import returns 404 and
+ * the mobile UI shows the sad-path 'Import impossible' alert).
+ *
+ * Owner is a deterministic system UUID (no FK to a real user — the
+ * recipes table doesn't enforce a FK at the ORM level). Visibility
+ * is PUBLIC so the existing visibility check in
+ * `RecipeService.importFromCommunity` accepts them.
+ *
+ * The loader is idempotent — running it twice does not duplicate
+ * rows: existing IDs are detected and updated in place, new ones
+ * are inserted.
+ */
+
+/**
+ * Sentinel UUID used as `owner_id` for all seeded public recipes.
+ * Marks them as system-curated, distinct from any real user account.
+ *
+ * Re-exported from `system-user.seed` so a single source of truth
+ * exists for the curator UUID across all seed files.
+ */
+export const PUBLIC_RECIPES_SYSTEM_OWNER_ID = SYSTEM_USER_ID;
+
+/**
+ * Shape of one seeded public recipe. Brewing metrics are
+ * approximations from public datasheets and BJCP style guidelines,
+ * adapted for a 20L homebrew batch.
+ */
+export interface PublicRecipeSeed {
+  id: string;
+  name: string;
+  description: string;
+  batch_size_l: number;
+  boil_time_min: number;
+  og_target: number;
+  fg_target: number;
+  abv_estimated: number;
+  ibu_target: number;
+  ebc_target: number;
+  efficiency_target: number;
+  avg_rating: number;
+  brew_count: number;
+}
+
+/**
+ * The 10 demo public recipes — 3 stylistic neighbours per demo
+ * bottle. UUIDs are deterministic (sequential + RFC4122 v4 variant
+ * bits) so the mobile `demoEquivalentRecipes` table can reference
+ * them statically without a database round-trip.
+ */
+export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
+  // --- IPA family (matches Punk IPA) ---
+  {
+    id: '00000000-0000-4000-8000-000000000001',
+    name: 'Session IPA Citra',
+    description:
+      "Session IPA tropicale et désaltérante autour d'un mono-houblon Citra. Houblonnée à cru pour un nez explosif d'agrumes et de fruit de la passion.",
+    batch_size_l: 20,
+    boil_time_min: 60,
+    og_target: 1.045,
+    fg_target: 1.01,
+    abv_estimated: 4.6,
+    ibu_target: 30,
+    ebc_target: 12,
+    efficiency_target: 72,
+    avg_rating: 4.7,
+    brew_count: 23,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000002',
+    name: 'NEIPA Tropical',
+    description:
+      'New England IPA voilée, ronde, peu amère, dominée par les esters fruités de la levure London Ale et un dry-hop massif Citra+Mosaic.',
+    batch_size_l: 20,
+    boil_time_min: 60,
+    og_target: 1.06,
+    fg_target: 1.012,
+    abv_estimated: 6.4,
+    ibu_target: 45,
+    ebc_target: 8,
+    efficiency_target: 70,
+    avg_rating: 4.5,
+    brew_count: 18,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000003',
+    name: 'White IPA',
+    description:
+      "Hybride witbier + IPA — base wheat malt, levure belge, houblons américains. Coriandre + écorce d'orange légères pour le pont stylistique.",
+    batch_size_l: 20,
+    boil_time_min: 60,
+    og_target: 1.054,
+    fg_target: 1.012,
+    abv_estimated: 5.5,
+    ibu_target: 40,
+    ebc_target: 10,
+    efficiency_target: 72,
+    avg_rating: 4.3,
+    brew_count: 12,
+  },
+  // --- Belgian / Saison family (matches La Chouffe + La Goudale) ---
+  {
+    id: '00000000-0000-4000-8000-000000000004',
+    name: 'Belgian Tripel',
+    description:
+      'Tripel classique sur base pilsner + sucre candi clair. Levure belge type Westmalle pour les esters fruités et phénols poivrés. Finale sèche.',
+    batch_size_l: 20,
+    boil_time_min: 90,
+    og_target: 1.075,
+    fg_target: 1.01,
+    abv_estimated: 8.5,
+    ibu_target: 30,
+    ebc_target: 18,
+    efficiency_target: 75,
+    avg_rating: 4.8,
+    brew_count: 31,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000005',
+    name: 'Saison Farmhouse',
+    description:
+      'Saison rustique inspirée des fermes du Hainaut. Levure saison à haute fermentation (28-32°C), atténuation très élevée, finale poivrée et acidulée.',
+    batch_size_l: 20,
+    boil_time_min: 90,
+    og_target: 1.055,
+    fg_target: 1.005,
+    abv_estimated: 6.5,
+    ibu_target: 25,
+    ebc_target: 10,
+    efficiency_target: 72,
+    avg_rating: 4.6,
+    brew_count: 19,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000006',
+    name: 'Witbier Orange',
+    description:
+      "Witbier traditionnelle 50% wheat / 50% pilsner. Coriandre + zeste d'orange amère de Curaçao en fin d'ébullition. Trouble naturel, finale acidulée.",
+    batch_size_l: 20,
+    boil_time_min: 60,
+    og_target: 1.046,
+    fg_target: 1.01,
+    abv_estimated: 4.8,
+    ibu_target: 18,
+    ebc_target: 8,
+    efficiency_target: 72,
+    avg_rating: 4.2,
+    brew_count: 9,
+  },
+  // --- Strong / Dark family (matches Rochefort 10) ---
+  {
+    id: '00000000-0000-4000-8000-000000000007',
+    name: 'Scotch Ale Wee Heavy',
+    description:
+      'Scotch Ale forte type Wee Heavy. Maltée à fond, caramel cuit, légère touche tourbée optionnelle. Maturation 3 mois recommandée.',
+    batch_size_l: 20,
+    boil_time_min: 90,
+    og_target: 1.08,
+    fg_target: 1.02,
+    abv_estimated: 8.2,
+    ibu_target: 30,
+    ebc_target: 50,
+    efficiency_target: 70,
+    avg_rating: 4.9,
+    brew_count: 27,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000008',
+    name: 'Imperial Stout',
+    description:
+      'Russian Imperial Stout sur base pale ale + multiples malts torréfiés (chocolate, roasted barley, black malt). Café noir, chocolat amer, vanille en arrière-plan.',
+    batch_size_l: 20,
+    boil_time_min: 90,
+    og_target: 1.09,
+    fg_target: 1.025,
+    abv_estimated: 9.5,
+    ibu_target: 60,
+    ebc_target: 80,
+    efficiency_target: 68,
+    avg_rating: 4.7,
+    brew_count: 22,
+  },
+  {
+    id: '00000000-0000-4000-8000-000000000009',
+    name: 'Baltic Porter',
+    description:
+      'Porter de la Baltique fermenté à froid avec une levure lager. Plus propre que le Russian Imperial Stout, notes de pruneau, café et chocolat noir.',
+    batch_size_l: 20,
+    boil_time_min: 90,
+    og_target: 1.075,
+    fg_target: 1.018,
+    abv_estimated: 7.5,
+    ibu_target: 35,
+    ebc_target: 70,
+    efficiency_target: 70,
+    avg_rating: 4.4,
+    brew_count: 14,
+  },
+  // --- Light / Lager family (matches La Goudale) ---
+  {
+    id: '00000000-0000-4000-8000-00000000000a',
+    name: 'Kölsch Tradition',
+    description:
+      'Kölsch de Cologne — bière hybride fermentée chaude par une levure ale puis lagering à froid. Pâle, sèche, finale légèrement noble (Tettnanger).',
+    batch_size_l: 20,
+    boil_time_min: 75,
+    og_target: 1.046,
+    fg_target: 1.01,
+    abv_estimated: 4.8,
+    ibu_target: 22,
+    ebc_target: 8,
+    efficiency_target: 75,
+    avg_rating: 4.4,
+    brew_count: 15,
+  },
+];
+
+/**
+ * Result returned by `seedPublicRecipes` for instrumentation /
+ * verification. Lets callers (tests, CLI, npm scripts) report what
+ * happened without re-querying the DB.
+ */
+export interface SeedPublicRecipesResult {
+  inserted: number;
+  updated: number;
+  total: number;
+}
+
+/**
+ * Idempotent loader for the curated public recipes above. Insert
+ * if the id is unknown, update in place otherwise. Always sets
+ * `visibility = PUBLIC`, `is_official = true`, and
+ * `imported_from_recipe_id = null` (these are originals, not
+ * imports). Owner is the system sentinel UUID.
+ */
+export async function seedPublicRecipes(
+  repository: Repository<RecipeOrmEntity>,
+  recipes: readonly PublicRecipeSeed[] = PUBLIC_RECIPES_SEED,
+): Promise<SeedPublicRecipesResult> {
+  let inserted = 0;
+  let updated = 0;
+
+  for (const recipe of recipes) {
+    const existing = await repository.findOne({ where: { id: recipe.id } });
+
+    if (existing) {
+      Object.assign(existing, {
+        owner_id: PUBLIC_RECIPES_SYSTEM_OWNER_ID,
+        name: recipe.name,
+        description: recipe.description,
+        visibility: RecipeVisibility.PUBLIC,
+        version: 1,
+        root_recipe_id: recipe.id,
+        parent_recipe_id: null,
+        batch_size_l: recipe.batch_size_l,
+        boil_time_min: recipe.boil_time_min,
+        og_target: recipe.og_target,
+        fg_target: recipe.fg_target,
+        abv_estimated: recipe.abv_estimated,
+        ibu_target: recipe.ibu_target,
+        ebc_target: recipe.ebc_target,
+        efficiency_target: recipe.efficiency_target,
+        avg_rating: recipe.avg_rating,
+        brew_count: recipe.brew_count,
+        last_brewed_at: null,
+        is_official: true,
+        imported_from_recipe_id: null,
+        import_provenance: null,
+      });
+      await repository.save(existing);
+      updated += 1;
+    } else {
+      const created = repository.create({
+        id: recipe.id,
+        owner_id: PUBLIC_RECIPES_SYSTEM_OWNER_ID,
+        name: recipe.name,
+        description: recipe.description,
+        visibility: RecipeVisibility.PUBLIC,
+        version: 1,
+        root_recipe_id: recipe.id,
+        parent_recipe_id: null,
+        batch_size_l: recipe.batch_size_l,
+        boil_time_min: recipe.boil_time_min,
+        og_target: recipe.og_target,
+        fg_target: recipe.fg_target,
+        abv_estimated: recipe.abv_estimated,
+        ibu_target: recipe.ibu_target,
+        ebc_target: recipe.ebc_target,
+        efficiency_target: recipe.efficiency_target,
+        avg_rating: recipe.avg_rating,
+        brew_count: recipe.brew_count,
+        last_brewed_at: null,
+        is_official: true,
+        imported_from_recipe_id: null,
+        import_provenance: null,
+      });
+      await repository.save(created);
+      inserted += 1;
+    }
+  }
+
+  return { inserted, updated, total: inserted + updated };
+}

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -255,59 +255,41 @@ export async function seedPublicRecipes(
   let updated = 0;
 
   for (const recipe of recipes) {
+    // Single payload shared by both insert and update branches —
+    // any drift would silently desync the two paths and is precisely
+    // what the duplication detector caught.
+    const payload = {
+      owner_id: PUBLIC_RECIPES_SYSTEM_OWNER_ID,
+      name: recipe.name,
+      description: recipe.description,
+      visibility: RecipeVisibility.PUBLIC,
+      version: 1,
+      root_recipe_id: recipe.id,
+      parent_recipe_id: null,
+      batch_size_l: recipe.batch_size_l,
+      boil_time_min: recipe.boil_time_min,
+      og_target: recipe.og_target,
+      fg_target: recipe.fg_target,
+      abv_estimated: recipe.abv_estimated,
+      ibu_target: recipe.ibu_target,
+      ebc_target: recipe.ebc_target,
+      efficiency_target: recipe.efficiency_target,
+      avg_rating: recipe.avg_rating,
+      brew_count: recipe.brew_count,
+      last_brewed_at: null,
+      is_official: true,
+      imported_from_recipe_id: null,
+      import_provenance: null,
+    };
+
     const existing = await repository.findOne({ where: { id: recipe.id } });
 
     if (existing) {
-      Object.assign(existing, {
-        owner_id: PUBLIC_RECIPES_SYSTEM_OWNER_ID,
-        name: recipe.name,
-        description: recipe.description,
-        visibility: RecipeVisibility.PUBLIC,
-        version: 1,
-        root_recipe_id: recipe.id,
-        parent_recipe_id: null,
-        batch_size_l: recipe.batch_size_l,
-        boil_time_min: recipe.boil_time_min,
-        og_target: recipe.og_target,
-        fg_target: recipe.fg_target,
-        abv_estimated: recipe.abv_estimated,
-        ibu_target: recipe.ibu_target,
-        ebc_target: recipe.ebc_target,
-        efficiency_target: recipe.efficiency_target,
-        avg_rating: recipe.avg_rating,
-        brew_count: recipe.brew_count,
-        last_brewed_at: null,
-        is_official: true,
-        imported_from_recipe_id: null,
-        import_provenance: null,
-      });
+      Object.assign(existing, payload);
       await repository.save(existing);
       updated += 1;
     } else {
-      const created = repository.create({
-        id: recipe.id,
-        owner_id: PUBLIC_RECIPES_SYSTEM_OWNER_ID,
-        name: recipe.name,
-        description: recipe.description,
-        visibility: RecipeVisibility.PUBLIC,
-        version: 1,
-        root_recipe_id: recipe.id,
-        parent_recipe_id: null,
-        batch_size_l: recipe.batch_size_l,
-        boil_time_min: recipe.boil_time_min,
-        og_target: recipe.og_target,
-        fg_target: recipe.fg_target,
-        abv_estimated: recipe.abv_estimated,
-        ibu_target: recipe.ibu_target,
-        ebc_target: recipe.ebc_target,
-        efficiency_target: recipe.efficiency_target,
-        avg_rating: recipe.avg_rating,
-        brew_count: recipe.brew_count,
-        last_brewed_at: null,
-        is_official: true,
-        imported_from_recipe_id: null,
-        import_provenance: null,
-      });
+      const created = repository.create({ id: recipe.id, ...payload });
       await repository.save(created);
       inserted += 1;
     }

--- a/packages/api/src/database/seeds/system-user.seed.spec.ts
+++ b/packages/api/src/database/seeds/system-user.seed.spec.ts
@@ -1,0 +1,117 @@
+import { Repository } from 'typeorm';
+
+import { User } from '../../user/entities/user.entity';
+import { UserRole } from '../../common/enums/role.enum';
+import {
+  SYSTEM_USER_EMAIL,
+  SYSTEM_USER_ID,
+  SYSTEM_USER_USERNAME,
+  seedSystemUser,
+} from './system-user.seed';
+
+type RepoMock = {
+  findOne: jest.Mock;
+  create: jest.Mock;
+  save: jest.Mock;
+};
+
+function buildRepoMock(): RepoMock {
+  return {
+    findOne: jest.fn(),
+    create: jest.fn((input: unknown) => input),
+    save: jest.fn((input: unknown) => Promise.resolve(input)),
+  };
+}
+
+describe('seedSystemUser (Issue #701 prerequisite)', () => {
+  describe('happy path', () => {
+    it('inserts the system user when missing', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await seedSystemUser(repo as unknown as Repository<User>);
+
+      expect(result).toEqual({ inserted: true, user_id: SYSTEM_USER_ID });
+      expect(repo.create).toHaveBeenCalledTimes(1);
+      expect(repo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates the user with deterministic id, email, username and is_active=false', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      await seedSystemUser(repo as unknown as Repository<User>);
+
+      const calls = repo.create.mock.calls as unknown[][];
+      const created = calls[0][0] as Record<string, unknown>;
+      expect(created.id).toBe(SYSTEM_USER_ID);
+      expect(created.email).toBe(SYSTEM_USER_EMAIL);
+      expect(created.username).toBe(SYSTEM_USER_USERNAME);
+      expect(created.is_active).toBe(false);
+      expect(created.role).toBe(UserRole.ADMIN);
+      expect(created.first_name).toBe('System');
+      expect(created.last_name).toBe('Brasse-Bouillon');
+      // Random unguessable password — non-empty bcrypt hash starting
+      // with $2 (bcrypt format), distinct on each call.
+      expect(typeof created.password_hash).toBe('string');
+      expect(created.password_hash as string).toMatch(/^\$2[aby]\$/);
+    });
+  });
+
+  describe('idempotency (sad path)', () => {
+    it('does NOT recreate the user if it already exists', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue({
+        id: SYSTEM_USER_ID,
+        email: SYSTEM_USER_EMAIL,
+        username: SYSTEM_USER_USERNAME,
+      });
+
+      const result = await seedSystemUser(repo as unknown as Repository<User>);
+
+      expect(result).toEqual({ inserted: false, user_id: SYSTEM_USER_ID });
+      expect(repo.create).not.toHaveBeenCalled();
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('treats the existing row as immutable (does not overwrite drift)', async () => {
+      const repo = buildRepoMock();
+      // Even if the existing row has been tampered with (e.g.
+      // is_active=true), the seed leaves it alone. Better than
+      // silently re-locking an account that may have been promoted.
+      repo.findOne.mockResolvedValue({
+        id: SYSTEM_USER_ID,
+        is_active: true,
+        role: UserRole.USER,
+      });
+
+      await seedSystemUser(repo as unknown as Repository<User>);
+
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('uses a fresh random password on each new insert', async () => {
+      const repo1 = buildRepoMock();
+      repo1.findOne.mockResolvedValue(null);
+      const repo2 = buildRepoMock();
+      repo2.findOne.mockResolvedValue(null);
+
+      await seedSystemUser(repo1 as unknown as Repository<User>);
+      await seedSystemUser(repo2 as unknown as Repository<User>);
+
+      const calls1 = repo1.create.mock.calls as unknown[][];
+      const calls2 = repo2.create.mock.calls as unknown[][];
+      const hash1 = (calls1[0][0] as Record<string, unknown>)
+        .password_hash as string;
+      const hash2 = (calls2[0][0] as Record<string, unknown>)
+        .password_hash as string;
+
+      // Two distinct invocations → two distinct hashes (bcrypt salt
+      // randomized per call). Defense in depth: even if a hash
+      // leaks in one env, others stay safe.
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+});

--- a/packages/api/src/database/seeds/system-user.seed.spec.ts
+++ b/packages/api/src/database/seeds/system-user.seed.spec.ts
@@ -91,6 +91,75 @@ describe('seedSystemUser (Issue #701 prerequisite)', () => {
     });
   });
 
+  describe('collision guard (sad path)', () => {
+    it('treats a row matching by email (different id) as the existing system user and skips', async () => {
+      const repo = buildRepoMock();
+      // Mimic TypeORM's OR-array `where` lookup — return a row that
+      // matches the reserved email but lives under the system id.
+      // The seed must skip without throwing or recreating.
+      repo.findOne.mockResolvedValue({
+        id: SYSTEM_USER_ID,
+        email: SYSTEM_USER_EMAIL,
+        username: SYSTEM_USER_USERNAME,
+      });
+
+      const result = await seedSystemUser(repo as unknown as Repository<User>);
+
+      expect(result).toEqual({ inserted: false, user_id: SYSTEM_USER_ID });
+      expect(repo.create).not.toHaveBeenCalled();
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('throws a clear error if a non-system user squats the reserved email', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue({
+        id: 'real-user-uuid-not-the-sentinel',
+        email: SYSTEM_USER_EMAIL,
+        username: 'someone-else',
+      });
+
+      await expect(
+        seedSystemUser(repo as unknown as Repository<User>),
+      ).rejects.toThrow(/reserved system credentials/i);
+      expect(repo.create).not.toHaveBeenCalled();
+      expect(repo.save).not.toHaveBeenCalled();
+    });
+
+    it('throws a clear error if a non-system user squats the reserved username', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue({
+        id: 'real-user-uuid-not-the-sentinel',
+        email: 'someone@example.com',
+        username: SYSTEM_USER_USERNAME,
+      });
+
+      await expect(
+        seedSystemUser(repo as unknown as Repository<User>),
+      ).rejects.toThrow(/Manual reconciliation required/i);
+    });
+
+    it('looks up existence by id, email AND username (not just id)', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      await seedSystemUser(repo as unknown as Repository<User>);
+
+      const calls = repo.findOne.mock.calls as unknown[][];
+      const arg = calls[0][0] as { where: unknown };
+      // OR-style lookup: an array of partial matchers covering all
+      // three reserved keys. Without this, a colliding email/username
+      // on a non-empty DB would crash the public-recipes orchestrator.
+      expect(Array.isArray(arg.where)).toBe(true);
+      expect(arg.where).toEqual(
+        expect.arrayContaining([
+          { id: SYSTEM_USER_ID },
+          { email: SYSTEM_USER_EMAIL },
+          { username: SYSTEM_USER_USERNAME },
+        ]),
+      );
+    });
+  });
+
   describe('edge cases', () => {
     it('uses a fresh random password on each new insert', async () => {
       const repo1 = buildRepoMock();

--- a/packages/api/src/database/seeds/system-user.seed.ts
+++ b/packages/api/src/database/seeds/system-user.seed.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'crypto';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 
@@ -56,9 +57,10 @@ export async function seedSystemUser(
   }
 
   // Random unguessable password — nobody ever logs in as 'system'.
-  // Generate inside the function so each environment's hash is
-  // distinct (defense in depth in case a hash leaks in one env).
-  const randomPassword = `system-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  // Use crypto.randomBytes for cryptographic randomness (not
+  // Math.random which is predictable). 32 bytes → 64 hex chars,
+  // way beyond what bcrypt can meaningfully hash.
+  const randomPassword = randomBytes(32).toString('hex');
   const passwordHash = await bcrypt.hash(randomPassword, 10);
 
   const created = repository.create({

--- a/packages/api/src/database/seeds/system-user.seed.ts
+++ b/packages/api/src/database/seeds/system-user.seed.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto';
+import { randomBytes } from 'node:crypto';
 import { Repository } from 'typeorm';
 import * as bcrypt from 'bcrypt';
 
@@ -46,13 +46,36 @@ export interface SeedSystemUserResult {
 /**
  * Idempotent loader for the system user. Returns whether the row
  * was actually inserted (false if it already existed).
+ *
+ * Existence is checked by id, email, *and* username — `users.email`
+ * and `users.username` both have UNIQUE indexes, so a row carrying
+ * either reserved value (even under a different id) would otherwise
+ * trip a unique-constraint failure mid-seed and abort the whole
+ * orchestration on a non-empty database. Matching on any of the
+ * three keeps the seed truly idempotent outside a fresh DB.
  */
 export async function seedSystemUser(
   repository: Repository<User>,
 ): Promise<SeedSystemUserResult> {
-  const existing = await repository.findOne({ where: { id: SYSTEM_USER_ID } });
+  const existing = await repository.findOne({
+    where: [
+      { id: SYSTEM_USER_ID },
+      { email: SYSTEM_USER_EMAIL },
+      { username: SYSTEM_USER_USERNAME },
+    ],
+  });
 
   if (existing) {
+    if (existing.id !== SYSTEM_USER_ID) {
+      // A real user account is squatting on the reserved system
+      // credentials. Refuse loudly rather than silently rewriting
+      // their row or letting the seed crash deeper down on the FK
+      // from public recipes — manual cleanup is required.
+      throw new Error(
+        `seedSystemUser: reserved system credentials (email=${SYSTEM_USER_EMAIL}, username=${SYSTEM_USER_USERNAME}) ` +
+          `are already taken by user ${existing.id}. Manual reconciliation required before seeding.`,
+      );
+    }
     return { inserted: false, user_id: SYSTEM_USER_ID };
   }
 

--- a/packages/api/src/database/seeds/system-user.seed.ts
+++ b/packages/api/src/database/seeds/system-user.seed.ts
@@ -1,0 +1,78 @@
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+
+import { User } from '../../user/entities/user.entity';
+import { UserRole } from '../../common/enums/role.enum';
+
+/**
+ * System user seed (Issue #701 prerequisite).
+ *
+ * Creates a non-loginable system account that owns all curated
+ * public content (public recipes, future seeded community ratings,
+ * etc.). The recipes table has a FK constraint
+ * `owner_id REFERENCES users(id)` so any seeded public recipe
+ * needs a real user row to point at.
+ *
+ * The account:
+ * - has a deterministic UUID so other seeds can reference it
+ * - has a random unguessable password hash (no one can ever log in
+ *   as 'system' even if the account leaks)
+ * - is `is_active: false` to belt-and-braces block login attempts
+ * - has role `admin` (only valid CHECK constraint values are
+ *   'admin' / 'user' / 'moderator' — admin is the closest fit for
+ *   a content-curator system account)
+ *
+ * The loader is idempotent — if the row exists, it's left
+ * untouched. We never overwrite the system user in case anything
+ * downstream came to rely on its current state.
+ */
+
+/**
+ * Sentinel UUID — referenced by other seeds (e.g. PUBLIC_RECIPES_SEED).
+ * Must remain stable across all environments and never collide with
+ * a real user-issued UUID (uses the all-zero variant).
+ */
+export const SYSTEM_USER_ID = '00000000-0000-4000-8000-000000000000';
+
+export const SYSTEM_USER_EMAIL = 'system@brasse-bouillon.local';
+export const SYSTEM_USER_USERNAME = 'system';
+
+export interface SeedSystemUserResult {
+  inserted: boolean;
+  user_id: string;
+}
+
+/**
+ * Idempotent loader for the system user. Returns whether the row
+ * was actually inserted (false if it already existed).
+ */
+export async function seedSystemUser(
+  repository: Repository<User>,
+): Promise<SeedSystemUserResult> {
+  const existing = await repository.findOne({ where: { id: SYSTEM_USER_ID } });
+
+  if (existing) {
+    return { inserted: false, user_id: SYSTEM_USER_ID };
+  }
+
+  // Random unguessable password — nobody ever logs in as 'system'.
+  // Generate inside the function so each environment's hash is
+  // distinct (defense in depth in case a hash leaks in one env).
+  const randomPassword = `system-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const passwordHash = await bcrypt.hash(randomPassword, 10);
+
+  const created = repository.create({
+    id: SYSTEM_USER_ID,
+    email: SYSTEM_USER_EMAIL,
+    username: SYSTEM_USER_USERNAME,
+    password_hash: passwordHash,
+    first_name: 'System',
+    last_name: 'Brasse-Bouillon',
+    role: UserRole.ADMIN,
+    is_active: false,
+  });
+
+  await repository.save(created);
+
+  return { inserted: true, user_id: SYSTEM_USER_ID };
+}

--- a/packages/mobile-app/src/features/recipes/application/__tests__/get-import-source-id.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/get-import-source-id.test.ts
@@ -1,0 +1,75 @@
+import { getImportSourceId } from "@/features/recipes/application/recipes.use-cases";
+
+const dataSourceMock = { useDemoData: true };
+
+jest.mock("@/core/data/data-source", () => ({
+  get dataSource() {
+    return dataSourceMock;
+  },
+}));
+
+describe("getImportSourceId (Issue #701 helper)", () => {
+  beforeEach(() => {
+    dataSourceMock.useDemoData = true;
+  });
+
+  describe("happy path — demo mode", () => {
+    it("returns the demo recipeId so demoRecipes lookup resolves", () => {
+      dataSourceMock.useDemoData = true;
+      const match = {
+        recipeId: "r-demo-1",
+        publicRecipeId: "00000000-0000-4000-8000-000000000001",
+      };
+
+      expect(getImportSourceId(match)).toBe("r-demo-1");
+    });
+
+    it("returns the demo recipeId even when publicRecipeId is missing", () => {
+      dataSourceMock.useDemoData = true;
+      const match = { recipeId: "r-demo-7" };
+
+      expect(getImportSourceId(match)).toBe("r-demo-7");
+    });
+  });
+
+  describe("happy path — backend mode", () => {
+    it("returns the publicRecipeId so the API can find a real PUBLIC row", () => {
+      dataSourceMock.useDemoData = false;
+      const match = {
+        recipeId: "r-demo-1",
+        publicRecipeId: "00000000-0000-4000-8000-000000000001",
+      };
+
+      expect(getImportSourceId(match)).toBe(
+        "00000000-0000-4000-8000-000000000001",
+      );
+    });
+  });
+
+  describe("sad path — backend mode without publicRecipeId", () => {
+    it("falls back to recipeId so the import attempt at least surfaces a clear 404", () => {
+      // Defensive fallback — legacy / partial mocks may not carry
+      // publicRecipeId. The import will sad-path with 404 from the
+      // backend, which is preferable to a runtime undefined error.
+      dataSourceMock.useDemoData = false;
+      const match = { recipeId: "r-demo-99" };
+
+      expect(getImportSourceId(match)).toBe("r-demo-99");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("does not mutate the input match", () => {
+      dataSourceMock.useDemoData = false;
+      const match = {
+        recipeId: "r-demo-1",
+        publicRecipeId: "00000000-0000-4000-8000-000000000001",
+      };
+      const snapshot = { ...match };
+
+      getImportSourceId(match);
+
+      expect(match).toEqual(snapshot);
+    });
+  });
+});

--- a/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
@@ -71,6 +71,28 @@ export type ImportRecipeResult = {
 };
 
 /**
+ * Pick the right recipe id to send to `importRecipeFromCommunity`
+ * depending on the active data source (Issue #701).
+ *
+ * - Demo mode (`useDemoData=true`) → returns `match.recipeId`
+ *   (e.g. 'r-demo-1') so the local-only flow looks up `demoRecipes`.
+ * - Backend mode → returns `match.publicRecipeId` (UUID) which
+ *   references a row in the `recipes` table seeded by
+ *   `public-recipes.seed.ts`. Falls back to `match.recipeId` if
+ *   `publicRecipeId` is missing (legacy / partial mocks) — the
+ *   import will then sad-path with 404 as before.
+ */
+export function getImportSourceId(match: {
+  recipeId: string;
+  publicRecipeId?: string;
+}): string {
+  if (dataSource.useDemoData) {
+    return match.recipeId;
+  }
+  return match.publicRecipeId ?? match.recipeId;
+}
+
+/**
  * Import a community (PUBLIC or UNLISTED) recipe into the current
  * user's catalog. In demo mode, simulates the backend by returning
  * the source recipe id (which already lives in `demoRecipes`) so

--- a/packages/mobile-app/src/features/scan/domain/scan.types.ts
+++ b/packages/mobile-app/src/features/scan/domain/scan.types.ts
@@ -187,7 +187,21 @@ export interface ScanLookupResult {
  * sorts by score desc and caps to the top 3.
  */
 export interface ScanRecipeMatch {
+  /**
+   * Demo-mode recipe id — references a row in `demoRecipes` so the
+   * UI can navigate to the resolvable detail page when the app
+   * runs in `EXPO_PUBLIC_USE_DEMO_DATA=true`.
+   */
   recipeId: string;
+  /**
+   * Backend-mode recipe id (UUID) — references a PUBLIC row in the
+   * `recipes` table seeded by `public-recipes.seed.ts` (Issue #701).
+   * Used as the source id when calling
+   * `POST /recipes/import-from-community/:id` against the real
+   * backend. Optional because legacy / partial mocks may not carry
+   * it; pickers fall back to `recipeId` if absent.
+   */
+  publicRecipeId?: string;
   name: string;
   brewer: string;
   rating: number;

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -14,7 +14,10 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 
-import { importRecipeFromCommunity } from "@/features/recipes/application/recipes.use-cases";
+import {
+  getImportSourceId,
+  importRecipeFromCommunity,
+} from "@/features/recipes/application/recipes.use-cases";
 import {
   ScanLookupBeerNotFoundError,
   ScanLookupInvalidBarcodeError,
@@ -308,7 +311,7 @@ function EquivalentRecipesSection({
         return (
           <Pressable
             key={recipe.recipeId}
-            onPress={() => handleImport(recipe.recipeId)}
+            onPress={() => handleImport(getImportSourceId(recipe))}
             disabled={isDisabled}
             style={({ pressed }) => {
               if (isImporting) return [styles.recipeRow];

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -44,6 +44,9 @@ jest.mock("@/features/scan/application/scan-lookup.use-cases", () => {
 
 jest.mock("@/features/recipes/application/recipes.use-cases", () => ({
   importRecipeFromCommunity: jest.fn(),
+  // The screen's helper picks the right id (demo vs backend); in
+  // tests we stay in demo mode so we just return match.recipeId.
+  getImportSourceId: (match: { recipeId: string }) => match.recipeId,
 }));
 
 const mockedLookup = lookupBeerByBarcode as jest.MockedFunction<

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2601,6 +2601,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
   "5060277380019": [
     {
       recipeId: "r-demo-1",
+      publicRecipeId: "00000000-0000-4000-8000-000000000001",
       name: "Session IPA Citra",
       brewer: "Marie",
       rating: 4.7,
@@ -2609,6 +2610,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
     {
       recipeId: "r-demo-7",
+      publicRecipeId: "00000000-0000-4000-8000-000000000002",
       name: "NEIPA Tropical",
       brewer: "Antoine",
       rating: 4.5,
@@ -2617,6 +2619,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
     {
       recipeId: "r-demo-13",
+      publicRecipeId: "00000000-0000-4000-8000-000000000003",
       name: "White IPA",
       brewer: "Lucas",
       rating: 4.3,
@@ -2628,6 +2631,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
   "5410702000133": [
     {
       recipeId: "r-demo-6",
+      publicRecipeId: "00000000-0000-4000-8000-000000000004",
       name: "Belgian Tripel",
       brewer: "Caroline",
       rating: 4.8,
@@ -2636,6 +2640,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
     {
       recipeId: "r-demo-9",
+      publicRecipeId: "00000000-0000-4000-8000-000000000005",
       name: "Saison Farmhouse",
       brewer: "Hugo",
       rating: 4.6,
@@ -2644,6 +2649,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
     {
       recipeId: "r-demo-2",
+      publicRecipeId: "00000000-0000-4000-8000-000000000006",
       name: "Witbier Orange",
       brewer: "Sophie",
       rating: 4.2,
@@ -2655,6 +2661,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
   "5410799000115": [
     {
       recipeId: "r-demo-15",
+      publicRecipeId: "00000000-0000-4000-8000-000000000007",
       name: "Scotch Ale Wee Heavy",
       brewer: "Pierre",
       rating: 4.9,
@@ -2663,6 +2670,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
     {
       recipeId: "r-demo-4",
+      publicRecipeId: "00000000-0000-4000-8000-000000000008",
       name: "Imperial Stout",
       brewer: "Nathalie",
       rating: 4.7,
@@ -2671,6 +2679,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
     {
       recipeId: "r-demo-11",
+      publicRecipeId: "00000000-0000-4000-8000-000000000009",
       name: "Baltic Porter",
       brewer: "Mehdi",
       rating: 4.4,
@@ -2683,6 +2692,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
   "3261570000044": [
     {
       recipeId: "r-demo-6",
+      publicRecipeId: "00000000-0000-4000-8000-000000000004",
       name: "Belgian Tripel",
       brewer: "Caroline",
       rating: 4.8,
@@ -2691,6 +2701,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
     {
       recipeId: "r-demo-9",
+      publicRecipeId: "00000000-0000-4000-8000-000000000005",
       name: "Saison Farmhouse",
       brewer: "Hugo",
       rating: 4.6,
@@ -2699,6 +2710,7 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
     },
     {
       recipeId: "r-demo-8",
+      publicRecipeId: "00000000-0000-4000-8000-00000000000a",
       name: "Kölsch Tradition",
       brewer: "Antoine",
       rating: 4.4,


### PR DESCRIPTION
## Summary

Unblocks the **happy path** of `POST /recipes/import-from-community/:id` in backend mode. Until now, tap '+ Importer' on an `EquivalentRecipesSection` row called the API with an `r-demo-N` identifier that exists only in mobile mocks → backend returned 404 → screen showed the sad-path 'Import impossible' alert. With this PR, each `r-demo-N` carries a companion `publicRecipeId` (UUID) that resolves to a real PUBLIC row in the `recipes` table seeded here.

Real-device validation 2026-04-28: scan + sad-path import already proven over Tailscale; the next APK rebuild will exercise the full happy path.

## What ships — Backend (`packages/api`)

| File | What |
|---|---|
| `src/database/seeds/system-user.seed.ts` | Non-loginable system account (UUID `00000000-0000-4000-8000-000000000000`, role admin, is_active=false, random bcrypt hash). FK pre-requisite for the recipes table. **Idempotent**: never overwrites existing row. |
| `src/database/seeds/public-recipes.seed.ts` | 10 PUBLIC + is_official recipes with deterministic UUIDs (`00000000-...000{1..a}`). 3 IPA / 3 Belgian-Saison / 3 Strong-Dark / 1 Lager. Realistic 20L brewing metrics + avg_rating + brew_count for #699 matching. |
| `scripts/run-public-recipes-seed.ts` | One-shot CLI mirroring `run-scan-catalog-seed.ts`. Seeds system user FIRST then recipes. Idempotent. |

## What ships — Mobile (`packages/mobile-app`)

| File | What |
|---|---|
| `src/features/scan/domain/scan.types.ts` | `ScanRecipeMatch` gains optional `publicRecipeId: string` (documented). |
| `src/mocks/demo-data.ts` | 12 entries in `demoEquivalentRecipes` (4 EAN × 3) now carry both `recipeId` and `publicRecipeId`. |
| `src/features/recipes/application/recipes.use-cases.ts` | New helper `getImportSourceId(match)` branches on `dataSource.useDemoData`: demo → recipeId, backend → publicRecipeId (with fallback). |
| `src/features/scan/presentation/BeerInfoCardScreen.tsx` | Uses the helper instead of hardcoding `recipe.recipeId`. |

## Tests (H/S/E convention)

- **`seedPublicRecipes`** — 8 tests (insert all 10, fields contract, idempotency, override list, UUID format, name contract).
- **`seedSystemUser`** — 5 tests (insert when missing, fields contract, immutability of existing row, password hash randomness across calls).
- **`getImportSourceId`** — 5 tests (demo / backend / fallback / no mutation).
- All existing scan + recipes mobile tests stay green (164 / 164).
- API full suite: 323 / 325 passed (2 skipped pre-existing).

## Manual verification

```bash
cd packages/api
npx ts-node -r tsconfig-paths/register scripts/run-public-recipes-seed.ts
# System user seed: { inserted: true, user_id: '00000000-...000' }
# Public recipes seed: { inserted: 10, updated: 0, total: 10 }

sqlite3 data/brasse-bouillon.db "SELECT COUNT(*) FROM recipes
  WHERE owner_id = '00000000-0000-4000-8000-000000000000';"
# 10
```

## UUID mapping (mobile mocks → backend seed)

| Demo recipe id | UUID | Recipe name |
|---|---|---|
| r-demo-1 | `...001` | Session IPA Citra |
| r-demo-7 | `...002` | NEIPA Tropical |
| r-demo-13 | `...003` | White IPA |
| r-demo-6 | `...004` | Belgian Tripel |
| r-demo-9 | `...005` | Saison Farmhouse |
| r-demo-2 | `...006` | Witbier Orange |
| r-demo-15 | `...007` | Scotch Ale Wee Heavy |
| r-demo-4 | `...008` | Imperial Stout |
| r-demo-11 | `...009` | Baltic Porter |
| r-demo-8 | `...00a` | Kölsch Tradition |

## Out of scope (deferred)

- **#766** — confirmation modal before import (follow-up, ~1h)
- **#767** — rename 'Mes Recettes' (brainstorm needed)
- **#699** — score-based matching algorithm (currently mocks)
- **#700** — mobile UI swap mocks for matching API
- Boot-time auto-seed flag — current pattern is one-shot CLI; auto-seed on `npm run dev:api` is a separate concern.

## Checklist

- [x] H/S/E tests for every new function
- [x] `tsc --noEmit` passes (mobile)
- [x] `lint:check` + `format:check` pass (both packages)
- [x] All existing tests still green
- [x] Local DB reseeded successfully
- [x] No `any`, no inline styles, no FK violation
- [x] PR documented + future scope captured in #766 #767

Closes #701.