### PR TITLE
chore(ci): add anthropics/claude-code-action review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,77 @@
+# ==============================================================================
+# Brasse-Bouillon — Claude Code Review
+#
+# Runs the official anthropics/claude-code-action on every pull request,
+# posting inline review comments. Replaces GitHub Copilot reviewer while
+# the personal-account Copilot premium quota is exhausted (until
+# 2026-06-01).
+#
+# Requirements:
+#   - GitHub repo secret ANTHROPIC_API_KEY (generate one at
+#     console.anthropic.com → Settings → API keys)
+#   - Repo permission: Settings → Actions → General → Workflow
+#     permissions → "Read and write permissions"
+#
+# Skipped on PRs from forks because secrets.ANTHROPIC_API_KEY is not
+# shared with forked-repo workflows by GitHub Actions; the action would
+# fail to authenticate. An authorized maintainer can still trigger a
+# review by re-running the workflow on a branch of this repo.
+# ==============================================================================
+
+name: Claude Code Review
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    name: Claude Code Review
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@main
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Review this pull request as a senior reviewer for the
+            Brasse-Bouillon monorepo (React Native + Expo + NestJS,
+            Clean Architecture, strict TypeScript, no `any`, named
+            exports only, design tokens for all styling).
+
+            Focus on, in this order:
+              1. Correctness — logic bugs, off-by-one errors, broken
+                 invariants, regressions in existing behaviour.
+              2. Security — XSS / SQL injection / command injection /
+                 hardcoded secrets / unvalidated input at boundaries.
+              3. Architecture — layering violations (domain ← application
+                 ← data → presentation), forbidden cross-feature imports,
+                 abuse of the data-source toggle pattern.
+              4. Tests — happy path + sad path + edge cases per project
+                 convention; no regressions on existing assertions.
+              5. Code quality — naming, dead code, duplication,
+                 over-engineering, missing TypeScript narrowing.
+
+            Post each finding as an inline review comment on the
+            relevant line. Tag each finding with one of:
+              [Must Have] — logic bug, security, broken behaviour.
+              [Should Have] — quality, naming, validation gap.
+              [Nice to Have] — style preference, optional optimisation.
+              [Disagree] — flag points the diff author may push back on.
+
+            End with a single overall verdict line:
+              "Verdict: APPROVE | REQUEST CHANGES | COMMENT"


### PR DESCRIPTION
## Summary

Replaces GitHub Copilot code review while the personal-account Copilot premium-request quota is exhausted (resets 2026-06-01). Adds the official `anthropics/claude-code-action` GitHub Action so every PR receives inline review comments automatically — no per-run trigger needed.

This is critical: Copilot is unavailable for the entire pre-blanche (2026-05-06) and pre-soutenance (2026-05-27) windows. Without a CI-side reviewer, the only bot left would be Codex.

## What changes

- New workflow `.github/workflows/claude-code-review.yml`:
  - Triggered on `pull_request` to `main` (opened / synchronize / reopened / ready_for_review).
  - Skipped on draft PRs and on PRs from forks (secret not shared with forked-repo workflows).
  - Permissions scoped to `contents:read + pull-requests:write + issues:write` — minimum needed to post inline review comments.
  - The prompt is tailored to the Brasse-Bouillon stack (Clean Architecture, strict TypeScript, design tokens) and asks the reviewer to triage findings as **Must Have / Should Have / Nice to Have / Disagree**, mirroring the project's existing PR review procedure (`CLAUDE.md` § PR Review Comments).
  - End verdict line: `Verdict: APPROVE | REQUEST CHANGES | COMMENT`.

## Required follow-up — maintainer action

After this PR merges, the repo needs a secret to authenticate the action:

1. Generate an Anthropic API key at https://console.anthropic.com → Settings → API keys (or reuse an existing one).
2. Add it as a repo secret: **Settings → Secrets and variables → Actions → New repository secret** with name `ANTHROPIC_API_KEY`.
3. Verify **Settings → Actions → General → Workflow permissions** is set to "Read and write permissions" (already required for the existing release-please metadata workflow).
4. Open a tiny test PR (or push a synchronize event to an existing PR) and confirm the new workflow runs and the action posts at least one inline review comment.

Without `ANTHROPIC_API_KEY`, the action step fails fast with an authentication error — no production impact.

## Pinning policy

- `actions/checkout` pinned by SHA (mirroring `sonarcloud.yml` and `ci.yml` conventions).
- `anthropics/claude-code-action` tracks `@main` intentionally — the action is in active development and Anthropic ships fixes frequently. Once a stable tagged release is widely adopted, switch to a SHA pin in a follow-up.

## Out of scope

- Removing the (already-skipped) Copilot reviewer request from the PR-creation workflow — there is no automated Copilot-request step in this repo today; the convention was a manual `gh api .../requested_reviewers` call documented in `CLAUDE.md`. Per memory `feedback_copilot_quota_until_2026-06-01.md`, that call is suppressed for the next month regardless.
- Switching from Codex to Claude as the primary bot. Codex (chatgpt-codex-connector) keeps running on its own quota and continues to post; this workflow is additive.

## Checklist

- [x] Workflow YAML syntax valid (mirrors `sonarcloud.yml` structure)
- [x] Permissions scoped to minimum required
- [x] Skip rules cover forks + drafts
- [x] No secrets in tracked files
- [ ] `ANTHROPIC_API_KEY` repo secret added — **follow-up after merge**
- [ ] First successful action run on a test PR — **follow-up after merge**