### PR TITLE
feat(scan): score-based recipe matching MVP — style + ABV + avg_rating (Issue #699)

### DIFF
--- a/packages/api/src/database/migrations/1780000000000-AddRecipeStyleColumn.ts
+++ b/packages/api/src/database/migrations/1780000000000-AddRecipeStyleColumn.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds a nullable `style` column on `recipes` so the score-based
+ * matching algorithm (Issue #699) can compare a scanned beer's
+ * style against a recipe's style — the heaviest similarity weight
+ * (50%) in the formula validated in the 2026-04-24 brainstorm.
+ *
+ * Nullable on purpose: every existing user-created recipe predates
+ * style tagging, and asking the user to retro-fit a value would be
+ * gratuitous churn. The matching service handles `null` by scoring
+ * style at 0 and falling back to ABV similarity alone.
+ *
+ * The companion seed update (`PUBLIC_RECIPES_SEED`) populates the
+ * 10 curated public recipes with concrete style values
+ * ('Session IPA', 'Belgian Tripel', etc.) so the demo top-3 ranking
+ * is editorially meaningful out of the box.
+ */
+export class AddRecipeStyleColumn1780000000000 implements MigrationInterface {
+  name = 'AddRecipeStyleColumn1780000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "recipes" ADD COLUMN "style" varchar(120)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_recipes_style" ON "recipes" ("style")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_recipes_style"`);
+    await queryRunner.query(`ALTER TABLE "recipes" DROP COLUMN "style"`);
+  }
+}

--- a/packages/api/src/database/migrations/1781000000000-ClearLegacyIsOfficialOnPublicSeedRecipes.ts
+++ b/packages/api/src/database/migrations/1781000000000-ClearLegacyIsOfficialOnPublicSeedRecipes.ts
@@ -1,0 +1,57 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * One-shot data migration to clear the legacy `is_official=true` flag
+ * on the 10 curated public recipes seeded by PR #768.
+ *
+ * Issue #699 introduced an "official-recipe shortcut" that forces the
+ * matching score to 100 when `is_official=true`. PR #768 inadvertently
+ * tagged every seeded PUBLIC recipe as official, which made
+ * `RecipeMatchingService.rankForBeer` collapse to insertion order
+ * (Codex P1 on PR #773).
+ *
+ * The seed payload was fixed to `is_official: false` going forward,
+ * but databases that already loaded PR #768's seed keep the old
+ * value until someone manually re-runs the seed CLI. This migration
+ * is the deploy-time equivalent: it idempotently aligns the 10
+ * deterministic seed UUIDs to the new contract on every environment.
+ *
+ * Down migration is intentionally a no-op: we never want to re-tag
+ * these rows as `is_official=true` (the matching shortcut would
+ * degenerate the ranking again). If a future need arises, edit the
+ * specific recipe row directly rather than reverting this migration.
+ */
+export class ClearLegacyIsOfficialOnPublicSeedRecipes1781000000000 implements MigrationInterface {
+  name = 'ClearLegacyIsOfficialOnPublicSeedRecipes1781000000000';
+
+  // Mirrors PUBLIC_RECIPES_SEED ids — kept literal here so the
+  // migration stays self-contained and runs identically regardless of
+  // how the seed file evolves later.
+  private readonly seedIds: readonly string[] = [
+    '00000000-0000-4000-8000-000000000001',
+    '00000000-0000-4000-8000-000000000002',
+    '00000000-0000-4000-8000-000000000003',
+    '00000000-0000-4000-8000-000000000004',
+    '00000000-0000-4000-8000-000000000005',
+    '00000000-0000-4000-8000-000000000006',
+    '00000000-0000-4000-8000-000000000007',
+    '00000000-0000-4000-8000-000000000008',
+    '00000000-0000-4000-8000-000000000009',
+    '00000000-0000-4000-8000-00000000000a',
+  ];
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const placeholders = this.seedIds.map(() => '?').join(', ');
+    // SQLite stores booleans as 0/1; use the integer literal so the
+    // statement is portable to Postgres later (where 0/1 cast back
+    // to false/true via the bool column type).
+    await queryRunner.query(
+      `UPDATE "recipes" SET "is_official" = 0 WHERE "id" IN (${placeholders})`,
+      [...this.seedIds],
+    );
+  }
+
+  public async down(): Promise<void> {
+    // Intentional no-op — see class docstring.
+  }
+}

--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -37,7 +37,7 @@ describe('seedPublicRecipes (Issue #701)', () => {
       expect(repo.save).toHaveBeenCalledTimes(10);
     });
 
-    it('tags every inserted row as PUBLIC + is_official + system owner', async () => {
+    it('tags every inserted row as PUBLIC + non-official + system owner', async () => {
       const repo = buildRepoMock();
       repo.findOne.mockResolvedValue(null);
 
@@ -46,7 +46,11 @@ describe('seedPublicRecipes (Issue #701)', () => {
       for (const call of repo.create.mock.calls as unknown[][]) {
         const arg = call[0] as Record<string, unknown>;
         expect(arg.visibility).toBe(RecipeVisibility.PUBLIC);
-        expect(arg.is_official).toBe(true);
+        // Stays non-official by design — the matching algorithm
+        // (Issue #699) treats `is_official=true` as a per-beer
+        // shortcut to score 100; tagging all 10 seed rows as
+        // official would collapse `rankForBeer` to insertion order.
+        expect(arg.is_official).toBe(false);
         expect(arg.owner_id).toBe(PUBLIC_RECIPES_SYSTEM_OWNER_ID);
         expect(arg.imported_from_recipe_id).toBeNull();
         expect(arg.import_provenance).toBeNull();
@@ -78,13 +82,16 @@ describe('seedPublicRecipes (Issue #701)', () => {
       expect(repo.save).toHaveBeenCalledTimes(10);
     });
 
-    it('forces visibility back to PUBLIC when overwriting a row that drifted', async () => {
+    it('forces visibility back to PUBLIC and is_official back to false when overwriting a drifted row', async () => {
       const repo = buildRepoMock();
       repo.findOne.mockImplementation(() =>
         Promise.resolve({
           id: 'drifted',
           visibility: RecipeVisibility.PRIVATE,
-          is_official: false,
+          // Drifted to true — the seed must reset this back to false
+          // so a manually-flipped row does not silently degenerate
+          // the matching ranking next time the seed runs.
+          is_official: true,
         }),
       );
 
@@ -93,7 +100,7 @@ describe('seedPublicRecipes (Issue #701)', () => {
       const firstSavedCall = repo.save.mock.calls[0] as unknown[];
       const savedCall = firstSavedCall[0] as Record<string, unknown>;
       expect(savedCall.visibility).toBe(RecipeVisibility.PUBLIC);
-      expect(savedCall.is_official).toBe(true);
+      expect(savedCall.is_official).toBe(false);
     });
   });
 

--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -140,6 +140,17 @@ describe('seedPublicRecipes (Issue #701)', () => {
       expect(names).toContain('Kölsch Tradition');
     });
 
+    it('tags every seeded recipe with a non-empty style for the matching algorithm', () => {
+      // The matching service (Issue #699) leans on `style` as the
+      // 50%-weighted similarity signal — a missing or empty style
+      // would silently drop a recipe to ABV-only ranking and
+      // demote it under any IPA in the editorial top-3.
+      for (const recipe of PUBLIC_RECIPES_SEED) {
+        expect(typeof recipe.style).toBe('string');
+        expect(recipe.style.length).toBeGreaterThan(0);
+      }
+    });
+
     it('uses deterministic UUIDs (sequential v4-shaped) so mobile mocks can hardcode references', () => {
       const ids = PUBLIC_RECIPES_SEED.map((r) => r.id);
       // All IDs share the system prefix; only the last segment differs.

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -44,6 +44,7 @@ export interface PublicRecipeSeed {
   id: string;
   name: string;
   description: string;
+  style: string;
   batch_size_l: number;
   boil_time_min: number;
   og_target: number;
@@ -69,6 +70,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'Session IPA Citra',
     description:
       "Session IPA tropicale et désaltérante autour d'un mono-houblon Citra. Houblonnée à cru pour un nez explosif d'agrumes et de fruit de la passion.",
+    style: 'Session IPA',
     batch_size_l: 20,
     boil_time_min: 60,
     og_target: 1.045,
@@ -85,6 +87,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'NEIPA Tropical',
     description:
       'New England IPA voilée, ronde, peu amère, dominée par les esters fruités de la levure London Ale et un dry-hop massif Citra+Mosaic.',
+    style: 'NEIPA',
     batch_size_l: 20,
     boil_time_min: 60,
     og_target: 1.06,
@@ -101,6 +104,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'White IPA',
     description:
       "Hybride witbier + IPA — base wheat malt, levure belge, houblons américains. Coriandre + écorce d'orange légères pour le pont stylistique.",
+    style: 'White IPA',
     batch_size_l: 20,
     boil_time_min: 60,
     og_target: 1.054,
@@ -118,6 +122,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'Belgian Tripel',
     description:
       'Tripel classique sur base pilsner + sucre candi clair. Levure belge type Westmalle pour les esters fruités et phénols poivrés. Finale sèche.',
+    style: 'Belgian Tripel',
     batch_size_l: 20,
     boil_time_min: 90,
     og_target: 1.075,
@@ -134,6 +139,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'Saison Farmhouse',
     description:
       'Saison rustique inspirée des fermes du Hainaut. Levure saison à haute fermentation (28-32°C), atténuation très élevée, finale poivrée et acidulée.',
+    style: 'Saison',
     batch_size_l: 20,
     boil_time_min: 90,
     og_target: 1.055,
@@ -150,6 +156,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'Witbier Orange',
     description:
       "Witbier traditionnelle 50% wheat / 50% pilsner. Coriandre + zeste d'orange amère de Curaçao en fin d'ébullition. Trouble naturel, finale acidulée.",
+    style: 'Witbier',
     batch_size_l: 20,
     boil_time_min: 60,
     og_target: 1.046,
@@ -167,6 +174,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'Scotch Ale Wee Heavy',
     description:
       'Scotch Ale forte type Wee Heavy. Maltée à fond, caramel cuit, légère touche tourbée optionnelle. Maturation 3 mois recommandée.',
+    style: 'Wee Heavy',
     batch_size_l: 20,
     boil_time_min: 90,
     og_target: 1.08,
@@ -183,6 +191,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'Imperial Stout',
     description:
       'Russian Imperial Stout sur base pale ale + multiples malts torréfiés (chocolate, roasted barley, black malt). Café noir, chocolat amer, vanille en arrière-plan.',
+    style: 'Imperial Stout',
     batch_size_l: 20,
     boil_time_min: 90,
     og_target: 1.09,
@@ -199,6 +208,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'Baltic Porter',
     description:
       'Porter de la Baltique fermenté à froid avec une levure lager. Plus propre que le Russian Imperial Stout, notes de pruneau, café et chocolat noir.',
+    style: 'Baltic Porter',
     batch_size_l: 20,
     boil_time_min: 90,
     og_target: 1.075,
@@ -216,6 +226,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     name: 'Kölsch Tradition',
     description:
       'Kölsch de Cologne — bière hybride fermentée chaude par une levure ale puis lagering à froid. Pâle, sèche, finale légèrement noble (Tettnanger).',
+    style: 'Kölsch',
     batch_size_l: 20,
     boil_time_min: 75,
     og_target: 1.046,
@@ -262,6 +273,7 @@ export async function seedPublicRecipes(
       owner_id: PUBLIC_RECIPES_SYSTEM_OWNER_ID,
       name: recipe.name,
       description: recipe.description,
+      style: recipe.style,
       visibility: RecipeVisibility.PUBLIC,
       version: 1,
       root_recipe_id: recipe.id,

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -254,9 +254,17 @@ export interface SeedPublicRecipesResult {
 /**
  * Idempotent loader for the curated public recipes above. Insert
  * if the id is unknown, update in place otherwise. Always sets
- * `visibility = PUBLIC`, `is_official = true`, and
+ * `visibility = PUBLIC`, `is_official = false`, and
  * `imported_from_recipe_id = null` (these are originals, not
  * imports). Owner is the system sentinel UUID.
+ *
+ * Note on `is_official`: the matching algorithm (Issue #699) treats
+ * `is_official = true` as a beer-specific shortcut that wins outright
+ * (score 100). Tagging the 10 seed recipes as official would make
+ * every PUBLIC row tie at 100 and collapse `rankForBeer` to insertion
+ * order — exactly the regression Codex caught on PR #773. The flag is
+ * reserved for future per-beer official clones (e.g. a brewer-endorsed
+ * Punk IPA clone for the Punk IPA bottle).
  */
 export async function seedPublicRecipes(
   repository: Repository<RecipeOrmEntity>,
@@ -289,7 +297,7 @@ export async function seedPublicRecipes(
       avg_rating: recipe.avg_rating,
       brew_count: recipe.brew_count,
       last_brewed_at: null,
-      is_official: true,
+      is_official: false,
       imported_from_recipe_id: null,
       import_provenance: null,
     };

--- a/packages/api/src/recipe/controllers/recipe.controller.spec.ts
+++ b/packages/api/src/recipe/controllers/recipe.controller.spec.ts
@@ -6,6 +6,7 @@ import { RecipeController } from './recipe.controller';
 import { RecipeHopAdditionStage } from '../domain/enums/recipe-hop-addition-stage.enum';
 import { RecipeHopType } from '../domain/enums/recipe-hop-type.enum';
 import { RecipeIbuEstimateDto } from '../dtos/recipe-ibu-estimate.dto';
+import { RecipeMatchingService } from '../services/recipe-matching.service';
 import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
 import { RecipeService } from '../services/recipe.service';
 import { RecipeStepOrmEntity } from '../entities/recipe-step.orm.entity';
@@ -19,6 +20,7 @@ import { UserRole } from '../../common/enums/role.enum';
 describe('RecipeController', () => {
   let controller: RecipeController;
   let service: RecipeService;
+  let matching: RecipeMatchingService;
 
   const mockRecipeOrm: RecipeOrmEntity = {
     id: '550e8400-e29b-41d4-a716-446655440001',
@@ -106,11 +108,18 @@ describe('RecipeController', () => {
             estimateMineIbu: jest.fn(),
           },
         },
+        {
+          provide: RecipeMatchingService,
+          useValue: {
+            rankForBeer: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     controller = module.get<RecipeController>(RecipeController);
     service = module.get<RecipeService>(RecipeService);
+    matching = module.get<RecipeMatchingService>(RecipeMatchingService);
   });
 
   afterEach(() => {
@@ -358,6 +367,33 @@ describe('RecipeController', () => {
       expect(estimateMineIbuSpy).toHaveBeenCalledWith(
         mockUser.id,
         'invalid-id',
+      );
+    });
+  });
+
+  describe('matchForBeer() - GET /recipes/match/:beerId', () => {
+    const beerId = '00000000-0000-4000-8000-deadbeefcafe';
+
+    it('happy: returns the ranked array straight from the matching service', async () => {
+      const ranked = [
+        { recipe: mockRecipeOrm, score: 87.5 },
+        { recipe: { ...mockRecipeOrm, name: 'Other' }, score: 60 },
+      ];
+      const spy = jest.spyOn(matching, 'rankForBeer').mockResolvedValue(ranked);
+
+      const result = await controller.matchForBeer(beerId);
+
+      expect(spy).toHaveBeenCalledWith(beerId);
+      expect(result).toBe(ranked);
+    });
+
+    it('sad: propagates NotFoundException when the beer id is unknown', async () => {
+      jest
+        .spyOn(matching, 'rankForBeer')
+        .mockRejectedValue(new NotFoundException('Beer not found'));
+
+      await expect(controller.matchForBeer(beerId)).rejects.toThrow(
+        NotFoundException,
       );
     });
   });

--- a/packages/api/src/recipe/controllers/recipe.controller.ts
+++ b/packages/api/src/recipe/controllers/recipe.controller.ts
@@ -28,11 +28,13 @@ import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { User } from '../../user/entities/user.entity';
 
 import { CreateRecipeDto } from '../dtos/create-recipe.dto';
+import { RankedRecipeDto } from '../dtos/ranked-recipe.dto';
 import { RecipeIbuEstimateDto } from '../dtos/recipe-ibu-estimate.dto';
 import { RecipeDto } from '../dtos/recipe.dto';
 import { RecipeStepDto } from '../dtos/recipe-step.dto';
 import { UpdateRecipeDto } from '../dtos/update-recipe.dto';
 import { UpdateRecipeStepDto } from '../dtos/update-recipe-step.dto';
+import { RecipeMatchingService } from '../services/recipe-matching.service';
 import { RecipeService } from '../services/recipe.service';
 
 /**
@@ -46,7 +48,10 @@ import { RecipeService } from '../services/recipe.service';
 @UseGuards(JwtAuthGuard)
 @Controller('recipes')
 export class RecipeController {
-  constructor(private readonly service: RecipeService) {}
+  constructor(
+    private readonly service: RecipeService,
+    private readonly matching: RecipeMatchingService,
+  ) {}
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
@@ -88,6 +93,21 @@ export class RecipeController {
   async listMine(@CurrentUser() user: User): Promise<RecipeDto[]> {
     const rows = await this.service.listMine(user.id);
     return rows.map((row) => RecipeDto.fromEntity(row));
+  }
+
+  @Get('match/:beerId')
+  @ApiOperation({
+    summary:
+      'Rank PUBLIC recipes by match score against a scanned beer (Issue #699)',
+    description:
+      'Returns the top-N PUBLIC recipes ordered by a similarity (style + ABV) and quality (avg_rating) score. The official-recipe shortcut wins outright. `limit` defaults to 3 and is capped at 10.',
+  })
+  @ApiOkResponse({ description: 'Ranked array of {recipe, score}' })
+  @ApiNotFoundResponse({ description: 'Beer catalog item not found' })
+  async matchForBeer(
+    @Param('beerId', new ParseUUIDPipe()) beerId: string,
+  ): Promise<RankedRecipeDto[]> {
+    return this.matching.rankForBeer(beerId);
   }
 
   @Get(':id')

--- a/packages/api/src/recipe/dtos/ranked-recipe.dto.ts
+++ b/packages/api/src/recipe/dtos/ranked-recipe.dto.ts
@@ -1,0 +1,14 @@
+import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
+
+/**
+ * Response item shape for `GET /recipes/match/:beerId` (Issue #699).
+ *
+ * Carries the recipe row plus its computed match score (0..100) so the
+ * mobile UI (Issue #700) can render the ranked list without recomputing
+ * anything client-side. Score breakdown is intentionally NOT exposed —
+ * the client only needs the ordering and the headline number.
+ */
+export interface RankedRecipeDto {
+  recipe: RecipeOrmEntity;
+  score: number;
+}

--- a/packages/api/src/recipe/entities/recipe.orm.entity.ts
+++ b/packages/api/src/recipe/entities/recipe.orm.entity.ts
@@ -17,6 +17,7 @@ import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
 @Index(['brew_count'])
 @Index(['last_brewed_at'])
 @Index(['imported_from_recipe_id'])
+@Index(['style'])
 export class RecipeOrmEntity {
   @PrimaryColumn('uuid')
   id: string;
@@ -87,6 +88,12 @@ export class RecipeOrmEntity {
 
   @Column({ type: 'boolean', nullable: false, default: false })
   is_official: boolean;
+
+  // BJCP-flavoured style tag fed to the scan matching algorithm
+  // (Issue #699). Nullable because pre-existing user recipes have no
+  // style and the matching service degrades gracefully.
+  @Column({ type: 'varchar', length: 120, nullable: true })
+  style?: string | null;
 
   // Import provenance fields (Issue #601). Populated when a user imports
   // a community recipe via POST /recipes/import-from-community/:id.

--- a/packages/api/src/recipe/recipe.module.ts
+++ b/packages/api/src/recipe/recipe.module.ts
@@ -5,11 +5,13 @@ import { RecipeFermentableOrmEntity } from './entities/recipe-fermentable.orm.en
 import { RecipeHopOrmEntity } from './entities/recipe-hop.orm.entity';
 import { RecipeIngredientsController } from './controllers/recipe-ingredients.controller';
 import { RecipeIngredientsService } from './services/recipe-ingredients.service';
+import { RecipeMatchingService } from './services/recipe-matching.service';
 import { RecipeOrmEntity } from './entities/recipe.orm.entity';
 import { RecipeService } from './services/recipe.service';
 import { RecipeStepOrmEntity } from './entities/recipe-step.orm.entity';
 import { RecipeWaterOrmEntity } from './entities/recipe-water.orm.entity';
 import { RecipeYeastOrmEntity } from './entities/recipe-yeast.orm.entity';
+import { ScanCatalogItemOrmEntity } from '../scan/entities/scan-catalog-item.orm.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
@@ -22,10 +24,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
       RecipeYeastOrmEntity,
       RecipeAdditiveOrmEntity,
       RecipeWaterOrmEntity,
+      // Read-only access for the matching service (Issue #699).
+      // Ownership of `scan_catalog_items` stays in `ScanModule`.
+      ScanCatalogItemOrmEntity,
     ]),
   ],
   controllers: [RecipeController, RecipeIngredientsController],
-  providers: [RecipeService, RecipeIngredientsService],
+  providers: [RecipeService, RecipeIngredientsService, RecipeMatchingService],
   exports: [RecipeService],
 })
 export class RecipeModule {}

--- a/packages/api/src/recipe/services/recipe-matching.service.spec.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.spec.ts
@@ -278,6 +278,56 @@ describe('RecipeMatchingService (Issue #699)', () => {
       expect(ranked.map((r) => r.recipe.name)).toEqual(['Public IPA']);
     });
 
+    it('edge: equal scores resolve deterministically by avg_rating desc then id asc', async () => {
+      // Codex P2 on PR #773 — without explicit tie-breakers the
+      // ranking falls back to the DB return order, which is not
+      // guaranteed. The contract: same scores → higher avg_rating
+      // wins ; same rating → lexicographically smaller id wins.
+      const beerId = await seedBeer(catalogRepo, {
+        style: 'IPA',
+        abv: 5,
+      });
+      // Three recipes that score identically on similarity (style
+      // exact, ABV exact). Differentiate only via avg_rating + id.
+      await seedRecipeWithId(
+        recipeRepo,
+        '00000000-0000-4000-8000-aaaaaaaaaaaa',
+        {
+          name: 'Z-low-rating',
+          style: 'IPA',
+          abv_estimated: 5,
+          avg_rating: 3,
+        },
+      );
+      await seedRecipeWithId(
+        recipeRepo,
+        '00000000-0000-4000-8000-bbbbbbbbbbbb',
+        {
+          name: 'A-high-rating',
+          style: 'IPA',
+          abv_estimated: 5,
+          avg_rating: 5,
+        },
+      );
+      await seedRecipeWithId(
+        recipeRepo,
+        '00000000-0000-4000-8000-cccccccccccc',
+        {
+          name: 'A-high-rating-tie',
+          style: 'IPA',
+          abv_estimated: 5,
+          avg_rating: 5,
+        },
+      );
+
+      const ranked = await service.rankForBeer(beerId, 3);
+      expect(ranked.map((r) => r.recipe.name)).toEqual([
+        'A-high-rating', // 5★ rating, smaller id (bbbb…)
+        'A-high-rating-tie', // 5★ rating, larger id (cccc…)
+        'Z-low-rating', // 3★ rating
+      ]);
+    });
+
     it('edge: caps the limit at 10 even if a larger value is requested', async () => {
       const beerId = await seedBeer(catalogRepo, {
         style: 'IPA',
@@ -365,6 +415,18 @@ async function seedRecipe(
   opts: MakeRecipeOpts,
 ): Promise<string> {
   const recipe = makeRecipe(opts);
+  await repo.save(recipe);
+  return recipe.id;
+}
+
+async function seedRecipeWithId(
+  repo: Repository<RecipeOrmEntity>,
+  id: string,
+  opts: MakeRecipeOpts,
+): Promise<string> {
+  const recipe = makeRecipe(opts);
+  recipe.id = id;
+  recipe.root_recipe_id = id;
   await repo.save(recipe);
   return recipe.id;
 }

--- a/packages/api/src/recipe/services/recipe-matching.service.spec.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.spec.ts
@@ -1,0 +1,377 @@
+jest.setTimeout(20000);
+
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { RecipeAdditiveOrmEntity } from '../entities/recipe-additive.orm.entity';
+import { RecipeFermentableOrmEntity } from '../entities/recipe-fermentable.orm.entity';
+import { RecipeHopOrmEntity } from '../entities/recipe-hop.orm.entity';
+import { RecipeMatchingService } from './recipe-matching.service';
+import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
+import { RecipeStepOrmEntity } from '../entities/recipe-step.orm.entity';
+import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
+import { RecipeWaterOrmEntity } from '../entities/recipe-water.orm.entity';
+import { RecipeYeastOrmEntity } from '../entities/recipe-yeast.orm.entity';
+import { ScanCatalogItemOrmEntity } from '../../scan/entities/scan-catalog-item.orm.entity';
+import { ScanCatalogSource } from '../../scan/domain/enums/scan-catalog-source.enum';
+import { ScanFermentationType } from '../../scan/domain/enums/scan-fermentation-type.enum';
+
+describe('RecipeMatchingService (Issue #699)', () => {
+  let module: TestingModule;
+  let service: RecipeMatchingService;
+  let recipeRepo: Repository<RecipeOrmEntity>;
+  let catalogRepo: Repository<ScanCatalogItemOrmEntity>;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [
+            RecipeOrmEntity,
+            RecipeStepOrmEntity,
+            RecipeFermentableOrmEntity,
+            RecipeHopOrmEntity,
+            RecipeYeastOrmEntity,
+            RecipeAdditiveOrmEntity,
+            RecipeWaterOrmEntity,
+            ScanCatalogItemOrmEntity,
+          ],
+          synchronize: true,
+          logging: false,
+        }),
+        TypeOrmModule.forFeature([RecipeOrmEntity, ScanCatalogItemOrmEntity]),
+      ],
+      providers: [RecipeMatchingService],
+    }).compile();
+
+    service = module.get(RecipeMatchingService);
+    recipeRepo = module.get(getRepositoryToken(RecipeOrmEntity));
+    catalogRepo = module.get(getRepositoryToken(ScanCatalogItemOrmEntity));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await recipeRepo.clear();
+    await catalogRepo.clear();
+  });
+
+  // ---------------------------------------------------------------
+  // scoreStyle
+  // ---------------------------------------------------------------
+  describe('scoreStyle', () => {
+    it('happy: exact case-insensitive match scores 100', () => {
+      expect(service.scoreStyle('IPA', 'IPA')).toBe(100);
+      expect(service.scoreStyle('ipa', 'IPA')).toBe(100);
+      expect(service.scoreStyle('  Belgian Tripel ', 'belgian tripel')).toBe(
+        100,
+      );
+    });
+
+    it('happy: same-family substring containment scores 70', () => {
+      expect(service.scoreStyle('IPA', 'Session IPA')).toBe(70);
+      expect(service.scoreStyle('Imperial Stout', 'Stout')).toBe(70);
+    });
+
+    it('sad: unrelated styles score 0', () => {
+      expect(service.scoreStyle('IPA', 'Belgian Tripel')).toBe(0);
+      expect(service.scoreStyle('Pilsner', 'Imperial Stout')).toBe(0);
+    });
+
+    it('edge: null / undefined / empty either side scores 0', () => {
+      expect(service.scoreStyle(null, 'IPA')).toBe(0);
+      expect(service.scoreStyle('IPA', undefined)).toBe(0);
+      expect(service.scoreStyle('', 'IPA')).toBe(0);
+      expect(service.scoreStyle('   ', 'IPA')).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // scoreAbv
+  // ---------------------------------------------------------------
+  describe('scoreAbv', () => {
+    it('happy: zero gap scores 100', () => {
+      expect(service.scoreAbv(5.5, 5.5)).toBe(100);
+    });
+
+    it('happy: 2% gap scores 50 (linear decay 25/percent)', () => {
+      expect(service.scoreAbv(5, 7)).toBe(50);
+      expect(service.scoreAbv(8, 6)).toBe(50);
+    });
+
+    it('sad: 4%+ gap clamps to 0', () => {
+      expect(service.scoreAbv(4, 8)).toBe(0);
+      expect(service.scoreAbv(2, 10)).toBe(0);
+    });
+
+    it('edge: missing values on either side score 0', () => {
+      expect(service.scoreAbv(null, 5)).toBe(0);
+      expect(service.scoreAbv(5, undefined)).toBe(0);
+      expect(service.scoreAbv(null, null)).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // scoreQuality
+  // ---------------------------------------------------------------
+  describe('scoreQuality', () => {
+    it('happy: 5.0 maps to 100, 1.0 to 20, 3.0 to 60', () => {
+      expect(service.scoreQuality(5)).toBe(100);
+      expect(service.scoreQuality(1)).toBe(20);
+      expect(service.scoreQuality(3)).toBe(60);
+    });
+
+    it('sad: null avg_rating scores 0 (do not crowd out rated peers)', () => {
+      expect(service.scoreQuality(null)).toBe(0);
+      expect(service.scoreQuality(undefined)).toBe(0);
+    });
+
+    it('edge: out-of-range ratings clamp safely', () => {
+      // Ratings outside 1..5 are not expected from the schema
+      // (numeric(3,2) avg) but the helper must not crash.
+      expect(service.scoreQuality(0.5)).toBe(20);
+      expect(service.scoreQuality(7)).toBe(100);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // computeFinalScore
+  // ---------------------------------------------------------------
+  describe('computeFinalScore', () => {
+    let beer: ScanCatalogItemOrmEntity;
+    beforeEach(() => {
+      beer = makeBeer({ style: 'IPA', abv: 5.5 });
+    });
+
+    it('happy: blended score = style*0.5 + ABV*0.25 + quality*0.25', () => {
+      // style 100 + ABV 100 + quality 100 → 50 + 25 + 25 = 100
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: 5,
+      });
+      expect(service.computeFinalScore(beer, recipe)).toBe(100);
+    });
+
+    it('happy: official-recipe shortcut wins outright (100) regardless of metrics', () => {
+      // Style mismatch + null rating would otherwise be ~0.
+      const official = makeRecipe({
+        style: 'Pilsner',
+        abv_estimated: null,
+        avg_rating: null,
+        is_official: true,
+      });
+      expect(service.computeFinalScore(beer, official)).toBe(100);
+    });
+
+    it('edge: a recipe with no style nor ABV nor rating still scores deterministically (0)', () => {
+      const empty = makeRecipe({
+        style: null,
+        abv_estimated: null,
+        avg_rating: null,
+      });
+      expect(service.computeFinalScore(beer, empty)).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // rankForBeer (integration with the in-memory DB)
+  // ---------------------------------------------------------------
+  describe('rankForBeer (integration)', () => {
+    it('happy: top-3 ordering for an IPA-shaped beer puts the closest IPA on top', async () => {
+      const beerId = await seedBeer(catalogRepo, {
+        style: 'Session IPA',
+        abv: 4.5,
+      });
+      await Promise.all([
+        seedRecipe(recipeRepo, {
+          name: 'Session IPA Citra',
+          style: 'Session IPA',
+          abv_estimated: 4.6,
+          avg_rating: 4.7,
+        }),
+        seedRecipe(recipeRepo, {
+          name: 'NEIPA',
+          style: 'NEIPA',
+          abv_estimated: 6.4,
+          avg_rating: 4.5,
+        }),
+        seedRecipe(recipeRepo, {
+          name: 'Belgian Tripel',
+          style: 'Belgian Tripel',
+          abv_estimated: 8.5,
+          avg_rating: 4.8,
+        }),
+        seedRecipe(recipeRepo, {
+          name: 'Imperial Stout',
+          style: 'Imperial Stout',
+          abv_estimated: 9.5,
+          avg_rating: 4.7,
+        }),
+      ]);
+
+      const ranked = await service.rankForBeer(beerId, 3);
+
+      expect(ranked).toHaveLength(3);
+      expect(ranked[0].recipe.name).toBe('Session IPA Citra');
+      // Scores must be strictly decreasing.
+      expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+      expect(ranked[1].score).toBeGreaterThanOrEqual(ranked[2].score);
+    });
+
+    it('happy: an official-flagged recipe beats every non-official peer', async () => {
+      const beerId = await seedBeer(catalogRepo, {
+        style: 'Pilsner',
+        abv: 5,
+      });
+      await seedRecipe(recipeRepo, {
+        name: 'Random NEIPA',
+        style: 'NEIPA',
+        abv_estimated: 6.5,
+        avg_rating: 5,
+      });
+      await seedRecipe(recipeRepo, {
+        name: 'Brewer-Endorsed Clone',
+        style: 'Belgian Tripel', // wildly off the beer style
+        abv_estimated: 9, // wildly off the beer ABV
+        avg_rating: null, // no rating
+        is_official: true,
+      });
+
+      const ranked = await service.rankForBeer(beerId, 3);
+      expect(ranked[0].recipe.name).toBe('Brewer-Endorsed Clone');
+      expect(ranked[0].score).toBe(100);
+    });
+
+    it('sad: unknown beerId throws NotFoundException', async () => {
+      await expect(
+        service.rankForBeer('00000000-0000-4000-8000-deadbeefcafe'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: ignores non-PUBLIC recipes (PRIVATE rows must never leak to ranking)', async () => {
+      const beerId = await seedBeer(catalogRepo, {
+        style: 'IPA',
+        abv: 5.5,
+      });
+      await seedRecipe(recipeRepo, {
+        name: 'Public IPA',
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: 4,
+      });
+      await seedRecipe(recipeRepo, {
+        name: 'Private Best Match',
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: 5,
+        visibility: RecipeVisibility.PRIVATE,
+      });
+
+      const ranked = await service.rankForBeer(beerId, 5);
+      expect(ranked.map((r) => r.recipe.name)).toEqual(['Public IPA']);
+    });
+
+    it('edge: caps the limit at 10 even if a larger value is requested', async () => {
+      const beerId = await seedBeer(catalogRepo, {
+        style: 'IPA',
+        abv: 5,
+      });
+      // Seed 12 distinct PUBLIC recipes.
+      for (let i = 0; i < 12; i += 1) {
+        await seedRecipe(recipeRepo, {
+          name: `Recipe ${i}`,
+          style: 'IPA',
+          abv_estimated: 5,
+          avg_rating: 4,
+        });
+      }
+
+      const ranked = await service.rankForBeer(beerId, 100);
+      expect(ranked.length).toBe(10);
+    });
+  });
+});
+
+// -----------------------------------------------------------------
+// Test fixtures
+// -----------------------------------------------------------------
+
+interface MakeBeerOpts {
+  style: string;
+  abv?: number | null;
+}
+
+function makeBeer(opts: MakeBeerOpts): ScanCatalogItemOrmEntity {
+  const beer = new ScanCatalogItemOrmEntity();
+  beer.id = randomUuidish();
+  beer.barcode = '0000000000000';
+  beer.name = 'Test Beer';
+  beer.brewery = 'Test Brewery';
+  beer.style = opts.style;
+  beer.abv = opts.abv ?? null;
+  beer.fermentation_type = ScanFermentationType.UNKNOWN;
+  beer.is_abv_estimated = false;
+  beer.is_ibu_estimated = false;
+  beer.is_color_ebc_estimated = false;
+  beer.is_style_estimated = false;
+  beer.source = ScanCatalogSource.SEED;
+  return beer;
+}
+
+async function seedBeer(
+  repo: Repository<ScanCatalogItemOrmEntity>,
+  opts: MakeBeerOpts,
+): Promise<string> {
+  const beer = makeBeer(opts);
+  await repo.save(beer);
+  return beer.id;
+}
+
+interface MakeRecipeOpts {
+  name: string;
+  style: string | null;
+  abv_estimated: number | null;
+  avg_rating: number | null;
+  visibility?: RecipeVisibility;
+  is_official?: boolean;
+}
+
+function makeRecipe(opts: MakeRecipeOpts): RecipeOrmEntity {
+  const recipe = new RecipeOrmEntity();
+  recipe.id = randomUuidish();
+  recipe.owner_id = '00000000-0000-4000-8000-000000000000';
+  recipe.name = opts.name;
+  recipe.visibility = opts.visibility ?? RecipeVisibility.PUBLIC;
+  recipe.version = 1;
+  recipe.root_recipe_id = recipe.id;
+  recipe.parent_recipe_id = null;
+  recipe.style = opts.style;
+  recipe.abv_estimated = opts.abv_estimated;
+  recipe.avg_rating = opts.avg_rating;
+  recipe.brew_count = 0;
+  recipe.is_official = opts.is_official ?? false;
+  return recipe;
+}
+
+async function seedRecipe(
+  repo: Repository<RecipeOrmEntity>,
+  opts: MakeRecipeOpts,
+): Promise<string> {
+  const recipe = makeRecipe(opts);
+  await repo.save(recipe);
+  return recipe.id;
+}
+
+let counter = 0;
+function randomUuidish(): string {
+  counter += 1;
+  const hex = counter.toString(16).padStart(12, '0');
+  return `00000000-0000-4000-8000-${hex}`;
+}

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -1,0 +1,129 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
+import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
+import { ScanCatalogItemOrmEntity } from '../../scan/entities/scan-catalog-item.orm.entity';
+import { RankedRecipeDto } from '../dtos/ranked-recipe.dto';
+
+/**
+ * Score-based recipe matching (Issue #699 — minimal viable demo scope).
+ *
+ * The 2026-04-24 brainstorm specifies a 7-component formula. This
+ * implementation ships the two heaviest similarity weights plus the
+ * dominant quality signal, which is enough to order the curated top-3
+ * editorially:
+ *
+ *   similarity (75%) = style (50%) + ABV (25%)
+ *   quality    (25%) = avg_rating
+ *   final      = similarity + quality        // already 0..100
+ *
+ * Bitterness, color, brew_count_confidence and recency are deferred
+ * to v0.2 — they refine the ranking but rarely change the top-3 on
+ * the curated seed set, and the demo runs against that seed.
+ */
+@Injectable()
+export class RecipeMatchingService {
+  constructor(
+    @InjectRepository(RecipeOrmEntity)
+    private readonly recipeRepo: Repository<RecipeOrmEntity>,
+    @InjectRepository(ScanCatalogItemOrmEntity)
+    private readonly catalogRepo: Repository<ScanCatalogItemOrmEntity>,
+  ) {}
+
+  async rankForBeer(
+    beerCatalogItemId: string,
+    limit = 3,
+  ): Promise<RankedRecipeDto[]> {
+    const beer = await this.catalogRepo.findOne({
+      where: { id: beerCatalogItemId },
+    });
+    if (!beer) {
+      throw new NotFoundException(
+        `Beer catalog item ${beerCatalogItemId} not found`,
+      );
+    }
+
+    const candidates = await this.recipeRepo.find({
+      where: { visibility: RecipeVisibility.PUBLIC },
+    });
+
+    const scored = candidates.map((recipe) => ({
+      recipe,
+      score: this.computeFinalScore(beer, recipe),
+    }));
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, Math.max(1, Math.min(limit, 10)));
+  }
+
+  /**
+   * Final score for a single recipe against a beer. Range 0..100.
+   * The official-recipe shortcut wins outright — flagged content
+   * always tops the editorial ranking regardless of metrics drift.
+   */
+  computeFinalScore(
+    beer: ScanCatalogItemOrmEntity,
+    recipe: RecipeOrmEntity,
+  ): number {
+    if (recipe.is_official) {
+      return 100;
+    }
+    const similarity =
+      this.scoreStyle(beer.style, recipe.style) * 0.5 +
+      this.scoreAbv(beer.abv, recipe.abv_estimated) * 0.25;
+    const quality = this.scoreQuality(recipe.avg_rating) * 0.25;
+    return similarity + quality;
+  }
+
+  /**
+   * Style similarity (0..100). Exact match → 100, same-family
+   * substring containment (e.g. "IPA" ⊂ "Session IPA") → 70, else → 0.
+   * Comparison is case-insensitive and ignores leading/trailing space.
+   */
+  scoreStyle(
+    beerStyle: string | null | undefined,
+    recipeStyle: string | null | undefined,
+  ): number {
+    if (!beerStyle || !recipeStyle) return 0;
+    const a = beerStyle.trim().toLowerCase();
+    const b = recipeStyle.trim().toLowerCase();
+    if (!a || !b) return 0;
+    if (a === b) return 100;
+    if (a.includes(b) || b.includes(a)) return 70;
+    return 0;
+  }
+
+  /**
+   * ABV similarity (0..100). Linear decay 25 points per percent gap:
+   * 0% → 100, 2% → 50, 4%+ → 0. Either side missing → 0.
+   */
+  scoreAbv(
+    beerAbv: number | null | undefined,
+    recipeAbv: number | null | undefined,
+  ): number {
+    if (
+      beerAbv === null ||
+      beerAbv === undefined ||
+      recipeAbv === null ||
+      recipeAbv === undefined
+    ) {
+      return 0;
+    }
+    const gap = Math.abs(beerAbv - recipeAbv);
+    return Math.max(0, 100 - 25 * gap);
+  }
+
+  /**
+   * Quality signal from `avg_rating` (0..100). Linear map:
+   * 1.0 → 20, 5.0 → 100. Null avg_rating → 0 (an unrated recipe
+   * should not crowd out a well-rated peer of similar similarity).
+   */
+  scoreQuality(avgRating: number | null | undefined): number {
+    if (avgRating === null || avgRating === undefined) return 0;
+    if (avgRating <= 0) return 0;
+    const clamped = Math.max(1, Math.min(5, avgRating));
+    return ((clamped - 1) / 4) * 80 + 20;
+  }
+}

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -54,7 +54,19 @@ export class RecipeMatchingService {
       score: this.computeFinalScore(beer, recipe),
     }));
 
-    scored.sort((a, b) => b.score - a.score);
+    // Deterministic ordering: primary on score desc, secondary on
+    // avg_rating desc (a higher-rated peer wins ties), tertiary on
+    // recipe id ascending (lexicographic, stable across DBs and
+    // restarts). Without these tie-breakers the ranking falls back
+    // on the DB return order which is not guaranteed — Codex P2 on
+    // PR #773.
+    scored.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      const ratingDelta =
+        (b.recipe.avg_rating ?? 0) - (a.recipe.avg_rating ?? 0);
+      if (ratingDelta !== 0) return ratingDelta;
+      return a.recipe.id.localeCompare(b.recipe.id);
+    });
     return scored.slice(0, Math.max(1, Math.min(limit, 10)));
   }
 


### PR DESCRIPTION
## Summary

- Backs the scan flow's "Recettes équivalentes" section in backend mode by ranking PUBLIC recipes against a scanned beer.
- Minimal-viable scope locked via Q&A this session: similarity = style (50%) + ABV (25%) ; quality = avg_rating ; final = sim + qual ; official-recipe shortcut (`is_official=true → 100`) wins outright.
- New migration adds `style varchar(120) NULL` + index on `recipes`. The 10 curated public recipes get concrete style strings (Session IPA, NEIPA, White IPA, Belgian Tripel, Saison, Witbier, Wee Heavy, Imperial Stout, Baltic Porter, Kölsch).
- New `RecipeMatchingService` exposes `rankForBeer(beerCatalogItemId, limit=3)` with pure scoring helpers and is wired through `RecipeModule` plus a new `GET /recipes/match/:beerId` route on `RecipeController` (JwtAuthGuard, literal-prefixed to avoid colliding with `GET /recipes/:id`).

## Changes

- `packages/api/src/database/migrations/1780000000000-AddRecipeStyleColumn.ts` — raw-SQL migration, idiomatic with the existing pattern.
- `packages/api/src/recipe/entities/recipe.orm.entity.ts` — `style?: string | null` + `@Index(['style'])`.
- `packages/api/src/database/seeds/public-recipes.seed.ts` + spec — 10 curated styles tagged, shared payload extended, contract test ensures every seeded recipe carries a non-empty style.
- `packages/api/src/recipe/services/recipe-matching.service.ts` + spec — pure helpers (`scoreStyle` / `scoreAbv` / `scoreQuality` / `computeFinalScore`) plus the integration `rankForBeer`. 19 tests (happy/sad/edge per helper, four integration cases).
- `packages/api/src/recipe/dtos/ranked-recipe.dto.ts` — response shape `{ recipe, score }`.
- `packages/api/src/recipe/recipe.module.ts` — registers `RecipeMatchingService`, adds `ScanCatalogItemOrmEntity` to `forFeature` (read-only access; ownership stays in `ScanModule`).
- `packages/api/src/recipe/controllers/recipe.controller.ts` + spec — new `GET /recipes/match/:beerId`, 2 controller tests (happy delegation + 404 propagation).

## Out of scope (logged in #699)

- Bitterness + color similarity components.
- BrewCount confidence + recency quality components.
- Weight renormalization on missing criteria.
- `low_confidence: true` annotation on the response.
- Mobile UI consumption — that is Issue #700 / Tier 1.3.

## Checklist

- [x] Happy path + sad path + edge cases covered (24 new tests, all green)
- [x] `npm run lint:check` clean (only the pre-existing scan.service.ts warning)
- [x] `npm run build` passes
- [x] `npx jest src/recipe src/database/seeds` passes (130/130)
- [x] No `any`, no inline styles, no AI attribution

Closes #699