### PR TITLE
feat(scan): hidden long-press demo override menu — soutenance safety net (Issue #642)

### DIFF
--- a/packages/mobile-app/src/features/scan/presentation/ScanScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/ScanScreen.tsx
@@ -27,6 +27,7 @@ import { Card } from "@/core/ui/Card";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { DemoOverrideMenu } from "@/features/scan/presentation/components/DemoOverrideMenu";
 import { useRouter } from "expo-router";
 
 type BarcodeScanEvent = {
@@ -175,6 +176,10 @@ export function ScanScreen() {
   const [isGuideModalVisible, setIsGuideModalVisible] = useState(false);
   const [isFallbackModalVisible, setIsFallbackModalVisible] = useState(false);
   const [isResetModalVisible, setIsResetModalVisible] = useState(false);
+  // Soutenance backup (#642): hidden long-press on the help button
+  // opens a list of seeded beers, used by the speaker to force a
+  // result if the live camera misfires on stage.
+  const [isDemoOverrideVisible, setIsDemoOverrideVisible] = useState(false);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -542,6 +547,12 @@ export function ScanScreen() {
                 pressed && styles.pressed,
               ]}
               onPress={() => setIsGuideModalVisible(true)}
+              // Hidden soutenance gesture (#642): long-press opens
+              // the demo override menu so the speaker can force a
+              // known result if the live scan misfires on stage.
+              // Undocumented for end users on purpose.
+              onLongPress={() => setIsDemoOverrideVisible(true)}
+              delayLongPress={1500}
             >
               <Text style={styles.helpButtonText}>?</Text>
             </Pressable>
@@ -964,6 +975,17 @@ export function ScanScreen() {
           </View>
         </View>
       </Modal>
+
+      <DemoOverrideMenu
+        visible={isDemoOverrideVisible}
+        onClose={() => setIsDemoOverrideVisible(false)}
+        onSelectBeer={(barcode) => {
+          setIsDemoOverrideVisible(false);
+          router.push(
+            `/(app)/dashboard/scan/lookup/${encodeURIComponent(barcode)}` as never,
+          );
+        }}
+      />
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/scan/presentation/ScanScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/ScanScreen.tsx
@@ -12,7 +12,13 @@ import type {
   ScanProcessOutcome,
 } from "@/features/scan/domain/scan.types";
 import { CameraView, useCameraPermissions } from "expo-camera";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   Modal,
   Pressable,
@@ -180,6 +186,11 @@ export function ScanScreen() {
   // opens a list of seeded beers, used by the speaker to force a
   // result if the live camera misfires on stage.
   const [isDemoOverrideVisible, setIsDemoOverrideVisible] = useState(false);
+  // React Native fires `onPress` on release even after `onLongPress`
+  // has triggered, which would open the guide modal behind the demo
+  // override sheet (Codex P1 #805). We track the long-press in a ref
+  // and skip the next `onPress` when the flag is set.
+  const longPressFiredRef = useRef(false);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
@@ -546,12 +557,23 @@ export function ScanScreen() {
                 styles.helpButton,
                 pressed && styles.pressed,
               ]}
-              onPress={() => setIsGuideModalVisible(true)}
+              onPress={() => {
+                if (longPressFiredRef.current) {
+                  // Consume the trailing onPress that React Native
+                  // fires on release after a long-press completes.
+                  longPressFiredRef.current = false;
+                  return;
+                }
+                setIsGuideModalVisible(true);
+              }}
               // Hidden soutenance gesture (#642): long-press opens
               // the demo override menu so the speaker can force a
               // known result if the live scan misfires on stage.
               // Undocumented for end users on purpose.
-              onLongPress={() => setIsDemoOverrideVisible(true)}
+              onLongPress={() => {
+                longPressFiredRef.current = true;
+                setIsDemoOverrideVisible(true);
+              }}
               delayLongPress={1500}
             >
               <Text style={styles.helpButtonText}>?</Text>

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/ScanScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/ScanScreen.test.tsx
@@ -445,4 +445,62 @@ describe("ScanScreen", () => {
     expect(screen.getByText("Barcode scan")).toBeTruthy();
     expect(screen.getByText("Switch to bottle mode")).toBeTruthy();
   });
+
+  describe("demo override hidden long-press (Issue #642)", () => {
+    it("opens the demo override menu on a long-press of the help button", async () => {
+      renderScreen();
+      await waitForReadyState();
+
+      const helpButton = screen.getByLabelText("Open scan guide");
+      fireEvent(helpButton, "longPress");
+
+      // The override menu lists seeded beers — Punk IPA is the
+      // canonical first entry and a stable assertion target.
+      expect(await screen.findByText("Punk IPA")).toBeTruthy();
+      // The regular guide modal must NOT be shown.
+      expect(screen.queryByText("How barcode verification works")).toBeNull();
+    });
+
+    it("does NOT open the guide modal on the trailing onPress that fires after a long-press", async () => {
+      renderScreen();
+      await waitForReadyState();
+
+      const helpButton = screen.getByLabelText("Open scan guide");
+      // Simulate the React Native sequence: onLongPress fires,
+      // then onPress fires on release. Without the guard the
+      // guide modal would open behind the override sheet.
+      fireEvent(helpButton, "longPress");
+      fireEvent.press(helpButton);
+
+      expect(await screen.findByText("Punk IPA")).toBeTruthy();
+      expect(screen.queryByText("How barcode verification works")).toBeNull();
+    });
+
+    it("opens the guide modal on a regular press (no long-press)", async () => {
+      renderScreen();
+      await waitForReadyState();
+
+      const helpButton = screen.getByLabelText("Open scan guide");
+      fireEvent.press(helpButton);
+
+      expect(
+        await screen.findByText("How barcode verification works"),
+      ).toBeTruthy();
+      // The override menu must NOT be shown.
+      expect(screen.queryByText(/Démo — bières seedées/i)).toBeNull();
+    });
+
+    it("navigates to the lookup route when a beer is selected from the override menu", async () => {
+      renderScreen();
+      await waitForReadyState();
+
+      fireEvent(screen.getByLabelText("Open scan guide"), "longPress");
+      // Punk IPA — barcode 5060277380019 (stable demo seed entry).
+      fireEvent.press(await screen.findByLabelText(/Forcer Punk IPA/i));
+
+      expect(mockPush).toHaveBeenCalledWith(
+        "/(app)/dashboard/scan/lookup/5060277380019",
+      );
+    });
+  });
 });

--- a/packages/mobile-app/src/features/scan/presentation/components/DemoOverrideMenu.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/components/DemoOverrideMenu.tsx
@@ -1,0 +1,183 @@
+import React, { useMemo } from "react";
+import {
+  FlatList,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import { colors, radius, spacing, typography } from "@/core/theme";
+import type { ScanCatalogItem } from "@/features/scan/domain/scan.types";
+import { demoScanCatalog } from "@/mocks/demo-data";
+
+/**
+ * DemoOverrideMenu — soutenance backup (#642).
+ *
+ * Hidden modal accessible via a long-press gesture on the scan
+ * screen header help button. Lists all beers from the demo catalog
+ * and, on tap, navigates the screen to the corresponding info card
+ * exactly as if the user had scanned the matching barcode.
+ *
+ * Intended use: stage emergency. If the live camera misfires or
+ * the demo bottle is missing on stage, the speaker triggers this
+ * menu and forces the result on a known beer to keep the demo
+ * flowing. Hidden from normal users — long-press is undocumented.
+ *
+ * Stays mounted in production builds (the gesture itself is the
+ * gate). No env-var protection on purpose: the speaker may need it
+ * regardless of build profile.
+ */
+
+type Props = Readonly<{
+  visible: boolean;
+  onClose: () => void;
+  onSelectBeer: (barcode: string) => void;
+}>;
+
+export function DemoOverrideMenu({ visible, onClose, onSelectBeer }: Props) {
+  const beers = useMemo<ScanCatalogItem[]>(
+    () =>
+      Object.values(demoScanCatalog).sort((a, b) =>
+        a.name.localeCompare(b.name),
+      ),
+    [],
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      accessibilityViewIsModal
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.sheet}>
+          <View style={styles.header}>
+            <Text style={styles.title}>Démo — bières seedées</Text>
+            <Text style={styles.subtitle}>
+              Tape une bière pour forcer le résultat du scan.
+            </Text>
+          </View>
+
+          <FlatList
+            data={beers}
+            keyExtractor={(item) => item.barcode}
+            ItemSeparatorComponent={() => <View style={styles.separator} />}
+            renderItem={({ item }) => (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={`Forcer ${item.name} (${item.brewery})`}
+                onPress={() => onSelectBeer(item.barcode)}
+                style={({ pressed }) => [
+                  styles.row,
+                  pressed ? styles.rowPressed : null,
+                ]}
+              >
+                <Text style={styles.rowName}>{item.name}</Text>
+                <Text style={styles.rowMeta}>
+                  {item.brewery}
+                  {item.style ? ` · ${item.style}` : ""}
+                  {item.abv != null ? ` · ${item.abv.toFixed(1)} %` : ""}
+                </Text>
+                <Text style={styles.rowBarcode}>{item.barcode}</Text>
+              </Pressable>
+            )}
+          />
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Fermer le menu démo"
+            onPress={onClose}
+            style={({ pressed }) => [
+              styles.cancelButton,
+              pressed ? styles.cancelPressed : null,
+            ]}
+          >
+            <Text style={styles.cancelText}>Annuler</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "flex-end",
+  },
+  sheet: {
+    backgroundColor: colors.neutral.white,
+    borderTopLeftRadius: radius.lg,
+    borderTopRightRadius: radius.lg,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
+    maxHeight: "75%",
+  },
+  header: {
+    paddingBottom: spacing.sm,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.neutral.border,
+    marginBottom: spacing.sm,
+  },
+  title: {
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+  },
+  subtitle: {
+    marginTop: spacing.xxs,
+    fontSize: typography.size.label,
+    color: colors.neutral.textSecondary,
+  },
+  separator: {
+    height: 1,
+    backgroundColor: colors.neutral.border,
+  },
+  row: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.xs,
+  },
+  rowPressed: {
+    backgroundColor: colors.state.infoBackground,
+  },
+  rowName: {
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.medium,
+    color: colors.neutral.textPrimary,
+  },
+  rowMeta: {
+    marginTop: spacing.xxs,
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+  },
+  rowBarcode: {
+    marginTop: spacing.xxs,
+    fontSize: typography.size.caption,
+    color: colors.neutral.muted,
+    fontVariant: ["tabular-nums"],
+  },
+  cancelButton: {
+    marginTop: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.sm,
+    borderWidth: 1,
+    borderColor: colors.brand.primary,
+    alignItems: "center",
+  },
+  cancelPressed: {
+    opacity: 0.7,
+  },
+  cancelText: {
+    color: colors.brand.primary,
+    fontSize: typography.size.label,
+    fontWeight: typography.weight.medium,
+  },
+});

--- a/packages/mobile-app/src/features/scan/presentation/components/__tests__/DemoOverrideMenu.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/components/__tests__/DemoOverrideMenu.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import React from "react";
+
+import { DemoOverrideMenu } from "@/features/scan/presentation/components/DemoOverrideMenu";
+
+describe("DemoOverrideMenu (Issue #642 — soutenance backup)", () => {
+  it("renders all seeded beers when visible", () => {
+    render(
+      <DemoOverrideMenu visible onClose={jest.fn()} onSelectBeer={jest.fn()} />,
+    );
+
+    // Sample assertions on a few well-known seeds (full list is
+    // 9 beers as of 2026-04-29 — see scan-catalog.seed.ts).
+    expect(screen.getByText("Punk IPA")).toBeTruthy();
+    expect(screen.getByText("La Chouffe")).toBeTruthy();
+    expect(screen.getByText("Rochefort 10")).toBeTruthy();
+    expect(screen.getByText(/Démo — bières seedées/i)).toBeTruthy();
+  });
+
+  it("renders nothing when not visible", () => {
+    render(
+      <DemoOverrideMenu
+        visible={false}
+        onClose={jest.fn()}
+        onSelectBeer={jest.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Punk IPA")).toBeNull();
+  });
+
+  it("calls onSelectBeer with the matching barcode when a row is tapped", () => {
+    const handleSelect = jest.fn();
+    render(
+      <DemoOverrideMenu
+        visible
+        onClose={jest.fn()}
+        onSelectBeer={handleSelect}
+      />,
+    );
+
+    fireEvent.press(screen.getByLabelText(/Forcer Punk IPA/i));
+
+    expect(handleSelect).toHaveBeenCalledTimes(1);
+    expect(handleSelect).toHaveBeenCalledWith("5060277380019");
+  });
+
+  it("calls onClose when the cancel button is tapped", () => {
+    const handleClose = jest.fn();
+    render(
+      <DemoOverrideMenu
+        visible
+        onClose={handleClose}
+        onSelectBeer={jest.fn()}
+      />,
+    );
+
+    fireEvent.press(screen.getByLabelText(/Fermer le menu démo/i));
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays brewery + style + ABV metadata on each row", () => {
+    render(
+      <DemoOverrideMenu visible onClose={jest.fn()} onSelectBeer={jest.fn()} />,
+    );
+
+    // Punk IPA: BrewDog · IPA · 5.4 %
+    expect(screen.getByText(/BrewDog · IPA · 5\.4 %/i)).toBeTruthy();
+  });
+
+  it("shows the EAN-13 barcode on each row (so the speaker can sanity-check it)", () => {
+    render(
+      <DemoOverrideMenu visible onClose={jest.fn()} onSelectBeer={jest.fn()} />,
+    );
+
+    expect(screen.getByText("5060277380019")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Sprint B chunk for #642 (Scan demo assets prep). Companion to PR #802 (demo script doc).

## Summary

Stage emergency hatch for the soutenance demo. If the live camera misfires or the demo bottle is missing on stage, the speaker performs a **hidden long-press (1.5s) on the help button** in the scan screen header to open a modal listing the seeded beers. Tap any → navigates directly to BeerInfoCardScreen with that barcode, exactly as if the user had scanned successfully.

The gesture is **undocumented for end users**. No env-var gating: the speaker may need it regardless of build profile (dev / preview / production).

## What's in

- New \`DemoOverrideMenu\` component (modal + FlatList of seeded beers, sorted by name)
- Long-press handler (1.5s threshold) on the existing help \`?\` button in \`ScanScreen.tsx\`
- 6 component tests (visible/hidden state, beer rows render, tap callback fires the right barcode, cancel button, metadata + barcode display)

## Known sync gap

Mobile \`demoScanCatalog\` carries **4 beers** while the API seed has **9** (drift since PR #791). The override surfaces the 4 mobile entries; the 5 API-only beers (Karmeliet Tripel, Westmalle Tripel, Duvel, Heineken, Cervoise Lancelot) need a separate mobile-mocks sync — captured in **#804**.

Practical impact for the soutenance: in production mode (\`EXPO_PUBLIC_USE_DEMO_DATA=false\`), the override menu still only lists 4 entries (sourced from mocks), but tapping any beer navigates to the live API which has all 9. To get the full 9-beer list in the menu, #804 needs to land.

For the **soutenance blanche on 2026-05-06**, the 4 currently-listed beers (Punk IPA, La Chouffe, Rochefort 10, La Goudale) cover the primary demo path, so this PR is functionally sufficient.

## Other #642 criteria addressed elsewhere

- ✅ 6+ beers seeded — done in PR #791 (now 9 beers)
- 🔍 Barcodes verified against real bottles — logistical, validated at the soutenance blanche
- 🔍 Rehearsal 2× without issue — soutenance blanche on 2026-05-06

## Checklist

- [x] Happy path + sad path + edge cases covered (6 tests)
- [x] \`tsc --noEmit\` passes
- [x] Build passes (\`npm run ci:check\` green)
- [x] All tests green (579 mobile / 61 suites — 6 new tests)
- [x] No \`any\`, no inline styles introduced
- [x] No hardcoded colors / spacing / fonts (theme tokens only)

Closes the override portion of #642 (other criteria are logistical).