### PR TITLE
chore(website): remove GA4 tracking + cookie consent banner (Chantier E.1)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,12 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-04-30
 
+### PR #815 merged (`0a5af5d`) — feat(seed): pre-seed Punk IPA brassin demo + 7 brewing-day steps (#782)
+
+- Closes #782. Migration adds 7 nullable columns to `batches`; idempotent seed loader inserts batch row + 7 BatchStep rows. Output of the 8-axis Brassins data model Q&A scoping session 2026-04-30; deferred richness captured in 7 backlog epics: #808 #809 #810 #811 #812 #813 #814.
+- Codex P1 fix (commit `879a703`): widened batch window 14d → 21d so all step offsets fit inside [started_at, completed_at] + regression-guard test.
+- SonarCloud duplication chase: 4 refactor commits (`e0e4302` `85cd539` `4e00a2f` `a291b86`) — extracted `seed-test-utils.ts` (RepoMock helpers), `seed-utils.ts` (`idempotentUpsertById<T>` generic), runSeed local helper, COLUMNS-array iteration in migration. 4.3% → 0.0% duplication on new code.
+
 ### PR #806 merged (`11931fc`) — chore(mocks): sync mobile demoScanCatalog with API seed (4→9 beers, #804)
 
 - Closes #804. Ports the 5 missing entries (Karmeliet Tripel, Westmalle Tripel, Duvel, Heineken, Cervoise Lancelot) to `demoScanCatalog`. Field values mirror the API seed verbatim. Heineken correctly tagged `fermentationType: 'lager'`.

--- a/packages/website/cookies-en.html
+++ b/packages/website/cookies-en.html
@@ -38,7 +38,7 @@
     <p class="lang-switch"><a href="cookies.html" lang="fr">Lire en français</a></p>
 
     <h1>Cookie Policy</h1>
-    <p class="meta"><strong>Last updated:</strong> February 27, 2026</p>
+    <p class="meta"><strong>Last updated:</strong> April 30, 2026</p>
 
     <h2>1. What is a cookie?</h2>
     <p>
@@ -47,30 +47,31 @@
     </p>
 
     <h2>2. Cookies used on Brasse-Bouillon</h2>
-    <ul>
-      <li><strong>Consent cookie</strong>: stores your choice (accepted/rejected) regarding analytics cookies.</li>
-      <li><strong>Audience measurement cookies</strong>: Google Analytics, only if you explicitly opt in.</li>
-    </ul>
+    <p>
+      <strong>Brasse-Bouillon does not use any tracking cookies or third-party audience
+      measurement tool.</strong> No browsing data is collected for analytics purposes.
+    </p>
+    <p>
+      Forms (newsletter, questionnaire, contact) embedded via Formspree may rely on the provider’s
+      own technical mechanisms to transmit messages. No advertising or profiling cookie is set by
+      the website itself.
+    </p>
 
     <h2>3. Legal basis</h2>
     <p>
-      Non-essential cookies (analytics) are set based on your <strong>prior consent</strong>
-      (opt-in), in accordance with applicable rules (including EU ePrivacy/GDPR where relevant).
+      Since the website sets no non-essential cookies, no prior consent is required for basic
+      browsing. Forms collecting personal data (email, message) remain subject to explicit consent
+      via a dedicated checkbox at submission, in line with GDPR.
     </p>
 
-    <h2>4. Retention period</h2>
+    <h2>4. Managing browser preferences</h2>
     <p>
-      Consent status is stored locally for up to 12 months, or until manually deleted by the user.
-      Analytics cookie retention depends on the third-party tool settings.
+      You can configure your browser at any time to block or delete residual third-party cookies
+      (e.g., those served by Google Fonts or the host). No specific Brasse-Bouillon mechanism
+      is required.
     </p>
 
-    <h2>5. Managing your preferences</h2>
-    <p>
-      You can update your choice at any time using the <strong>“Cookies”</strong> button on the website,
-      or by deleting cookies in your browser settings.
-    </p>
-
-    <h2>6. Contact</h2>
+    <h2>5. Contact</h2>
     <p>
       For any cookie-related question:
       <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.

--- a/packages/website/cookies.html
+++ b/packages/website/cookies.html
@@ -38,7 +38,7 @@
     <p class="lang-switch"><a href="cookies-en.html" lang="en">Read in English</a></p>
 
     <h1>Politique cookies</h1>
-    <p class="meta"><strong>Dernière mise à jour :</strong> 27 février 2026</p>
+    <p class="meta"><strong>Dernière mise à jour :</strong> 30 avril 2026</p>
 
     <h2>1. Qu’est-ce qu’un cookie ?</h2>
     <p>
@@ -47,32 +47,34 @@
     </p>
 
     <h2>2. Cookies utilisés sur Brasse-Bouillon</h2>
-    <ul>
-      <li><strong>Cookie de consentement</strong> : mémorise votre choix (accepté/refusé) pour les cookies de mesure d’audience.</li>
-      <li><strong>Cookies de mesure d’audience</strong> : Google Analytics, uniquement si vous acceptez explicitement.</li>
-    </ul>
+    <p>
+      <strong>Brasse-Bouillon n’utilise aucun cookie de tracking ni outil de mesure d’audience tiers.</strong>
+      Aucune donnée de navigation n’est collectée à des fins analytiques.
+    </p>
+    <p>
+      Les formulaires (newsletter, questionnaire, contact) intégrés via Formspree peuvent reposer
+      sur des mécanismes techniques propres au prestataire pour la transmission des messages.
+      Aucun cookie publicitaire ni de profilage n’est déposé par le site lui-même.
+    </p>
 
     <h2>3. Base légale</h2>
     <p>
-      Les cookies non essentiels (analytics) sont déposés sur la base de votre <strong>consentement préalable</strong>
-      (opt-in), conformément aux règles applicables (notamment ePrivacy/RGPD en UE).
+      Le site n’ayant aucun cookie non essentiel, aucun consentement préalable n’est requis pour
+      la simple navigation. Les formulaires intégrant des données personnelles (email, message)
+      restent soumis à un consentement explicite via une case à cocher dédiée à chaque envoi,
+      conformément au RGPD.
     </p>
 
-    <h2>4. Durée de conservation</h2>
+    <h2>4. Gestion des préférences navigateur</h2>
     <p>
-      Le statut de consentement est conservé localement jusqu’à 12 mois maximum ou jusqu’à suppression
-      manuelle par l’utilisateur. Les durées des cookies analytics dépendent de l’outil tiers.
+      Vous pouvez à tout moment configurer votre navigateur pour bloquer ou supprimer les cookies
+      tiers résiduels (par exemple ceux des polices Google Fonts ou de l’hébergeur). Aucun
+      mécanisme spécifique côté Brasse-Bouillon n’est nécessaire.
     </p>
 
-    <h2>5. Gestion des préférences</h2>
+    <h2>5. Contact</h2>
     <p>
-      Vous pouvez modifier vos choix à tout moment via le bouton <strong>« Cookies »</strong> affiché sur le site,
-      ou en supprimant les cookies depuis votre navigateur.
-    </p>
-
-    <h2>6. Contact</h2>
-    <p>
-      Pour toute question relative aux cookies :
+      Pour toute question relative à la politique cookies :
       <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
     </p>
   </main>

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -40,9 +40,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap" rel="stylesheet">
 
-  <!-- Analytics loaded only after explicit cookie consent -->
-
-  <link rel="stylesheet" href="site.css?v=20260228-cookie-fix-1">
+  <link rel="stylesheet" href="site.css">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -477,22 +477,8 @@
     </div>
   </main>
 
-  <div class="cookie-banner" id="cookieBannerEn" role="dialog" aria-live="polite" aria-label="Cookie preferences">
-    <h3>🍪 Cookie preferences</h3>
-    <p>
-      We use audience measurement cookies only with your explicit consent.
-      You can accept, refuse, or change your decision at any time.
-    </p>
-    <div class="cookie-actions">
-      <button class="btn btn-primary" type="button" data-consent-action="accept">Accept</button>
-      <button class="btn btn-secondary" type="button" data-consent-action="reject">Reject</button>
-    </div>
-  </div>
-  <button class="cookie-manage" id="cookieManageEn" type="button">Cookies</button>
-
   <script src="site.js"></script>
   <script>
-    const GA_MEASUREMENT_ID = 'G-RVCT6NGFVG';
     const QUESTIONNAIRE_ENDPOINT = 'https://formspree.io/f/xeellqan';
     const NEWSLETTER_ENDPOINT = 'https://formspree.io/f/mqaqqvab';
 
@@ -544,53 +530,7 @@
       });
     }
 
-    function initializeConsentBannerEn() {
-      const storageKey = 'bb_cookie_consent_v1';
-      const banner = document.getElementById('cookieBannerEn');
-      const manageBtn = document.getElementById('cookieManageEn');
-      if (!banner || !manageBtn) return;
-
-      const readConsent = () => window.localStorage.getItem(storageKey);
-      const showBanner = () => banner.classList.add('visible');
-      const hideBanner = () => banner.classList.remove('visible');
-
-      const loadAnalytics = () => {
-        if (window.__bbAnalyticsLoaded) return;
-        window.__bbAnalyticsLoaded = true;
-
-        const script = document.createElement('script');
-        script.async = true;
-        script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
-        document.head.appendChild(script);
-
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = function gtag() { window.dataLayer.push(arguments); };
-        window.gtag('js', new Date());
-        window.gtag('config', GA_MEASUREMENT_ID, { anonymize_ip: true });
-      };
-
-      const applyConsent = (value) => {
-        window.localStorage.setItem(storageKey, value);
-        hideBanner();
-        if (value === 'accepted') {
-          loadAnalytics();
-        }
-      };
-
-      banner.querySelector('[data-consent-action="accept"]').addEventListener('click', () => applyConsent('accepted'));
-      banner.querySelector('[data-consent-action="reject"]').addEventListener('click', () => applyConsent('rejected'));
-      manageBtn.addEventListener('click', showBanner);
-
-      const current = readConsent();
-      if (current === 'accepted') {
-        loadAnalytics();
-      } else if (current !== 'rejected') {
-        showBanner();
-      }
-    }
-
     renderRoadmapEn();
-    initializeConsentBannerEn();
 
     BBShared.setupQuestionnaire({
       formId: 'questionnaireFormEn',

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -37,10 +37,8 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap" rel="stylesheet">
-  
-  <!-- Analytics loaded only after explicit cookie consent -->
-  
-  <link rel="stylesheet" href="site.css?v=20260228-cookie-fix-1">
+
+  <link rel="stylesheet" href="site.css">
   
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -569,22 +567,8 @@
     </div>
   </main>
 
-  <div class="cookie-banner" id="cookieBannerFr" role="dialog" aria-live="polite" aria-label="Préférences cookies">
-    <h3>🍪 Gestion des cookies</h3>
-    <p>
-      Nous utilisons des cookies de mesure d’audience uniquement avec ton accord explicite.
-      Tu peux accepter, refuser, ou changer d’avis à tout moment.
-    </p>
-    <div class="cookie-actions">
-      <button class="btn btn-primary" type="button" data-consent-action="accept">Accepter</button>
-      <button class="btn btn-secondary" type="button" data-consent-action="reject">Refuser</button>
-    </div>
-  </div>
-  <button class="cookie-manage" id="cookieManageFr" type="button">Cookies</button>
-
   <script src="site.js"></script>
   <script>
-    const GA_MEASUREMENT_ID = 'G-RVCT6NGFVG';
     const QUESTIONNAIRE_ENDPOINT = 'https://formspree.io/f/xeellqan';
     const NEWSLETTER_ENDPOINT = 'https://formspree.io/f/mqaqqvab';
 
@@ -636,53 +620,7 @@
       });
     }
 
-    function initializeConsentBannerFr() {
-      const storageKey = 'bb_cookie_consent_v1';
-      const banner = document.getElementById('cookieBannerFr');
-      const manageBtn = document.getElementById('cookieManageFr');
-      if (!banner || !manageBtn) return;
-
-      const readConsent = () => window.localStorage.getItem(storageKey);
-      const showBanner = () => banner.classList.add('visible');
-      const hideBanner = () => banner.classList.remove('visible');
-
-      const loadAnalytics = () => {
-        if (window.__bbAnalyticsLoaded) return;
-        window.__bbAnalyticsLoaded = true;
-
-        const script = document.createElement('script');
-        script.async = true;
-        script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
-        document.head.appendChild(script);
-
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = function gtag() { window.dataLayer.push(arguments); };
-        window.gtag('js', new Date());
-        window.gtag('config', GA_MEASUREMENT_ID, { anonymize_ip: true });
-      };
-
-      const applyConsent = (value) => {
-        window.localStorage.setItem(storageKey, value);
-        hideBanner();
-        if (value === 'accepted') {
-          loadAnalytics();
-        }
-      };
-
-      banner.querySelector('[data-consent-action="accept"]').addEventListener('click', () => applyConsent('accepted'));
-      banner.querySelector('[data-consent-action="reject"]').addEventListener('click', () => applyConsent('rejected'));
-      manageBtn.addEventListener('click', showBanner);
-
-      const current = readConsent();
-      if (current === 'accepted') {
-        loadAnalytics();
-      } else if (current !== 'rejected') {
-        showBanner();
-      }
-    }
-
     renderRoadmapFr();
-    initializeConsentBannerFr();
 
     BBShared.setupQuestionnaire({
       formId: 'questionnaireFormFr',

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -38,7 +38,7 @@
     <p class="lang-switch"><a href="privacy.html" lang="fr">Lire en français</a></p>
 
     <h1>Privacy Policy</h1>
-    <p class="meta"><strong>Last updated:</strong> February 27, 2026</p>
+    <p class="meta"><strong>Last updated:</strong> April 30, 2026</p>
 
     <h2>1. Data controller</h2>
     <p>
@@ -51,22 +51,25 @@
       <li>Contact details (email, message) through the contact form.</li>
       <li>Newsletter subscription data (email).</li>
       <li>Product questionnaire data (profile, usage, priorities, suggestions).</li>
-      <li>Minimal technical data (cookie consent status, analytics data if consent is given).</li>
     </ul>
+    <p>
+      The site uses no third-party audience measurement tool and no tracking cookies.
+      No browsing data is collected for analytics purposes.
+    </p>
 
     <h2>3. Purposes and legal bases</h2>
     <ul>
       <li><strong>Replying to messages</strong>: legitimate interest and/or pre-contractual steps.</li>
-      <li><strong>Sending newsletters</strong>: explicit consent.</li>
+      <li><strong>Sending newsletters</strong>: explicit consent (form checkbox).</li>
       <li><strong>Improving the product</strong> through questionnaire responses: explicit consent.</li>
-      <li><strong>Audience measurement</strong>: explicit consent (cookie opt-in).</li>
     </ul>
 
     <h2>4. Recipients and international transfers</h2>
     <p>
-      Data may be processed by technical processors (e.g., Formspree for forms, GitHub Pages for hosting,
-      Google Analytics if consented). These services may involve transfers outside the EU (including the US).
-      Where required, appropriate safeguards are used (such as standard contractual clauses or equivalent mechanisms).
+      Data may be processed by technical processors (Formspree for receiving forms, GitHub Pages
+      for static hosting). These services may involve transfers outside the EU (including the US).
+      Where required, appropriate safeguards are used (such as standard contractual clauses or
+      equivalent mechanisms).
     </p>
 
     <h2>5. Data retention</h2>
@@ -74,7 +77,6 @@
       <li>Contact data: up to 3 years after the last interaction.</li>
       <li>Newsletter data: until unsubscribe, or 3 years of inactivity.</li>
       <li>Questionnaire data: up to 3 years for product analysis.</li>
-      <li>Cookie consent record: up to 12 months (or local deletion by the user).</li>
     </ul>
 
     <h2>6. Your rights</h2>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -38,7 +38,7 @@
     <p class="lang-switch"><a href="privacy-en.html" lang="en">Read in English</a></p>
 
     <h1>Politique de confidentialité</h1>
-    <p class="meta"><strong>Dernière mise à jour :</strong> 27 février 2026</p>
+    <p class="meta"><strong>Dernière mise à jour :</strong> 30 avril 2026</p>
 
     <h2>1. Responsable du traitement</h2>
     <p>
@@ -51,22 +51,24 @@
       <li>Données de contact (email, message) via formulaire de contact.</li>
       <li>Données d’inscription newsletter (email).</li>
       <li>Données de questionnaire produit (profil, usages, priorités, suggestions).</li>
-      <li>Données techniques minimales (statut de consentement cookies, mesures d’audience si consentement).</li>
     </ul>
+    <p>
+      Le site n’utilise aucun outil de mesure d’audience tiers et aucun cookie de tracking.
+      Aucune donnée de navigation n’est collectée à des fins analytiques.
+    </p>
 
     <h2>3. Finalités et bases légales</h2>
     <ul>
       <li><strong>Répondre aux messages</strong> : intérêt légitime et/ou mesures précontractuelles.</li>
-      <li><strong>Envoyer la newsletter</strong> : consentement explicite.</li>
+      <li><strong>Envoyer la newsletter</strong> : consentement explicite (case à cocher au formulaire).</li>
       <li><strong>Améliorer le produit</strong> via questionnaire : consentement explicite.</li>
-      <li><strong>Mesurer l’audience</strong> : consentement explicite (opt-in cookies).</li>
     </ul>
 
     <h2>4. Destinataires et transferts internationaux</h2>
     <p>
-      Les données peuvent être traitées par des sous-traitants techniques (ex. Formspree pour les formulaires,
-      GitHub Pages pour l’hébergement, Google Analytics en cas de consentement). Ces services peuvent impliquer
-      des transferts hors UE (notamment vers les États-Unis). Lorsque nécessaire, des garanties appropriées
+      Les données peuvent être traitées par des sous-traitants techniques (Formspree pour la réception
+      des formulaires, GitHub Pages pour l’hébergement statique). Ces services peuvent impliquer des
+      transferts hors UE (notamment vers les États-Unis). Lorsque nécessaire, des garanties appropriées
       sont utilisées (clauses contractuelles types ou mécanisme équivalent).
     </p>
 
@@ -75,7 +77,6 @@
       <li>Contact : jusqu’à 3 ans après le dernier échange.</li>
       <li>Newsletter : jusqu’au désabonnement ou 3 ans d’inactivité.</li>
       <li>Questionnaire : jusqu’à 3 ans pour l’analyse produit.</li>
-      <li>Consentement cookies : jusqu’à 12 mois (ou suppression locale par l’utilisateur).</li>
     </ul>
 
     <h2>6. Vos droits</h2>

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -696,105 +696,6 @@
       text-decoration: underline;
     }
 
-    .cookie-banner {
-      position: fixed;
-      left: 50%;
-      bottom: 78px;
-      transform: translateX(-50%);
-      z-index: 1500;
-      display: none;
-      width: min(860px, calc(100% - 24px));
-      padding: 16px;
-      border-radius: 14px;
-      border: 1px solid rgba(141, 88, 50, 0.28);
-      background: rgba(255, 253, 248, 0.98);
-      box-shadow: 0 18px 34px rgba(53, 38, 27, 0.24);
-    }
-
-    .cookie-banner.visible {
-      display: block;
-    }
-
-    .cookie-banner h3 {
-      margin: 0 0 8px;
-      color: var(--color-secondary);
-      font-size: 1rem;
-    }
-
-    .cookie-banner p {
-      margin: 0;
-      font-size: 0.9rem;
-      color: #4e4035;
-    }
-
-    .cookie-actions {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 8px;
-      margin-top: 12px;
-    }
-
-    .cookie-actions .btn {
-      min-height: 40px;
-      padding: 9px 14px;
-      font-size: 0.88rem;
-    }
-
-    .cookie-manage {
-      position: fixed;
-      left: 50%;
-      bottom: 16px;
-      transform: translateX(-50%);
-      z-index: 1300;
-      border: 1px solid rgba(141, 88, 50, 0.32);
-      background: #fff;
-      color: var(--color-secondary);
-      border-radius: 999px;
-      padding: 8px 14px;
-      font-size: 0.82rem;
-      font-weight: 700;
-      cursor: pointer;
-      box-shadow: var(--shadow-sm);
-    }
-
-    .cookie-banner.visible + .cookie-manage {
-      opacity: 0;
-      pointer-events: none;
-    }
-
-/* Fallback haute priorité pour éviter tout affichage des cookies dans le flux */
-#cookieBannerFr,
-#cookieBannerEn {
-  position: fixed !important;
-  left: 50% !important;
-  right: auto !important;
-  top: auto !important;
-  bottom: 78px !important;
-  transform: translateX(-50%) !important;
-  margin: 0 !important;
-  width: min(860px, calc(100vw - 24px)) !important;
-  max-width: 860px;
-  z-index: 1500 !important;
-}
-
-#cookieManageFr,
-#cookieManageEn {
-  position: fixed !important;
-  left: 50% !important;
-  right: auto !important;
-  top: auto !important;
-  bottom: 16px !important;
-  transform: translateX(-50%) !important;
-  margin: 0 !important;
-  z-index: 1300 !important;
-}
-
-#cookieBannerFr.visible + #cookieManageFr,
-#cookieBannerEn.visible + #cookieManageEn {
-  opacity: 0;
-  pointer-events: none;
-}
-
     .sr-only {
       position: absolute;
       width: 1px;
@@ -842,17 +743,6 @@
 
       .header-nav { display: none; }
       .header-logo span { font-size: 1.1rem; }
-
-  #cookieBannerFr,
-  #cookieBannerEn {
-    bottom: 86px !important;
-    width: calc(100vw - 16px) !important;
-  }
-
-  #cookieManageFr,
-  #cookieManageEn {
-    bottom: 10px !important;
-  }
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/packages/website/terms-en.html
+++ b/packages/website/terms-en.html
@@ -81,8 +81,9 @@
 
     <h2>7. Third-party services</h2>
     <p>
-      The website may rely on third-party services (e.g., Formspree, Google Analytics if consented).
-      Their operation is governed by their own terms and policies.
+      The website may rely on third-party services (e.g., Formspree for receiving forms).
+      Their operation is governed by their own terms and policies. The website does not use
+      any third-party audience measurement tool or tracking cookies.
     </p>
 
     <h2>8. Intended audience</h2>

--- a/packages/website/terms.html
+++ b/packages/website/terms.html
@@ -80,8 +80,9 @@
 
     <h2>7. Liens vers des services tiers</h2>
     <p>
-      Le site peut intégrer des services tiers (ex. Formspree, Google Analytics si consentement).
-      Leur fonctionnement relève de leurs propres conditions et politiques.
+      Le site peut intégrer des services tiers (ex. Formspree pour la réception des formulaires).
+      Leur fonctionnement relève de leurs propres conditions et politiques. Le site n’utilise aucun
+      outil de mesure d’audience tiers ni cookie de tracking.
     </p>
 
     <h2>8. Public concerné</h2>


### PR DESCRIPTION
## Summary

First sub-task of the website refresh (Chantier E — tooling & non-conformities). Removes Google Analytics tracking and the associated cookie consent banner from the public marketing site.

**Why** : the website refresh strategy retained "no analytics for now" — pre-store traffic is too low to justify analytics overhead, and removing the consent banner is an immediate UX win. We will revisit (likely Plausible or similar privacy-friendly tool) once we have meaningful traffic post store launch.

## What ships

### `index.html` and `index-en.html`
- Removes the cookie banner dialog (`#cookieBannerFr` / `#cookieBannerEn`) and the cookie-manage toggle button
- Removes the `GA_MEASUREMENT_ID` constant (`G-RVCT6NGFVG`) and the gtag loader
- Removes the `initializeConsentBannerFr()` / `initializeConsentBannerEn()` functions and their `bb_cookie_consent_v1` localStorage handling
- Removes the `?v=20260228-cookie-fix-1` cache buster on `site.css`
- Removes the "Analytics loaded only after explicit cookie consent" HTML comment

### `site.css`
- Removes the `.cookie-banner`, `.cookie-actions`, `.cookie-manage` rule groups
- Removes the `#cookieBannerFr/En` and `#cookieManageFr/En` `!important` fallback overrides
- Removes the mobile media-query overrides that targeted the same banner IDs
- **Preserved** : `.consent` and `.consent-note` (still used by the Formspree newsletter forms for opt-in checkboxes)

### Policy pages refresh
- `privacy.html` / `privacy-en.html` — drop the "analytics if consented" data category, simplify the recipients section (Formspree + GitHub Pages only), drop the cookie-consent retention line, refresh "last updated" date
- `cookies.html` / `cookies-en.html` — rewrite as "no tracking cookies, no third-party audience measurement tool"; replace the obsolete cookies list and the "Cookies button" preferences block with browser-side guidance
- `terms.html` / `terms-en.html` — drop "Google Analytics if consented" from the third-party services paragraph; explicitly state the website does not use any third-party audience measurement tool or tracking cookies

## Out of scope (deferred)

- Other Chantier E sub-tasks (E.2 a11y, E.3 perf, E.4 SEO, E.5 lint, E.6 CSP/security, E.7 mobile <360px) — separate PRs
- Choosing a privacy-friendly analytics replacement — deferred to post store launch decision
- Removing `cookies.html` / `cookies-en.html` themselves — kept as policy pages explaining the no-tracking stance

## Verification

- `python3 packages/website/scripts/quality_gate.py` — ✅ passed locally
- Manual sweep `grep -rn "Google Analytics\|gtag\|GA_MEASUREMENT\|cookie-banner\|cookieBanner\|initializeConsentBanner" packages/website/` — no remaining references
- `.consent` / `.consent-note` rules confirmed still present in `site.css` (used by Formspree forms)

## Commits in this PR

- `e0b130d` chore(website): remove GA4 tracking + cookie consent banner from home pages
- `d108517` chore(website): remove cookie banner CSS rules from site.css
- `4d4fa32` chore(website): refresh privacy/cookies/terms pages — no tracking, no GA4

## Checklist

- [ ] CI green (path-filtered to `packages/website/`)
- [ ] Visual review on Cloudflare Pages preview (banner gone, no console errors)
- [ ] PROJECT_LOG entry added at merge time

Refs the website refresh plan documented in private session notes (`penses-tu-qu-en-parall-le-on-squishy-bear`).