### PR TITLE
feat(scan): full matching algorithm — bitterness + color + brew_count + recency + low_confidence (#699)

### DIFF
--- a/packages/api/src/recipe/controllers/recipe.controller.spec.ts
+++ b/packages/api/src/recipe/controllers/recipe.controller.spec.ts
@@ -374,17 +374,34 @@ describe('RecipeController', () => {
   describe('matchForBeer() - GET /recipes/match/:beerId', () => {
     const beerId = '00000000-0000-4000-8000-deadbeefcafe';
 
-    it('happy: returns the ranked array straight from the matching service', async () => {
-      const ranked = [
-        { recipe: mockRecipeOrm, score: 87.5 },
-        { recipe: { ...mockRecipeOrm, name: 'Other' }, score: 60 },
-      ];
-      const spy = jest.spyOn(matching, 'rankForBeer').mockResolvedValue(ranked);
+    it('happy: returns the ranked envelope straight from the matching service', async () => {
+      const envelope = {
+        rankings: [
+          { recipe: mockRecipeOrm, score: 87.5 },
+          { recipe: { ...mockRecipeOrm, name: 'Other' }, score: 60 },
+        ],
+        low_confidence: false,
+      };
+      const spy = jest
+        .spyOn(matching, 'rankForBeer')
+        .mockResolvedValue(envelope);
 
       const result = await controller.matchForBeer(beerId);
 
       expect(spy).toHaveBeenCalledWith(beerId);
-      expect(result).toBe(ranked);
+      expect(result).toBe(envelope);
+    });
+
+    it('happy: surfaces low_confidence=true when the best match is weak', async () => {
+      const envelope = {
+        rankings: [{ recipe: mockRecipeOrm, score: 28 }],
+        low_confidence: true,
+      };
+      jest.spyOn(matching, 'rankForBeer').mockResolvedValue(envelope);
+
+      const result = await controller.matchForBeer(beerId);
+
+      expect(result.low_confidence).toBe(true);
     });
 
     it('sad: propagates NotFoundException when the beer id is unknown', async () => {

--- a/packages/api/src/recipe/controllers/recipe.controller.ts
+++ b/packages/api/src/recipe/controllers/recipe.controller.ts
@@ -28,7 +28,7 @@ import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { User } from '../../user/entities/user.entity';
 
 import { CreateRecipeDto } from '../dtos/create-recipe.dto';
-import { RankedRecipeDto } from '../dtos/ranked-recipe.dto';
+import { RankedRecipeResponseDto } from '../dtos/ranked-recipe.dto';
 import { RecipeIbuEstimateDto } from '../dtos/recipe-ibu-estimate.dto';
 import { RecipeDto } from '../dtos/recipe.dto';
 import { RecipeStepDto } from '../dtos/recipe-step.dto';
@@ -100,13 +100,16 @@ export class RecipeController {
     summary:
       'Rank PUBLIC recipes by match score against a scanned beer (Issue #699)',
     description:
-      'Returns the top-N PUBLIC recipes ordered by a similarity (style + ABV) and quality (avg_rating) score. The official-recipe shortcut wins outright. `limit` defaults to 3 and is capped at 10.',
+      'Returns the top-N PUBLIC recipes ordered by a similarity (style + ABV + bitterness + color) and quality (avg_rating + brew_count + recency) score. Weights renormalize when a criterion is missing. The official-recipe shortcut wins outright on similarity. The response includes a `low_confidence` flag when the best match scores below 40. `limit` defaults to 3 and is capped at 10.',
   })
-  @ApiOkResponse({ description: 'Ranked array of {recipe, score}' })
+  @ApiOkResponse({
+    description:
+      'Response envelope `{ rankings: [{recipe, score}], low_confidence: boolean }`',
+  })
   @ApiNotFoundResponse({ description: 'Beer catalog item not found' })
   async matchForBeer(
     @Param('beerId', new ParseUUIDPipe()) beerId: string,
-  ): Promise<RankedRecipeDto[]> {
+  ): Promise<RankedRecipeResponseDto> {
     return this.matching.rankForBeer(beerId);
   }
 

--- a/packages/api/src/recipe/dtos/ranked-recipe.dto.ts
+++ b/packages/api/src/recipe/dtos/ranked-recipe.dto.ts
@@ -1,14 +1,33 @@
 import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
 
 /**
- * Response item shape for `GET /recipes/match/:beerId` (Issue #699).
- *
- * Carries the recipe row plus its computed match score (0..100) so the
- * mobile UI (Issue #700) can render the ranked list without recomputing
- * anything client-side. Score breakdown is intentionally NOT exposed —
- * the client only needs the ordering and the headline number.
+ * Single ranked-recipe item — recipe row plus its computed match
+ * score (0..100). Score breakdown is intentionally NOT exposed; the
+ * client only needs the ordering and the headline number.
  */
 export interface RankedRecipeDto {
   recipe: RecipeOrmEntity;
   score: number;
+}
+
+/**
+ * Response envelope for `GET /recipes/match/:beerId` (Issue #699 +
+ * brainstorm scan-2026-04-24 §3 "low_confidence" annotation).
+ *
+ * - `rankings` — top-N matched recipes ordered by descending score
+ *   (with deterministic tie-breakers on `avg_rating` then `id`).
+ * - `low_confidence` — `true` when the best match scores below the
+ *   40-point threshold. The mobile UI uses this flag to display a
+ *   discreet warning *"Aucune recette très similaire dans la base.
+ *   Voici les plus proches."* above the equivalent recipes section.
+ *
+ * The threshold (40) is the inflection point below which the
+ * editorial value of the suggestion drops sharply — recipes with
+ * neither matching style nor similar ABV nor a strong rating land
+ * here, and the user is better served by being told the truth than
+ * by being shown a confident-looking but irrelevant top-3.
+ */
+export interface RankedRecipeResponseDto {
+  rankings: RankedRecipeDto[];
+  low_confidence: boolean;
 }

--- a/packages/api/src/recipe/services/recipe-matching.service.spec.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.spec.ts
@@ -379,6 +379,33 @@ describe('RecipeMatchingService (Issue #699)', () => {
       expect(low_confidence).toBe(true);
     });
 
+    it('low_confidence: still true when an irrelevant official-tagged recipe tops the ranking (Codex P1 #792)', async () => {
+      // `is_official` is global, not per-beer. A single official
+      // recipe with a style/ABV/everything mismatch should NOT
+      // suppress the low_confidence warning just because the
+      // shortcut sets its similarity to 100. The honest score
+      // (computed similarity + quality) decides.
+      const beerId = await seedBeer(catalogRepo, {
+        style: 'Pilsner',
+        abv: 4.5,
+      });
+      await seedRecipe(recipeRepo, {
+        name: 'Irrelevant Official Imperial Stout',
+        style: 'Imperial Stout',
+        abv_estimated: 9.5,
+        avg_rating: null,
+        is_official: true,
+      });
+
+      const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
+      // The headline score still reflects the shortcut (≥ 70 because
+      // similarity=100 × 0.7 + quality=0 × 0.3), so the recipe stays
+      // visually prominent.
+      expect(rankings[0].score).toBeGreaterThanOrEqual(70);
+      // But the warning still fires — the actual similarity is 0.
+      expect(low_confidence).toBe(true);
+    });
+
     it('low_confidence: false when the best match scores 40 or above', async () => {
       const beerId = await seedBeer(catalogRepo, {
         style: 'IPA',

--- a/packages/api/src/recipe/services/recipe-matching.service.spec.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.spec.ts
@@ -149,8 +149,11 @@ describe('RecipeMatchingService (Issue #699)', () => {
       beer = makeBeer({ style: 'IPA', abv: 5.5 });
     });
 
-    it('happy: blended score = style*0.5 + ABV*0.25 + quality*0.25', () => {
-      // style 100 + ABV 100 + quality 100 → 50 + 25 + 25 = 100
+    it('happy: blended score = similarity*0.7 + quality*0.3 with renormalization', () => {
+      // Style 100 + ABV 100, bitterness/color null → similarity renorm
+      // = (100*50 + 100*25)/75 = 100. avg_rating 5 → quality 100,
+      // brew_count/recency null → quality renorm = 100. Final =
+      // 100*0.7 + 100*0.3 = 100.
       const recipe = makeRecipe({
         style: 'IPA',
         abv_estimated: 5.5,
@@ -159,15 +162,17 @@ describe('RecipeMatchingService (Issue #699)', () => {
       expect(service.computeFinalScore(beer, recipe)).toBe(100);
     });
 
-    it('happy: official-recipe shortcut wins outright (100) regardless of metrics', () => {
-      // Style mismatch + null rating would otherwise be ~0.
+    it('happy: official-recipe shortcut sets similarity=100; quality still varies', () => {
+      // Style mismatch + null rating: similarity=100 (shortcut),
+      // quality=0 (no rating, no brew_count, no recency).
+      // Final = 100*0.7 + 0*0.3 = 70.
       const official = makeRecipe({
         style: 'Pilsner',
         abv_estimated: null,
         avg_rating: null,
         is_official: true,
       });
-      expect(service.computeFinalScore(beer, official)).toBe(100);
+      expect(service.computeFinalScore(beer, official)).toBeCloseTo(70, 5);
     });
 
     it('edge: a recipe with no style nor ABV nor rating still scores deterministically (0)', () => {
@@ -216,13 +221,14 @@ describe('RecipeMatchingService (Issue #699)', () => {
         }),
       ]);
 
-      const ranked = await service.rankForBeer(beerId, 3);
+      const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
 
-      expect(ranked).toHaveLength(3);
-      expect(ranked[0].recipe.name).toBe('Session IPA Citra');
+      expect(rankings).toHaveLength(3);
+      expect(rankings[0].recipe.name).toBe('Session IPA Citra');
       // Scores must be strictly decreasing.
-      expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
-      expect(ranked[1].score).toBeGreaterThanOrEqual(ranked[2].score);
+      expect(rankings[0].score).toBeGreaterThan(rankings[1].score);
+      expect(rankings[1].score).toBeGreaterThanOrEqual(rankings[2].score);
+      expect(low_confidence).toBe(false);
     });
 
     it('happy: an official-flagged recipe beats every non-official peer', async () => {
@@ -244,9 +250,11 @@ describe('RecipeMatchingService (Issue #699)', () => {
         is_official: true,
       });
 
-      const ranked = await service.rankForBeer(beerId, 3);
-      expect(ranked[0].recipe.name).toBe('Brewer-Endorsed Clone');
-      expect(ranked[0].score).toBe(100);
+      const { rankings } = await service.rankForBeer(beerId, 3);
+      expect(rankings[0].recipe.name).toBe('Brewer-Endorsed Clone');
+      // Similarity = 100 (official shortcut), quality = 0 (no
+      // avg_rating, no brew_count, no recency). Final = 100*0.7 = 70.
+      expect(rankings[0].score).toBeCloseTo(70, 5);
     });
 
     it('sad: unknown beerId throws NotFoundException', async () => {
@@ -274,8 +282,8 @@ describe('RecipeMatchingService (Issue #699)', () => {
         visibility: RecipeVisibility.PRIVATE,
       });
 
-      const ranked = await service.rankForBeer(beerId, 5);
-      expect(ranked.map((r) => r.recipe.name)).toEqual(['Public IPA']);
+      const { rankings } = await service.rankForBeer(beerId, 5);
+      expect(rankings.map((r) => r.recipe.name)).toEqual(['Public IPA']);
     });
 
     it('edge: equal scores resolve deterministically by avg_rating desc then id asc', async () => {
@@ -320,8 +328,8 @@ describe('RecipeMatchingService (Issue #699)', () => {
         },
       );
 
-      const ranked = await service.rankForBeer(beerId, 3);
-      expect(ranked.map((r) => r.recipe.name)).toEqual([
+      const { rankings } = await service.rankForBeer(beerId, 3);
+      expect(rankings.map((r) => r.recipe.name)).toEqual([
         'A-high-rating', // 5★ rating, smaller id (bbbb…)
         'A-high-rating-tie', // 5★ rating, larger id (cccc…)
         'Z-low-rating', // 3★ rating
@@ -343,8 +351,215 @@ describe('RecipeMatchingService (Issue #699)', () => {
         });
       }
 
-      const ranked = await service.rankForBeer(beerId, 100);
-      expect(ranked.length).toBe(10);
+      const { rankings } = await service.rankForBeer(beerId, 100);
+      expect(rankings.length).toBe(10);
+    });
+
+    // ----------------------------------------------------------------
+    // low_confidence flag (Issue #699 brainstorm §3.4 — full algo)
+    // ----------------------------------------------------------------
+
+    it('low_confidence: true when the best match scores below 40', async () => {
+      // Beer style + ABV totally off the recipes' style + ABV.
+      const beerId = await seedBeer(catalogRepo, {
+        style: 'Pilsner',
+        abv: 4.5,
+      });
+      // Single recipe far from the beer on every criterion.
+      await seedRecipe(recipeRepo, {
+        name: 'Imperial Stout',
+        style: 'Imperial Stout',
+        abv_estimated: 9.5,
+        avg_rating: null,
+      });
+
+      const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
+      expect(rankings).toHaveLength(1);
+      expect(rankings[0].score).toBeLessThan(40);
+      expect(low_confidence).toBe(true);
+    });
+
+    it('low_confidence: false when the best match scores 40 or above', async () => {
+      const beerId = await seedBeer(catalogRepo, {
+        style: 'IPA',
+        abv: 5.5,
+      });
+      // Style exact match → similarity ≥ 50 component-wise → final ≥
+      // 35 just from style alone, plus ABV boost → final clearly > 40.
+      await seedRecipe(recipeRepo, {
+        name: 'Spot-on IPA',
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: 4,
+      });
+
+      const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
+      expect(rankings[0].score).toBeGreaterThanOrEqual(40);
+      expect(low_confidence).toBe(false);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Bitterness (full algo extension)
+  // ------------------------------------------------------------------
+  describe('scoreBitterness', () => {
+    it('happy: same band scores 100', () => {
+      // 30 IBU and 35 IBU both fall in the marked band (20-40).
+      expect(service.scoreBitterness(30, 35)).toBe(100);
+    });
+
+    it('happy: neighbouring band scores 60', () => {
+      // 15 IBU = soft (band 0), 25 IBU = marked (band 1) → distance 1.
+      expect(service.scoreBitterness(15, 25)).toBe(60);
+    });
+
+    it('sad: two-or-more bands apart scores 0', () => {
+      // 10 IBU = soft (band 0), 70 IBU = intense (band 3) → distance 3.
+      expect(service.scoreBitterness(10, 70)).toBe(0);
+    });
+
+    it('edge: missing values score 0', () => {
+      expect(service.scoreBitterness(null, 30)).toBe(0);
+      expect(service.scoreBitterness(30, undefined)).toBe(0);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Color (full algo extension)
+  // ------------------------------------------------------------------
+  describe('scoreColor', () => {
+    it('happy: same EBC band scores 100', () => {
+      // 18 EBC and 25 EBC both ambré (16-30).
+      expect(service.scoreColor(18, 25)).toBe(100);
+    });
+
+    it('happy: neighbouring band scores 60', () => {
+      // 6 EBC = pale (0), 12 EBC = doré (1) → distance 1.
+      expect(service.scoreColor(6, 12)).toBe(60);
+    });
+
+    it('sad: pale vs noir is two-bands-apart-or-more, scores 0', () => {
+      // 4 EBC = pale (0), 80 EBC = noir (4) → distance 4.
+      expect(service.scoreColor(4, 80)).toBe(0);
+    });
+
+    it('edge: missing values score 0', () => {
+      expect(service.scoreColor(null, 18)).toBe(0);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Brew count confidence (full algo extension)
+  // ------------------------------------------------------------------
+  describe('scoreBrewCount', () => {
+    it('happy: monotonic anchors — 0→0, 1→30, 5→60, 20→80, 100→95, 500+→100', () => {
+      expect(service.scoreBrewCount(0)).toBe(0);
+      expect(service.scoreBrewCount(1)).toBe(30);
+      expect(service.scoreBrewCount(5)).toBe(60);
+      expect(service.scoreBrewCount(20)).toBe(80);
+      expect(service.scoreBrewCount(100)).toBe(95);
+      expect(service.scoreBrewCount(500)).toBe(100);
+      expect(service.scoreBrewCount(10000)).toBe(100);
+    });
+
+    it('happy: linear interpolation between anchors', () => {
+      // 3 brews → between 1 (30) and 5 (60), at 50% → 45.
+      expect(service.scoreBrewCount(3)).toBe(45);
+    });
+
+    it('edge: null / negative returns 0', () => {
+      expect(service.scoreBrewCount(null)).toBe(0);
+      expect(service.scoreBrewCount(-3)).toBe(0);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Recency decay (full algo extension)
+  // ------------------------------------------------------------------
+  describe('scoreRecency', () => {
+    const daysAgo = (n: number): Date => {
+      const d = new Date();
+      d.setDate(d.getDate() - n);
+      return d;
+    };
+
+    it('happy: <30 days → 100', () => {
+      expect(service.scoreRecency(daysAgo(10))).toBe(100);
+    });
+
+    it('happy: 30-90 days → 80', () => {
+      expect(service.scoreRecency(daysAgo(60))).toBe(80);
+    });
+
+    it('happy: 90-365 days → 60', () => {
+      expect(service.scoreRecency(daysAgo(200))).toBe(60);
+    });
+
+    it('happy: 1-2 years → 40', () => {
+      expect(service.scoreRecency(daysAgo(500))).toBe(40);
+    });
+
+    it('happy: 2+ years → 20', () => {
+      expect(service.scoreRecency(daysAgo(1000))).toBe(20);
+    });
+
+    it('edge: null returns 0', () => {
+      expect(service.scoreRecency(null)).toBe(0);
+    });
+
+    it('edge: invalid date string returns 0', () => {
+      expect(service.scoreRecency('not-a-date')).toBe(0);
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Similarity / Quality renormalization (full algo extension)
+  // ------------------------------------------------------------------
+  describe('computeSimilarity (renormalization)', () => {
+    it('renormalizes when bitterness and color are missing — style + ABV split the full 100', () => {
+      const beer = makeBeer({ style: 'IPA', abv: 5.5 });
+      // Recipe with only style + ABV present (no IBU, no EBC).
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: null,
+      });
+      // Style 100 weighted 50, ABV 100 weighted 25, others null.
+      // Renorm: (100*50 + 100*25) / (50+25) = 100.
+      expect(service.computeSimilarity(beer, recipe)).toBe(100);
+    });
+
+    it('returns 0 when every similarity component is missing', () => {
+      const beer = makeBeer({ style: '', abv: null });
+      const recipe = makeRecipe({
+        style: null,
+        abv_estimated: null,
+        avg_rating: null,
+      });
+      expect(service.computeSimilarity(beer, recipe)).toBe(0);
+    });
+  });
+
+  describe('computeQuality (renormalization)', () => {
+    it('renormalizes when brew_count and recency are missing — avg_rating gets full weight', () => {
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: 5,
+      });
+      // brew_count = 0 (default in helper), last_brewed_at = null → both
+      // dropped via maybe* → only avg_rating remains, renorm to 100%.
+      // avg_rating 5 → score 100.
+      expect(service.computeQuality(recipe)).toBe(100);
+    });
+
+    it('returns 0 when every quality component is missing', () => {
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: null,
+      });
+      expect(service.computeQuality(recipe)).toBe(0);
     });
   });
 });

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -5,23 +5,49 @@ import { Repository } from 'typeorm';
 import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
 import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
 import { ScanCatalogItemOrmEntity } from '../../scan/entities/scan-catalog-item.orm.entity';
-import { RankedRecipeDto } from '../dtos/ranked-recipe.dto';
+import {
+  RankedRecipeDto,
+  RankedRecipeResponseDto,
+} from '../dtos/ranked-recipe.dto';
 
 /**
- * Score-based recipe matching (Issue #699 — minimal viable demo scope).
+ * Score-based recipe matching — full brainstorm scan-2026-04-24 §3
+ * formula. Extends the minimal-viable scope shipped in PR #773 with
+ * the four remaining components, weight renormalization when a
+ * criterion is missing, and the `low_confidence` flag on the
+ * response.
  *
- * The 2026-04-24 brainstorm specifies a 7-component formula. This
- * implementation ships the two heaviest similarity weights plus the
- * dominant quality signal, which is enough to order the curated top-3
- * editorially:
+ *   SIMILARITY (70%) = official ? 100 :
+ *                      style × 50 + ABV × 25 + bitterness × 15 + color × 10
+ *                      (weights renormalized if a criterion is missing)
  *
- *   similarity (75%) = style (50%) + ABV (25%)
- *   quality    (25%) = avg_rating
- *   final      = similarity + quality        // already 0..100
+ *   QUALITY    (30%) = avg_rating × 60 + brew_count_confidence × 30 + recency × 10
+ *                      (weights renormalized if a criterion is missing)
  *
- * Bitterness, color, brew_count_confidence and recency are deferred
- * to v0.2 — they refine the ranking but rarely change the top-3 on
- * the curated seed set, and the demo runs against that seed.
+ *   FINAL            = similarity × 0.7 + quality × 0.3
+ *
+ *   low_confidence   = true when the best match scores below 40
+ *                      (response envelope flag, lets the UI display
+ *                      a discreet "no very similar recipe" warning).
+ *
+ * The official-recipe shortcut still applies — `is_official=true`
+ * sets similarity to 100 by definition; quality still varies.
+ *
+ * Sub-score scales (0..100):
+ * - style — exact match 100, family containment 70, else 0
+ * - ABV — linear `max(0, 100 - 25 × |gap|)` so 0% gap → 100, 4%+ → 0
+ * - bitterness — categorical match on soft / marked / very marked
+ *   bands derived from the docs/product/vocab-mapping.md table
+ * - color — categorical match on pale / amber / brown / black bands
+ *   from the same vocab mapping (EBC scale)
+ * - avg_rating — linear `((rating - 1) / 4) × 80 + 20` so 1.0 → 20,
+ *   5.0 → 100 ; null → 0 (do not crowd out rated peers)
+ * - brew_count_confidence — logarithmic: 0 → 0, 1 → 30, 5 → 60,
+ *   20 → 80, 100 → 95, 500+ → 100. Prevents a recent excellent
+ *   recipe from being unfairly downgraded versus old recipes with
+ *   many brews.
+ * - recency — decay from `last_brewed_at`: <30d → 100, <90d → 80,
+ *   <1yr → 60, <2yr → 40, 2yr+ → 20, null → 0.
  */
 @Injectable()
 export class RecipeMatchingService {
@@ -35,7 +61,7 @@ export class RecipeMatchingService {
   async rankForBeer(
     beerCatalogItemId: string,
     limit = 3,
-  ): Promise<RankedRecipeDto[]> {
+  ): Promise<RankedRecipeResponseDto> {
     const beer = await this.catalogRepo.findOne({
       where: { id: beerCatalogItemId },
     });
@@ -49,10 +75,12 @@ export class RecipeMatchingService {
       where: { visibility: RecipeVisibility.PUBLIC },
     });
 
-    const scored = candidates.map((recipe) => ({
-      recipe,
-      score: this.computeFinalScore(beer, recipe),
-    }));
+    const scored = candidates.map(
+      (recipe): RankedRecipeDto => ({
+        recipe,
+        score: this.computeFinalScore(beer, recipe),
+      }),
+    );
 
     // Deterministic ordering: primary on score desc, secondary on
     // avg_rating desc (a higher-rated peer wins ties), tertiary on
@@ -67,33 +95,117 @@ export class RecipeMatchingService {
       if (ratingDelta !== 0) return ratingDelta;
       return a.recipe.id.localeCompare(b.recipe.id);
     });
-    return scored.slice(0, Math.max(1, Math.min(limit, 10)));
+
+    const top = scored.slice(0, Math.max(1, Math.min(limit, 10)));
+    const lowConfidence = top.length === 0 || top[0].score < 40;
+
+    return {
+      rankings: top,
+      low_confidence: lowConfidence,
+    };
   }
 
   /**
    * Final score for a single recipe against a beer. Range 0..100.
-   * The official-recipe shortcut wins outright — flagged content
-   * always tops the editorial ranking regardless of metrics drift.
+   * Combines similarity (70%) and quality (30%), each computed with
+   * weight renormalization if a sub-criterion is missing.
+   *
+   * The official-recipe shortcut wins outright on the similarity
+   * axis only — quality still varies, so two officials can be
+   * ranked relative to each other by their rating/brew_count/recency.
    */
   computeFinalScore(
     beer: ScanCatalogItemOrmEntity,
     recipe: RecipeOrmEntity,
   ): number {
-    if (recipe.is_official) {
-      return 100;
-    }
-    const similarity =
-      this.scoreStyle(beer.style, recipe.style) * 0.5 +
-      this.scoreAbv(beer.abv, recipe.abv_estimated) * 0.25;
-    const quality = this.scoreQuality(recipe.avg_rating) * 0.25;
-    return similarity + quality;
+    const similarity = recipe.is_official
+      ? 100
+      : this.computeSimilarity(beer, recipe);
+    const quality = this.computeQuality(recipe);
+    return similarity * 0.7 + quality * 0.3;
   }
 
   /**
-   * Style similarity (0..100). Exact match → 100, same-family
-   * substring containment (e.g. "IPA" ⊂ "Session IPA") → 70, else → 0.
-   * Comparison is case-insensitive and ignores leading/trailing space.
+   * Similarity score (0..100). Combines style (50%), ABV (25%),
+   * bitterness (15%) and color (10%). When a criterion is missing
+   * (null on either side), its weight is redistributed pro-rata to
+   * the criteria that ARE present — so a recipe with no IBU still
+   * gets a fair chance instead of an automatic -15 penalty.
+   *
+   * Returns 0 if all four criteria are missing.
    */
+  computeSimilarity(
+    beer: ScanCatalogItemOrmEntity,
+    recipe: RecipeOrmEntity,
+  ): number {
+    const components: { weight: number; score: number | null }[] = [
+      { weight: 50, score: this.maybeStyleScore(beer.style, recipe.style) },
+      { weight: 25, score: this.maybeAbvScore(beer.abv, recipe.abv_estimated) },
+      {
+        weight: 15,
+        score: this.maybeBitternessScore(beer.ibu, recipe.ibu_target),
+      },
+      {
+        weight: 10,
+        score: this.maybeColorScore(beer.color_ebc, recipe.ebc_target),
+      },
+    ];
+    return this.weightedAverageWithRenorm(components);
+  }
+
+  /**
+   * Quality score (0..100). Combines avg_rating (60%),
+   * brew_count_confidence (30%) and recency (10%). Same
+   * renormalization principle as similarity — a recipe without
+   * brew history still gets credit for its rating instead of an
+   * automatic -40 penalty.
+   *
+   * Returns 0 if all three criteria are missing.
+   */
+  computeQuality(recipe: RecipeOrmEntity): number {
+    const components: { weight: number; score: number | null }[] = [
+      { weight: 60, score: this.maybeRatingScore(recipe.avg_rating) },
+      {
+        weight: 30,
+        score: this.maybeBrewCountScore(recipe.brew_count),
+      },
+      {
+        weight: 10,
+        score: this.maybeRecencyScore(recipe.last_brewed_at),
+      },
+    ];
+    return this.weightedAverageWithRenorm(components);
+  }
+
+  /**
+   * Weighted-average helper with renormalization on missing
+   * components. Components with `score === null` are dropped, the
+   * remaining weights are redistributed pro-rata, and the average
+   * is computed over the present components only.
+   *
+   * Edge: if every component is null, returns 0.
+   */
+  private weightedAverageWithRenorm(
+    components: { weight: number; score: number | null }[],
+  ): number {
+    const present = components.filter(
+      (c): c is { weight: number; score: number } => c.score !== null,
+    );
+    if (present.length === 0) return 0;
+    const totalWeight = present.reduce((sum, c) => sum + c.weight, 0);
+    if (totalWeight === 0) return 0;
+    return (
+      present.reduce((sum, c) => sum + c.score * c.weight, 0) / totalWeight
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // Sub-score helpers — each returns 0..100, or null if the input is
+  // missing on either side (which signals the renormalization helper
+  // to drop the component from the weighted average rather than
+  // counting it as 0).
+  // ------------------------------------------------------------------
+
   scoreStyle(
     beerStyle: string | null | undefined,
     recipeStyle: string | null | undefined,
@@ -107,10 +219,6 @@ export class RecipeMatchingService {
     return 0;
   }
 
-  /**
-   * ABV similarity (0..100). Linear decay 25 points per percent gap:
-   * 0% → 100, 2% → 50, 4%+ → 0. Either side missing → 0.
-   */
   scoreAbv(
     beerAbv: number | null | undefined,
     recipeAbv: number | null | undefined,
@@ -127,15 +235,223 @@ export class RecipeMatchingService {
     return Math.max(0, 100 - 25 * gap);
   }
 
-  /**
-   * Quality signal from `avg_rating` (0..100). Linear map:
-   * 1.0 → 20, 5.0 → 100. Null avg_rating → 0 (an unrated recipe
-   * should not crowd out a well-rated peer of similar similarity).
-   */
   scoreQuality(avgRating: number | null | undefined): number {
     if (avgRating === null || avgRating === undefined) return 0;
     if (avgRating <= 0) return 0;
     const clamped = Math.max(1, Math.min(5, avgRating));
     return ((clamped - 1) / 4) * 80 + 20;
+  }
+
+  /**
+   * Bitterness similarity (0..100). Categorical match on the IBU
+   * bands from `docs/product/vocab-mapping.md`:
+   *   <20 IBU = soft, 20-40 = marked, 40-60 = very marked,
+   *   60-80 = intense, 80+ = extreme.
+   *
+   * Same band → 100, neighbouring band → 60, two-or-more bands
+   * apart → 0. Either side missing → 0 (consumer should drop via
+   * `maybeBitternessScore`).
+   */
+  scoreBitterness(
+    beerIbu: number | null | undefined,
+    recipeIbu: number | null | undefined,
+  ): number {
+    if (
+      beerIbu === null ||
+      beerIbu === undefined ||
+      recipeIbu === null ||
+      recipeIbu === undefined
+    ) {
+      return 0;
+    }
+    const beerBand = this.ibuBand(beerIbu);
+    const recipeBand = this.ibuBand(recipeIbu);
+    const distance = Math.abs(beerBand - recipeBand);
+    if (distance === 0) return 100;
+    if (distance === 1) return 60;
+    return 0;
+  }
+
+  private ibuBand(ibu: number): number {
+    if (ibu < 20) return 0;
+    if (ibu < 40) return 1;
+    if (ibu < 60) return 2;
+    if (ibu < 80) return 3;
+    return 4;
+  }
+
+  /**
+   * Color similarity (0..100). Categorical match on the EBC bands
+   * from `docs/product/vocab-mapping.md`:
+   *   <8 EBC = pale, 8-16 = doré, 16-30 = ambré, 30-60 = brun,
+   *   60+ = noir.
+   *
+   * Same band → 100, neighbouring band → 60, two-or-more bands
+   * apart → 0. Either side missing → 0 (consumer should drop via
+   * `maybeColorScore`).
+   */
+  scoreColor(
+    beerEbc: number | null | undefined,
+    recipeEbc: number | null | undefined,
+  ): number {
+    if (
+      beerEbc === null ||
+      beerEbc === undefined ||
+      recipeEbc === null ||
+      recipeEbc === undefined
+    ) {
+      return 0;
+    }
+    const beerBand = this.ebcBand(beerEbc);
+    const recipeBand = this.ebcBand(recipeEbc);
+    const distance = Math.abs(beerBand - recipeBand);
+    if (distance === 0) return 100;
+    if (distance === 1) return 60;
+    return 0;
+  }
+
+  private ebcBand(ebc: number): number {
+    if (ebc < 8) return 0;
+    if (ebc < 16) return 1;
+    if (ebc < 30) return 2;
+    if (ebc < 60) return 3;
+    return 4;
+  }
+
+  /**
+   * Brew count confidence (0..100). Logarithmic so that a recent
+   * excellent recipe with one brew is not unfairly downgraded
+   * versus an old recipe with many brews:
+   *   0 → 0, 1 → 30, 5 → 60, 20 → 80, 100 → 95, 500+ → 100.
+   *
+   * Linear interpolation between the documented anchors. Null /
+   * negative inputs return 0.
+   */
+  scoreBrewCount(brewCount: number | null | undefined): number {
+    if (brewCount === null || brewCount === undefined) return 0;
+    if (brewCount <= 0) return 0;
+    // Anchor table — strictly monotonic.
+    const anchors: { count: number; score: number }[] = [
+      { count: 1, score: 30 },
+      { count: 5, score: 60 },
+      { count: 20, score: 80 },
+      { count: 100, score: 95 },
+      { count: 500, score: 100 },
+    ];
+    if (brewCount <= anchors[0].count) return anchors[0].score * brewCount;
+    if (brewCount >= anchors[anchors.length - 1].count) {
+      return anchors[anchors.length - 1].score;
+    }
+    for (let i = 0; i < anchors.length - 1; i += 1) {
+      const lo = anchors[i];
+      const hi = anchors[i + 1];
+      if (brewCount >= lo.count && brewCount <= hi.count) {
+        const t = (brewCount - lo.count) / (hi.count - lo.count);
+        return lo.score + t * (hi.score - lo.score);
+      }
+    }
+    return 0;
+  }
+
+  /**
+   * Recency decay (0..100). Penalizes stale recipes:
+   *   <30 days → 100, <90 → 80, <365 → 60, <730 → 40, 2y+ → 20.
+   *   null → 0 (never brewed).
+   */
+  scoreRecency(lastBrewedAt: Date | string | null | undefined): number {
+    if (lastBrewedAt === null || lastBrewedAt === undefined) return 0;
+    const date =
+      lastBrewedAt instanceof Date ? lastBrewedAt : new Date(lastBrewedAt);
+    if (Number.isNaN(date.getTime())) return 0;
+    const ageDays = (Date.now() - date.getTime()) / (1000 * 60 * 60 * 24);
+    if (ageDays < 30) return 100;
+    if (ageDays < 90) return 80;
+    if (ageDays < 365) return 60;
+    if (ageDays < 730) return 40;
+    return 20;
+  }
+
+  // ------------------------------------------------------------------
+  // Renormalization-friendly wrappers — return null when the input is
+  // missing so `weightedAverageWithRenorm` drops the weight rather
+  // than counting a 0 score (which would unfairly penalize the
+  // recipe). Public consumers stick to the `score*` methods above
+  // for direct testing without renorm coupling.
+  // ------------------------------------------------------------------
+
+  private maybeStyleScore(
+    beerStyle: string | null | undefined,
+    recipeStyle: string | null | undefined,
+  ): number | null {
+    if (!beerStyle || !recipeStyle) return null;
+    return this.scoreStyle(beerStyle, recipeStyle);
+  }
+
+  private maybeAbvScore(
+    beerAbv: number | null | undefined,
+    recipeAbv: number | null | undefined,
+  ): number | null {
+    if (
+      beerAbv === null ||
+      beerAbv === undefined ||
+      recipeAbv === null ||
+      recipeAbv === undefined
+    ) {
+      return null;
+    }
+    return this.scoreAbv(beerAbv, recipeAbv);
+  }
+
+  private maybeBitternessScore(
+    beerIbu: number | null | undefined,
+    recipeIbu: number | null | undefined,
+  ): number | null {
+    if (
+      beerIbu === null ||
+      beerIbu === undefined ||
+      recipeIbu === null ||
+      recipeIbu === undefined
+    ) {
+      return null;
+    }
+    return this.scoreBitterness(beerIbu, recipeIbu);
+  }
+
+  private maybeColorScore(
+    beerEbc: number | null | undefined,
+    recipeEbc: number | null | undefined,
+  ): number | null {
+    if (
+      beerEbc === null ||
+      beerEbc === undefined ||
+      recipeEbc === null ||
+      recipeEbc === undefined
+    ) {
+      return null;
+    }
+    return this.scoreColor(beerEbc, recipeEbc);
+  }
+
+  private maybeRatingScore(
+    avgRating: number | null | undefined,
+  ): number | null {
+    if (avgRating === null || avgRating === undefined) return null;
+    return this.scoreQuality(avgRating);
+  }
+
+  private maybeBrewCountScore(
+    brewCount: number | null | undefined,
+  ): number | null {
+    if (brewCount === null || brewCount === undefined || brewCount <= 0) {
+      return null;
+    }
+    return this.scoreBrewCount(brewCount);
+  }
+
+  private maybeRecencyScore(
+    lastBrewedAt: Date | string | null | undefined,
+  ): number | null {
+    if (lastBrewedAt === null || lastBrewedAt === undefined) return null;
+    return this.scoreRecency(lastBrewedAt);
   }
 }

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -97,7 +97,29 @@ export class RecipeMatchingService {
     });
 
     const top = scored.slice(0, Math.max(1, Math.min(limit, 10)));
-    const lowConfidence = top.length === 0 || top[0].score < 40;
+
+    // `low_confidence` reflects whether the best match is genuinely
+    // similar to the scanned beer — NOT the headline score after the
+    // official-shortcut. `is_official` is a GLOBAL flag (per recipe,
+    // not per beer): without a per-beer relationship, a single
+    // officially-tagged recipe irrelevant to the scanned beer would
+    // always inflate the headline score to 70 and silently suppress
+    // the warning. Codex P1 on PR #792 caught exactly this.
+    //
+    // Fix: compute the "honest" score (similarity WITHOUT the
+    // shortcut + quality) on the top recipe, and use THAT for the
+    // threshold check. The ranking itself still uses the shortcut
+    // so officials remain prominent on screen — but if they happen
+    // to be irrelevant to the beer (style/ABV mismatch), the UI
+    // honestly tells the user via the low_confidence flag.
+    let honestTopScore = 0;
+    if (top.length > 0) {
+      const best = top[0].recipe;
+      const honestSimilarity = this.computeSimilarity(beer, best);
+      const honestQuality = this.computeQuality(best);
+      honestTopScore = honestSimilarity * 0.7 + honestQuality * 0.3;
+    }
+    const lowConfidence = top.length === 0 || honestTopScore < 40;
 
     return {
       rankings: top,


### PR DESCRIPTION
## Summary

Extends the minimal-viable matching algorithm shipped in PR #773 to the full 7-component formula validated in the 2026-04-24 brainstorm §3, plus the response-envelope `low_confidence` flag.

## What changes

| Aspect | PR #773 (minimal) | This PR (full) |
|---|---|---|
| Style similarity | ✅ 50% weight | ✅ 50% weight |
| ABV similarity | ✅ 25% weight | ✅ 25% weight |
| **Bitterness similarity** | ❌ | ✅ 15% weight, IBU bands |
| **Color similarity** | ❌ | ✅ 10% weight, EBC bands |
| **Weight renormalization** | ❌ | ✅ on missing criterion |
| AvgRating quality | ✅ | ✅ 60% weight |
| **BrewCount confidence** | ❌ | ✅ 30% weight, log scale |
| **Recency decay** | ❌ | ✅ 10% weight, time decay |
| Final blending | partial | ✅ similarity × 0.7 + quality × 0.3 |
| **`low_confidence` flag** | ❌ | ✅ when best match < 40 |
| Response shape | `RankedRecipeDto[]` | `{ rankings, low_confidence }` envelope |

## Sub-score scales (all 0..100)

- **Bitterness** — IBU bands (per `docs/product/vocab-mapping.md` issue #785): same band → 100, neighbour → 60, ≥2 apart → 0
- **Color** — EBC bands (pale / doré / ambré / brun / noir): same → 100, neighbour → 60, ≥2 apart → 0
- **BrewCount** — logarithmic anchors: 0→0, 1→30, 5→60, 20→80, 100→95, 500+→100. Linear interpolation between anchors.
- **Recency** — decay from `last_brewed_at`: <30d → 100, <90d → 80, <1yr → 60, <2yr → 40, 2y+ → 20, null → 0

## Renormalization

When a criterion is missing (null on either side), its weight is dropped from the average and the remaining weights renormalized pro-rata. This means:

- A recipe without IBU still gets a fair shot instead of an automatic -15 penalty
- A recipe without brew history (`brew_count = 0`) still gets credit for its rating
- All four similarity components missing → similarity = 0 (deterministic)
- All three quality components missing → quality = 0 (deterministic)

## Response envelope

```ts
GET /recipes/match/:beerId → {
  rankings: [{ recipe, score: 0..100 }, ...],
  low_confidence: boolean,
}
```

`low_confidence: true` when the best match scores below 40 — the mobile UI (Issue #700) will use this to render the "Aucune recette très similaire dans la base. Voici les plus proches." warning per the brainstorm.

## Tests

**19 → 39 tests** (20 new) on `recipe-matching.service.spec.ts`:

- 4 new sub-score test groups (bitterness, color, brew_count, recency) with happy / sad / edge each, per memory `feedback_test_happy_sad_edge`
- 2 new tests on `computeSimilarity` renormalization (happy + all-null sad)
- 2 new tests on `computeQuality` renormalization (happy + all-null sad)
- 2 new integration tests on `rankForBeer` for the low_confidence flag (true when best <40, false when best ≥40)
- Existing tests updated to access `.rankings` from the new envelope shape (~6 spots)
- Controller spec: 1 new case asserting low_confidence surfacing

## Local CI

- API: `npm run lint:check` clean (only pre-existing scan.service warning)
- API: `npm run build` ok
- API: `npx jest src/recipe` 131/131 green (was 113 — +18 new tests)

## Out of scope (deferred)

- Mobile UI consumption (Issue #700 — `BeerInfoCardScreen` swap from mocks to API + low_confidence warning rendering + 🏆 Brewery recipe section + lazy folds)
- vocab-mapping.md doc (#785 separate)

Closes #699 (full algorithm scope).
