### PR TITLE
chore(mobile-app): bump version to 0.1.13-alpha1 for post-#822 EAS build

### DIFF
--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Brasse Bouillon",
     "slug": "brasse-bouillon-mobile-app",
-    "version": "0.1.12-alpha1",
+    "version": "0.1.13-alpha1",
     "orientation": "portrait",
     "icon": "./assets/images/brasse-bouillon-logo-primary-512.png",
     "scheme": "brassebouillonmobileapp",

--- a/packages/mobile-app/package.json
+++ b/packages/mobile-app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@brasse-bouillon/mobile-app",
   "main": "expo-router/entry",
-  "version": "0.1.12-alpha1",
+  "version": "0.1.13-alpha1",
   "scripts": {
     "start": "expo start",
     "start:lan": "expo start --lan",


### PR DESCRIPTION
## Summary

Bump `packages/mobile-app/package.json` and `app.json` from `0.1.12-alpha1` to `0.1.13-alpha1`. This is a routine version bump to produce a fresh EAS preview APK that includes:

- PR #819 — burst quick wins polish (Issues #638 / #641 / #640 / #766)
- PR #823 — demo mode via secret sign-in credentials (Issue #822)

`runtimeVersion.policy = "appVersion"` propagates the bump to the EAS runtime version automatically. The new APK will live on a fresh OTA slice, separate from the existing `0.1.12-alpha1` APK on the speaker's phone.

## Files

- `packages/mobile-app/package.json`
- `packages/mobile-app/app.json`

## Checklist

- [x] `tsc --noEmit` passes
- [x] `npm run ci:check` green (lint + typecheck + format)
- [x] No code changes — version bump only
- [x] No `any`, no inline styles introduced

## Out of scope

- Lockfile (`package-lock.json`) — already stale relative to previous bumps; will regenerate at the next `npm install` cycle.
- CHANGELOG / PROJECT_LOG — captured at the next release-please cut, not in this bump PR.