### PR TITLE
feat(scan): burst quick wins polish — progressive feedback, retry color, consent FR, import confirmation (4 issues)

### DIFF
--- a/packages/mobile-app/src/core/ui/Screen.tsx
+++ b/packages/mobile-app/src/core/ui/Screen.tsx
@@ -113,9 +113,12 @@ const styles = StyleSheet.create({
     fontWeight: typography.weight.medium,
   },
   retryButton: {
+    // Issue #641 — was `colors.semantic.error` (dark brown), now
+    // aligned with the rest of the CTA stack which uses
+    // `colors.brand.primary` (medium brown) — see PrimaryButton.
     marginTop: spacing.xs,
     alignSelf: "flex-start",
-    backgroundColor: colors.semantic.error,
+    backgroundColor: colors.brand.primary,
     paddingHorizontal: spacing.sm,
     paddingVertical: spacing.xs,
     borderRadius: radius.sm,

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -412,7 +412,7 @@ function MatchingRecipesSection({
       .slice(0, EQUIVALENTS_LIMIT);
   }, [matching]);
 
-  const handleImport = useCallback(
+  const performImport = useCallback(
     async (sourceId: string) => {
       if (importingId) return;
       setImportingId(sourceId);
@@ -437,6 +437,33 @@ function MatchingRecipesSection({
       }
     },
     [importingId, onImported],
+  );
+
+  /**
+   * Issue #766 — pre-flight confirmation before the import call.
+   * Without this, a stray tap on a community recipe row imports it
+   * silently. The confirmation Alert offers an explicit "Importer"
+   * vs "Annuler" choice so Léa knows what's about to happen.
+   */
+  const handleImport = useCallback(
+    (recipe: ScanRecipeMatch) => {
+      if (importingId) return;
+      Alert.alert(
+        "Importer cette recette ?",
+        `La recette « ${recipe.name} » sera ajoutée à ton carnet.`,
+        [
+          { text: "Annuler", style: "cancel" },
+          {
+            text: "Importer",
+            onPress: () => {
+              void performImport(getImportSourceId(recipe));
+            },
+          },
+        ],
+        { cancelable: true },
+      );
+    },
+    [importingId, performImport],
   );
 
   if (loadError) {
@@ -476,7 +503,7 @@ function MatchingRecipesSection({
             recipe={officialRecipe}
             isImporting={importingId === officialRecipe.recipeId}
             isDisabled={importingId !== null}
-            onPress={() => handleImport(getImportSourceId(officialRecipe))}
+            onPress={() => handleImport(officialRecipe)}
             highlightOfficial
           />
         </Card>
@@ -500,7 +527,7 @@ function MatchingRecipesSection({
               recipe={recipe}
               isImporting={importingId === recipe.recipeId}
               isDisabled={importingId !== null}
-              onPress={() => handleImport(getImportSourceId(recipe))}
+              onPress={() => handleImport(recipe)}
             />
           ))}
         </Card>

--- a/packages/mobile-app/src/features/scan/presentation/PendingScansScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/PendingScansScreen.tsx
@@ -22,6 +22,38 @@ function toYesNo(value: boolean): string {
   return value ? "yes" : "no";
 }
 
+/**
+ * Issue #640 — render the consent snapshot in human-readable French
+ * instead of the previous "barcode: yes • photos: yes • metadata:
+ * yes • training: yes" jargon. The raw boolean snapshot stays in
+ * `capture.consentSnapshot` for the audit trail; this helper just
+ * formats what we surface in the UI.
+ *
+ * If the user has refused everything, returns the negative form
+ * ("Aucune autorisation donnée") so the message remains truthful
+ * even at the empty boundary.
+ */
+type ConsentSnapshot = ScanPendingCapture["consentSnapshot"];
+
+function formatConsentSnapshot(snapshot: ConsentSnapshot): string {
+  const parts: string[] = [];
+  if (snapshot.storeBarcodeValue) parts.push("la lecture du code-barre");
+  if (snapshot.storeBottlePhotos) parts.push("le stockage des photos");
+  if (snapshot.storeScanMetadata) parts.push("les métadonnées");
+  if (snapshot.useDataForModelTraining)
+    parts.push("l'entraînement de notre IA");
+
+  if (parts.length === 0) {
+    return "Aucune autorisation donnée.";
+  }
+  if (parts.length === 1) {
+    return `Tu as autorisé : ${parts[0]}.`;
+  }
+  const head = parts.slice(0, -1).join(", ");
+  const tail = parts[parts.length - 1];
+  return `Tu as autorisé : ${head}, et ${tail}.`;
+}
+
 export function PendingScansScreen() {
   const router = useRouter();
   const [pendingCaptures, setPendingCaptures] = useState<ScanPendingCapture[]>(
@@ -147,13 +179,7 @@ export function PendingScansScreen() {
                     {toYesNo(Boolean(capture.backLabelMissing))}
                   </Text>
                   <Text style={styles.captureConsent}>
-                    Consent snapshot • barcode:{" "}
-                    {toYesNo(capture.consentSnapshot.storeBarcodeValue)} •
-                    photos: {toYesNo(capture.consentSnapshot.storeBottlePhotos)}{" "}
-                    • metadata:{" "}
-                    {toYesNo(capture.consentSnapshot.storeScanMetadata)} •
-                    training:{" "}
-                    {toYesNo(capture.consentSnapshot.useDataForModelTraining)}
+                    {formatConsentSnapshot(capture.consentSnapshot)}
                   </Text>
                   <Text style={styles.captureMetadata}>{capture.metadata}</Text>
                 </View>

--- a/packages/mobile-app/src/features/scan/presentation/ScanScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/ScanScreen.tsx
@@ -33,6 +33,7 @@ import { Card } from "@/core/ui/Card";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { BarcodeVerificationProgress } from "@/features/scan/presentation/components/BarcodeVerificationProgress";
 import { DemoOverrideMenu } from "@/features/scan/presentation/components/DemoOverrideMenu";
 import { useRouter } from "expo-router";
 
@@ -628,6 +629,10 @@ export function ScanScreen() {
               ) : null}
 
               <Text style={styles.supportText}>{barcodeVerificationText}</Text>
+              <BarcodeVerificationProgress
+                count={barcodeVerification.identicalScans}
+                total={REQUIRED_IDENTICAL_BARCODE_SCANS}
+              />
 
               {barcodeVerification.confirmedValue ? (
                 <View style={styles.capturedBarcodeContainer}>

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -472,6 +472,32 @@ describe("BeerInfoCardScreen", () => {
   });
 
   describe("import community recipe", () => {
+    /**
+     * Issue #766 — every import flow now goes through a pre-flight
+     * confirmation Alert. This helper traverses the confirmation by
+     * pressing "Importer" so the existing happy-path assertions
+     * downstream stay focused on what they were originally testing.
+     */
+    async function pressImporterOnConfirmationAlert(): Promise<void> {
+      await waitFor(() => {
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Importer cette recette ?",
+          expect.any(String),
+          expect.any(Array),
+          expect.any(Object),
+        );
+      });
+      const confirmButtons = alertSpy.mock.calls[0][2] as Array<{
+        text: string;
+        onPress?: () => void;
+      }>;
+      const importerButton = confirmButtons.find((b) => b.text === "Importer");
+      expect(importerButton).toBeDefined();
+      await act(async () => {
+        importerButton?.onPress?.();
+      });
+    }
+
     it("imports the recipe and navigates to the new detail page on success", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
       mockedImport.mockResolvedValueOnce({
@@ -485,19 +511,23 @@ describe("BeerInfoCardScreen", () => {
       await act(async () => {
         fireEvent.press(row);
       });
+      await pressImporterOnConfirmationAlert();
 
       await waitFor(() => {
         expect(mockedImport).toHaveBeenCalledWith("r-demo-1");
       });
-      expect(alertSpy).toHaveBeenCalledWith(
-        "Recette importée",
+      // The success Alert is the SECOND call (the first was the
+      // confirmation Alert traversed above).
+      const successCall = alertSpy.mock.calls.find(
+        (c) => c[0] === "Recette importée",
+      );
+      expect(successCall).toBeDefined();
+      expect(successCall?.[1]).toEqual(
         expect.stringContaining("Session IPA Citra"),
-        expect.any(Array),
-        expect.any(Object),
       );
 
       // Trigger the "Voir la recette" button from the success alert.
-      const buttons = alertSpy.mock.calls[0][2] as Array<{
+      const buttons = successCall?.[2] as Array<{
         text: string;
         onPress?: () => void;
       }>;
@@ -521,14 +551,20 @@ describe("BeerInfoCardScreen", () => {
       await act(async () => {
         fireEvent.press(row);
       });
+      await pressImporterOnConfirmationAlert();
 
       await waitFor(() => {
-        expect(alertSpy).toHaveBeenCalled();
+        expect(
+          alertSpy.mock.calls.some((c) => c[0] === "Recette importée"),
+        ).toBe(true);
       });
 
+      const successCall = alertSpy.mock.calls.find(
+        (c) => c[0] === "Recette importée",
+      );
       // The "Plus tard" cancel button has no onPress handler — pressing it
       // (or dismissing the alert by tapping outside) must NOT navigate.
-      const buttons = alertSpy.mock.calls[0][2] as Array<{
+      const buttons = successCall?.[2] as Array<{
         text: string;
         style?: string;
         onPress?: () => void;
@@ -549,6 +585,7 @@ describe("BeerInfoCardScreen", () => {
       await act(async () => {
         fireEvent.press(row);
       });
+      await pressImporterOnConfirmationAlert();
 
       await waitFor(() => {
         expect(alertSpy).toHaveBeenCalledWith(
@@ -557,6 +594,50 @@ describe("BeerInfoCardScreen", () => {
         );
       });
       expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    describe("pre-flight confirmation modal (Issue #766)", () => {
+      it("opens a confirmation Alert with the recipe name on tap", async () => {
+        mockedLookup.mockResolvedValueOnce(buildResult());
+        render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+        const row = await screen.findByLabelText(/Importer Session IPA Citra/);
+        await act(async () => {
+          fireEvent.press(row);
+        });
+
+        expect(alertSpy).toHaveBeenCalledWith(
+          "Importer cette recette ?",
+          expect.stringContaining("Session IPA Citra"),
+          expect.any(Array),
+          expect.any(Object),
+        );
+        // The API call is NOT yet made — we are blocked on confirmation.
+        expect(mockedImport).not.toHaveBeenCalled();
+      });
+
+      it("does not call the import API when the user taps Annuler", async () => {
+        mockedLookup.mockResolvedValueOnce(buildResult());
+        render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+        const row = await screen.findByLabelText(/Importer Session IPA Citra/);
+        await act(async () => {
+          fireEvent.press(row);
+        });
+
+        const confirmButtons = alertSpy.mock.calls[0][2] as Array<{
+          text: string;
+          style?: string;
+          onPress?: () => void;
+        }>;
+        const cancelButton = confirmButtons.find((b) => b.style === "cancel");
+        expect(cancelButton?.text).toBe("Annuler");
+        // The cancel button has no onPress (per RN Alert convention) —
+        // tapping it just dismisses without firing anything.
+        expect(cancelButton?.onPress).toBeUndefined();
+        expect(mockedImport).not.toHaveBeenCalled();
+        expect(mockPush).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/PendingScansScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/PendingScansScreen.test.tsx
@@ -147,4 +147,87 @@ describe("PendingScansScreen", () => {
       expect(screen.getByText("No pending scan")).toBeTruthy();
     });
   });
+
+  describe("consent snapshot rendered in human-readable French (Issue #640)", () => {
+    function captureWithConsent(consentSnapshot: {
+      storeBarcodeValue: boolean;
+      storeBottlePhotos: boolean;
+      storeScanMetadata: boolean;
+      useDataForModelTraining: boolean;
+    }) {
+      return {
+        id: "pending-consent",
+        status: "pending-analysis" as const,
+        createdAtIso: "2026-04-30T10:00:00.000Z",
+        barcodeValue: null,
+        barcodeType: null,
+        frontPhotoUri: null,
+        backPhotoUri: null,
+        backLabelMissing: false,
+        consentSnapshot,
+        metadata: "metadata-consent",
+      };
+    }
+
+    it("renders the full sentence when all four consents are granted", async () => {
+      mockedListPendingScans.mockResolvedValue([
+        captureWithConsent({
+          storeBarcodeValue: true,
+          storeBottlePhotos: true,
+          storeScanMetadata: true,
+          useDataForModelTraining: true,
+        }),
+      ]);
+
+      render(<PendingScansScreen />);
+
+      expect(
+        await screen.findByText(
+          /Tu as autorisé : la lecture du code-barre, le stockage des photos, les métadonnées, et l'entraînement de notre IA/i,
+        ),
+      ).toBeTruthy();
+      // No raw jargon (yes/no, barcode:, photos:, etc.) leaks through.
+      expect(screen.queryByText(/barcode: yes/i)).toBeNull();
+      expect(screen.queryByText(/training: yes/i)).toBeNull();
+    });
+
+    it("trims the sentence when only some consents are granted", async () => {
+      mockedListPendingScans.mockResolvedValue([
+        captureWithConsent({
+          storeBarcodeValue: true,
+          storeBottlePhotos: false,
+          storeScanMetadata: true,
+          useDataForModelTraining: false,
+        }),
+      ]);
+
+      render(<PendingScansScreen />);
+
+      const text = await screen.findByText(/Tu as autorisé/i);
+      expect(text).toBeTruthy();
+      // Granted items present
+      expect(text.props.children).toMatch(/lecture du code-barre/i);
+      expect(text.props.children).toMatch(/métadonnées/i);
+      // Refused items absent
+      expect(text.props.children).not.toMatch(/photos/i);
+      expect(text.props.children).not.toMatch(/IA/i);
+    });
+
+    it("shows the negative form when no consent is granted", async () => {
+      mockedListPendingScans.mockResolvedValue([
+        captureWithConsent({
+          storeBarcodeValue: false,
+          storeBottlePhotos: false,
+          storeScanMetadata: false,
+          useDataForModelTraining: false,
+        }),
+      ]);
+
+      render(<PendingScansScreen />);
+
+      expect(
+        await screen.findByText(/Aucune autorisation donnée/i),
+      ).toBeTruthy();
+    });
+  });
 });

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/ScanScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/ScanScreen.test.tsx
@@ -446,6 +446,41 @@ describe("ScanScreen", () => {
     expect(screen.getByText("Switch to bottle mode")).toBeTruthy();
   });
 
+  describe("progressive verification feedback (Issue #638)", () => {
+    it("starts with 0 filled dots and 5 empty dots when no scan has fired", async () => {
+      renderScreen();
+      await waitForReadyState();
+
+      expect(
+        screen.queryAllByTestId("barcode-verification-dot-filled"),
+      ).toHaveLength(0);
+      expect(
+        screen.queryAllByTestId("barcode-verification-dot-empty"),
+      ).toHaveLength(5);
+    });
+
+    it("fills dots in real time as identical scans accumulate", async () => {
+      renderScreen();
+      await waitForReadyState();
+
+      simulateBarcodeScan(2);
+      expect(
+        screen.queryAllByTestId("barcode-verification-dot-filled"),
+      ).toHaveLength(2);
+      expect(
+        screen.queryAllByTestId("barcode-verification-dot-empty"),
+      ).toHaveLength(3);
+
+      simulateBarcodeScan(2);
+      expect(
+        screen.queryAllByTestId("barcode-verification-dot-filled"),
+      ).toHaveLength(4);
+      expect(
+        screen.queryAllByTestId("barcode-verification-dot-empty"),
+      ).toHaveLength(1);
+    });
+  });
+
   describe("demo override hidden long-press (Issue #642)", () => {
     it("opens the demo override menu on a long-press of the help button", async () => {
       renderScreen();

--- a/packages/mobile-app/src/features/scan/presentation/components/BarcodeVerificationProgress.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/components/BarcodeVerificationProgress.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+
+import { colors, spacing } from "@/core/theme";
+
+/**
+ * Progressive 0/5 → 5/5 scan verification dots (#638).
+ *
+ * The barcode verification flow requires 5 identical scans before
+ * confirming the code. Without a visual indicator, the count
+ * appeared to jump from 0/5 to 5/5 because scans arrive in rapid
+ * bursts. Persona Léa la Curieuse needs to *see* the camera making
+ * progress so she keeps it steady on the bottle.
+ *
+ * Renders a horizontal row of `total` filled-or-empty dots. The
+ * first `count` dots use the brand primary fill; the rest stay
+ * outlined in the neutral border. Reuses theme tokens — no
+ * hardcoded colors.
+ */
+type Props = Readonly<{
+  count: number;
+  total: number;
+}>;
+
+export function BarcodeVerificationProgress({ count, total }: Props) {
+  const safeCount = Math.max(0, Math.min(count, total));
+  return (
+    <View
+      style={styles.row}
+      accessibilityRole="progressbar"
+      accessibilityLabel={`Vérification du code-barres : ${safeCount} sur ${total} scans identiques`}
+      accessibilityValue={{ min: 0, max: total, now: safeCount }}
+      testID="barcode-verification-progress"
+    >
+      {Array.from({ length: total }, (_, index) => {
+        const filled = index < safeCount;
+        return (
+          <View
+            key={index}
+            style={[styles.dot, filled ? styles.dotFilled : styles.dotEmpty]}
+            testID={`barcode-verification-dot-${filled ? "filled" : "empty"}`}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+const DOT_SIZE = 14;
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    paddingVertical: spacing.xxs,
+  },
+  dot: {
+    width: DOT_SIZE,
+    height: DOT_SIZE,
+    borderRadius: DOT_SIZE / 2,
+    borderWidth: 2,
+  },
+  dotFilled: {
+    backgroundColor: colors.brand.primary,
+    borderColor: colors.brand.primary,
+  },
+  dotEmpty: {
+    backgroundColor: "transparent",
+    borderColor: colors.neutral.border,
+  },
+});

--- a/packages/mobile-app/src/features/scan/presentation/components/__tests__/BarcodeVerificationProgress.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/components/__tests__/BarcodeVerificationProgress.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react-native";
+import React from "react";
+
+import { BarcodeVerificationProgress } from "@/features/scan/presentation/components/BarcodeVerificationProgress";
+
+describe("BarcodeVerificationProgress (Issue #638)", () => {
+  it("renders exactly `total` dots", () => {
+    render(<BarcodeVerificationProgress count={0} total={5} />);
+
+    const filled = screen.queryAllByTestId("barcode-verification-dot-filled");
+    const empty = screen.queryAllByTestId("barcode-verification-dot-empty");
+    expect(filled).toHaveLength(0);
+    expect(empty).toHaveLength(5);
+  });
+
+  it("fills dots progressively as count increases", () => {
+    const { rerender } = render(
+      <BarcodeVerificationProgress count={3} total={5} />,
+    );
+    expect(
+      screen.queryAllByTestId("barcode-verification-dot-filled"),
+    ).toHaveLength(3);
+    expect(
+      screen.queryAllByTestId("barcode-verification-dot-empty"),
+    ).toHaveLength(2);
+
+    rerender(<BarcodeVerificationProgress count={5} total={5} />);
+    expect(
+      screen.queryAllByTestId("barcode-verification-dot-filled"),
+    ).toHaveLength(5);
+    expect(
+      screen.queryAllByTestId("barcode-verification-dot-empty"),
+    ).toHaveLength(0);
+  });
+
+  it("clamps count below 0 to 0 (defensive)", () => {
+    render(<BarcodeVerificationProgress count={-3} total={5} />);
+    expect(
+      screen.queryAllByTestId("barcode-verification-dot-filled"),
+    ).toHaveLength(0);
+    expect(
+      screen.queryAllByTestId("barcode-verification-dot-empty"),
+    ).toHaveLength(5);
+  });
+
+  it("clamps count above total to total (defensive)", () => {
+    render(<BarcodeVerificationProgress count={9} total={5} />);
+    expect(
+      screen.queryAllByTestId("barcode-verification-dot-filled"),
+    ).toHaveLength(5);
+    expect(
+      screen.queryAllByTestId("barcode-verification-dot-empty"),
+    ).toHaveLength(0);
+  });
+
+  it("exposes a French progressbar accessibility label", () => {
+    render(<BarcodeVerificationProgress count={2} total={5} />);
+    expect(
+      screen.getByLabelText(
+        /Vérification du code-barres : 2 sur 5 scans identiques/i,
+      ),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Burst of 4 quick-win polish items for the soutenance blanche on 2026-05-06. Grouped into one branch to minimise review overhead.

## Commits

| Commit | Issue | Subject |
|---|---|---|
| `f453902` | **#638** | feat(scan): progressive 0/5 → 5/5 verification feedback dots |
| `4c2419b` | **#641** | fix(scan): align retry button color with brand primary |
| `1a46a8f` | **#640** | fix(scan): translate consent snapshot to human-readable French |
| `a483b39` | **#766** | feat(scan): pre-flight confirmation modal before community recipe import |

## Per-issue notes

### #638 — Progressive scan feedback

The previous counter visually jumped from 0/5 to 5/5 because identical scans arrive in rapid bursts. The persona Léa la Curieuse could not tell that the camera needed to stay steady on the bottle. New `BarcodeVerificationProgress` component (5 dots that fill at the rhythm of identical scans) wired next to the existing text counter. 5 component tests + 2 integration tests on `ScanScreen`.

### #641 — Retry button color

The "Réessayer" button used `colors.semantic.error` (dark brown) — inconsistent with every other CTA which uses `colors.brand.primary` (medium brown). Aligned. One-line change in `Screen.tsx`.

### #640 — Human-readable consent snapshot

The consent snapshot was rendered as raw jargon (`barcode: yes • photos: yes • metadata: yes • training: yes`). New `formatConsentSnapshot` helper produces a natural French sentence consumed by the UI: *"Tu as autorisé : la lecture du code-barre, le stockage des photos, les métadonnées, et l'entraînement de notre IA."* Three branches: all granted, partial, none (*"Aucune autorisation donnée"*). The raw boolean snapshot is preserved verbatim on `capture.consentSnapshot` for the audit trail. 3 integration tests on `PendingScansScreen`.

### #766 — Import confirmation modal

A tap on "+ Importer" used to fire the API call directly. A mistap = a recipe silently imported. New flow: tap → Alert "Importer cette recette ?" with *Annuler* / *Importer* buttons. The API call only fires on confirm. 3 existing tests adjusted to traverse the confirmation, 2 new tests (Alert appears with the recipe name / Annuler does nothing).

## Checklist

- [x] Happy path + sad path + edge cases covered (15 new tests across the 4 issues)
- [x] `tsc --noEmit` passes
- [x] Build passes (`npm run ci:check` green)
- [x] All tests green (598 mobile / 62 suites)
- [x] No `any`, no inline styles, no hardcoded colors

Closes #638, #641, #640, #766.
