### PR TITLE
feat(scan): photo fallback CTA on invalid barcode — placeholder for v0.2 photo capture (Issue #797)

### DIFF
--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -251,6 +251,7 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
         {status.variant === "not_a_beer" ? (
           <NotABeerCTA onScanAgain={handleBack} />
         ) : null}
+        {status.variant === "invalid" ? <PhotoFallbackCTA /> : null}
       </Screen>
     );
   }
@@ -556,6 +557,41 @@ function UnknownBeerCTAs({
       >
         <Text style={styles.unknownCtaSecondaryText}>
           Ajouter cette bière au catalogue
+        </Text>
+      </Pressable>
+    </View>
+  );
+}
+
+/**
+ * "Photo fallback" CTA — shown beneath the invalid-barcode error
+ * (#797, sub-PR 3/3 of [Epic] #794). When the camera reads a
+ * malformed code-barres, offers the user a forward-looking "take a
+ * photo of the label" path. The real photo capture / OCR feature
+ * lives in epic #751 and lands in v0.2; for now the CTA opens an
+ * informational alert so Léa is not stuck on a dead-end screen.
+ */
+const PHOTO_FALLBACK_TITLE = "Reconnaissance visuelle de l'étiquette";
+const PHOTO_FALLBACK_BODY =
+  "Cette fonctionnalité arrive dans la v0.2 (epic #751). En attendant, scanne le code-barres ou saisis-le manuellement.";
+
+function PhotoFallbackCTA() {
+  const handlePress = useCallback(() => {
+    Alert.alert(PHOTO_FALLBACK_TITLE, PHOTO_FALLBACK_BODY, [{ text: "OK" }]);
+  }, []);
+  return (
+    <View style={styles.unknownCard}>
+      <Pressable
+        onPress={handlePress}
+        accessibilityRole="button"
+        accessibilityLabel="Photographier l'étiquette"
+        style={({ pressed }) => [
+          styles.unknownCta,
+          pressed ? styles.unknownCtaPressed : null,
+        ]}
+      >
+        <Text style={styles.unknownCtaText}>
+          Photographier l&apos;étiquette
         </Text>
       </Pressable>
     </View>

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -431,6 +431,44 @@ describe("BeerInfoCardScreen", () => {
         expect(mockReplace).toHaveBeenCalledWith("/(app)/dashboard/scan");
       });
     });
+
+    describe("photo fallback CTA on invalid barcode (Issue #797)", () => {
+      it("renders 'Photographier l'étiquette' CTA when the screen lands without a barcode param", async () => {
+        // No barcodeParam → sets ERROR_INVALID directly without hitting the lookup.
+        render(<BeerInfoCardScreen barcodeParam={undefined} />);
+
+        expect(
+          await screen.findByLabelText(/Photographier l'étiquette/i),
+        ).toBeTruthy();
+        expect(mockedLookup).not.toHaveBeenCalled();
+      });
+
+      it("opens an informational alert referencing v0.2 / epic #751 when the CTA is pressed", async () => {
+        render(<BeerInfoCardScreen barcodeParam={undefined} />);
+
+        const cta = await screen.findByLabelText(/Photographier l'étiquette/i);
+        fireEvent.press(cta);
+
+        expect(alertSpy).toHaveBeenCalledWith(
+          expect.stringMatching(/Reconnaissance visuelle/i),
+          expect.stringMatching(/v0\.2.*#751/i),
+          expect.any(Array),
+        );
+      });
+
+      it("does NOT render the photo fallback CTA on a not-found error", async () => {
+        mockedLookup.mockRejectedValueOnce(
+          new ScanLookupBeerNotFoundError("3760215750042"),
+        );
+
+        render(<BeerInfoCardScreen barcodeParam="3760215750042" />);
+
+        await screen.findByText(/n'est pas dans notre catalogue/);
+        expect(
+          screen.queryByLabelText(/Photographier l'étiquette/i),
+        ).toBeNull();
+      });
+    });
   });
 
   describe("import community recipe", () => {


### PR DESCRIPTION
Sub-PR 3/3 of [Epic] #794 (scan jury edge cases). PR #799 (B) and PR #800 (D) already merged.

## Summary

When the camera reads a malformed code-barres (or no barcode is provided), the user previously hit a dead-end \"Vérifie ce que tu as scanné\" message with no path forward.

- New \`PhotoFallbackCTA\` rendered below the invalid-barcode error
- Tapping the CTA opens an \`Alert.alert\` titled *\"Reconnaissance visuelle de l'étiquette\"* explaining the feature lands in v0.2 (epic #751) and inviting the user to scan the code-barres in the meantime
- 3 new tests: CTA renders on \`invalid\` variant, alert content references v0.2 + #751, regression guard (does not render on other error variants)

## Demo impact

Closes the third (and last) jury edge case for Léa la Curieuse. Even on a totally unreadable bottle label, the demo no longer dead-ends — the jury sees a forward-looking promise.

## Checklist

- [x] Happy path + sad path + edge cases covered (3 new tests)
- [x] \`tsc --noEmit\` passes
- [x] Build passes (\`npm run ci:check\` green)
- [x] All tests green (573 mobile / 60 suites)
- [x] No \`any\`, no inline styles introduced

Closes #797