### PR TITLE
feat(scan): not-a-beer detection — filter OFF by category + dedicated UI (Issue #798)

### DIFF
--- a/packages/api/src/common/filters/http-exception.filter.spec.ts
+++ b/packages/api/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,161 @@
+import {
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+
+import { HttpExceptionFilter } from './http-exception.filter';
+
+type ResponseMock = {
+  status: jest.Mock;
+  json: jest.Mock;
+};
+
+type RequestMock = {
+  url: string;
+  method: string;
+};
+
+const createHttpHost = (
+  request: RequestMock,
+  response: ResponseMock,
+): ArgumentsHost =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => request,
+      getResponse: () => response,
+    }),
+  }) as unknown as ArgumentsHost;
+
+describe('HttpExceptionFilter', () => {
+  const request: RequestMock = { url: '/test/path', method: 'GET' };
+  let response: ResponseMock;
+  let filter: HttpExceptionFilter;
+
+  beforeEach(() => {
+    response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    filter = new HttpExceptionFilter();
+  });
+
+  test('happy path: extracts message from a plain string HttpException response', () => {
+    const host = createHttpHost(request, response);
+    const exception = new HttpException('Forbidden', HttpStatus.FORBIDDEN);
+
+    filter.catch(exception, host);
+
+    expect(response.status).toHaveBeenCalledWith(HttpStatus.FORBIDDEN);
+    const payload = (response.json.mock.calls as unknown[][])[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toEqual(
+      expect.objectContaining({
+        statusCode: HttpStatus.FORBIDDEN,
+        message: 'Forbidden',
+        path: '/test/path',
+      }),
+    );
+    expect(payload).toHaveProperty('timestamp');
+  });
+
+  test('happy path: extracts message from object response with string `message`', () => {
+    const host = createHttpHost(request, response);
+    const exception = new HttpException(
+      { message: 'Validation failed' },
+      HttpStatus.BAD_REQUEST,
+    );
+
+    filter.catch(exception, host);
+
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Validation failed' }),
+    );
+  });
+
+  test('happy path: extracts first element when message is an array (validation errors)', () => {
+    const host = createHttpHost(request, response);
+    const exception = new HttpException(
+      { message: ['First error', 'Second error'] },
+      HttpStatus.BAD_REQUEST,
+    );
+
+    filter.catch(exception, host);
+
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'First error' }),
+    );
+  });
+
+  test('sad path: falls back to "Internal Server Error" when message cannot be extracted', () => {
+    const host = createHttpHost(request, response);
+    const exception = new HttpException(
+      { custom: 'no-message-field' },
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+
+    filter.catch(exception, host);
+
+    expect(response.json).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Internal Server Error' }),
+    );
+  });
+
+  test('preserves additional structured fields from custom exceptions (Issue #798 — Codex P1)', () => {
+    const host = createHttpHost(request, response);
+    const exception = new UnprocessableEntityException({
+      message: 'Product is not a beer.',
+      errorCode: 'NOT_A_BEER',
+      barcode: '5449000000996',
+      productName: 'Coca-Cola Original',
+    });
+
+    filter.catch(exception, host);
+
+    const payload = (response.json.mock.calls as unknown[][])[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(payload).toEqual(
+      expect.objectContaining({
+        statusCode: HttpStatus.UNPROCESSABLE_ENTITY,
+        message: 'Product is not a beer.',
+        errorCode: 'NOT_A_BEER',
+        barcode: '5449000000996',
+        productName: 'Coca-Cola Original',
+        path: '/test/path',
+      }),
+    );
+  });
+
+  test('edge case: ignores reserved keys (statusCode, error, timestamp, path) when present in exception payload', () => {
+    const host = createHttpHost(request, response);
+    const exception = new HttpException(
+      {
+        message: 'spoofed',
+        statusCode: 999,
+        error: 'spoofed',
+        timestamp: 'spoofed',
+        path: 'spoofed',
+        legitimateExtra: 'kept',
+      },
+      HttpStatus.BAD_REQUEST,
+    );
+
+    filter.catch(exception, host);
+
+    const payload = (response.json.mock.calls as unknown[][])[0][0] as Record<
+      string,
+      unknown
+    >;
+    // Spoofed reserved fields must NOT override the canonical envelope
+    expect(payload.statusCode).toBe(HttpStatus.BAD_REQUEST);
+    expect(payload.path).toBe('/test/path');
+    expect(payload.timestamp).not.toBe('spoofed');
+    // The non-reserved extra is preserved
+    expect(payload.legitimateExtra).toBe('kept');
+  });
+});

--- a/packages/api/src/common/filters/http-exception.filter.ts
+++ b/packages/api/src/common/filters/http-exception.filter.ts
@@ -12,7 +12,23 @@ interface ErrorResponse {
   message: string;
   timestamp: string;
   path: string;
+  // Custom exceptions can carry structured fields (e.g.
+  // `errorCode`, domain identifiers) on their response object —
+  // those are spread alongside the standard fields. See
+  // `extractAdditionalFields` for the exact whitelist behaviour.
+  [key: string]: unknown;
 }
+
+// Fields owned by the standardized error envelope. Anything else
+// on the exception response object is treated as caller-provided
+// structured payload and forwarded to the client.
+const RESERVED_RESPONSE_KEYS = new Set([
+  'statusCode',
+  'message',
+  'timestamp',
+  'path',
+  'error',
+]);
 
 /**
  * Global HTTP Exception Filter
@@ -77,6 +93,34 @@ export class HttpExceptionFilter implements ExceptionFilter {
   }
 
   /**
+   * Pulls any non-reserved fields off an object exception response so
+   * structured custom payloads (e.g. `NotABeerException` with
+   * `errorCode` + `barcode` + `productName`) flow through to the
+   * client instead of being silently stripped to the standard 4
+   * fields. Existing exceptions that pass a string or only put the
+   * reserved keys are unaffected.
+   */
+  private extractAdditionalFields(
+    exceptionResponse: unknown,
+  ): Record<string, unknown> {
+    if (
+      typeof exceptionResponse !== 'object' ||
+      exceptionResponse === null ||
+      Array.isArray(exceptionResponse)
+    ) {
+      return {};
+    }
+    const obj = exceptionResponse as Record<string, unknown>;
+    const extras: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      if (!RESERVED_RESPONSE_KEYS.has(key)) {
+        extras[key] = value;
+      }
+    }
+    return extras;
+  }
+
+  /**
    * Catches HttpException and sends standardized JSON response
    *
    * @param exception - The thrown exception (e.g., ConflictException)
@@ -96,11 +140,15 @@ export class HttpExceptionFilter implements ExceptionFilter {
 
     // Extract error message safely with type checking
     const message = this.extractMessage(exceptionResponse);
+    const additional = this.extractAdditionalFields(exceptionResponse);
 
-    // Build standardized error response
+    // Build standardized error response. Additional structured
+    // fields (e.g. `errorCode`) are merged BEFORE the timestamp /
+    // path tail so the canonical envelope keys win on collisions.
     const errorResponse: ErrorResponse = {
       statusCode: status,
       message,
+      ...additional,
       timestamp: new Date().toISOString(),
       path: request.url,
     };

--- a/packages/api/src/scan/exceptions/not-a-beer.exception.ts
+++ b/packages/api/src/scan/exceptions/not-a-beer.exception.ts
@@ -1,0 +1,37 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+
+/**
+ * Not-A-Beer Exception (Issue #798 — scan jury edge case D).
+ *
+ * Thrown when OpenFoodFacts resolves the barcode to an existing
+ * product but the product's `categories_tags` do not include any
+ * beer category (`en:beers`, `en:beer*`). Rather than refusing
+ * with a generic 404, we surface the product name so the mobile
+ * client can render a helpful "Vous avez scanné <productName> —
+ * ce n'est pas une bière" screen instead of treating it as a
+ * normal not-found error.
+ *
+ * HTTP Status: 422 Unprocessable Entity
+ * Response body:
+ * {
+ *   "statusCode": 422,
+ *   "message": {
+ *     "errorCode": "NOT_A_BEER",
+ *     "barcode": "5449000000996",
+ *     "productName": "Coca-Cola Original"
+ *   },
+ *   "error": "Unprocessable Entity"
+ * }
+ *
+ * The mobile data layer keys off `errorCode === 'NOT_A_BEER'` to
+ * dispatch to its dedicated UI variant.
+ */
+export class NotABeerException extends UnprocessableEntityException {
+  constructor(barcode: string, productName: string | null) {
+    super({
+      errorCode: 'NOT_A_BEER',
+      barcode,
+      productName,
+    });
+  }
+}

--- a/packages/api/src/scan/exceptions/not-a-beer.exception.ts
+++ b/packages/api/src/scan/exceptions/not-a-beer.exception.ts
@@ -29,6 +29,13 @@ import { UnprocessableEntityException } from '@nestjs/common';
 export class NotABeerException extends UnprocessableEntityException {
   constructor(barcode: string, productName: string | null) {
     super({
+      // Human-readable summary kept on `message` so the global
+      // HttpExceptionFilter has something to extract; the structured
+      // `errorCode` / `barcode` / `productName` ride alongside via
+      // the filter's spread-extra-fields behaviour.
+      message: productName
+        ? `Product "${productName}" (barcode ${barcode}) is not a beer.`
+        : `Product (barcode ${barcode}) is not a beer.`,
       errorCode: 'NOT_A_BEER',
       barcode,
       productName,

--- a/packages/api/src/scan/services/scan.service.spec.ts
+++ b/packages/api/src/scan/services/scan.service.spec.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
 import { QueryFailedError, Repository } from 'typeorm';
 
 import { ScanCatalogSource } from '../domain/enums/scan-catalog-source.enum';
@@ -611,6 +615,73 @@ describe('ScanService', () => {
       await expect(service.lookupByBarcode(VALID_EAN)).rejects.toBeInstanceOf(
         NotFoundException,
       );
+    });
+
+    test('sad path — OFF returns a non-beer product AND no cache → 422 NotABeer with product name (Issue #798)', async () => {
+      catalogItemRepository.findOne.mockResolvedValueOnce(null);
+      openFoodFactsClient.lookupByBarcode.mockResolvedValueOnce({
+        found: true,
+        payload: {
+          code: VALID_EAN,
+          status: 1,
+          product: {
+            product_name: 'Coca-Cola Original',
+            categories_tags: ['en:beverages', 'en:carbonated-drinks'],
+          },
+        },
+        name: 'Coca-Cola Original',
+        brewery: null,
+        abv: null,
+        isBeer: false,
+      });
+
+      const error = await service
+        .lookupByBarcode(VALID_EAN)
+        .then(() => null)
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      const response = (
+        error as UnprocessableEntityException
+      ).getResponse() as {
+        errorCode: string;
+        barcode: string;
+        productName: string;
+      };
+      expect(response.errorCode).toBe('NOT_A_BEER');
+      expect(response.barcode).toBe(VALID_EAN);
+      expect(response.productName).toBe('Coca-Cola Original');
+      expect(catalogItemRepository.save).not.toHaveBeenCalled();
+    });
+
+    test('sad path — OFF returns a non-beer product BUT cache has prior beer entry → degraded stale (Issue #798)', async () => {
+      const previouslyCached = createCatalogItem({
+        id: 'cat-prior-beer',
+        barcode: VALID_EAN,
+        source: ScanCatalogSource.OPENFOODFACTS,
+        fetched_at: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      });
+      catalogItemRepository.findOne.mockResolvedValueOnce(previouslyCached);
+      openFoodFactsClient.lookupByBarcode.mockResolvedValueOnce({
+        found: true,
+        payload: {
+          code: VALID_EAN,
+          status: 1,
+          product: {
+            product_name: 'Coca-Cola Original',
+            categories_tags: ['en:beverages'],
+          },
+        },
+        name: 'Coca-Cola Original',
+        brewery: null,
+        abv: null,
+        isBeer: false,
+      });
+
+      const result = await service.lookupByBarcode(VALID_EAN);
+
+      expect(result.source).toBe('cache_hit_stale');
+      expect(catalogItemRepository.save).not.toHaveBeenCalled();
     });
 
     test('edge case — invalid barcode rejected by domain validation → BadRequest', async () => {

--- a/packages/api/src/scan/services/scan.service.ts
+++ b/packages/api/src/scan/services/scan.service.ts
@@ -8,6 +8,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { randomUUID } from 'crypto';
 import { QueryFailedError, Repository } from 'typeorm';
 
+import { NotABeerException } from '../exceptions/not-a-beer.exception';
 import { ScanCatalogSource } from '../domain/enums/scan-catalog-source.enum';
 import { ScanImageFace } from '../domain/enums/scan-image-face.enum';
 import { ScanRequestStatus } from '../domain/enums/scan-request-status.enum';
@@ -523,20 +524,29 @@ export class ScanService {
       );
     }
 
-    if (!lookup.found || !lookup.isBeer) {
-      // OFF lost the product OR returned a non-beer item (cider /
-      // food / soft drink). Either way, do not pollute the
-      // beer-only scan_catalog_items table with a placeholder row.
-      // Codex P2 #729: dropping isBeer filtering would let any
-      // food barcode create a beer entry with style = 'Unknown'.
+    if (!lookup.found) {
+      // OFF lost the product. Either degrade to cache or 404.
       if (cached) {
-        // We still have a cache row — return as stale (better
-        // degraded than 404 / a hard refusal).
         return this.buildLookupResult(cached, 'cache_hit_stale');
       }
       throw new NotFoundException(
-        `Barcode ${barcode} not found as a beer in OpenFoodFacts and not in the local catalog.`,
+        `Barcode ${barcode} not found in OpenFoodFacts and not in the local catalog.`,
       );
+    }
+
+    if (!lookup.isBeer) {
+      // OFF returned a real product, but its categories_tags do
+      // not include any beer category (cider / food / soft drink).
+      // Issue #798 jury edge case D — surface the product name so
+      // the mobile client can render a dedicated "ce n'est pas une
+      // bière" screen instead of treating this as a generic 404.
+      // Codex P2 #729: never pollute the beer-only catalog with
+      // non-beer placeholder rows. Cache fallback still applies
+      // for previously-stored beer entries on the same barcode.
+      if (cached) {
+        return this.buildLookupResult(cached, 'cache_hit_stale');
+      }
+      throw new NotABeerException(barcode, lookup.name);
     }
 
     const persisted = await this.upsertFromOpenFoodFacts(

--- a/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
@@ -3,6 +3,7 @@ import { HttpError } from "@/core/http/http-error";
 import {
   ScanLookupBeerNotFoundError,
   ScanLookupInvalidBarcodeError,
+  ScanLookupNotABeerError,
   ScanLookupServiceUnavailableError,
   lookupBeerByBarcode,
 } from "@/features/scan/application/scan-lookup.use-cases";
@@ -133,6 +134,41 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
 
       await expect(lookupBeerByBarcode("5060277380019")).rejects.toBeInstanceOf(
         ScanLookupServiceUnavailableError,
+      );
+    });
+
+    it("translates a 422 NOT_A_BEER HttpError to ScanLookupNotABeerError carrying the product name (Issue #798)", async () => {
+      mockFetchLookup.mockRejectedValueOnce(
+        new HttpError(422, "Not a beer", {
+          statusCode: 422,
+          errorCode: "NOT_A_BEER",
+          barcode: "5449000000996",
+          productName: "Coca-Cola Original",
+        }),
+      );
+
+      const rejected = await lookupBeerByBarcode("5449000000996").catch(
+        (e: unknown) => e,
+      );
+
+      expect(rejected).toBeInstanceOf(ScanLookupNotABeerError);
+      expect((rejected as ScanLookupNotABeerError).productName).toBe(
+        "Coca-Cola Original",
+      );
+      expect((rejected as ScanLookupNotABeerError).barcode).toBe(
+        "5449000000996",
+      );
+    });
+
+    it("re-throws a 422 HttpError that is NOT NOT_A_BEER (other validation errors)", async () => {
+      const validationError = new HttpError(422, "Some other 422", {
+        statusCode: 422,
+        message: "Validation failed",
+      });
+      mockFetchLookup.mockRejectedValueOnce(validationError);
+
+      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
+        validationError,
       );
     });
 

--- a/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
@@ -71,6 +71,27 @@ export class ScanLookupServiceUnavailableError extends Error {
   }
 }
 
+/**
+ * Error thrown when OpenFoodFacts resolved the barcode to a real
+ * product, but the product's category is not a beer (e.g. soda,
+ * food, water). Backend issues a 422 with `errorCode: NOT_A_BEER`,
+ * the scanned barcode, and the product name (so the UI can say
+ * "Vous avez scanné Coca-Cola"). Issue #798 jury edge case D.
+ */
+export class ScanLookupNotABeerError extends Error {
+  constructor(
+    public readonly barcode: string,
+    public readonly productName: string | null,
+  ) {
+    super(
+      `Barcode "${barcode}" resolved to a non-beer product${
+        productName ? ` (${productName})` : ""
+      }.`,
+    );
+    this.name = "ScanLookupNotABeerError";
+  }
+}
+
 function normaliseBarcode(input: string): string {
   return input.trim().replace(/\D/g, "");
 }
@@ -118,7 +139,30 @@ export async function lookupBeerByBarcode(
       if (error.status === 503) {
         throw new ScanLookupServiceUnavailableError(barcode);
       }
+      if (error.status === 422 && isNotABeerDetails(error.details)) {
+        throw new ScanLookupNotABeerError(
+          barcode,
+          error.details.productName ?? null,
+        );
+      }
     }
     throw error;
   }
+}
+
+/**
+ * Type guard for the 422 NOT_A_BEER response body shape produced by
+ * the API's `NotABeerException` (#798). NestJS spreads the object
+ * passed to `super({...})` at the top level of the response payload,
+ * so we look for `errorCode === 'NOT_A_BEER'` directly there.
+ */
+function isNotABeerDetails(
+  details: unknown,
+): details is { errorCode: "NOT_A_BEER"; productName?: string | null } {
+  return (
+    typeof details === "object" &&
+    details !== null &&
+    "errorCode" in details &&
+    (details as { errorCode: unknown }).errorCode === "NOT_A_BEER"
+  );
 }

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -23,6 +23,7 @@ import { getMatchingRecipes } from "@/features/scan/application/recipe-matching.
 import {
   ScanLookupBeerNotFoundError,
   ScanLookupInvalidBarcodeError,
+  ScanLookupNotABeerError,
   ScanLookupServiceUnavailableError,
   lookupBeerByBarcode,
 } from "@/features/scan/application/scan-lookup.use-cases";
@@ -47,7 +48,12 @@ type BeerInfoCardScreenProps = {
   barcodeParam?: string | string[];
 };
 
-type ErrorVariant = "not_found" | "unavailable" | "invalid" | "generic";
+type ErrorVariant =
+  | "not_found"
+  | "not_a_beer"
+  | "unavailable"
+  | "invalid"
+  | "generic";
 
 type ScreenStatus =
   | { kind: "loading" }
@@ -58,6 +64,7 @@ type ScreenStatus =
       message: string;
       canRetry: boolean;
       barcode?: string;
+      productName?: string | null;
     };
 
 const ERROR_NOT_FOUND =
@@ -67,6 +74,10 @@ const ERROR_UNAVAILABLE =
 const ERROR_INVALID =
   "Ce code-barres n'est pas reconnu (8 à 14 chiffres attendus). Vérifie ce que tu as scanné.";
 const ERROR_GENERIC = "Impossible de récupérer cette bière pour le moment.";
+const ERROR_NOT_A_BEER_KNOWN = (productName: string) =>
+  `Tu as scanné « ${productName} » — ce n'est pas une bière. Tente avec une bouteille de bière.`;
+const ERROR_NOT_A_BEER_UNKNOWN =
+  "Ce produit n'est pas une bière. Tente avec une bouteille de bière.";
 
 // Placeholder destination for the v0.1 unknown-beer mailto CTAs
 // (#796). Will be replaced by a real catalog-suggestion form in v0.2
@@ -86,6 +97,18 @@ function mapErrorToStatus(error: unknown): ScreenStatus {
       message: ERROR_NOT_FOUND,
       canRetry: false,
       barcode: error.barcode,
+    };
+  }
+  if (error instanceof ScanLookupNotABeerError) {
+    return {
+      kind: "error",
+      variant: "not_a_beer",
+      message: error.productName
+        ? ERROR_NOT_A_BEER_KNOWN(error.productName)
+        : ERROR_NOT_A_BEER_UNKNOWN,
+      canRetry: false,
+      barcode: error.barcode,
+      productName: error.productName,
     };
   }
   if (error instanceof ScanLookupServiceUnavailableError) {
@@ -224,6 +247,9 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
         />
         {status.variant === "not_found" && status.barcode ? (
           <UnknownBeerCTAs barcode={status.barcode} />
+        ) : null}
+        {status.variant === "not_a_beer" ? (
+          <NotABeerCTA onScanAgain={handleBack} />
         ) : null}
       </Screen>
     );
@@ -531,6 +557,35 @@ function UnknownBeerCTAs({
         <Text style={styles.unknownCtaSecondaryText}>
           Ajouter cette bière au catalogue
         </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+/**
+ * "Not a beer" CTA — shown beneath the not-a-beer error message
+ * (#798, persona Léa la Curieuse). The product name is already in
+ * the error message line itself; this component just offers the
+ * single "Scanner une bière" CTA that returns the user to the
+ * scan camera so they can try with an actual beer.
+ */
+function NotABeerCTA({
+  onScanAgain,
+}: Readonly<{
+  onScanAgain: () => void;
+}>) {
+  return (
+    <View style={styles.unknownCard}>
+      <Pressable
+        onPress={onScanAgain}
+        accessibilityRole="button"
+        accessibilityLabel="Retourner au scan pour tenter une autre bouteille"
+        style={({ pressed }) => [
+          styles.unknownCta,
+          pressed ? styles.unknownCtaPressed : null,
+        ]}
+      >
+        <Text style={styles.unknownCtaText}>Scanner une bière</Text>
       </Pressable>
     </View>
   );

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -13,6 +13,7 @@ import { getMatchingRecipes } from "@/features/scan/application/recipe-matching.
 import { importRecipeFromCommunity } from "@/features/recipes/application/recipes.use-cases";
 import {
   ScanLookupBeerNotFoundError,
+  ScanLookupNotABeerError,
   ScanLookupServiceUnavailableError,
   lookupBeerByBarcode,
 } from "@/features/scan/application/scan-lookup.use-cases";
@@ -383,6 +384,51 @@ describe("BeerInfoCardScreen", () => {
         expect(
           screen.queryByLabelText(/Suggérer une correction par email/i),
         ).toBeNull();
+      });
+    });
+
+    describe("not-a-beer detection (Issue #798)", () => {
+      it("displays the product name and a 'Scanner une bière' CTA when the lookup throws ScanLookupNotABeerError", async () => {
+        mockedLookup.mockRejectedValueOnce(
+          new ScanLookupNotABeerError("5449000000996", "Coca-Cola Original"),
+        );
+
+        render(<BeerInfoCardScreen barcodeParam="5449000000996" />);
+
+        expect(await screen.findByText(/Coca-Cola Original/i)).toBeTruthy();
+        expect(screen.getByText(/ce n'est pas une bière/i)).toBeTruthy();
+        expect(
+          screen.getByLabelText(
+            /Retourner au scan pour tenter une autre bouteille/i,
+          ),
+        ).toBeTruthy();
+      });
+
+      it("falls back to a generic message when the product name is null", async () => {
+        mockedLookup.mockRejectedValueOnce(
+          new ScanLookupNotABeerError("5449000000996", null),
+        );
+
+        render(<BeerInfoCardScreen barcodeParam="5449000000996" />);
+
+        expect(
+          await screen.findByText(/Ce produit n'est pas une bière/i),
+        ).toBeTruthy();
+      });
+
+      it("the 'Scanner une bière' CTA navigates back to the scan view", async () => {
+        mockedLookup.mockRejectedValueOnce(
+          new ScanLookupNotABeerError("5449000000996", "Coca-Cola Original"),
+        );
+
+        render(<BeerInfoCardScreen barcodeParam="5449000000996" />);
+
+        const cta = await screen.findByLabelText(
+          /Retourner au scan pour tenter une autre bouteille/i,
+        );
+        fireEvent.press(cta);
+
+        expect(mockReplace).toHaveBeenCalledWith("/(app)/dashboard/scan");
       });
     });
   });


### PR DESCRIPTION
Sub-PR 2/3 of [Epic] #794 (scan jury edge cases). PR #799 (B) was sub-PR 1/3 and is already merged.

## Summary

**Backend** (`packages/api`):
- New \`NotABeerException\` (422 UnprocessableEntityException) carrying \`errorCode='NOT_A_BEER'\` + barcode + product name
- \`ScanService.lookupByBarcode\` splits the previous combined \`!found || !isBeer\` check into two distinct branches: 404 NotFound (genuinely missing) vs 422 NotABeer (real product, non-beer category). Cache-stale fallback preserved on both paths
- 2 new spec tests + existing 23 still green

**Mobile** (\`packages/mobile-app\`):
- New \`ScanLookupNotABeerError\` typed error (barcode + productName)
- Use-case translates 422 HttpError with \`errorCode='NOT_A_BEER'\` into the typed error; other 422s pass through unchanged
- \`BeerInfoCardScreen\` extends \`ErrorVariant\` with \`not_a_beer\`, renders dedicated UI: *"Tu as scanné « Coca-Cola » — ce n'est pas une bière"* + "Scanner une bière" CTA returning to the camera
- 2 new use-case tests + 3 new screen tests

## Demo impact

If the jury scans a Coca-Cola or any non-beer barcode, the app no longer renders the wrong product as a beer. Instead, it shows a clear "ce n'est pas une bière" screen with the actual product name + a CTA back to the scan camera.

## Checklist

- [x] Happy path + sad path + edge cases covered (5 new tests across 4 files)
- [x] \`tsc --noEmit\` passes (mobile + API)
- [x] Build passes (\`npm run ci:check\` green on mobile, \`lint:check\` green on API)
- [x] All tests green (570 mobile / 384 API including 2 pre-existing skipped)
- [x] No \`any\`, no inline styles introduced

Closes #798