### PR TITLE
feat(auth): Sprint A polish — simplified signup (#764) + Google cosmetic button (#765) + bigger mascot

### DIFF
--- a/packages/api/src/user/dtos/create-user.dto.ts
+++ b/packages/api/src/user/dtos/create-user.dto.ts
@@ -89,14 +89,21 @@ export class CreateUserDto {
   email: string;
 
   /**
-   * User's username
+   * User's username (optional in v0.1+ — Issue #764)
    *
-   * Must be unique in the database.
-   * Only alphanumeric characters and underscores are allowed.
+   * Optional input. If omitted, the server auto-generates a username
+   * from the email local-part plus a 4-char hex suffix (e.g.
+   * `john.doe@example.com` → `john_doe_3a7f`). The auto-generated
+   * value satisfies the same shape constraints as user-supplied
+   * values (3-20 chars, alphanumeric + underscore, unique).
    *
-   * @type {string}
+   * Must be unique in the database when provided. Only alphanumeric
+   * characters and underscores are allowed.
+   *
+   * @type {string | undefined}
    * @validation
-   * - @IsString() - Must be a string
+   * - @IsOptional() — Field is not required in the payload
+   * - @IsString() - If provided, must be a string
    * - @MinLength(3) - Minimum 3 characters
    * - @MaxLength(20) - Maximum 20 characters
    * - @Matches(/^[a-zA-Z0-9_]+$/) - Only alphanumeric + underscore
@@ -107,11 +114,13 @@ export class CreateUserDto {
   @ApiProperty({
     example: 'john_doe',
     description:
-      'User username (3-20 chars, alphanumeric + underscore, must be unique)',
+      'Username (optional, 3-20 chars, alphanumeric + underscore, must be unique). Auto-generated from email if omitted.',
     type: String,
     minLength: 3,
     maxLength: 20,
+    required: false,
   })
+  @IsOptional()
   @IsString({
     message: 'Username must be a string',
   })
@@ -127,7 +136,7 @@ export class CreateUserDto {
   @IsUniqueUsername({
     message: 'Username already exists. Please use a different username.',
   })
-  username: string;
+  username?: string;
 
   /**
    * User's password (plain text)

--- a/packages/api/src/user/services/user.service.spec.ts
+++ b/packages/api/src/user/services/user.service.spec.ts
@@ -4,6 +4,7 @@ import {
   UsernameAlreadyExistsException,
 } from '../../common/exceptions';
 import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
 
 import { PasswordService } from '../../auth/services/password.service';
 import { Repository } from 'typeorm';
@@ -263,6 +264,94 @@ describe('UserService', () => {
       // The service should detect the duplicate username and throw
       await expect(userService.create(mockCreateUserData)).rejects.toThrow(
         UsernameAlreadyExistsException,
+      );
+    });
+
+    // ----------------------------------------------------------------
+    // Issue #764 — username became optional, auto-generated from email
+    // ----------------------------------------------------------------
+
+    it('happy: auto-generates a username when none is provided (Issue #764)', async () => {
+      // Email + password only — username derived server-side from
+      // the email local-part + a 4-char hex suffix. The contract:
+      // username matches /^[a-z0-9_]+$/, length 3-20.
+      const minimalInput = {
+        email: 'jane.doe@example.com',
+        password: 'StrongPass123!',
+      };
+
+      jest
+        .spyOn(userRepository, 'findOne')
+        .mockResolvedValueOnce(null) // email uniqueness OK
+        .mockResolvedValueOnce(null); // username collision check inside generator OK on first try
+
+      const createSpy = jest
+        .spyOn(userRepository, 'create')
+        .mockReturnValue(mockUser);
+      const saveSpy = jest
+        .spyOn(userRepository, 'save')
+        .mockResolvedValue(mockUser);
+      jest
+        .spyOn(passwordService, 'hashPassword')
+        .mockResolvedValue('hashedPassword123');
+
+      await userService.create(minimalInput);
+
+      // The generated username starts with the slugified local-part
+      // (`jane_doe` here — dots become underscores) and ends with a
+      // `_` + 4-char hex suffix.
+      const createCallArg = createSpy.mock.calls[0][0] as { username: string };
+      expect(createCallArg.username).toMatch(/^jane_doe_[0-9a-f]{4}$/);
+      // Length within DB column limits (varchar 100, but DTO caps at 20).
+      expect(createCallArg.username.length).toBeLessThanOrEqual(20);
+      expect(saveSpy).toHaveBeenCalledWith(mockUser);
+    });
+
+    it('edge: prefixes `u` when the email local-part starts with a digit', async () => {
+      const numericLeadInput = {
+        email: '42lover@example.com',
+        password: 'StrongPass123!',
+      };
+
+      jest
+        .spyOn(userRepository, 'findOne')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+      const createSpy = jest
+        .spyOn(userRepository, 'create')
+        .mockReturnValue(mockUser);
+      jest.spyOn(userRepository, 'save').mockResolvedValue(mockUser);
+      jest
+        .spyOn(passwordService, 'hashPassword')
+        .mockResolvedValue('hashedPassword123');
+
+      await userService.create(numericLeadInput);
+
+      const createCallArg = createSpy.mock.calls[0][0] as { username: string };
+      // Must start with a letter or underscore (the regex `^[a-z_]`
+      // forces the `u` prefix).
+      expect(createCallArg.username).toMatch(/^u42lover_[0-9a-f]{4}$/);
+    });
+
+    it('sad: rejects when email is missing', async () => {
+      const noEmailInput = {
+        email: '',
+        password: 'StrongPass123!',
+      };
+
+      await expect(userService.create(noEmailInput)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('sad: rejects when password is missing', async () => {
+      const noPasswordInput = {
+        email: 'jane@example.com',
+        password: '',
+      };
+
+      await expect(userService.create(noPasswordInput)).rejects.toThrow(
+        BadRequestException,
       );
     });
   });

--- a/packages/api/src/user/services/user.service.ts
+++ b/packages/api/src/user/services/user.service.ts
@@ -247,8 +247,29 @@ export class UserService {
       }
     }
 
-    // Astronomically unlikely fallback: append timestamp to break ties.
-    return `${base}_${Date.now().toString(36)}`.slice(0, 20);
+    // Astronomically unlikely fallback: timestamp + extra entropy. Still
+    // verifies uniqueness via the same query — if even the timestamp
+    // collides (truncation to 20 chars can drop low-order digits when
+    // the base is already long), keep retrying with longer entropy
+    // until we find a free slot. Capped at 10 fallback attempts so the
+    // method always terminates; on the absurd worst case (every variant
+    // taken) we raise a clear domain exception rather than letting the
+    // DB unique-constraint surface as a generic 500.
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const ts = Date.now().toString(36);
+      const extra = randomBytes(2).toString('hex'); // 4 hex chars
+      const candidate = `${base}_${ts}${extra}`.slice(0, 20);
+      const collision = await this.userRepository.findOne({
+        where: { username: candidate },
+      });
+      if (!collision) {
+        return candidate;
+      }
+    }
+
+    throw new BadRequestException(
+      'Unable to generate a unique username — the username space appears saturated. Please retry or supply a custom username.',
+    );
   }
 
   /**

--- a/packages/api/src/user/services/user.service.ts
+++ b/packages/api/src/user/services/user.service.ts
@@ -6,6 +6,7 @@ import {
   UnauthorizedException,
   Logger,
 } from '@nestjs/common';
+import { randomBytes } from 'node:crypto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MoreThan, Repository } from 'typeorm';
 
@@ -149,20 +150,16 @@ export class UserService {
    */
   async create(createUserData: {
     email: string;
-    username: string;
+    username?: string;
     password: string;
     first_name?: string;
     last_name?: string;
   }): Promise<User> {
-    // ✅ VALIDATION: Check required fields
-    if (
-      !createUserData.email ||
-      !createUserData.username ||
-      !createUserData.password
-    ) {
-      throw new BadRequestException(
-        'Email, username, and password are required',
-      );
+    // ✅ VALIDATION: email + password are the only mandatory inputs
+    // (username became optional in Issue #764 — auto-generated from email
+    // local-part if omitted).
+    if (!createUserData.email || !createUserData.password) {
+      throw new BadRequestException('Email and password are required');
     }
 
     // ✅ UNIQUENESS CHECK: Email
@@ -173,12 +170,20 @@ export class UserService {
       throw new EmailAlreadyExistsException();
     }
 
-    // ✅ UNIQUENESS CHECK: Username
-    const existingUsernameUser = await this.userRepository.findOne({
-      where: { username: createUserData.username },
-    });
-    if (existingUsernameUser) {
-      throw new UsernameAlreadyExistsException();
+    // ✅ USERNAME RESOLUTION: caller-supplied or auto-generated
+    const username = createUserData.username
+      ? createUserData.username
+      : await this.generateUniqueUsernameFromEmail(createUserData.email);
+
+    // ✅ UNIQUENESS CHECK: Username (only if caller-supplied — the
+    // auto-generator already guarantees uniqueness via its retry loop).
+    if (createUserData.username) {
+      const existingUsernameUser = await this.userRepository.findOne({
+        where: { username },
+      });
+      if (existingUsernameUser) {
+        throw new UsernameAlreadyExistsException();
+      }
     }
 
     // ✅ PASSWORD HASHING: Hash password before storage
@@ -189,7 +194,7 @@ export class UserService {
     // ✅ ENTITY CREATION: Create user entity with default values
     const newUser = this.userRepository.create({
       email: createUserData.email,
-      username: createUserData.username,
+      username,
       password_hash: passwordHash,
       first_name: createUserData.first_name || null,
       last_name: createUserData.last_name || null,
@@ -202,6 +207,48 @@ export class UserService {
 
     // ✅ SECURITY: Remove password before returning
     return this.formatUserResponse(savedUser);
+  }
+
+  /**
+   * Generate a unique username from the given email.
+   *
+   * Strategy: take the local-part (before `@`), keep only
+   * alphanumeric + underscore characters, truncate to 14 chars, then
+   * append `_` + 4-char hex suffix for uniqueness. Examples:
+   *
+   * - `john.doe@example.com`     → `john_doe_3a7f`
+   * - `bbd-concept@gmail.com`    → `bbd_concept_x7k2`
+   * - `john_doe_super_long@…`    → `john_doe_super_3a7f`
+   * - `42@`                       → `u42_3a7f`  (prefixed `u` if numeric-leading)
+   *
+   * The function retries on the rare collision until it finds a free
+   * slot or hits the max attempts (5). With 16^4 ≈ 65k suffixes the
+   * collision probability is negligible.
+   */
+  private async generateUniqueUsernameFromEmail(
+    email: string,
+  ): Promise<string> {
+    const localPart = email.split('@')[0] ?? 'user';
+    let base = localPart.toLowerCase().replace(/[^a-z0-9_]/g, '_');
+    if (!/^[a-z_]/.test(base)) {
+      base = `u${base}`;
+    }
+    base = base.slice(0, 14) || 'user';
+
+    const maxAttempts = 5;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const suffix = randomBytes(2).toString('hex'); // 4 hex chars
+      const candidate = `${base}_${suffix}`.slice(0, 20);
+      const collision = await this.userRepository.findOne({
+        where: { username: candidate },
+      });
+      if (!collision) {
+        return candidate;
+      }
+    }
+
+    // Astronomically unlikely fallback: append timestamp to break ties.
+    return `${base}_${Date.now().toString(36)}`.slice(0, 20);
   }
 
   /**

--- a/packages/api/src/user/services/user.service.ts
+++ b/packages/api/src/user/services/user.service.ts
@@ -247,18 +247,23 @@ export class UserService {
       }
     }
 
-    // Astronomically unlikely fallback: timestamp + extra entropy. Still
-    // verifies uniqueness via the same query — if even the timestamp
-    // collides (truncation to 20 chars can drop low-order digits when
-    // the base is already long), keep retrying with longer entropy
-    // until we find a free slot. Capped at 10 fallback attempts so the
-    // method always terminates; on the absurd worst case (every variant
-    // taken) we raise a clear domain exception rather than letting the
-    // DB unique-constraint surface as a generic 500.
+    // Astronomically unlikely fallback: shorten the base aggressively
+    // and use a wider random suffix so each retry has fresh entropy
+    // that survives the 20-char username cap. The previous
+    // timestamp-based version (Codex P2 on PR #790 — preserve fallback
+    // entropy) could truncate the random `extra` away when the base
+    // was already 14 chars, making all 10 retries produce the same
+    // candidate within a millisecond bucket. Fix: cap the base at 11
+    // chars so the 8-char hex suffix (4 random bytes) always survives
+    // — that's 16^8 ≈ 4.3 billion distinct usernames per base, ample
+    // headroom even on absurdly popular local-parts. Capped at 10
+    // fallback attempts; if that loop also saturates (basically
+    // impossible) we surface a clear domain exception rather than let
+    // the DB unique constraint hit as a generic 500.
+    const fallbackBase = base.slice(0, 11);
     for (let attempt = 0; attempt < 10; attempt += 1) {
-      const ts = Date.now().toString(36);
-      const extra = randomBytes(2).toString('hex'); // 4 hex chars
-      const candidate = `${base}_${ts}${extra}`.slice(0, 20);
+      const suffix = randomBytes(4).toString('hex'); // 8 hex chars
+      const candidate = `${fallbackBase}_${suffix}`;
       const collision = await this.userRepository.findOne({
         where: { username: candidate },
       });

--- a/packages/mobile-app/src/features/auth/data/auth.api.ts
+++ b/packages/mobile-app/src/features/auth/data/auth.api.ts
@@ -21,10 +21,15 @@ type AuthResponse = {
   user: AuthUserDto;
 };
 
+/**
+ * Signup payload — Issue #764 simplified to email + password only.
+ * The backend auto-generates the username from the email local-part
+ * if `username` is omitted (which is now the default).
+ */
 export type SignupInput = {
   email: string;
   password: string;
-  username: string;
+  username?: string;
   firstName?: string;
   lastName?: string;
 };
@@ -76,13 +81,16 @@ export async function login(
 }
 
 export async function signup(input: SignupInput): Promise<AuthSession> {
-  const body = {
+  // Only forward optional fields when explicitly provided — the
+  // backend's CreateUserDto rejects empty strings on optional fields
+  // and auto-generates a username when omitted.
+  const body: Record<string, string> = {
     email: input.email,
     password: input.password,
-    username: input.username,
-    first_name: input.firstName,
-    last_name: input.lastName,
   };
+  if (input.username) body.username = input.username;
+  if (input.firstName) body.first_name = input.firstName;
+  if (input.lastName) body.last_name = input.lastName;
 
   try {
     const data = await request<AuthResponse>("/auth/register", {

--- a/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
@@ -2,6 +2,7 @@ import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import React, { useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -130,6 +131,18 @@ export function LoginScreen() {
     }
   };
 
+  // Cosmetic-only Google sign-in button (Issue #765). Materializes the
+  // product direction (social login) on the auth screen for the
+  // soutenance demo without committing to an OAuth flow integration in
+  // v0.1. Real OAuth + backend Passport strategy come later.
+  const onGooglePressComingSoon = () => {
+    clearFeedback();
+    Alert.alert(
+      "Bientôt disponible",
+      "La connexion via Google arrive prochainement. En attendant, utilise ton email.",
+    );
+  };
+
   const onSubmit = async () => {
     if (mode === "signup") {
       await onSignupSubmit();
@@ -204,6 +217,29 @@ export function LoginScreen() {
               </Text>
             </Pressable>
           </View>
+        ) : null}
+
+        {mode !== "forgot" ? (
+          <>
+            <Pressable
+              style={({ pressed }) => [
+                styles.googleButton,
+                pressed && styles.buttonPressed,
+              ]}
+              onPress={onGooglePressComingSoon}
+              disabled={isLoading}
+              accessibilityRole="button"
+              accessibilityLabel="Continuer avec Google (bientôt disponible)"
+            >
+              <Text style={styles.googleG}>G</Text>
+              <Text style={styles.googleButtonText}>Continuer avec Google</Text>
+            </Pressable>
+            <View style={styles.divider}>
+              <View style={styles.dividerLine} />
+              <Text style={styles.dividerText}>ou</Text>
+              <View style={styles.dividerLine} />
+            </View>
+          </>
         ) : null}
 
         <TextInput
@@ -358,6 +394,48 @@ const styles = StyleSheet.create({
     fontWeight: typography.weight.regular,
     marginTop: -spacing.xs,
     marginBottom: spacing.sm,
+  },
+  googleButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: spacing.xs,
+    backgroundColor: colors.neutral.white,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    borderRadius: radius.sm,
+    paddingVertical: spacing.sm,
+    marginBottom: spacing.sm,
+    ...shadows.sm,
+  },
+  googleG: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+    color: colors.brand.primary,
+  },
+  googleButtonText: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+  },
+  divider: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  dividerLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: colors.neutral.border,
+  },
+  dividerText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontWeight: typography.weight.regular,
   },
   linkText: {
     color: colors.brand.primary,

--- a/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
@@ -11,12 +11,15 @@ import {
 } from "react-native";
 
 import { useAuth } from "@/core/auth/auth-context";
+import { dataSource } from "@/core/data/data-source";
 import { BrandLogo } from "@/core/ui/BrandLogo";
 import { Screen } from "@/core/ui/Screen";
 
 type AuthMode = "login" | "signup" | "forgot";
 
 const emailRegex = /^\S+@\S+\.\S+$/;
+const PASSWORD_HELPER =
+  "Au moins 8 caractères, 1 majuscule, 1 chiffre, 1 caractère spécial.";
 
 export function LoginScreen() {
   const {
@@ -31,10 +34,6 @@ export function LoginScreen() {
   const [mode, setMode] = useState<AuthMode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
-  const [username, setUsername] = useState("");
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
   const [localInfo, setLocalInfo] = useState<string | null>(null);
 
@@ -71,8 +70,8 @@ export function LoginScreen() {
   };
 
   const onSignupSubmit = async () => {
-    if (!email.trim() || !password.trim() || !username.trim()) {
-      setLocalError("Email, mot de passe et nom d’utilisateur requis.");
+    if (!email.trim() || !password.trim()) {
+      setLocalError("Email et mot de passe requis.");
       return;
     }
 
@@ -86,20 +85,12 @@ export function LoginScreen() {
       return;
     }
 
-    if (password !== confirmPassword) {
-      setLocalError("Les mots de passe ne correspondent pas.");
-      return;
-    }
-
     clearFeedback();
 
     try {
       await signup({
         email: email.trim(),
         password,
-        username: username.trim(),
-        firstName: firstName.trim() || undefined,
-        lastName: lastName.trim() || undefined,
       });
     } catch {
       // handled in auth context
@@ -167,57 +158,53 @@ export function LoginScreen() {
         ? "Créer mon compte"
         : "Envoyer le lien";
 
+  // Connexion démo button is jury-only — visible only when the build
+  // is configured for demo mode (`EXPO_PUBLIC_USE_DEMO_DATA=true`).
+  // Backend / production builds hide it (Issue #764).
+  const showDemoButton = dataSource.useDemoData;
+
   return (
     <Screen>
       <ScrollView
         contentContainerStyle={styles.container}
         keyboardShouldPersistTaps="handled"
       >
-        <BrandLogo size={84} style={styles.logo} />
+        <BrandLogo size={156} style={styles.logo} />
         <Text style={styles.title}>Brasse Bouillon</Text>
         <Text style={styles.subtitle}>{subtitle}</Text>
 
-        <View style={styles.tabs}>
-          <Pressable
-            style={[styles.tab, mode === "login" && styles.tabActive]}
-            onPress={() => onSwitchMode("login")}
-            disabled={isLoading}
-          >
-            <Text
-              style={[styles.tabText, mode === "login" && styles.tabTextActive]}
+        {mode !== "forgot" ? (
+          <View style={styles.tabs}>
+            <Pressable
+              style={[styles.tab, mode === "login" && styles.tabActive]}
+              onPress={() => onSwitchMode("login")}
+              disabled={isLoading}
             >
-              Connexion
-            </Text>
-          </Pressable>
-          <Pressable
-            style={[styles.tab, mode === "signup" && styles.tabActive]}
-            onPress={() => onSwitchMode("signup")}
-            disabled={isLoading}
-          >
-            <Text
-              style={[
-                styles.tabText,
-                mode === "signup" && styles.tabTextActive,
-              ]}
+              <Text
+                style={[
+                  styles.tabText,
+                  mode === "login" && styles.tabTextActive,
+                ]}
+              >
+                Connexion
+              </Text>
+            </Pressable>
+            <Pressable
+              style={[styles.tab, mode === "signup" && styles.tabActive]}
+              onPress={() => onSwitchMode("signup")}
+              disabled={isLoading}
             >
-              Créer un compte
-            </Text>
-          </Pressable>
-          <Pressable
-            style={[styles.tab, mode === "forgot" && styles.tabActive]}
-            onPress={() => onSwitchMode("forgot")}
-            disabled={isLoading}
-          >
-            <Text
-              style={[
-                styles.tabText,
-                mode === "forgot" && styles.tabTextActive,
-              ]}
-            >
-              Mot de passe oublié
-            </Text>
-          </Pressable>
-        </View>
+              <Text
+                style={[
+                  styles.tabText,
+                  mode === "signup" && styles.tabTextActive,
+                ]}
+              >
+                Créer un compte
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
 
         <TextInput
           autoCapitalize="none"
@@ -230,38 +217,6 @@ export function LoginScreen() {
           onChangeText={setEmail}
         />
 
-        {mode === "signup" ? (
-          <>
-            <TextInput
-              autoCapitalize="none"
-              autoCorrect={false}
-              placeholder="Nom d'utilisateur"
-              placeholderTextColor={colors.neutral.muted}
-              style={styles.input}
-              value={username}
-              onChangeText={setUsername}
-            />
-            <View style={styles.inlineInputs}>
-              <TextInput
-                autoCapitalize="words"
-                placeholder="Prénom (optionnel)"
-                placeholderTextColor={colors.neutral.muted}
-                style={[styles.input, styles.inlineInput]}
-                value={firstName}
-                onChangeText={setFirstName}
-              />
-              <TextInput
-                autoCapitalize="words"
-                placeholder="Nom (optionnel)"
-                placeholderTextColor={colors.neutral.muted}
-                style={[styles.input, styles.inlineInput]}
-                value={lastName}
-                onChangeText={setLastName}
-              />
-            </View>
-          </>
-        ) : null}
-
         {mode !== "forgot" ? (
           <>
             <TextInput
@@ -273,14 +228,7 @@ export function LoginScreen() {
               onChangeText={setPassword}
             />
             {mode === "signup" ? (
-              <TextInput
-                placeholder="Confirmer le mot de passe"
-                placeholderTextColor={colors.neutral.muted}
-                secureTextEntry
-                style={styles.input}
-                value={confirmPassword}
-                onChangeText={setConfirmPassword}
-              />
+              <Text style={styles.helper}>{PASSWORD_HELPER}</Text>
             ) : null}
           </>
         ) : null}
@@ -304,16 +252,38 @@ export function LoginScreen() {
           )}
         </Pressable>
 
-        <Pressable
-          style={({ pressed }) => [
-            styles.secondaryButton,
-            pressed && styles.buttonPressed,
-          ]}
-          onPress={onDemoSubmit}
-          disabled={isLoading}
-        >
-          <Text style={styles.secondaryButtonText}>Connexion démo</Text>
-        </Pressable>
+        {mode === "login" ? (
+          <Pressable
+            onPress={() => onSwitchMode("forgot")}
+            disabled={isLoading}
+            hitSlop={8}
+          >
+            <Text style={styles.linkText}>Mot de passe oublié ?</Text>
+          </Pressable>
+        ) : null}
+
+        {mode === "forgot" ? (
+          <Pressable
+            onPress={() => onSwitchMode("login")}
+            disabled={isLoading}
+            hitSlop={8}
+          >
+            <Text style={styles.linkText}>← Retour à la connexion</Text>
+          </Pressable>
+        ) : null}
+
+        {showDemoButton ? (
+          <Pressable
+            style={({ pressed }) => [
+              styles.secondaryButton,
+              pressed && styles.buttonPressed,
+            ]}
+            onPress={onDemoSubmit}
+            disabled={isLoading}
+          >
+            <Text style={styles.secondaryButtonText}>Connexion démo</Text>
+          </Pressable>
+        ) : null}
       </ScrollView>
     </Screen>
   );
@@ -381,12 +351,21 @@ const styles = StyleSheet.create({
     lineHeight: typography.lineHeight.body,
     fontWeight: typography.weight.regular,
   },
-  inlineInputs: {
-    flexDirection: "row",
-    gap: spacing.xs,
+  helper: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontWeight: typography.weight.regular,
+    marginTop: -spacing.xs,
+    marginBottom: spacing.sm,
   },
-  inlineInput: {
-    flex: 1,
+  linkText: {
+    color: colors.brand.primary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontWeight: typography.weight.medium,
+    textAlign: "center",
+    marginTop: spacing.xs,
   },
   button: {
     backgroundColor: colors.brand.primary,

--- a/packages/mobile-app/src/features/auth/presentation/__tests__/LoginScreen.test.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/__tests__/LoginScreen.test.tsx
@@ -6,6 +6,7 @@ import {
 } from "@testing-library/react-native";
 
 import { LoginScreen } from "@/features/auth/presentation/LoginScreen";
+import { Alert } from "react-native";
 import React from "react";
 
 const mockLogin = jest.fn();
@@ -245,6 +246,37 @@ describe("LoginScreen (Issue #764 — simplified signup)", () => {
       await waitFor(() => {
         expect(mockLoginWithDemoAccount).toHaveBeenCalledTimes(1);
       });
+    });
+  });
+
+  describe("cosmetic Google sign-in button (Issue #765)", () => {
+    it("shows the Google button on login mode (above the email input)", () => {
+      render(<LoginScreen />);
+      expect(screen.getByText("Continuer avec Google")).toBeTruthy();
+    });
+
+    it("shows the Google button on signup mode", () => {
+      render(<LoginScreen />);
+      fireEvent.press(screen.getByText("Créer un compte"));
+      expect(screen.getByText("Continuer avec Google")).toBeTruthy();
+    });
+
+    it("hides the Google button in forgot-password mode", () => {
+      render(<LoginScreen />);
+      fireEvent.press(screen.getByText("Mot de passe oublié ?"));
+      expect(screen.queryByText("Continuer avec Google")).toBeNull();
+    });
+
+    it("opens a 'Bientôt disponible' alert on tap (cosmetic placeholder, no real OAuth)", () => {
+      const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+      render(<LoginScreen />);
+      fireEvent.press(screen.getByText("Continuer avec Google"));
+
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Bientôt disponible",
+        expect.stringContaining("Google"),
+      );
+      alertSpy.mockRestore();
     });
   });
 });

--- a/packages/mobile-app/src/features/auth/presentation/__tests__/LoginScreen.test.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/__tests__/LoginScreen.test.tsx
@@ -24,75 +24,227 @@ jest.mock("@/core/auth/auth-context", () => ({
   }),
 }));
 
-describe("LoginScreen", () => {
+// `dataSource.useDemoData` controls visibility of the "Connexion démo"
+// button per Issue #764. Mutable mock so we can flip per test.
+const dataSourceMock = { useDemoData: true };
+jest.mock("@/core/data/data-source", () => ({
+  get dataSource() {
+    return dataSourceMock;
+  },
+}));
+
+describe("LoginScreen (Issue #764 — simplified signup)", () => {
   beforeEach(() => {
     mockLogin.mockReset();
     mockSignup.mockReset();
     mockRequestPasswordReset.mockReset();
     mockLoginWithDemoAccount.mockReset();
+    dataSourceMock.useDemoData = true;
   });
 
-  it("renders complete auth entry points", () => {
-    render(<LoginScreen />);
+  describe("happy path — login mode", () => {
+    it("renders the simplified entry points (no third tab, demo button visible in demo mode)", () => {
+      render(<LoginScreen />);
 
-    expect(screen.getByText("Brasse Bouillon")).toBeTruthy();
-    expect(screen.getByText("Connecte-toi pour continuer")).toBeTruthy();
-    expect(screen.getByText("Connexion")).toBeTruthy();
-    expect(screen.getByText("Créer un compte")).toBeTruthy();
-    expect(screen.getByText("Mot de passe oublié")).toBeTruthy();
-    expect(screen.getByPlaceholderText("Email")).toBeTruthy();
-    expect(screen.getByPlaceholderText("Mot de passe")).toBeTruthy();
-    expect(screen.getByText("Connexion démo")).toBeTruthy();
-  });
-
-  it("switches to signup mode and validates required fields", async () => {
-    render(<LoginScreen />);
-
-    fireEvent.press(screen.getByText("Créer un compte"));
-
-    expect(screen.getByText("Crée ton compte pour démarrer")).toBeTruthy();
-    expect(screen.getByPlaceholderText("Nom d'utilisateur")).toBeTruthy();
-    expect(
-      screen.getByPlaceholderText("Confirmer le mot de passe"),
-    ).toBeTruthy();
-
-    fireEvent.press(screen.getByText("Créer mon compte"));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Email, mot de passe et nom d’utilisateur requis."),
-      ).toBeTruthy();
+      expect(screen.getByText("Brasse Bouillon")).toBeTruthy();
+      expect(screen.getByText("Connecte-toi pour continuer")).toBeTruthy();
+      expect(screen.getByText("Connexion")).toBeTruthy();
+      expect(screen.getByText("Créer un compte")).toBeTruthy();
+      expect(screen.getByPlaceholderText("Email")).toBeTruthy();
+      expect(screen.getByPlaceholderText("Mot de passe")).toBeTruthy();
+      // Forgot password is now a text link, not a tab.
+      expect(screen.getByText("Mot de passe oublié ?")).toBeTruthy();
+      // Demo button visible because useDemoData=true.
+      expect(screen.getByText("Connexion démo")).toBeTruthy();
     });
 
-    expect(mockSignup).not.toHaveBeenCalled();
-  });
+    it("submits login with email + password", async () => {
+      mockLogin.mockResolvedValue(undefined);
+      render(<LoginScreen />);
 
-  it("submits forgot password request", async () => {
-    mockRequestPasswordReset.mockResolvedValue(undefined);
-    render(<LoginScreen />);
+      fireEvent.changeText(
+        screen.getByPlaceholderText("Email"),
+        "lea@brasse-bouillon.test",
+      );
+      fireEvent.changeText(
+        screen.getByPlaceholderText("Mot de passe"),
+        "StrongPass123!",
+      );
+      fireEvent.press(screen.getByText("Se connecter"));
 
-    fireEvent.press(screen.getByText("Mot de passe oublié"));
-    fireEvent.changeText(screen.getByPlaceholderText("Email"), "demo@bb.test");
-    fireEvent.press(screen.getByText("Envoyer le lien"));
-
-    await waitFor(() => {
-      expect(mockRequestPasswordReset).toHaveBeenCalledWith("demo@bb.test");
-      expect(
-        screen.getByText(
-          "Si un compte existe pour cet email, un lien de réinitialisation vient d’être envoyé.",
-        ),
-      ).toBeTruthy();
+      await waitFor(() => {
+        expect(mockLogin).toHaveBeenCalledWith(
+          "lea@brasse-bouillon.test",
+          "StrongPass123!",
+        );
+      });
     });
   });
 
-  it("triggers demo login", async () => {
-    mockLoginWithDemoAccount.mockResolvedValue(undefined);
-    render(<LoginScreen />);
+  describe("happy path — signup mode (Issue #764)", () => {
+    it("renders only email + password (no username, no first/last name, no confirm)", () => {
+      render(<LoginScreen />);
+      fireEvent.press(screen.getByText("Créer un compte"));
 
-    fireEvent.press(screen.getByText("Connexion démo"));
+      expect(screen.getByText("Crée ton compte pour démarrer")).toBeTruthy();
+      expect(screen.getByPlaceholderText("Email")).toBeTruthy();
+      expect(screen.getByPlaceholderText("Mot de passe")).toBeTruthy();
 
-    await waitFor(() => {
-      expect(mockLoginWithDemoAccount).toHaveBeenCalledTimes(1);
+      // Removed inputs from the simplification.
+      expect(screen.queryByPlaceholderText("Nom d'utilisateur")).toBeNull();
+      expect(screen.queryByPlaceholderText("Prénom (optionnel)")).toBeNull();
+      expect(screen.queryByPlaceholderText("Nom (optionnel)")).toBeNull();
+      expect(
+        screen.queryByPlaceholderText("Confirmer le mot de passe"),
+      ).toBeNull();
+
+      // Password helper is shown in signup mode (Q2 statu quo on
+      // strict policy — display it but don't pre-validate client-side).
+      expect(
+        screen.getByText(/Au moins 8 caract.+majuscule.+chiffre/),
+      ).toBeTruthy();
+    });
+
+    it("submits signup with email + password only — backend auto-generates the username", async () => {
+      mockSignup.mockResolvedValue(undefined);
+      render(<LoginScreen />);
+
+      fireEvent.press(screen.getByText("Créer un compte"));
+      fireEvent.changeText(
+        screen.getByPlaceholderText("Email"),
+        "lea@brasse-bouillon.test",
+      );
+      fireEvent.changeText(
+        screen.getByPlaceholderText("Mot de passe"),
+        "StrongPass123!",
+      );
+      fireEvent.press(screen.getByText("Créer mon compte"));
+
+      await waitFor(() => {
+        expect(mockSignup).toHaveBeenCalledWith({
+          email: "lea@brasse-bouillon.test",
+          password: "StrongPass123!",
+        });
+      });
+    });
+  });
+
+  describe("sad path — validation", () => {
+    it("rejects signup with missing email or password", async () => {
+      render(<LoginScreen />);
+      fireEvent.press(screen.getByText("Créer un compte"));
+      fireEvent.press(screen.getByText("Créer mon compte"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Email et mot de passe requis.")).toBeTruthy();
+      });
+
+      expect(mockSignup).not.toHaveBeenCalled();
+    });
+
+    it("rejects signup with password shorter than 8 chars", async () => {
+      render(<LoginScreen />);
+      fireEvent.press(screen.getByText("Créer un compte"));
+      fireEvent.changeText(
+        screen.getByPlaceholderText("Email"),
+        "lea@brasse-bouillon.test",
+      );
+      fireEvent.changeText(
+        screen.getByPlaceholderText("Mot de passe"),
+        "short",
+      );
+      fireEvent.press(screen.getByText("Créer mon compte"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            "Le mot de passe doit contenir au moins 8 caractères.",
+          ),
+        ).toBeTruthy();
+      });
+
+      expect(mockSignup).not.toHaveBeenCalled();
+    });
+
+    it("rejects login with invalid email format", async () => {
+      render(<LoginScreen />);
+      fireEvent.changeText(
+        screen.getByPlaceholderText("Email"),
+        "not-an-email",
+      );
+      fireEvent.changeText(
+        screen.getByPlaceholderText("Mot de passe"),
+        "StrongPass123!",
+      );
+      fireEvent.press(screen.getByText("Se connecter"));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Merci de renseigner un email valide."),
+        ).toBeTruthy();
+      });
+
+      expect(mockLogin).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("forgot password (link, not tab)", () => {
+    it("opens forgot mode via the link, hides login/signup tabs, shows back link", () => {
+      render(<LoginScreen />);
+      fireEvent.press(screen.getByText("Mot de passe oublié ?"));
+
+      expect(
+        screen.getByText("Reçois un lien de réinitialisation"),
+      ).toBeTruthy();
+      expect(screen.getByText("← Retour à la connexion")).toBeTruthy();
+      // No password field in forgot mode.
+      expect(screen.queryByPlaceholderText("Mot de passe")).toBeNull();
+    });
+
+    it("submits forgot password request", async () => {
+      mockRequestPasswordReset.mockResolvedValue(undefined);
+      render(<LoginScreen />);
+      fireEvent.press(screen.getByText("Mot de passe oublié ?"));
+      fireEvent.changeText(
+        screen.getByPlaceholderText("Email"),
+        "demo@bb.test",
+      );
+      fireEvent.press(screen.getByText("Envoyer le lien"));
+
+      await waitFor(() => {
+        expect(mockRequestPasswordReset).toHaveBeenCalledWith("demo@bb.test");
+        expect(
+          screen.getByText(
+            "Si un compte existe pour cet email, un lien de réinitialisation vient d’être envoyé.",
+          ),
+        ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("conditional demo button (Issue #764)", () => {
+    it("shows the demo button when EXPO_PUBLIC_USE_DEMO_DATA=true", () => {
+      dataSourceMock.useDemoData = true;
+      render(<LoginScreen />);
+      expect(screen.getByText("Connexion démo")).toBeTruthy();
+    });
+
+    it("hides the demo button when EXPO_PUBLIC_USE_DEMO_DATA=false (production / backend mode)", () => {
+      dataSourceMock.useDemoData = false;
+      render(<LoginScreen />);
+      expect(screen.queryByText("Connexion démo")).toBeNull();
+    });
+
+    it("triggers demo login when the button is tapped (demo mode)", async () => {
+      mockLoginWithDemoAccount.mockResolvedValue(undefined);
+      dataSourceMock.useDemoData = true;
+      render(<LoginScreen />);
+
+      fireEvent.press(screen.getByText("Connexion démo"));
+
+      await waitFor(() => {
+        expect(mockLoginWithDemoAccount).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/packages/website/docs/ROADMAP.md
+++ b/packages/website/docs/ROADMAP.md
@@ -49,6 +49,7 @@ This document outlines the major stages of the **Brasse-Bouillon** mobile app de
 * FAQ and featured recipe section
 * Integration of recent backend/frontend progress (tools suite completion, dashboard/discovery refresh, recipe-detail enhancements, and product API expansion)
 * Auth experience refresh — simplified email-and-password signup, bigger brand mascot, cleaner forgot-password flow, demo connection now scoped to demo builds only (Issue #764)
+* Sign in with Google — cosmetic preview on the auth screen indicating the upcoming social-login support (Issue #765 — full OAuth flow planned for v0.2)
 
 ### Phase 6 — Beta testing and community activation
 

--- a/packages/website/docs/ROADMAP.md
+++ b/packages/website/docs/ROADMAP.md
@@ -48,6 +48,7 @@ This document outlines the major stages of the **Brasse-Bouillon** mobile app de
 * Development log aligned with delivered product increments
 * FAQ and featured recipe section
 * Integration of recent backend/frontend progress (tools suite completion, dashboard/discovery refresh, recipe-detail enhancements, and product API expansion)
+* Auth experience refresh — simplified email-and-password signup, bigger brand mascot, cleaner forgot-password flow, demo connection now scoped to demo builds only (Issue #764)
 
 ### Phase 6 — Beta testing and community activation
 


### PR DESCRIPTION
## Summary

Sprint A auth-screen polish bundle — three coordinated changes shipping together because they share the LoginScreen surface and were locked under the same J-29 sprint scoping decision (Topic A).

- **Issue #764** — simplified signup form (email + password only, bigger mascot, conditional demo button, KISS auth screen)
- **Issue #765** — cosmetic "Continuer avec Google" button (preview, no real OAuth)
- Public roadmap updated on `packages/website/docs/ROADMAP.md` (Phase 5 in-progress) to announce both

## Why bundle

Both issues touch the same `LoginScreen.tsx` and were carried by the same scoping decision (Topic A: "Auth + Google OAuth cosmétique"). Reviewing as one PR keeps the visual snapshot coherent (a single screenshot tells the full story) and avoids merge thrash on the same file.

## Changes — Issue #764 (signup simplification)

### Backend (`packages/api`)
- `CreateUserDto.username` → optional (`@IsOptional()`)
- `UserService.create()` — auto-generates a unique username from the email local-part (`john.doe@example.com` → `john_doe_3a7f`) with a 5-attempt random-suffix loop; the post-collision fallback also re-queries for uniqueness (Codex P2 fix in `bc3206f`); throws a clean `BadRequestException` if the username space is saturated rather than letting the DB unique constraint surface as a generic 500
- 4 new tests on the auto-generation behavior + sad-path missing email / missing password

### Mobile (`packages/mobile-app`)
- `LoginScreen.tsx` rewritten:
  - BrandLogo 84 → 156
  - 2 tabs (Connexion / Créer un compte) instead of 3 ; forgot password as a text link
  - Signup form: email + password + helper text only (no username, first/last name, confirm-password)
  - Démo button rendered conditionally on `dataSource.useDemoData`
- `auth.api.ts`: `SignupInput.username` optional, payload omits optional fields when undefined
- 12 new component tests

## Changes — Issue #765 (Google button cosmetic)

### Mobile (`packages/mobile-app`)
- `LoginScreen.tsx`:
  - Adds a "Continuer avec Google" button above the email input (login + signup modes)
  - "ou" divider separating Google from email/password
  - Tap → `Alert.alert("Bientôt disponible", "...")` — no real OAuth call
  - Hidden in forgot-password mode
  - Accessibility label spells out "(bientôt disponible)" for screen readers
- 4 new component tests on visibility + tap behavior

## Changes — Website roadmap

`packages/website/docs/ROADMAP.md` Phase 5 in-progress section gets two bullets:
- Auth experience refresh (Issue #764)
- Sign in with Google cosmetic preview (Issue #765)

Done table will receive entries via `roadmap_sync.py` after merge.

## Acceptance criteria

### Issue #764
- [x] Signup form: only Email + Password inputs (+ submit)
- [x] No 'confirm password' field
- [x] No username/firstName/lastName fields in signup
- [x] Password policy displayed as a helper line under the input
- [x] Demo button hidden when `EXPO_PUBLIC_USE_DEMO_DATA !== 'true'`
- [x] Backend `/auth/register` accepts email+password only
- [x] Auto-generated username matches `/^[a-z][a-z0-9_]+_[0-9a-f]{4}$/` shape
- [x] Codex P2 (fallback uniqueness) fixed in `bc3206f`

### Issue #765
- [x] Google button visible on login + signup
- [x] Google button hidden in forgot-password mode
- [x] Tap shows `Bientôt disponible` alert (no real OAuth)
- [x] Cosmetic-only — no backend integration in v0.1

## Local CI

- API: `npm run lint` clean (only pre-existing scan.service warning), `npm run build` ok, `npx jest src/auth src/user` 50 passed / 2 skipped
- Mobile: `npm run ci:check` clean, `npx jest src/features/auth` 23 tests green (16 LoginScreen + 7 ProfileScreen)

## Out of scope (logged for v0.2)

- Real Google OAuth flow + backend Passport strategy + ID token verification (#765 vision block)
- Apple sign-in
- Email magic-link option
- Migration to make `users.username` nullable in DB

Closes #764
Closes #765
