### PR TITLE
feat(seed): pre-seed Punk IPA brassin demo + 7 brewing-day steps (Issue #782 minimal+)

### DIFF
--- a/packages/api/scripts/run-demo-batch-seed.ts
+++ b/packages/api/scripts/run-demo-batch-seed.ts
@@ -1,0 +1,59 @@
+/**
+ * One-shot script to seed the demo Punk IPA brassin row + its 7
+ * brewing-day steps against the local dev database (Issue #782).
+ *
+ * Usage:
+ *   cd packages/api
+ *   npx ts-node -r tsconfig-paths/register scripts/run-demo-batch-seed.ts
+ *
+ * Prerequisites:
+ *   - The Punk IPA recipe (#701) must be seeded first. The script
+ *     orchestrates the full chain (system user → public recipes →
+ *     demo batch) so a fresh DB can be bootstrapped end-to-end in
+ *     one invocation.
+ *
+ * Idempotent: safe to run multiple times. Existing rows are
+ * updated in place; missing ones are inserted.
+ */
+import 'reflect-metadata';
+
+import dataSource from '../src/database/data-source';
+import { BatchOrmEntity } from '../src/batch/entities/batch.orm.entity';
+import { BatchStepOrmEntity } from '../src/batch/entities/batch-step.orm.entity';
+import { RecipeOrmEntity } from '../src/recipe/entities/recipe.orm.entity';
+import { User } from '../src/user/entities/user.entity';
+import { seedDemoBatch } from '../src/database/seeds/demo-batch.seed';
+import { seedPublicRecipes } from '../src/database/seeds/public-recipes.seed';
+import { seedSystemUser } from '../src/database/seeds/system-user.seed';
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  // Step 1 — system user (FK target for the demo batch's owner_id
+  // and the public recipes' owner_id).
+  const userRepo = dataSource.getRepository(User);
+  const userResult = await seedSystemUser(userRepo);
+  console.log('System user seed:', userResult);
+
+  // Step 2 — public recipes (FK target for the demo batch's
+  // recipe_id). Required even on re-runs because it brings the
+  // schema row up to the latest curated values.
+  const recipeRepo = dataSource.getRepository(RecipeOrmEntity);
+  const recipeResult = await seedPublicRecipes(recipeRepo);
+  console.log('Public recipes seed:', recipeResult);
+
+  // Step 3 — demo batch + 7 brewing-day steps.
+  const batchRepo = dataSource.getRepository(BatchOrmEntity);
+  const stepRepo = dataSource.getRepository(BatchStepOrmEntity);
+  const batchResult = await seedDemoBatch(batchRepo, recipeRepo, stepRepo);
+  console.log('Demo batch seed:', batchResult);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/batch/entities/batch.orm.entity.ts
+++ b/packages/api/src/batch/entities/batch.orm.entity.ts
@@ -21,6 +21,34 @@ export class BatchOrmEntity {
   @Column({ type: 'varchar', length: 36, nullable: false })
   recipe_id: string;
 
+  // Issue #782 minimal++ — narrative + metric fields kept on the row
+  // itself so the brassin carries the basics expected by the demo
+  // story (title, free-text recap, target vs final volume, OG/FG/ABV
+  // trio) independently of the linked recipe. All nullable so
+  // legacy rows don't need backfill. Richer per-stage volumes,
+  // measurements, observations, and step transitions live in the
+  // v0.2/v0.3 backlog (#808-#814).
+  @Column({ type: 'varchar', length: 120, nullable: true })
+  name?: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  notes?: string | null;
+
+  @Column({ type: 'real', nullable: true })
+  target_volume_l?: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  final_volume_l?: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  og_actual?: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  fg_actual?: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  abv_actual?: number | null;
+
   @Column({
     type: 'varchar',
     length: 20,

--- a/packages/api/src/database/migrations/1782000000000-AddBatchDemoNarrativeFields.ts
+++ b/packages/api/src/database/migrations/1782000000000-AddBatchDemoNarrativeFields.ts
@@ -1,0 +1,73 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds the minimum-viable narrative + metric columns to `batches`
+ * so a brassin can carry a human-friendly title, free-text notes,
+ * the basic volume reality (target vs final), and the brewing-day
+ * gravity / ABV trio (Issue #782 — pre-seed Punk IPA brassin demo,
+ * minimal+ version validated through the 8-axis data model Q&A on
+ * 2026-04-30).
+ *
+ * Decisions per axis (KISS for blanche, rich variants deferred to
+ * the v0.2/v0.3 backlog issues #808-#814):
+ *
+ * - Axis 1 (identity)        → name + notes
+ * - Axis 2 (volumes)         → target_volume_l + final_volume_l
+ * - Axis 3 (gravity + ABV)   → og_actual + fg_actual + abv_actual
+ * - Axis 4 (intermediate measurements) → none — see #811
+ * - Axis 5 (observations)    → notes covers it for v0.1 — see #812
+ * - Axis 6 (steps)           → seeds 9 BatchStep rows, no schema change
+ * - Axis 7 (alerts)          → none — see #814
+ * - Axis 8 (photos)          → none — see #808
+ *
+ * All columns are nullable: pre-existing batches predate this
+ * scope, and we don't want to force-fill arbitrary defaults during
+ * the migration. New brassins (v0.1+) start populating these as
+ * the brewer fills the form.
+ *
+ * Type rationale: aligned with the existing `recipes.og_target` /
+ * `recipes.fg_target` convention which uses SQLite `real`
+ * (double-precision floating-point). FP64 has ample headroom for
+ * brewing precision — gravity 1.057 vs 1.058 is nowhere near the
+ * representation limit. Decimal types are reserved for monetary
+ * values; brewing metrics use real.
+ */
+export class AddBatchDemoNarrativeFields1782000000000 implements MigrationInterface {
+  name = 'AddBatchDemoNarrativeFields1782000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "name" varchar(120)`,
+    );
+    await queryRunner.query(`ALTER TABLE "batches" ADD COLUMN "notes" text`);
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "target_volume_l" real`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "final_volume_l" real`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "og_actual" real`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "fg_actual" real`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "abv_actual" real`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "abv_actual"`);
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "fg_actual"`);
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "og_actual"`);
+    await queryRunner.query(
+      `ALTER TABLE "batches" DROP COLUMN "final_volume_l"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batches" DROP COLUMN "target_volume_l"`,
+    );
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "notes"`);
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "name"`);
+  }
+}

--- a/packages/api/src/database/migrations/1782000000000-AddBatchDemoNarrativeFields.ts
+++ b/packages/api/src/database/migrations/1782000000000-AddBatchDemoNarrativeFields.ts
@@ -32,42 +32,36 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * representation limit. Decimal types are reserved for monetary
  * values; brewing metrics use real.
  */
+// Columns added in this migration, in their semantic creation order
+// (down migration drops them in reverse). Keeping the list as a
+// shared constant lets the up / down methods iterate instead of
+// repeating 7 verbatim ALTER statements each.
+const COLUMNS: ReadonlyArray<{ name: string; sqlType: string }> = [
+  { name: 'name', sqlType: 'varchar(120)' },
+  { name: 'notes', sqlType: 'text' },
+  { name: 'target_volume_l', sqlType: 'real' },
+  { name: 'final_volume_l', sqlType: 'real' },
+  { name: 'og_actual', sqlType: 'real' },
+  { name: 'fg_actual', sqlType: 'real' },
+  { name: 'abv_actual', sqlType: 'real' },
+];
+
 export class AddBatchDemoNarrativeFields1782000000000 implements MigrationInterface {
   name = 'AddBatchDemoNarrativeFields1782000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(
-      `ALTER TABLE "batches" ADD COLUMN "name" varchar(120)`,
-    );
-    await queryRunner.query(`ALTER TABLE "batches" ADD COLUMN "notes" text`);
-    await queryRunner.query(
-      `ALTER TABLE "batches" ADD COLUMN "target_volume_l" real`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "batches" ADD COLUMN "final_volume_l" real`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "batches" ADD COLUMN "og_actual" real`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "batches" ADD COLUMN "fg_actual" real`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "batches" ADD COLUMN "abv_actual" real`,
-    );
+    for (const col of COLUMNS) {
+      await queryRunner.query(
+        `ALTER TABLE "batches" ADD COLUMN "${col.name}" ${col.sqlType}`,
+      );
+    }
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "abv_actual"`);
-    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "fg_actual"`);
-    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "og_actual"`);
-    await queryRunner.query(
-      `ALTER TABLE "batches" DROP COLUMN "final_volume_l"`,
-    );
-    await queryRunner.query(
-      `ALTER TABLE "batches" DROP COLUMN "target_volume_l"`,
-    );
-    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "notes"`);
-    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "name"`);
+    for (const col of [...COLUMNS].reverse()) {
+      await queryRunner.query(
+        `ALTER TABLE "batches" DROP COLUMN "${col.name}"`,
+      );
+    }
   }
 }

--- a/packages/api/src/database/seeds/demo-batch.seed.spec.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.spec.ts
@@ -1,0 +1,227 @@
+import { Repository } from 'typeorm';
+
+import { BatchOrmEntity } from '../../batch/entities/batch.orm.entity';
+import { BatchStatus } from '../../batch/domain/enums/batch-status.enum';
+import { BatchStepOrmEntity } from '../../batch/entities/batch-step.orm.entity';
+import { BatchStepStatus } from '../../batch/domain/enums/batch-step-status.enum';
+import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
+import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
+import {
+  DEMO_PUNK_IPA_BATCH_ID,
+  DEMO_PUNK_IPA_RECIPE_ID,
+  DemoBatchPrerequisiteMissingError,
+  seedDemoBatch,
+} from './demo-batch.seed';
+import { SYSTEM_USER_ID } from './system-user.seed';
+
+type RepoMock = {
+  findOne: jest.Mock;
+  create: jest.Mock;
+  save: jest.Mock;
+};
+
+function buildRepoMock(): RepoMock {
+  return {
+    findOne: jest.fn(),
+    create: jest.fn((input: unknown) => input),
+    save: jest.fn((input: unknown) => Promise.resolve(input)),
+  };
+}
+
+const FAKE_NOW = new Date('2026-04-30T12:00:00.000Z');
+
+describe('seedDemoBatch (Issue #782)', () => {
+  describe('sad path — prerequisite recipe missing', () => {
+    it('throws DemoBatchPrerequisiteMissingError when the Punk IPA recipe is not in the recipes table', async () => {
+      const batchRepo = buildRepoMock();
+      const recipeRepo = buildRepoMock();
+      const stepRepo = buildRepoMock();
+      recipeRepo.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        seedDemoBatch(
+          batchRepo as unknown as Repository<BatchOrmEntity>,
+          recipeRepo as unknown as Repository<RecipeOrmEntity>,
+          stepRepo as unknown as Repository<BatchStepOrmEntity>,
+          FAKE_NOW,
+        ),
+      ).rejects.toBeInstanceOf(DemoBatchPrerequisiteMissingError);
+
+      // No batch or step writes happened.
+      expect(batchRepo.create).not.toHaveBeenCalled();
+      expect(batchRepo.save).not.toHaveBeenCalled();
+      expect(stepRepo.create).not.toHaveBeenCalled();
+      expect(stepRepo.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('happy path — recipe exists, neither batch nor steps exist', () => {
+    let batchRepo: RepoMock;
+    let recipeRepo: RepoMock;
+    let stepRepo: RepoMock;
+
+    beforeEach(async () => {
+      batchRepo = buildRepoMock();
+      recipeRepo = buildRepoMock();
+      stepRepo = buildRepoMock();
+      recipeRepo.findOne.mockResolvedValueOnce({
+        id: DEMO_PUNK_IPA_RECIPE_ID,
+      });
+      batchRepo.findOne.mockResolvedValueOnce(null);
+      stepRepo.findOne.mockResolvedValue(null);
+
+      await seedDemoBatch(
+        batchRepo as unknown as Repository<BatchOrmEntity>,
+        recipeRepo as unknown as Repository<RecipeOrmEntity>,
+        stepRepo as unknown as Repository<BatchStepOrmEntity>,
+        FAKE_NOW,
+      );
+    });
+
+    it('inserts the batch row with the demo narrative + metric payload', () => {
+      expect(batchRepo.create).toHaveBeenCalledTimes(1);
+      const created = (
+        batchRepo.create.mock.calls[0] as unknown[]
+      )[0] as Record<string, unknown>;
+      expect(created.id).toBe(DEMO_PUNK_IPA_BATCH_ID);
+      expect(created.owner_id).toBe(SYSTEM_USER_ID);
+      expect(created.recipe_id).toBe(DEMO_PUNK_IPA_RECIPE_ID);
+      expect(created.name).toBe('Mon premier Punk IPA');
+      expect(created.status).toBe(BatchStatus.COMPLETED);
+      expect(created.target_volume_l).toBe(20);
+      expect(created.final_volume_l).toBe(18);
+      expect(created.og_actual).toBe(1.057);
+      expect(created.fg_actual).toBe(1.013);
+      expect(created.abv_actual).toBe(5.8);
+      expect(created.notes).toMatch(/Première Punk IPA/i);
+    });
+
+    it('seeds 7 BatchStep rows all marked COMPLETED', () => {
+      expect(stepRepo.create).toHaveBeenCalledTimes(7);
+      for (const call of stepRepo.create.mock.calls as unknown[][]) {
+        const arg = call[0] as Record<string, unknown>;
+        expect(arg.batch_id).toBe(DEMO_PUNK_IPA_BATCH_ID);
+        expect(arg.status).toBe(BatchStepStatus.COMPLETED);
+        expect(arg.label).toEqual(expect.any(String));
+        expect(arg.description).toEqual(expect.any(String));
+      }
+    });
+
+    it('orders steps from 1 to 7 and uses only canonical RecipeStepType values', () => {
+      const orders = (stepRepo.create.mock.calls as unknown[][]).map(
+        (call) => (call[0] as Record<string, unknown>).step_order,
+      );
+      expect(orders).toEqual([1, 2, 3, 4, 5, 6, 7]);
+
+      const types = (stepRepo.create.mock.calls as unknown[][]).map(
+        (call) => (call[0] as Record<string, unknown>).type,
+      );
+      const validTypes = Object.values(RecipeStepType);
+      for (const t of types) {
+        expect(validTypes).toContain(t);
+      }
+    });
+
+    it('reports inserted=1, no updates, 7 inserted steps', async () => {
+      const result = await seedDemoBatch(
+        buildRepoMock() as unknown as Repository<BatchOrmEntity>,
+        ((): RepoMock => {
+          const repo = buildRepoMock();
+          repo.findOne.mockResolvedValueOnce({ id: DEMO_PUNK_IPA_RECIPE_ID });
+          return repo;
+        })() as unknown as Repository<RecipeOrmEntity>,
+        ((): RepoMock => {
+          const repo = buildRepoMock();
+          repo.findOne.mockResolvedValue(null);
+          return repo;
+        })() as unknown as Repository<BatchStepOrmEntity>,
+        FAKE_NOW,
+      );
+      // The batch repo above has no findOne mock returning an existing row,
+      // so the loader sees null and inserts.
+      expect(result).toEqual({
+        insertedBatch: 1,
+        updatedBatch: 0,
+        insertedSteps: 7,
+        updatedSteps: 0,
+      });
+    });
+  });
+
+  describe('idempotency — re-running updates instead of inserting', () => {
+    it('updates the existing batch row + 7 steps in place when re-run', async () => {
+      const batchRepo = buildRepoMock();
+      const recipeRepo = buildRepoMock();
+      const stepRepo = buildRepoMock();
+
+      recipeRepo.findOne.mockResolvedValueOnce({
+        id: DEMO_PUNK_IPA_RECIPE_ID,
+      });
+      // Existing batch + 7 existing steps (re-run scenario).
+      batchRepo.findOne.mockResolvedValueOnce({
+        id: DEMO_PUNK_IPA_BATCH_ID,
+        // Older stale values that the seed should overwrite.
+        name: 'Stale name',
+        status: BatchStatus.IN_PROGRESS,
+      });
+      stepRepo.findOne.mockResolvedValue({
+        batch_id: DEMO_PUNK_IPA_BATCH_ID,
+        step_order: 1,
+        status: BatchStepStatus.IN_PROGRESS,
+      });
+
+      const result = await seedDemoBatch(
+        batchRepo as unknown as Repository<BatchOrmEntity>,
+        recipeRepo as unknown as Repository<RecipeOrmEntity>,
+        stepRepo as unknown as Repository<BatchStepOrmEntity>,
+        FAKE_NOW,
+      );
+
+      expect(result).toEqual({
+        insertedBatch: 0,
+        updatedBatch: 1,
+        insertedSteps: 0,
+        updatedSteps: 7,
+      });
+      // No `create` calls since we're updating in place.
+      expect(batchRepo.create).not.toHaveBeenCalled();
+      expect(stepRepo.create).not.toHaveBeenCalled();
+      // The save calls write the refreshed payload.
+      expect(batchRepo.save).toHaveBeenCalledTimes(1);
+      expect(stepRepo.save).toHaveBeenCalledTimes(7);
+    });
+  });
+
+  describe('edge case — date offsets relative to runtime', () => {
+    it('anchors started_at 14 days before the provided `now` and completed_at 7 days before', async () => {
+      const batchRepo = buildRepoMock();
+      const recipeRepo = buildRepoMock();
+      const stepRepo = buildRepoMock();
+      recipeRepo.findOne.mockResolvedValueOnce({
+        id: DEMO_PUNK_IPA_RECIPE_ID,
+      });
+      batchRepo.findOne.mockResolvedValueOnce(null);
+      stepRepo.findOne.mockResolvedValue(null);
+
+      await seedDemoBatch(
+        batchRepo as unknown as Repository<BatchOrmEntity>,
+        recipeRepo as unknown as Repository<RecipeOrmEntity>,
+        stepRepo as unknown as Repository<BatchStepOrmEntity>,
+        FAKE_NOW,
+      );
+
+      const batchPayload = (batchRepo.create.mock.calls[0] as unknown[])[0] as {
+        started_at: Date;
+        completed_at: Date;
+      };
+      const expectedStart = new Date('2026-04-16T12:00:00.000Z');
+      const expectedEnd = new Date('2026-04-23T12:00:00.000Z');
+      expect(batchPayload.started_at.toISOString()).toBe(
+        expectedStart.toISOString(),
+      );
+      expect(batchPayload.completed_at.toISOString()).toBe(
+        expectedEnd.toISOString(),
+      );
+    });
+  });
+});

--- a/packages/api/src/database/seeds/demo-batch.seed.spec.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.spec.ts
@@ -12,7 +12,7 @@ import {
   DemoBatchPrerequisiteMissingError,
   seedDemoBatch,
 } from './demo-batch.seed';
-import { RepoMock, buildRepoMock } from './seed-test-utils';
+import { buildRepoMock } from './seed-test-utils';
 import { SYSTEM_USER_ID } from './system-user.seed';
 
 const FAKE_NOW = new Date('2026-04-30T12:00:00.000Z');
@@ -43,9 +43,9 @@ describe('seedDemoBatch (Issue #782)', () => {
   });
 
   describe('happy path — recipe exists, neither batch nor steps exist', () => {
-    let batchRepo: RepoMock;
-    let recipeRepo: RepoMock;
-    let stepRepo: RepoMock;
+    let batchRepo: ReturnType<typeof buildRepoMock>;
+    let recipeRepo: ReturnType<typeof buildRepoMock>;
+    let stepRepo: ReturnType<typeof buildRepoMock>;
 
     beforeEach(async () => {
       batchRepo = buildRepoMock();

--- a/packages/api/src/database/seeds/demo-batch.seed.spec.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.spec.ts
@@ -12,21 +12,8 @@ import {
   DemoBatchPrerequisiteMissingError,
   seedDemoBatch,
 } from './demo-batch.seed';
+import { RepoMock, buildRepoMock } from './seed-test-utils';
 import { SYSTEM_USER_ID } from './system-user.seed';
-
-type RepoMock = {
-  findOne: jest.Mock;
-  create: jest.Mock;
-  save: jest.Mock;
-};
-
-function buildRepoMock(): RepoMock {
-  return {
-    findOne: jest.fn(),
-    create: jest.fn((input: unknown) => input),
-    save: jest.fn((input: unknown) => Promise.resolve(input)),
-  };
-}
 
 const FAKE_NOW = new Date('2026-04-30T12:00:00.000Z');
 

--- a/packages/api/src/database/seeds/demo-batch.seed.spec.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.spec.ts
@@ -17,6 +17,27 @@ import { SYSTEM_USER_ID } from './system-user.seed';
 
 const FAKE_NOW = new Date('2026-04-30T12:00:00.000Z');
 
+/**
+ * Wraps `seedDemoBatch` with the boilerplate `as unknown as
+ * Repository<X>` casts the spec needs to pass jest mocks into the
+ * strictly-typed loader signature. Extracted so the cast triplet
+ * does not appear verbatim across every test (SonarCloud
+ * duplication on new code).
+ */
+function runSeed(
+  batchRepo: ReturnType<typeof buildRepoMock>,
+  recipeRepo: ReturnType<typeof buildRepoMock>,
+  stepRepo: ReturnType<typeof buildRepoMock>,
+  now: Date = FAKE_NOW,
+): ReturnType<typeof seedDemoBatch> {
+  return seedDemoBatch(
+    batchRepo as unknown as Repository<BatchOrmEntity>,
+    recipeRepo as unknown as Repository<RecipeOrmEntity>,
+    stepRepo as unknown as Repository<BatchStepOrmEntity>,
+    now,
+  );
+}
+
 describe('seedDemoBatch (Issue #782)', () => {
   describe('sad path — prerequisite recipe missing', () => {
     it('throws DemoBatchPrerequisiteMissingError when the Punk IPA recipe is not in the recipes table', async () => {
@@ -26,12 +47,7 @@ describe('seedDemoBatch (Issue #782)', () => {
       recipeRepo.findOne.mockResolvedValueOnce(null);
 
       await expect(
-        seedDemoBatch(
-          batchRepo as unknown as Repository<BatchOrmEntity>,
-          recipeRepo as unknown as Repository<RecipeOrmEntity>,
-          stepRepo as unknown as Repository<BatchStepOrmEntity>,
-          FAKE_NOW,
-        ),
+        runSeed(batchRepo, recipeRepo, stepRepo),
       ).rejects.toBeInstanceOf(DemoBatchPrerequisiteMissingError);
 
       // No batch or step writes happened.
@@ -57,12 +73,7 @@ describe('seedDemoBatch (Issue #782)', () => {
       batchRepo.findOne.mockResolvedValueOnce(null);
       stepRepo.findOne.mockResolvedValue(null);
 
-      await seedDemoBatch(
-        batchRepo as unknown as Repository<BatchOrmEntity>,
-        recipeRepo as unknown as Repository<RecipeOrmEntity>,
-        stepRepo as unknown as Repository<BatchStepOrmEntity>,
-        FAKE_NOW,
-      );
+      await runSeed(batchRepo, recipeRepo, stepRepo);
     });
 
     it('inserts the batch row with the demo narrative + metric payload', () => {
@@ -110,19 +121,18 @@ describe('seedDemoBatch (Issue #782)', () => {
     });
 
     it('reports inserted=1, no updates, 7 inserted steps', async () => {
-      const result = await seedDemoBatch(
-        buildRepoMock() as unknown as Repository<BatchOrmEntity>,
-        ((): RepoMock => {
-          const repo = buildRepoMock();
-          repo.findOne.mockResolvedValueOnce({ id: DEMO_PUNK_IPA_RECIPE_ID });
-          return repo;
-        })() as unknown as Repository<RecipeOrmEntity>,
-        ((): RepoMock => {
-          const repo = buildRepoMock();
-          repo.findOne.mockResolvedValue(null);
-          return repo;
-        })() as unknown as Repository<BatchStepOrmEntity>,
-        FAKE_NOW,
+      const freshBatchRepo = buildRepoMock();
+      const freshRecipeRepo = buildRepoMock();
+      freshRecipeRepo.findOne.mockResolvedValueOnce({
+        id: DEMO_PUNK_IPA_RECIPE_ID,
+      });
+      const freshStepRepo = buildRepoMock();
+      freshStepRepo.findOne.mockResolvedValue(null);
+
+      const result = await runSeed(
+        freshBatchRepo,
+        freshRecipeRepo,
+        freshStepRepo,
       );
       // The batch repo above has no findOne mock returning an existing row,
       // so the loader sees null and inserts.
@@ -157,12 +167,7 @@ describe('seedDemoBatch (Issue #782)', () => {
         status: BatchStepStatus.IN_PROGRESS,
       });
 
-      const result = await seedDemoBatch(
-        batchRepo as unknown as Repository<BatchOrmEntity>,
-        recipeRepo as unknown as Repository<RecipeOrmEntity>,
-        stepRepo as unknown as Repository<BatchStepOrmEntity>,
-        FAKE_NOW,
-      );
+      const result = await runSeed(batchRepo, recipeRepo, stepRepo);
 
       expect(result).toEqual({
         insertedBatch: 0,
@@ -190,12 +195,7 @@ describe('seedDemoBatch (Issue #782)', () => {
       batchRepo.findOne.mockResolvedValueOnce(null);
       stepRepo.findOne.mockResolvedValue(null);
 
-      await seedDemoBatch(
-        batchRepo as unknown as Repository<BatchOrmEntity>,
-        recipeRepo as unknown as Repository<RecipeOrmEntity>,
-        stepRepo as unknown as Repository<BatchStepOrmEntity>,
-        FAKE_NOW,
-      );
+      await runSeed(batchRepo, recipeRepo, stepRepo);
 
       const batchPayload = (batchRepo.create.mock.calls[0] as unknown[])[0] as {
         started_at: Date;

--- a/packages/api/src/database/seeds/demo-batch.seed.spec.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.spec.ts
@@ -201,7 +201,7 @@ describe('seedDemoBatch (Issue #782)', () => {
         started_at: Date;
         completed_at: Date;
       };
-      const expectedStart = new Date('2026-04-16T12:00:00.000Z');
+      const expectedStart = new Date('2026-04-09T12:00:00.000Z');
       const expectedEnd = new Date('2026-04-23T12:00:00.000Z');
       expect(batchPayload.started_at.toISOString()).toBe(
         expectedStart.toISOString(),
@@ -209,6 +209,44 @@ describe('seedDemoBatch (Issue #782)', () => {
       expect(batchPayload.completed_at.toISOString()).toBe(
         expectedEnd.toISOString(),
       );
+    });
+
+    it('keeps every seeded step inside the parent batch [started_at, completed_at] window (Codex P1 #815 regression guard)', async () => {
+      const batchRepo = buildRepoMock();
+      const recipeRepo = buildRepoMock();
+      const stepRepo = buildRepoMock();
+      recipeRepo.findOne.mockResolvedValueOnce({
+        id: DEMO_PUNK_IPA_RECIPE_ID,
+      });
+      batchRepo.findOne.mockResolvedValueOnce(null);
+      stepRepo.findOne.mockResolvedValue(null);
+
+      await runSeed(batchRepo, recipeRepo, stepRepo);
+
+      const batchPayload = (batchRepo.create.mock.calls[0] as unknown[])[0] as {
+        started_at: Date;
+        completed_at: Date;
+      };
+      const batchStart = batchPayload.started_at.getTime();
+      const batchEnd = batchPayload.completed_at.getTime();
+
+      for (const call of stepRepo.create.mock.calls as unknown[][]) {
+        const step = call[0] as {
+          step_order: number;
+          started_at: Date;
+          completed_at: Date;
+        };
+        const stepStart = step.started_at.getTime();
+        const stepEnd = step.completed_at.getTime();
+        // Both timestamps must sit inside the parent batch window —
+        // Codex caught a regression where step 7 (packaging) and
+        // step 6 (conditioning) finished after the batch was marked
+        // COMPLETED, producing future-dated "completed" steps.
+        expect(stepStart).toBeGreaterThanOrEqual(batchStart);
+        expect(stepEnd).toBeLessThanOrEqual(batchEnd);
+        // And every step must end at or after it started.
+        expect(stepEnd).toBeGreaterThanOrEqual(stepStart);
+      }
     });
   });
 });

--- a/packages/api/src/database/seeds/demo-batch.seed.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.ts
@@ -7,6 +7,7 @@ import { BatchStepStatus } from '../../batch/domain/enums/batch-step-status.enum
 import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
 import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
 import { SYSTEM_USER_ID } from './system-user.seed';
+import { idempotentUpsertById } from './seed-utils';
 
 /**
  * Seed for `batches` table — pre-populated demo brassin (Issue #782,
@@ -237,25 +238,11 @@ export async function seedDemoBatch(
       'à souhait — équilibre amertume/fruité tropical réussi.',
   };
 
-  let insertedBatch = 0;
-  let updatedBatch = 0;
-
-  const existingBatch = await batchRepository.findOne({
-    where: { id: DEMO_PUNK_IPA_BATCH_ID },
-  });
-
-  if (existingBatch) {
-    Object.assign(existingBatch, batchPayload);
-    await batchRepository.save(existingBatch);
-    updatedBatch = 1;
-  } else {
-    const created = batchRepository.create({
-      id: DEMO_PUNK_IPA_BATCH_ID,
-      ...batchPayload,
-    });
-    await batchRepository.save(created);
-    insertedBatch = 1;
-  }
+  const batchOutcome = await idempotentUpsertById(
+    batchRepository,
+    { id: DEMO_PUNK_IPA_BATCH_ID },
+    batchPayload,
+  );
 
   let insertedSteps = 0;
   let updatedSteps = 0;
@@ -268,36 +255,29 @@ export async function seedDemoBatch(
       startedAt.getTime() + template.endOffsetMs,
     );
 
-    const stepPayload = {
-      type: template.type,
-      label: template.label,
-      description: template.description,
-      status: BatchStepStatus.COMPLETED,
-      started_at: stepStartedAt,
-      completed_at: stepCompletedAt,
-    };
-
-    const existingStep = await stepRepository.findOne({
-      where: {
+    const stepOutcome = await idempotentUpsertById(
+      stepRepository,
+      {
         batch_id: DEMO_PUNK_IPA_BATCH_ID,
         step_order: template.step_order,
       },
-    });
-
-    if (existingStep) {
-      Object.assign(existingStep, stepPayload);
-      await stepRepository.save(existingStep);
-      updatedSteps += 1;
-    } else {
-      const createdStep = stepRepository.create({
-        batch_id: DEMO_PUNK_IPA_BATCH_ID,
-        step_order: template.step_order,
-        ...stepPayload,
-      });
-      await stepRepository.save(createdStep);
-      insertedSteps += 1;
-    }
+      {
+        type: template.type,
+        label: template.label,
+        description: template.description,
+        status: BatchStepStatus.COMPLETED,
+        started_at: stepStartedAt,
+        completed_at: stepCompletedAt,
+      },
+    );
+    insertedSteps += stepOutcome.inserted;
+    updatedSteps += stepOutcome.updated;
   }
 
-  return { insertedBatch, updatedBatch, insertedSteps, updatedSteps };
+  return {
+    insertedBatch: batchOutcome.inserted,
+    updatedBatch: batchOutcome.updated,
+    insertedSteps,
+    updatedSteps,
+  };
 }

--- a/packages/api/src/database/seeds/demo-batch.seed.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.ts
@@ -1,0 +1,303 @@
+import { Repository } from 'typeorm';
+
+import { BatchOrmEntity } from '../../batch/entities/batch.orm.entity';
+import { BatchStatus } from '../../batch/domain/enums/batch-status.enum';
+import { BatchStepOrmEntity } from '../../batch/entities/batch-step.orm.entity';
+import { BatchStepStatus } from '../../batch/domain/enums/batch-step-status.enum';
+import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
+import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
+import { SYSTEM_USER_ID } from './system-user.seed';
+
+/**
+ * Seed for `batches` table — pre-populated demo brassin (Issue #782,
+ * minimal+ version).
+ *
+ * Pre-seeds a `Batch` row tied to the curated Punk IPA public recipe
+ * (seeded by `seedPublicRecipes`, ID `00000000-0000-4000-8000-000000000001`)
+ * so the demo flow tells a complete story end-to-end:
+ *   1. j'ai scanné Punk IPA   (PR #768 + scan flow shipped)
+ *   2. j'ai importé la recette (PR #743 community import)
+ *   3. j'ai brassé             (THIS SEED — visible under Mes Brassins)
+ *
+ * The brassin is left in `COMPLETED` state with `started_at` ~14
+ * days ago and `completed_at` ~7 days ago, computed relative to seed
+ * runtime so the dates always feel fresh on stage. Owner is the
+ * `SYSTEM_USER` sentinel — no real user account is touched.
+ *
+ * This is the **minimal+** scope of #782. Measurements, observations,
+ * step transitions, volumes, OG/FG/ABV are all deferred to the
+ * larger #605 data model rewrite — those columns do not exist yet on
+ * the `batches` table. The current seed only populates what fits the
+ * existing schema + the two narrative columns added by migration
+ * `AddBatchDemoNarrativeFields1782000000000`.
+ *
+ * Idempotent: re-running updates the row in place rather than
+ * inserting duplicates. Keyed by the deterministic UUID below.
+ */
+
+/**
+ * Deterministic UUID for the demo brassin. Picked from the
+ * `00000000-0000-4000-8000-…` range used by curated public recipes,
+ * suffix `b1` → "brassin one".
+ */
+export const DEMO_PUNK_IPA_BATCH_ID = '00000000-0000-4000-8000-0000000000b1';
+
+/**
+ * Recipe ID the demo brassin is linked to. Matches the Punk IPA
+ * entry seeded by `seedPublicRecipes`.
+ */
+export const DEMO_PUNK_IPA_RECIPE_ID = '00000000-0000-4000-8000-000000000001';
+
+/**
+ * Days-ago anchor. The demo brassin started 14 days before the seed
+ * runs and completed 7 days before the seed runs (so the brassin is
+ * "fresh" but unambiguously in the past). Recomputed at every seed
+ * run to keep the timeline plausible whatever the calendar date.
+ */
+const DAYS_SINCE_STARTED = 14;
+const DAYS_SINCE_COMPLETED = 7;
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+function daysAgo(days: number, now: Date = new Date()): Date {
+  return new Date(now.getTime() - days * ONE_DAY_MS);
+}
+
+/**
+ * The 7 brewing-day steps of the Punk IPA demo brassin. Uses the
+ * existing 5-type RecipeStepType enum (MASH/BOIL/WHIRLPOOL/
+ * FERMENTATION/PACKAGING); the FERMENTATION type appears 3 times
+ * with distinct labels because the BJCP-style brewing flow has
+ * three distinct fermentation phases worth surfacing on the
+ * brassin timeline (primary, dry hop, conditioning).
+ *
+ * Time anchors are relative offsets from the parent Batch dates,
+ * computed at seed time. Brewing day (mash → whirlpool) lives on
+ * day 1 across ~4 hours; fermentation phases stretch over the
+ * 14-day window between started_at and completed_at.
+ */
+interface DemoStepTemplate {
+  step_order: number;
+  type: RecipeStepType;
+  label: string;
+  description: string;
+  /** Offset in milliseconds from `Batch.started_at`. */
+  startOffsetMs: number;
+  /** Offset in milliseconds from `Batch.started_at`. */
+  endOffsetMs: number;
+}
+
+const DEMO_STEPS: readonly DemoStepTemplate[] = [
+  {
+    step_order: 1,
+    type: RecipeStepType.MASH,
+    label: 'Empâtage',
+    description:
+      'Mash 60 min à 67°C dans 30 L (rapport 3 L/kg). Iode test négatif à 60 min.',
+    startOffsetMs: 9 * ONE_HOUR_MS,
+    endOffsetMs: 10 * ONE_HOUR_MS,
+  },
+  {
+    step_order: 2,
+    type: RecipeStepType.BOIL,
+    label: 'Ébullition + houblonnage',
+    description:
+      'Boil 60 min, Magnum à T-60min (amertume), Citra à T-15min, Mosaic flameout.',
+    startOffsetMs: 10 * ONE_HOUR_MS,
+    endOffsetMs: 11 * ONE_HOUR_MS,
+  },
+  {
+    step_order: 3,
+    type: RecipeStepType.WHIRLPOOL,
+    label: 'Whirlpool + refroidissement',
+    description:
+      'Whirlpool 20 min puis refroidissement à 19°C via plate chiller.',
+    startOffsetMs: 11 * ONE_HOUR_MS,
+    endOffsetMs: 12 * ONE_HOUR_MS,
+  },
+  {
+    step_order: 4,
+    type: RecipeStepType.FERMENTATION,
+    label: 'Fermentation primaire',
+    description:
+      'Pitch SafAle US-05 réhydratée. Primary 7 jours à 19°C. Krausen massif jour 2-3.',
+    startOffsetMs: 12 * ONE_HOUR_MS,
+    endOffsetMs: 7 * ONE_DAY_MS,
+  },
+  {
+    step_order: 5,
+    type: RecipeStepType.FERMENTATION,
+    label: 'Dry hop',
+    description: 'Dry hop Citra + Mosaic 3 jours, températures stables 19°C.',
+    startOffsetMs: 7 * ONE_DAY_MS,
+    endOffsetMs: 10 * ONE_DAY_MS,
+  },
+  {
+    step_order: 6,
+    type: RecipeStepType.FERMENTATION,
+    label: 'Conditionnement',
+    description:
+      'Garde 4 jours à 4°C pour clarification et sédimentation des houblons.',
+    startOffsetMs: 10 * ONE_DAY_MS,
+    endOffsetMs: 14 * ONE_DAY_MS,
+  },
+  {
+    step_order: 7,
+    type: RecipeStepType.PACKAGING,
+    label: 'Mise en bouteille',
+    description:
+      'Embouteillage avec sucre de refermentation 7g/L. 18 L finaux.',
+    startOffsetMs: 14 * ONE_DAY_MS,
+    endOffsetMs: 14 * ONE_DAY_MS + ONE_HOUR_MS,
+  },
+];
+
+/**
+ * Result returned by `seedDemoBatch` for instrumentation. Lets
+ * callers (CLI, tests) report what happened without re-querying.
+ */
+export interface SeedDemoBatchResult {
+  /** 0 or 1 — the batch row was inserted as new. */
+  insertedBatch: number;
+  /** 0 or 1 — the batch row already existed and was updated in place. */
+  updatedBatch: number;
+  /** Number of step rows inserted (subset of 7). */
+  insertedSteps: number;
+  /** Number of step rows updated in place. */
+  updatedSteps: number;
+}
+
+/**
+ * Reason a seed run can skip rather than insert/update — typically
+ * the linked recipe row is missing because `seedPublicRecipes` has
+ * not run yet.
+ */
+export class DemoBatchPrerequisiteMissingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DemoBatchPrerequisiteMissingError';
+  }
+}
+
+/**
+ * Idempotent loader. Looks up the Punk IPA recipe by ID; if absent,
+ * throws `DemoBatchPrerequisiteMissingError` so the caller knows to
+ * run `seedPublicRecipes` first. Otherwise inserts (or updates in
+ * place) the demo brassin row + the 7 brewing-day steps.
+ *
+ * The narrative copy is in French because it is surfaced verbatim
+ * to the user on the mobile UI. All other code in this file stays
+ * in English per project convention.
+ *
+ * Step seeding follows the same idempotency contract as the batch
+ * row itself: existing rows (matched by composite PK
+ * batch_id + step_order) are updated in place; missing rows are
+ * inserted. Re-running the seed never duplicates.
+ */
+export async function seedDemoBatch(
+  batchRepository: Repository<BatchOrmEntity>,
+  recipeRepository: Repository<RecipeOrmEntity>,
+  stepRepository: Repository<BatchStepOrmEntity>,
+  now: Date = new Date(),
+): Promise<SeedDemoBatchResult> {
+  const recipe = await recipeRepository.findOne({
+    where: { id: DEMO_PUNK_IPA_RECIPE_ID },
+  });
+
+  if (!recipe) {
+    throw new DemoBatchPrerequisiteMissingError(
+      `Cannot seed demo batch — Punk IPA recipe ${DEMO_PUNK_IPA_RECIPE_ID} ` +
+        `is not in the recipes table. Run seedPublicRecipes first.`,
+    );
+  }
+
+  const startedAt = daysAgo(DAYS_SINCE_STARTED, now);
+  const completedAt = daysAgo(DAYS_SINCE_COMPLETED, now);
+
+  const batchPayload = {
+    owner_id: SYSTEM_USER_ID,
+    recipe_id: DEMO_PUNK_IPA_RECIPE_ID,
+    name: 'Mon premier Punk IPA',
+    status: BatchStatus.COMPLETED,
+    current_step_order: null,
+    started_at: startedAt,
+    fermentation_started_at: startedAt,
+    fermentation_completed_at: completedAt,
+    completed_at: completedAt,
+    target_volume_l: 20,
+    final_volume_l: 18,
+    og_actual: 1.057,
+    fg_actual: 1.013,
+    abv_actual: 5.8,
+    notes:
+      'Première Punk IPA brassée à la maison, inspirée par la fiche ' +
+      'BrewDog DIY Dog. Le krausen a été massif au jour 3, le dry hop ' +
+      'Citra + Mosaic a donné un nez tropical superbe. Sec et houblonné ' +
+      'à souhait — équilibre amertume/fruité tropical réussi.',
+  };
+
+  let insertedBatch = 0;
+  let updatedBatch = 0;
+
+  const existingBatch = await batchRepository.findOne({
+    where: { id: DEMO_PUNK_IPA_BATCH_ID },
+  });
+
+  if (existingBatch) {
+    Object.assign(existingBatch, batchPayload);
+    await batchRepository.save(existingBatch);
+    updatedBatch = 1;
+  } else {
+    const created = batchRepository.create({
+      id: DEMO_PUNK_IPA_BATCH_ID,
+      ...batchPayload,
+    });
+    await batchRepository.save(created);
+    insertedBatch = 1;
+  }
+
+  let insertedSteps = 0;
+  let updatedSteps = 0;
+
+  for (const template of DEMO_STEPS) {
+    const stepStartedAt = new Date(
+      startedAt.getTime() + template.startOffsetMs,
+    );
+    const stepCompletedAt = new Date(
+      startedAt.getTime() + template.endOffsetMs,
+    );
+
+    const stepPayload = {
+      type: template.type,
+      label: template.label,
+      description: template.description,
+      status: BatchStepStatus.COMPLETED,
+      started_at: stepStartedAt,
+      completed_at: stepCompletedAt,
+    };
+
+    const existingStep = await stepRepository.findOne({
+      where: {
+        batch_id: DEMO_PUNK_IPA_BATCH_ID,
+        step_order: template.step_order,
+      },
+    });
+
+    if (existingStep) {
+      Object.assign(existingStep, stepPayload);
+      await stepRepository.save(existingStep);
+      updatedSteps += 1;
+    } else {
+      const createdStep = stepRepository.create({
+        batch_id: DEMO_PUNK_IPA_BATCH_ID,
+        step_order: template.step_order,
+        ...stepPayload,
+      });
+      await stepRepository.save(createdStep);
+      insertedSteps += 1;
+    }
+  }
+
+  return { insertedBatch, updatedBatch, insertedSteps, updatedSteps };
+}

--- a/packages/api/src/database/seeds/demo-batch.seed.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.ts
@@ -50,12 +50,21 @@ export const DEMO_PUNK_IPA_BATCH_ID = '00000000-0000-4000-8000-0000000000b1';
 export const DEMO_PUNK_IPA_RECIPE_ID = '00000000-0000-4000-8000-000000000001';
 
 /**
- * Days-ago anchor. The demo brassin started 14 days before the seed
- * runs and completed 7 days before the seed runs (so the brassin is
- * "fresh" but unambiguously in the past). Recomputed at every seed
- * run to keep the timeline plausible whatever the calendar date.
+ * Days-ago anchors for the demo brassin. The window between
+ * `started_at` and `completed_at` is intentionally **14 days**
+ * because the step offsets below are calibrated to that span (mash
+ * to packaging). The brassin completed 7 days before "now" so the
+ * timeline feels unambiguously in the past on stage.
+ *
+ * Codex P1 #815 caught a regression earlier: with a 7-day window
+ * (started_at=-14d, completed_at=-7d) the 14-day step offsets
+ * placed step 7 (packaging) past the parent batch's completion,
+ * producing "completed steps in the future". The 21/7 anchors
+ * below close the inconsistency: completed_at = started_at + 14d
+ * exactly, so step 7 ends on the same instant the batch is marked
+ * COMPLETED.
  */
-const DAYS_SINCE_STARTED = 14;
+const DAYS_SINCE_STARTED = 21;
 const DAYS_SINCE_COMPLETED = 7;
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
@@ -149,8 +158,11 @@ const DEMO_STEPS: readonly DemoStepTemplate[] = [
     label: 'Mise en bouteille',
     description:
       'Embouteillage avec sucre de refermentation 7g/L. 18 L finaux.',
-    startOffsetMs: 14 * ONE_DAY_MS,
-    endOffsetMs: 14 * ONE_DAY_MS + ONE_HOUR_MS,
+    // Packaging is the final hour of the 14-day window. Ending at
+    // exactly 14d aligns the step's completed_at with the parent
+    // batch's completed_at — no future-dated steps.
+    startOffsetMs: 14 * ONE_DAY_MS - ONE_HOUR_MS,
+    endOffsetMs: 14 * ONE_DAY_MS,
   },
 ];
 

--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -7,20 +7,7 @@ import {
   PUBLIC_RECIPES_SYSTEM_OWNER_ID,
   seedPublicRecipes,
 } from './public-recipes.seed';
-
-type RepoMock = {
-  findOne: jest.Mock;
-  create: jest.Mock;
-  save: jest.Mock;
-};
-
-function buildRepoMock(): RepoMock {
-  return {
-    findOne: jest.fn(),
-    create: jest.fn((input: unknown) => input),
-    save: jest.fn((input: unknown) => Promise.resolve(input)),
-  };
-}
+import { buildRepoMock } from './seed-test-utils';
 
 describe('seedPublicRecipes (Issue #701)', () => {
   describe('happy path', () => {

--- a/packages/api/src/database/seeds/scan-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/scan-catalog.seed.spec.ts
@@ -3,20 +3,7 @@ import { Repository } from 'typeorm';
 import { ScanCatalogItemOrmEntity } from '../../scan/entities/scan-catalog-item.orm.entity';
 import { ScanCatalogSource } from '../../scan/domain/enums/scan-catalog-source.enum';
 import { SCAN_CATALOG_SEED_BEERS, seedScanCatalog } from './scan-catalog.seed';
-
-type RepoMock = {
-  findOne: jest.Mock;
-  create: jest.Mock;
-  save: jest.Mock;
-};
-
-function buildRepoMock(): RepoMock {
-  return {
-    findOne: jest.fn(),
-    create: jest.fn((input: unknown) => input),
-    save: jest.fn((input: unknown) => Promise.resolve(input)),
-  };
-}
+import { buildRepoMock } from './seed-test-utils';
 
 describe('seedScanCatalog (Epic #693 part 5/5)', () => {
   describe('happy path', () => {

--- a/packages/api/src/database/seeds/seed-test-utils.ts
+++ b/packages/api/src/database/seeds/seed-test-utils.ts
@@ -5,9 +5,13 @@
  * follows the same idempotent contract: receives a TypeORM
  * `Repository`, looks up by id, creates or updates in place, returns
  * a stats object. The unit tests for those seeds therefore share the
- * same mock harness — keeping it in one place avoids 4 verbatim
- * copies across the spec files (which SonarCloud flags as
- * duplication on new code).
+ * same mock harness — keeping it in one place avoids verbatim copies
+ * across the spec files (which SonarCloud flags as duplication on
+ * new code).
+ *
+ * The runtime upsert helper (`idempotentUpsertById`) lives in
+ * `seed-utils.ts` next to it — keeping the test harness separate so
+ * the production bundle doesn't pull in jest types.
  */
 
 /**

--- a/packages/api/src/database/seeds/seed-test-utils.ts
+++ b/packages/api/src/database/seeds/seed-test-utils.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared test helpers for seed loaders.
+ *
+ * Each seed (system-user, scan-catalog, public-recipes, demo-batch)
+ * follows the same idempotent contract: receives a TypeORM
+ * `Repository`, looks up by id, creates or updates in place, returns
+ * a stats object. The unit tests for those seeds therefore share the
+ * same mock harness — keeping it in one place avoids 4 verbatim
+ * copies across the spec files (which SonarCloud flags as
+ * duplication on new code).
+ */
+
+/**
+ * Minimal repository mock surface used across seed unit tests.
+ * `findOne` is stubbed per-test to drive the insert vs update branch.
+ * `create` echoes its input so assertions can introspect the payload.
+ * `save` resolves with whatever it received so the loader sees a
+ * persisted entity it can chain off of.
+ */
+export type RepoMock = {
+  findOne: jest.Mock;
+  create: jest.Mock;
+  save: jest.Mock;
+};
+
+/**
+ * Constructs a fresh repository mock with the conventional defaults:
+ * `create` returns its argument unchanged, `save` resolves with the
+ * argument it received. `findOne` is left unstubbed — each test
+ * configures it explicitly to express the scenario under test.
+ */
+export function buildRepoMock(): RepoMock {
+  return {
+    findOne: jest.fn(),
+    create: jest.fn((input: unknown) => input),
+    save: jest.fn((input: unknown) => Promise.resolve(input)),
+  };
+}

--- a/packages/api/src/database/seeds/seed-utils.ts
+++ b/packages/api/src/database/seeds/seed-utils.ts
@@ -1,0 +1,56 @@
+import {
+  DeepPartial,
+  FindOptionsWhere,
+  ObjectLiteral,
+  Repository,
+} from 'typeorm';
+
+/**
+ * Outcome of one idempotent upsert. Lets seed loaders accumulate
+ * insert vs update counters without re-querying the table.
+ */
+export type UpsertOutcome = {
+  inserted: 0 | 1;
+  updated: 0 | 1;
+};
+
+/**
+ * Generic idempotent upsert helper used across seed loaders.
+ *
+ * The seed-time contract every loader follows: look up the row by
+ * deterministic identifier, update it in place when present, insert
+ * it otherwise. The pattern is repeated verbatim across multiple
+ * seeds (system-user, scan-catalog, public-recipes, demo-batch) —
+ * extracting it here avoids the verbatim duplication that
+ * SonarCloud flags as new-code duplication, and keeps the loaders
+ * focused on their per-row payload.
+ *
+ * Generic over the entity type so the helper preserves the strict
+ * typing of each repository's `create` and `save` methods.
+ *
+ * @param repository — TypeORM repository targeting the entity table.
+ * @param where — predicate uniquely identifying the row by its
+ *                deterministic seed identifier (typically `{ id }`).
+ * @param payload — full data to write, both for insert and update.
+ *                  On update, fields are spread onto the existing
+ *                  entity via Object.assign so any column not in
+ *                  payload retains its previous value.
+ */
+export async function idempotentUpsertById<T extends ObjectLiteral>(
+  repository: Repository<T>,
+  where: FindOptionsWhere<T>,
+  payload: DeepPartial<T>,
+): Promise<UpsertOutcome> {
+  const existing = await repository.findOne({ where });
+  if (existing) {
+    Object.assign(existing, payload);
+    await repository.save(existing);
+    return { inserted: 0, updated: 1 };
+  }
+  const created = repository.create({
+    ...where,
+    ...payload,
+  } as DeepPartial<T>);
+  await repository.save(created);
+  return { inserted: 1, updated: 0 };
+}

--- a/packages/api/src/database/seeds/system-user.seed.spec.ts
+++ b/packages/api/src/database/seeds/system-user.seed.spec.ts
@@ -2,26 +2,13 @@ import { Repository } from 'typeorm';
 
 import { User } from '../../user/entities/user.entity';
 import { UserRole } from '../../common/enums/role.enum';
+import { buildRepoMock } from './seed-test-utils';
 import {
   SYSTEM_USER_EMAIL,
   SYSTEM_USER_ID,
   SYSTEM_USER_USERNAME,
   seedSystemUser,
 } from './system-user.seed';
-
-type RepoMock = {
-  findOne: jest.Mock;
-  create: jest.Mock;
-  save: jest.Mock;
-};
-
-function buildRepoMock(): RepoMock {
-  return {
-    findOne: jest.fn(),
-    create: jest.fn((input: unknown) => input),
-    save: jest.fn((input: unknown) => Promise.resolve(input)),
-  };
-}
 
 describe('seedSystemUser (Issue #701 prerequisite)', () => {
   describe('happy path', () => {


### PR DESCRIPTION
Closes the v0.1 demo loop *\"j'ai scanné Punk IPA → j'ai importé la recette → j'ai brassé\"*. Mes Brassins now surfaces a deterministic *Mon premier Punk IPA* completed brassin with realistic narrative + metric + step timeline, anchored to system time at seed runtime.

## Summary

Scope drawn from the **8-axis Brassins data model Q&A scoping session 2026-04-30** (issues #808-#814 capture the deferred v0.2/v0.3 richness):

| Axis | Decision | Backlog |
|---|---|---|
| 1 — identity | \`name\` + \`notes\` columns added | #808 |
| 2 — volumes | \`target_volume_l\` + \`final_volume_l\` | #809 |
| 3 — gravity + ABV | \`og_actual\` + \`fg_actual\` + \`abv_actual\` | #810 |
| 4 — measurements | none | #811 |
| 5 — observations | \`notes\` covers v0.1 | #812 |
| 6 — steps | **seed 7 BatchStep rows** (no schema change) | #813 |
| 7 — alerts | none | #814 |
| 8 — photos | none | #808 (consolidated) |

## Files

- **Migration** \`1782000000000-AddBatchDemoNarrativeFields.ts\` — adds 7 nullable columns to \`batches\` (name varchar(120), notes text, target/final volume real, og/fg/abv real). Aligned with existing \`recipes.og_target\` convention (SQLite real, not decimal).
- **Entity** \`BatchOrmEntity\` — 7 corresponding \`@Column\` properties.
- **Seed** \`demo-batch.seed.ts\` — idempotent \`seedDemoBatch(batchRepo, recipeRepo, stepRepo, now)\`. Throws \`DemoBatchPrerequisiteMissingError\` if the Punk IPA recipe is missing (callers run \`seedPublicRecipes\` first).
- **Spec** \`demo-batch.seed.spec.ts\` — 7 tests covering happy path (insert batch + 7 steps), idempotency (re-run updates in place), sad path (missing recipe), edge case (date offsets relative to \`now\`).
- **CLI** \`scripts/run-demo-batch-seed.ts\` — orchestrates \`seedSystemUser → seedPublicRecipes → seedDemoBatch\` in one invocation. Idempotent end-to-end.

## Demo behaviour

In demo or production mode, after running the new CLI:
- Mes Brassins lists *Mon premier Punk IPA — COMPLETED — il y a 7 jours*
- Detail screen shows the title + notes narrative + the 4 dates (started/completed/fermentation start/end) + OG 1.057 / FG 1.013 / ABV 5.8% / Volume 18 L (vs target 20 L)
- Timeline section renders 7 steps (Empâtage → Ébullition + houblonnage → Whirlpool → Primary → Dry hop → Conditionnement → Mise en bouteille), all COMPLETED with realistic timestamps

## Step type mapping

The existing \`RecipeStepType\` enum has 5 canonical types (\`MASH\` / \`BOIL\` / \`WHIRLPOOL\` / \`FERMENTATION\` / \`PACKAGING\`). The 7-step demo flow uses \`FERMENTATION\` three times (primary, dry hop, conditioning) with distinct labels. Extending the enum to cover sparge / cool / pitch as separate types is **out of scope** here — that is a sibling concern to the rich step model in #813.

## Checklist

- [x] Happy path + sad path + edge case covered (7 tests)
- [x] \`tsc --noEmit\` passes (the 5 pre-existing TS errors in unrelated test fixtures predate this branch)
- [x] Build passes (\`nest build\` green)
- [x] All API tests green (395 passing, 7 new)
- [x] Lint clean (1 pre-existing warning, 0 errors)
- [x] No \`any\`, no inline styles, no hardcoded colors

Closes #782 (minimal+ scope; rich measurements / observations / per-step details deferred to the 7 epics #808-#814).