### PR TITLE
fix(dashboard): truncate header identity text instead of overlapping the action buttons

### DIFF
--- a/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
+++ b/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
@@ -555,9 +555,11 @@ export function DashboardScreen() {
                 {displayName.charAt(0).toUpperCase()}
               </Text>
             </View>
-            <View>
-              <Text style={styles.headerName}>{displayName}</Text>
-              <Text style={styles.headerSubtitle}>
+            <View style={styles.headerText}>
+              <Text style={styles.headerName} numberOfLines={1}>
+                {displayName}
+              </Text>
+              <Text style={styles.headerSubtitle} numberOfLines={1}>
                 Tableau de bord brassage
               </Text>
             </View>
@@ -844,11 +846,17 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: spacing.sm,
     flex: 1,
+    minWidth: 0,
+  },
+  headerText: {
+    flex: 1,
+    minWidth: 0,
   },
   headerActions: {
     flexDirection: "row",
     alignItems: "center",
     gap: spacing.xs,
+    flexShrink: 0,
   },
   avatar: {
     width: 40,


### PR DESCRIPTION
## Summary

User-reported bug from a 2026-05-01 mobile screenshot: on the home header card, **\"Tableau de bord brassage\"** ran under the **\"Profil\"** + **\"Voir plus\"** action buttons. The screenshot showed *\"Tableau de bo…\"* — the *\"…\"* was actually the start of the buttons themselves, not an ellipsis. The button cluster was visually overlapping the text.

Root cause: the inner `<View>` wrapping the `displayName` + subtitle had no flex constraints, so it took its intrinsic width and grew past the right edge of the row. The action cluster (`headerActions`) had no `flexShrink: 0`, but had a higher intrinsic width on a normal phone, which let the layout engine push the text behind it instead of truncating.

## Fix

- Tag the inner text wrapper as `styles.headerText` with `flex: 1 + minWidth: 0` so it occupies the remaining row width and reports a min-content of 0 to the flex algorithm.
- Add `minWidth: 0` to `styles.headerIdentity` (its parent) for the same reason — without it React Native's flex implementation refuses to shrink the row.
- Add `flexShrink: 0` to `styles.headerActions` to lock the button cluster at its intrinsic width (we never want the buttons to shrink; the text is the elastic side).
- Add `numberOfLines={1}` on the two Texts so the overflow case truncates with a proper *\"…\"* instead of clipping or wrapping.

Pure layout fix — no behaviour change, no accessibility change, no new dependency.

## Files

- `packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx` — JSX nest update + 3 style tweaks + 1 new style.

## Tests

- Existing `DashboardScreen.test.tsx` still green (the test does not assert on layout properties; the JSX assertions on `displayName` + subtitle are unaffected by the truncation behaviour).
- 65 suites / 622 tests still green overall.

## Acceptance

- [x] On a typical phone width, the displayName + subtitle no longer overlap the action buttons.
- [x] When the displayName is unusually long (rare in practice), it truncates with an ellipsis instead of overflowing.
- [x] The action buttons stay at their intrinsic width — no shrinking, no wrapping.

## Out of scope

- Responsive redesign of the header card on tablets — the `flex` model already handles wider viewports.
- Replacing the action button labels with icons-only on small screens — defer; the truncation handles the overflow case.

## Checklist

- [x] `tsc --noEmit` passes
- [x] `npm run ci:check` green (lint + typecheck + format)
- [x] No `any`, no inline styles, no hardcoded colors (uses `spacing.*`, `colors.*`, `typography.*` design tokens)
- [x] No new dependencies