### PR TITLE
feat(scan): mobile matching view — official section + equivalents + low_confidence (Issue #700)

### DIFF
--- a/packages/mobile-app/src/core/theme/colors.ts
+++ b/packages/mobile-app/src/core/theme/colors.ts
@@ -23,5 +23,6 @@ export const colors = {
     errorBackground: "#fff0f0",
     successBackground: "#f4f8e8",
     infoBackground: "#f8f8f8",
+    warningBackground: "#fdf3df",
   },
 } as const;

--- a/packages/mobile-app/src/features/scan/application/__tests__/recipe-matching.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/recipe-matching.use-cases.test.ts
@@ -1,0 +1,120 @@
+import { getMatchingRecipes } from "@/features/scan/application/recipe-matching.use-cases";
+
+const dataSourceMock = { useDemoData: true };
+jest.mock("@/core/data/data-source", () => ({
+  get dataSource() {
+    return dataSourceMock;
+  },
+}));
+
+jest.mock("@/features/scan/data/recipe-matching.api", () => ({
+  fetchMatchingRecipes: jest.fn(),
+}));
+jest.mock("@/mocks/demo-data", () => ({
+  getDemoEquivalentRecipes: jest.fn(),
+}));
+
+import { fetchMatchingRecipes } from "@/features/scan/data/recipe-matching.api";
+import { getDemoEquivalentRecipes } from "@/mocks/demo-data";
+
+const mockApiFetch = fetchMatchingRecipes as jest.MockedFunction<
+  typeof fetchMatchingRecipes
+>;
+const mockDemoEquivalents = getDemoEquivalentRecipes as jest.MockedFunction<
+  typeof getDemoEquivalentRecipes
+>;
+
+describe("getMatchingRecipes (Issue #700)", () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+    mockDemoEquivalents.mockReset();
+    dataSourceMock.useDemoData = true;
+  });
+
+  describe("demo mode", () => {
+    it("happy: returns the demo equivalent recipes wrapped in the envelope", async () => {
+      const demoRecipes = [
+        {
+          recipeId: "r-demo-1",
+          publicRecipeId: "uuid-1",
+          name: "Session IPA Citra",
+          brewer: "Communauté Brasse-Bouillon",
+          rating: 4.7,
+          brewedCount: 23,
+          score: 92,
+        },
+      ];
+      mockDemoEquivalents.mockReturnValue(demoRecipes);
+
+      const result = await getMatchingRecipes({
+        id: "uuid-beer",
+        barcode: "5060277380019",
+      });
+
+      expect(mockDemoEquivalents).toHaveBeenCalledWith("5060277380019");
+      expect(mockApiFetch).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        rankings: demoRecipes,
+        lowConfidence: false,
+      });
+    });
+
+    it("sad: when the demo set has no match for the barcode, returns empty rankings + low_confidence=true", async () => {
+      mockDemoEquivalents.mockReturnValue([]);
+
+      const result = await getMatchingRecipes({
+        id: "uuid-beer",
+        barcode: "9999999999999",
+      });
+
+      expect(result).toEqual({ rankings: [], lowConfidence: true });
+    });
+  });
+
+  describe("backend mode", () => {
+    beforeEach(() => {
+      dataSourceMock.useDemoData = false;
+    });
+
+    it("happy: forwards the call to the API with the catalog item id and passes through the envelope", async () => {
+      const apiResponse = {
+        rankings: [
+          {
+            recipeId: "uuid-recipe",
+            publicRecipeId: "uuid-recipe",
+            name: "Hop Forward IPA",
+            brewer: "Communauté Brasse-Bouillon",
+            rating: 4.5,
+            brewedCount: 10,
+            score: 88,
+          },
+        ],
+        lowConfidence: false,
+      };
+      mockApiFetch.mockResolvedValue(apiResponse);
+
+      const result = await getMatchingRecipes({
+        id: "uuid-beer",
+        barcode: "5060277380019",
+      });
+
+      expect(mockApiFetch).toHaveBeenCalledWith("uuid-beer");
+      expect(mockDemoEquivalents).not.toHaveBeenCalled();
+      expect(result).toBe(apiResponse);
+    });
+
+    it("sad: low_confidence=true from the API surfaces unchanged in the envelope", async () => {
+      mockApiFetch.mockResolvedValue({
+        rankings: [],
+        lowConfidence: true,
+      });
+
+      const result = await getMatchingRecipes({
+        id: "uuid-beer",
+        barcode: "5060277380019",
+      });
+
+      expect(result.lowConfidence).toBe(true);
+    });
+  });
+});

--- a/packages/mobile-app/src/features/scan/application/recipe-matching.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/recipe-matching.use-cases.ts
@@ -1,0 +1,50 @@
+/**
+ * Use-case for the recipe-matching feature on the scan info card
+ * (Issue #700 — mobile UI consumer of Issue #699's API).
+ *
+ * Branches on `dataSource.useDemoData`:
+ *
+ * - **demo mode** (`EXPO_PUBLIC_USE_DEMO_DATA=true`) — reads from
+ *   the curated `demoEquivalentRecipes` mock keyed by barcode.
+ *   Returns `lowConfidence: false` because the demo set is
+ *   editorially curated to always have at least one strong match.
+ *
+ * - **backend mode** — calls `GET /recipes/match/:beerId` via the
+ *   `recipe-matching.api` data layer. Pass-through on the envelope
+ *   shape: API `low_confidence` (snake_case) → UI `lowConfidence`.
+ *
+ * Both branches return the same `ScanMatchingResult` envelope so
+ * the presentation layer doesn't have to know which mode it's in.
+ */
+import { dataSource } from "@/core/data/data-source";
+
+import { fetchMatchingRecipes } from "@/features/scan/data/recipe-matching.api";
+import type {
+  ScanCatalogItem,
+  ScanMatchingResult,
+} from "@/features/scan/domain/scan.types";
+import { getDemoEquivalentRecipes } from "@/mocks/demo-data";
+
+/**
+ * Resolve the top-N matching recipes for a given recognised beer.
+ *
+ * Accepts the full `ScanCatalogItem` so the use-case has both the
+ * `barcode` (demo lookup key) and the `id` (backend lookup key)
+ * without forcing the caller to pick the right one upstream.
+ */
+export async function getMatchingRecipes(
+  beer: Pick<ScanCatalogItem, "id" | "barcode">,
+): Promise<ScanMatchingResult> {
+  if (dataSource.useDemoData) {
+    const rankings = getDemoEquivalentRecipes(beer.barcode);
+    return {
+      rankings,
+      // The demo set is curated — when we have at least one match,
+      // it's by construction relevant. When the barcode isn't in
+      // the demo map (rankings empty) the warning IS appropriate.
+      lowConfidence: rankings.length === 0,
+    };
+  }
+
+  return fetchMatchingRecipes(beer.id);
+}

--- a/packages/mobile-app/src/features/scan/data/recipe-matching.api.ts
+++ b/packages/mobile-app/src/features/scan/data/recipe-matching.api.ts
@@ -1,0 +1,83 @@
+/**
+ * Data layer for the backend `GET /recipes/match/:beerId` endpoint
+ * (Issue #699 — full matching algorithm with low_confidence flag).
+ *
+ * Mirrors the api response shape `RankedRecipeResponseDto` and
+ * normalizes the snake_case wire fields to camelCase. Use-case
+ * orchestration (demo data branching, error handling) lives in
+ * `application/recipe-matching.use-cases.ts`.
+ */
+import { request } from "@/core/http/http-client";
+
+import type { ScanMatchingResult, ScanRecipeMatch } from "../domain/scan.types";
+
+/**
+ * Wire shape — single ranked recipe carried inside the envelope.
+ * The backend embeds the full ORM row, but the mobile UI only
+ * needs a curated subset.
+ */
+type RankedRecipeWireDto = {
+  recipe: {
+    id: string;
+    name: string;
+    style?: string | null;
+    avg_rating?: number | null;
+    brew_count: number;
+    is_official: boolean;
+    owner_id: string;
+    // Other fields are present in the wire response but not
+    // consumed by the matching UI; intentionally omitted to keep
+    // the contract narrow.
+  };
+  score: number;
+};
+
+type MatchingResponseWireDto = {
+  rankings: RankedRecipeWireDto[];
+  low_confidence: boolean;
+};
+
+/**
+ * Map a single wire row to the mobile `ScanRecipeMatch` shape used
+ * across the scan presentation layer. `recipeId` carries the
+ * backend UUID so the UI can navigate / import via
+ * `POST /recipes/import-from-community/:id`. `brewer` is derived
+ * from the owner — for the v0.1 seed all curated PUBLIC recipes
+ * carry the system sentinel UUID, which we surface as the
+ * generic "Communauté Brasse-Bouillon" attribution. Per-author
+ * attribution will land with the community v0.2 work.
+ */
+function mapRankedRecipe(dto: RankedRecipeWireDto): ScanRecipeMatch {
+  return {
+    recipeId: dto.recipe.id,
+    publicRecipeId: dto.recipe.id,
+    name: dto.recipe.name,
+    brewer: "Communauté Brasse-Bouillon",
+    rating: dto.recipe.avg_rating ?? 0,
+    brewedCount: dto.recipe.brew_count,
+    score: dto.score,
+    isOfficial: dto.recipe.is_official,
+    style: dto.recipe.style ?? undefined,
+  };
+}
+
+/**
+ * Fetch the top-N recipes that best match the given beer catalog
+ * item id, plus the `low_confidence` flag the API computes when the
+ * best match is genuinely below the threshold (per brainstorm
+ * scan-2026-04-24 §3.4 + Codex P1 fix on PR #792).
+ *
+ * Throws on transport or HTTP errors — the use-case layer is
+ * responsible for translating those into UI-facing error messages.
+ */
+export async function fetchMatchingRecipes(
+  beerCatalogItemId: string,
+): Promise<ScanMatchingResult> {
+  const data = await request<MatchingResponseWireDto>(
+    `/recipes/match/${beerCatalogItemId}`,
+  );
+  return {
+    rankings: data.rankings.map(mapRankedRecipe),
+    lowConfidence: data.low_confidence,
+  };
+}

--- a/packages/mobile-app/src/features/scan/domain/scan.types.ts
+++ b/packages/mobile-app/src/features/scan/domain/scan.types.ts
@@ -207,4 +207,39 @@ export interface ScanRecipeMatch {
   rating: number;
   brewedCount: number;
   score: number;
+  /**
+   * `true` if the recipe is the brewer-endorsed official clone of
+   * a beer (Issue #699). Drives the pharmacy metaphor split on the
+   * scan result screen: officials surface in the "🏆 Brewery
+   * recipe" section, non-officials in "🧪 Recettes équivalentes".
+   */
+  isOfficial?: boolean;
+  /**
+   * Style label of the recipe (e.g. "Session IPA", "Belgian
+   * Tripel"). Surfaced on the recipe row alongside the brewer +
+   * rating per the brainstorm scan-2026-04-24 §2 layout. Optional
+   * because legacy mocks did not carry it.
+   */
+  style?: string;
+}
+
+/**
+ * Response envelope for the recipe-matching backend (Issue #699).
+ * Mirrors the API's `RankedRecipeResponseDto` so the data layer can
+ * pass-through without remapping in shape.
+ *
+ * - `rankings` — top-N matched recipes ordered by descending score.
+ * - `lowConfidence` — `true` when the best match is below 40 (the
+ *   API threshold). The UI displays a discreet warning above the
+ *   "Recettes équivalentes" section so the user knows the proposed
+ *   recipes are merely the closest, not genuinely similar (per
+ *   brainstorm scan-2026-04-24 §3.4).
+ *
+ * Shape kept consumer-driven: today the data comes from
+ * `getDemoEquivalentRecipes(barcode)` in demo mode; tomorrow the
+ * same shape lands from `GET /recipes/match/:beerId` in backend mode.
+ */
+export interface ScanMatchingResult {
+  rankings: ReadonlyArray<ScanRecipeMatch>;
+  lowConfidence: boolean;
 }

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -18,6 +18,7 @@ import {
   getImportSourceId,
   importRecipeFromCommunity,
 } from "@/features/recipes/application/recipes.use-cases";
+import { getMatchingRecipes } from "@/features/scan/application/recipe-matching.use-cases";
 import {
   ScanLookupBeerNotFoundError,
   ScanLookupInvalidBarcodeError,
@@ -30,15 +31,14 @@ import {
   ibuToBitternessWord,
 } from "@/features/scan/application/lookup-formatters";
 import type {
+  ScanCatalogItem,
   ScanLookupResult,
+  ScanMatchingResult,
   ScanRecipeMatch,
 } from "@/features/scan/domain/scan.types";
 import { BeerHero } from "@/features/scan/presentation/components/BeerHero";
 import { Collapsible } from "@/features/scan/presentation/components/Collapsible";
-import {
-  getDemoBreweryStory,
-  getDemoEquivalentRecipes,
-} from "@/mocks/demo-data";
+import { getDemoBreweryStory } from "@/mocks/demo-data";
 
 import { useRouter } from "expo-router";
 
@@ -182,8 +182,8 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
 
         <AtAGlance result={status.result} />
 
-        <EquivalentRecipesSection
-          barcode={status.result.item.barcode}
+        <MatchingRecipesSection
+          beer={status.result.item}
           onImported={(recipeId) =>
             router.push(`/(app)/recipes/${recipeId}` as never)
           }
@@ -254,19 +254,62 @@ function GlanceCell({ label, value }: { label: string; value: string }) {
 
 const IMPORT_ERROR_MESSAGE =
   "Impossible d'importer cette recette pour le moment. Réessaie dans quelques instants.";
+const MATCHING_LOAD_ERROR =
+  "Impossible de charger les recettes équivalentes. Réessaie plus tard.";
+const LOW_CONFIDENCE_MESSAGE =
+  "Aucune recette très similaire dans la base. Voici les plus proches.";
+const EQUIVALENTS_LIMIT = 3;
 
-function EquivalentRecipesSection({
-  barcode,
+/**
+ * Matching recipes section — pharmacy metaphor split per the
+ * brainstorm scan-2026-04-24 §2:
+ *
+ *   🏆 Brewery recipe   — single card at the top, brand badge + gold
+ *                         accent. Only shown when one of the ranked
+ *                         recipes has `isOfficial: true`.
+ *   🧪 Recettes équivalentes — top 3 non-official picks beneath.
+ *
+ * `low_confidence` warning surfaces above the equivalents block so
+ * Léa la Curieuse knows the proposed alternatives are merely the
+ * closest, not genuinely similar.
+ */
+function MatchingRecipesSection({
+  beer,
   onImported,
 }: Readonly<{
-  barcode: string;
+  beer: Pick<ScanCatalogItem, "id" | "barcode">;
   onImported: (recipeId: string) => void;
 }>) {
-  const recipes = useMemo<ReadonlyArray<ScanRecipeMatch>>(
-    () => getDemoEquivalentRecipes(barcode),
-    [barcode],
-  );
+  const [matching, setMatching] = useState<ScanMatchingResult | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [importingId, setImportingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoadError(null);
+    void getMatchingRecipes(beer)
+      .then((result) => {
+        if (!cancelled) setMatching(result);
+      })
+      .catch(() => {
+        if (!cancelled) setLoadError(MATCHING_LOAD_ERROR);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [beer]);
+
+  const officialRecipe = useMemo<ScanRecipeMatch | null>(() => {
+    if (!matching) return null;
+    return matching.rankings.find((r) => r.isOfficial) ?? null;
+  }, [matching]);
+
+  const equivalentRecipes = useMemo<ReadonlyArray<ScanRecipeMatch>>(() => {
+    if (!matching) return [];
+    return matching.rankings
+      .filter((r) => !r.isOfficial)
+      .slice(0, EQUIVALENTS_LIMIT);
+  }, [matching]);
 
   const handleImport = useCallback(
     async (sourceId: string) => {
@@ -295,55 +338,127 @@ function EquivalentRecipesSection({
     [importingId, onImported],
   );
 
-  if (recipes.length === 0) {
-    return null;
+  if (loadError) {
+    return (
+      <Card style={styles.recipesCard}>
+        <Text style={styles.recipesEmpty}>{loadError}</Text>
+      </Card>
+    );
+  }
+
+  // While loading, render nothing — the page already shows the
+  // beer hero + at-a-glance, the matching list takes a moment to
+  // arrive and a flash of "Aucune recette" would mislead Léa.
+  if (!matching) return null;
+
+  if (matching.rankings.length === 0) {
+    return (
+      <Card style={styles.recipesCard}>
+        <Text style={styles.recipesTitle}>🧪 Recettes équivalentes</Text>
+        <Text style={styles.recipesEmpty}>
+          Aucune recette équivalente n&apos;a encore été partagée pour cette
+          bière.
+        </Text>
+      </Card>
+    );
   }
 
   return (
-    <Card style={styles.recipesCard}>
-      <Text style={styles.recipesTitle}>🧪 Recettes équivalentes</Text>
-      <Text style={styles.recipesSubtitle}>
-        Notées par la communauté Brasse Bouillon
-      </Text>
-      {recipes.map((recipe) => {
-        const isImporting = importingId === recipe.recipeId;
-        const isDisabled = importingId !== null;
-        return (
-          <Pressable
-            key={recipe.recipeId}
-            onPress={() => handleImport(getImportSourceId(recipe))}
-            disabled={isDisabled}
-            style={({ pressed }) => {
-              if (isImporting) return [styles.recipeRow];
-              if (isDisabled)
-                return [styles.recipeRow, styles.recipeRowDisabled];
-              return [
-                styles.recipeRow,
-                pressed ? styles.recipeRowPressed : null,
-              ];
-            }}
-            accessibilityRole="button"
-            accessibilityState={{ disabled: isDisabled, busy: isImporting }}
-            accessibilityLabel={`Importer ${recipe.name} par ${recipe.brewer}, noté ${recipe.rating} sur 5`}
-          >
-            <View style={styles.recipeRowLeft}>
-              <Text style={styles.recipeName} numberOfLines={2}>
-                {recipe.name}
-              </Text>
-              <Text style={styles.recipeBrewer}>
-                {recipe.brewer} · brassée {recipe.brewedCount} fois · ★{" "}
-                {recipe.rating.toFixed(1)}
-              </Text>
-            </View>
-            <View style={styles.recipeRowRight}>
-              <Text style={styles.recipeAction}>
-                {isImporting ? "Import…" : "+ Importer"}
-              </Text>
-            </View>
-          </Pressable>
-        );
-      })}
-    </Card>
+    <View>
+      {officialRecipe ? (
+        <Card style={styles.officialCard}>
+          <Text style={styles.officialTitle}>🏆 Recette officielle</Text>
+          <Text style={styles.officialSubtitle}>
+            La recette d&apos;origine, signée par la brasserie
+          </Text>
+          <RecipeRow
+            recipe={officialRecipe}
+            isImporting={importingId === officialRecipe.recipeId}
+            isDisabled={importingId !== null}
+            onPress={() => handleImport(getImportSourceId(officialRecipe))}
+            highlightOfficial
+          />
+        </Card>
+      ) : null}
+
+      {equivalentRecipes.length > 0 ? (
+        <Card style={styles.recipesCard}>
+          <Text style={styles.recipesTitle}>🧪 Recettes équivalentes</Text>
+          <Text style={styles.recipesSubtitle}>
+            Notées par la communauté Brasse Bouillon
+          </Text>
+          {matching.lowConfidence ? (
+            <Text style={styles.lowConfidenceWarning}>
+              {LOW_CONFIDENCE_MESSAGE}
+            </Text>
+          ) : null}
+          {equivalentRecipes.map((recipe) => (
+            <RecipeRow
+              key={recipe.recipeId}
+              recipe={recipe}
+              isImporting={importingId === recipe.recipeId}
+              isDisabled={importingId !== null}
+              onPress={() => handleImport(getImportSourceId(recipe))}
+            />
+          ))}
+        </Card>
+      ) : null}
+    </View>
+  );
+}
+
+/**
+ * Single recipe row — used by both the official 🏆 card and each
+ * equivalent recipe in the 🧪 list. `highlightOfficial` swaps the
+ * default neutral palette for the gold accent on the official card
+ * to honor the pharmacy metaphor (brand vs generic visual cue).
+ */
+function RecipeRow({
+  recipe,
+  isImporting,
+  isDisabled,
+  onPress,
+  highlightOfficial = false,
+}: Readonly<{
+  recipe: ScanRecipeMatch;
+  isImporting: boolean;
+  isDisabled: boolean;
+  onPress: () => void;
+  highlightOfficial?: boolean;
+}>) {
+  const meta: string[] = [recipe.brewer];
+  if (recipe.style) meta.push(recipe.style);
+  meta.push(`brassée ${recipe.brewedCount} fois`);
+  if (recipe.rating > 0) meta.push(`★ ${recipe.rating.toFixed(1)}`);
+  const metaLine = meta.join(" · ");
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={isDisabled}
+      style={({ pressed }) => [
+        styles.recipeRow,
+        highlightOfficial ? styles.recipeRowOfficial : null,
+        isDisabled && !isImporting ? styles.recipeRowDisabled : null,
+        !isImporting && !isDisabled && pressed ? styles.recipeRowPressed : null,
+      ]}
+      accessibilityRole="button"
+      accessibilityState={{ disabled: isDisabled, busy: isImporting }}
+      accessibilityLabel={`Importer ${recipe.name} par ${recipe.brewer}${
+        recipe.rating > 0 ? `, noté ${recipe.rating} sur 5` : ""
+      }`}
+    >
+      <View style={styles.recipeRowLeft}>
+        <Text style={styles.recipeName} numberOfLines={2}>
+          {recipe.name}
+        </Text>
+        <Text style={styles.recipeBrewer}>{metaLine}</Text>
+      </View>
+      <View style={styles.recipeRowRight}>
+        <Text style={styles.recipeAction}>
+          {isImporting ? "Import…" : "+ Importer"}
+        </Text>
+      </View>
+    </Pressable>
   );
 }
 
@@ -464,6 +579,43 @@ const styles = StyleSheet.create({
     fontSize: typography.size.body,
     fontWeight: typography.weight.medium,
     color: colors.neutral.textPrimary,
+  },
+  officialCard: {
+    marginBottom: spacing.md,
+    padding: spacing.md,
+    borderWidth: 1,
+    borderColor: colors.brand.primary,
+    backgroundColor: colors.state.infoBackground,
+  },
+  officialTitle: {
+    fontSize: typography.size.body,
+    fontWeight: typography.weight.bold,
+    color: colors.brand.primary,
+    marginBottom: spacing.xxs,
+  },
+  officialSubtitle: {
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+    marginBottom: spacing.sm,
+  },
+  recipeRowOfficial: {
+    borderBottomWidth: 0,
+  },
+  lowConfidenceWarning: {
+    fontSize: typography.size.caption,
+    color: colors.semantic.warning,
+    backgroundColor: colors.state.warningBackground,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.sm,
+    marginBottom: spacing.sm,
+    fontStyle: "italic",
+  },
+  recipesEmpty: {
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+    fontStyle: "italic",
+    paddingVertical: spacing.xs,
   },
   recipesCard: {
     marginBottom: spacing.md,

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -381,17 +381,16 @@ function MatchingRecipesSection({
         </Card>
       ) : null}
 
+      {matching.lowConfidence ? (
+        <Text style={styles.lowConfidenceWarning}>{LOW_CONFIDENCE_MESSAGE}</Text>
+      ) : null}
+
       {equivalentRecipes.length > 0 ? (
         <Card style={styles.recipesCard}>
           <Text style={styles.recipesTitle}>🧪 Recettes équivalentes</Text>
           <Text style={styles.recipesSubtitle}>
             Notées par la communauté Brasse Bouillon
           </Text>
-          {matching.lowConfidence ? (
-            <Text style={styles.lowConfidenceWarning}>
-              {LOW_CONFIDENCE_MESSAGE}
-            </Text>
-          ) : null}
           {equivalentRecipes.map((recipe) => (
             <RecipeRow
               key={recipe.recipeId}

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -382,7 +382,9 @@ function MatchingRecipesSection({
       ) : null}
 
       {matching.lowConfidence ? (
-        <Text style={styles.lowConfidenceWarning}>{LOW_CONFIDENCE_MESSAGE}</Text>
+        <Text style={styles.lowConfidenceWarning}>
+          {LOW_CONFIDENCE_MESSAGE}
+        </Text>
       ) : null}
 
       {equivalentRecipes.length > 0 ? (

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -166,7 +166,8 @@ describe("BeerInfoCardScreen", () => {
       expect(screen.getByText("De session")).toBeTruthy();
       expect(screen.getByText("Ambrée")).toBeTruthy();
       expect(screen.getByText("Modérément amère")).toBeTruthy();
-      expect(screen.getByText("🧪 Recettes équivalentes")).toBeTruthy();
+      // The matching section renders after a second async effect; wait for it.
+      expect(await screen.findByText("🧪 Recettes équivalentes")).toBeTruthy();
       // The demo set maps Punk IPA to existing demoRecipes
       // (r-demo-1 / r-demo-7 / r-demo-13) so taps land on real
       // recipe detail pages.

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -533,7 +533,9 @@ describe("BeerInfoCardScreen", () => {
       // Official section appears.
       expect(await screen.findByText(/🏆 Recette officielle/)).toBeTruthy();
       // Warning must also appear even though there are no community equivalents.
-      expect(screen.getByText(/Aucune recette très similaire dans la base/)).toBeTruthy();
+      expect(
+        screen.getByText(/Aucune recette très similaire dans la base/),
+      ).toBeTruthy();
     });
 
     it("renders an error message when the matching API throws", async () => {

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -509,6 +509,33 @@ describe("BeerInfoCardScreen", () => {
       expect(empty).toBeTruthy();
     });
 
+    it("shows low_confidence warning even when only an official recipe is returned (no equivalents)", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      mockedMatching.mockResolvedValueOnce({
+        rankings: [
+          {
+            recipeId: "r-official-only",
+            publicRecipeId: "00000000-0000-4000-8000-officialonly1",
+            name: "Punk IPA — Recette officielle",
+            brewer: "BrewDog",
+            rating: 4.9,
+            brewedCount: 100,
+            score: 100,
+            isOfficial: true,
+            style: "American IPA",
+          },
+        ],
+        lowConfidence: true,
+      });
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      // Official section appears.
+      expect(await screen.findByText(/🏆 Recette officielle/)).toBeTruthy();
+      // Warning must also appear even though there are no community equivalents.
+      expect(screen.getByText(/Aucune recette très similaire dans la base/)).toBeTruthy();
+    });
+
     it("renders an error message when the matching API throws", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
       mockedMatching.mockRejectedValueOnce(new Error("network"));

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -9,6 +9,7 @@ import {
 import React from "react";
 
 import { BeerInfoCardScreen } from "@/features/scan/presentation/BeerInfoCardScreen";
+import { getMatchingRecipes } from "@/features/scan/application/recipe-matching.use-cases";
 import { importRecipeFromCommunity } from "@/features/recipes/application/recipes.use-cases";
 import {
   ScanLookupBeerNotFoundError,
@@ -49,12 +50,54 @@ jest.mock("@/features/recipes/application/recipes.use-cases", () => ({
   getImportSourceId: (match: { recipeId: string }) => match.recipeId,
 }));
 
+jest.mock("@/features/scan/application/recipe-matching.use-cases", () => ({
+  getMatchingRecipes: jest.fn(),
+}));
+
 const mockedLookup = lookupBeerByBarcode as jest.MockedFunction<
   typeof lookupBeerByBarcode
 >;
 const mockedImport = importRecipeFromCommunity as jest.MockedFunction<
   typeof importRecipeFromCommunity
 >;
+const mockedMatching = getMatchingRecipes as jest.MockedFunction<
+  typeof getMatchingRecipes
+>;
+
+// Default matching response — Punk IPA scan returns a curated trio
+// of equivalent IPA-family recipes. Tests can override per case.
+const PUNK_IPA_MATCHES = [
+  {
+    recipeId: "r-demo-1",
+    publicRecipeId: "00000000-0000-4000-8000-000000000001",
+    name: "Session IPA Citra",
+    brewer: "Communauté Brasse-Bouillon",
+    rating: 4.7,
+    brewedCount: 23,
+    score: 92,
+    style: "Session IPA",
+  },
+  {
+    recipeId: "r-demo-2",
+    publicRecipeId: "00000000-0000-4000-8000-000000000002",
+    name: "NEIPA Tropical",
+    brewer: "Communauté Brasse-Bouillon",
+    rating: 4.5,
+    brewedCount: 18,
+    score: 78,
+    style: "NEIPA",
+  },
+  {
+    recipeId: "r-demo-3",
+    publicRecipeId: "00000000-0000-4000-8000-000000000003",
+    name: "White IPA",
+    brewer: "Communauté Brasse-Bouillon",
+    rating: 4.3,
+    brewedCount: 12,
+    score: 65,
+    style: "White IPA",
+  },
+];
 
 function buildResult(
   overrides: Partial<ScanLookupResult["item"]> = {},
@@ -95,6 +138,13 @@ describe("BeerInfoCardScreen", () => {
     mockReplace.mockReset();
     mockedLookup.mockReset();
     mockedImport.mockReset();
+    mockedMatching.mockReset();
+    // Default matching response: Punk IPA equivalents, no warning.
+    // Individual tests override via mockedMatching.mockResolvedValueOnce.
+    mockedMatching.mockResolvedValue({
+      rankings: PUNK_IPA_MATCHES,
+      lowConfidence: false,
+    });
     alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => undefined);
   });
 
@@ -344,6 +394,130 @@ describe("BeerInfoCardScreen", () => {
         );
       });
       expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("matching view envelope (Issue #700)", () => {
+    it("displays the low_confidence warning when the API flags it", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      mockedMatching.mockResolvedValueOnce({
+        rankings: PUNK_IPA_MATCHES.slice(0, 1),
+        lowConfidence: true,
+      });
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      const warning = await screen.findByText(
+        /Aucune recette très similaire dans la base/,
+      );
+      expect(warning).toBeTruthy();
+    });
+
+    it("does NOT display the low_confidence warning when lowConfidence is false", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      // default beforeEach already sets lowConfidence: false
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      // Wait for the rankings to be rendered (find the first equivalent).
+      await screen.findByText("Session IPA Citra");
+      expect(screen.queryByText(/Aucune recette très similaire/)).toBeNull();
+    });
+
+    it("renders the 🏆 Recette officielle section above the equivalents when one is flagged official", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      mockedMatching.mockResolvedValueOnce({
+        rankings: [
+          {
+            recipeId: "r-official-punk",
+            publicRecipeId: "00000000-0000-4000-8000-officialpunk",
+            name: "Punk IPA — Recette officielle",
+            brewer: "BrewDog",
+            rating: 4.9,
+            brewedCount: 100,
+            score: 100,
+            isOfficial: true,
+            style: "American IPA",
+          },
+          ...PUNK_IPA_MATCHES,
+        ],
+        lowConfidence: false,
+      });
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      // Official section title appears.
+      const officialTitle = await screen.findByText(/🏆 Recette officielle/);
+      expect(officialTitle).toBeTruthy();
+      // Official recipe row also rendered.
+      expect(screen.getByText("Punk IPA — Recette officielle")).toBeTruthy();
+      // Equivalents below.
+      expect(screen.getByText("Session IPA Citra")).toBeTruthy();
+    });
+
+    it("does not render the 🏆 section when no recipe is flagged official", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      // default mock: PUNK_IPA_MATCHES — no isOfficial=true
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      await screen.findByText("Session IPA Citra");
+      expect(screen.queryByText(/🏆 Recette officielle/)).toBeNull();
+    });
+
+    it("caps equivalents to 3 even when the API returns more", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      mockedMatching.mockResolvedValueOnce({
+        rankings: [
+          ...PUNK_IPA_MATCHES,
+          {
+            recipeId: "r-demo-4",
+            publicRecipeId: "00000000-0000-4000-8000-000000000004",
+            name: "Belgian Tripel",
+            brewer: "Communauté Brasse-Bouillon",
+            rating: 4.8,
+            brewedCount: 31,
+            score: 50,
+            style: "Belgian Tripel",
+          },
+        ],
+        lowConfidence: false,
+      });
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      await screen.findByText("Session IPA Citra");
+      expect(screen.getByText("NEIPA Tropical")).toBeTruthy();
+      expect(screen.getByText("White IPA")).toBeTruthy();
+      // 4th recipe is filtered out (cap at 3).
+      expect(screen.queryByText("Belgian Tripel")).toBeNull();
+    });
+
+    it("renders an empty state when the API returns zero rankings", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      mockedMatching.mockResolvedValueOnce({
+        rankings: [],
+        lowConfidence: false,
+      });
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      const empty = await screen.findByText(
+        /Aucune recette équivalente n'a encore été partagée/,
+      );
+      expect(empty).toBeTruthy();
+    });
+
+    it("renders an error message when the matching API throws", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      mockedMatching.mockRejectedValueOnce(new Error("network"));
+
+      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      const errorMsg = await screen.findByText(
+        /Impossible de charger les recettes équivalentes/,
+      );
+      expect(errorMsg).toBeTruthy();
     });
   });
 });

--- a/packages/website/docs/ROADMAP.md
+++ b/packages/website/docs/ROADMAP.md
@@ -50,6 +50,7 @@ This document outlines the major stages of the **Brasse-Bouillon** mobile app de
 * Integration of recent backend/frontend progress (tools suite completion, dashboard/discovery refresh, recipe-detail enhancements, and product API expansion)
 * Auth experience refresh — simplified email-and-password signup, bigger brand mascot, cleaner forgot-password flow, demo connection now scoped to demo builds only (Issue #764)
 * Sign in with Google — cosmetic preview on the auth screen indicating the upcoming social-login support (Issue #765 — full OAuth flow planned for v0.2)
+* Live recipe matching — dedicated "🏆 Official Recipe" section above community alternatives (capped at 3) with a low-confidence notice when the best match is below the confidence threshold (Issue #700, powered by the score engine from Issue #699)
 
 ### Phase 6 — Beta testing and community activation
 


### PR DESCRIPTION
## Summary

- Add `ScanMatchingResult` envelope type (`rankings` + `lowConfidence`) and `isOfficial`/`style` fields to `ScanRecipeMatch` in domain
- New `recipe-matching.api.ts` data layer: fetches `GET /recipes/match/:beerId`, maps `MatchingResponseWireDto` (snake_case) → `ScanMatchingResult` (camelCase)
- New `recipe-matching.use-cases.ts`: branches on `dataSource.useDemoData` — demo path wraps `getDemoEquivalentRecipes()` in the envelope; backend path delegates to `fetchMatchingRecipes()`
- `BeerInfoCardScreen`: full refactor of the equivalents section into `MatchingRecipesSection` — splits official recipe (🏆 gold accent) above community alternatives (🧪 capped at 3); renders a low-confidence notice when `matching.lowConfidence === true`; loading state + error handling
- Add `warningBackground` design token to `colors.ts`
- 4 new use-case tests (demo happy/sad + backend happy/sad); 7 new presentation tests (envelope scenarios: low_confidence, official section presence/absence, cap at 3, empty state, API error)
- `website/docs/ROADMAP.md` Phase 5 updated with #700 entry

## Checklist

- [x] Happy path + sad path + edge cases covered
- [x] `tsc --noEmit` passes
- [x] Build passes
- [x] Existing tests still green (560 / 560)
- [x] No `any`, no inline styles introduced

Closes #700