### PR TITLE
feat(beer-encyclopedia): add French legal denomination reference

### DIFF
--- a/packages/beer-encyclopedia/db/models/__init__.py
+++ b/packages/beer-encyclopedia/db/models/__init__.py
@@ -9,6 +9,7 @@ from db.models.beer import Beer
 from db.models.brewery import Brewery
 from db.models.correction import CommunityCorrection
 from db.models.ingredient import BeerIngredient, Ingredient
+from db.models.legal_denomination import LegalDenomination
 from db.models.media import Media
 from db.models.source import EntitySource, Source
 from db.models.style import Style
@@ -22,6 +23,7 @@ __all__ = [
     "CommunityCorrection",
     "EntitySource",
     "Ingredient",
+    "LegalDenomination",
     "Media",
     "Source",
     "Style",

--- a/packages/beer-encyclopedia/db/models/beer.py
+++ b/packages/beer-encyclopedia/db/models/beer.py
@@ -18,9 +18,12 @@ from sqlalchemy import (
     Text,
     text,
 )
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship, validates
+from sqlalchemy.types import JSON
 
 from db.models.base import Base, TimestampMixin, UUIDMixin
+from db.models.legal_denomination import LEGAL_DENOMINATION_VALUES
 
 if TYPE_CHECKING:
     from db.models.brewery import Brewery
@@ -34,6 +37,17 @@ if TYPE_CHECKING:
 # module-level constant so migration and validation logic reference a
 # single source of truth.
 BEER_SOURCE_VALUES = ("openfoodfacts", "internal", "community")
+
+# Valid alcohol groups under article L-3321-1 of the French Code de la
+# santé publique. Group 2 was historically merged into group 3, so the
+# current legal nomenclature exposes only {1, 3, 4, 5} — beer falls in
+# group 3 (fermented non-distilled drinks alongside wine, cider, mead).
+ALCOHOL_GROUP_VALUES: tuple[int, ...] = (1, 3, 4, 5)
+
+# JSONB on PostgreSQL (indexable, queryable), JSON on other dialects
+# (SQLite under tests). Mirrors the pattern in db/models/source.py so the
+# allergens column is portable across environments.
+_AllergensType = JSON().with_variant(JSONB(), "postgresql")
 
 
 class Beer(Base, UUIDMixin, TimestampMixin):
@@ -65,6 +79,22 @@ class Beer(Base, UUIDMixin, TimestampMixin):
                 ", ".join(f"'{v}'" for v in BEER_SOURCE_VALUES)
             ),
             name="ck_beers_source_valid",
+        ),
+        CheckConstraint(
+            "legal_denomination IS NULL OR legal_denomination IN ({})".format(
+                ", ".join(f"'{v}'" for v in LEGAL_DENOMINATION_VALUES)
+            ),
+            name="ck_beers_legal_denomination_valid",
+        ),
+        CheckConstraint(
+            "alcohol_group IS NULL OR alcohol_group IN ({})".format(
+                ", ".join(str(v) for v in ALCOHOL_GROUP_VALUES)
+            ),
+            name="ck_beers_alcohol_group_valid",
+        ),
+        CheckConstraint(
+            "country_of_origin IS NULL OR length(country_of_origin) = 2",
+            name="ck_beers_country_of_origin_iso2",
         ),
     )
 
@@ -107,6 +137,17 @@ class Beer(Base, UUIDMixin, TimestampMixin):
         DateTime(timezone=True), nullable=True
     )
 
+    # French regulatory fields (decree 92-307 modified by 2016-1531,
+    # regulation EU 1169/2011, article L-3321-1 of the Code de la santé
+    # publique). All four are nullable: pre-existing rows and rows
+    # imported from non-FR sources may legitimately leave them blank.
+    legal_denomination: Mapped[str | None] = mapped_column(
+        String(50), nullable=True
+    )
+    country_of_origin: Mapped[str | None] = mapped_column(String(2), nullable=True)
+    allergens: Mapped[list[str] | None] = mapped_column(_AllergensType, nullable=True)
+    alcohol_group: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+
     brewery: Mapped[Brewery | None] = relationship(back_populates="beers")
     style: Mapped[Style | None] = relationship(back_populates="beers")
     tasting_profile: Mapped[TastingProfile | None] = relationship(
@@ -141,3 +182,64 @@ class Beer(Base, UUIDMixin, TimestampMixin):
                 f"Beer.source must be one of ({valid}), got {value!r}"
             )
         return value
+
+    @validates("legal_denomination")
+    def _validate_legal_denomination(
+        self, _key: str, value: str | None
+    ) -> str | None:
+        """Reject invalid ``legal_denomination`` values at the ORM layer.
+
+        Same rationale as ``_validate_source``: surface the error at
+        assignment time rather than at flush time. ``None`` is allowed
+        because the field is optional (only meaningful for FR beers).
+        """
+        if value is None:
+            return value
+        if value not in LEGAL_DENOMINATION_VALUES:
+            valid = ", ".join(LEGAL_DENOMINATION_VALUES)
+            raise ValueError(
+                f"Beer.legal_denomination must be one of ({valid}) or None, "
+                f"got {value!r}"
+            )
+        return value
+
+    @validates("alcohol_group")
+    def _validate_alcohol_group(
+        self, _key: str, value: int | None
+    ) -> int | None:
+        """Reject invalid ``alcohol_group`` values at the ORM layer.
+
+        Article L-3321-1 of the French Code de la santé publique exposes
+        only groups {1, 3, 4, 5} — group 2 was merged into group 3.
+        ``None`` is allowed for non-FR beers.
+        """
+        if value is None:
+            return value
+        if value not in ALCOHOL_GROUP_VALUES:
+            valid = ", ".join(str(v) for v in ALCOHOL_GROUP_VALUES)
+            raise ValueError(
+                f"Beer.alcohol_group must be one of ({valid}) or None, "
+                f"got {value!r}"
+            )
+        return value
+
+    @validates("country_of_origin")
+    def _validate_country_of_origin(
+        self, _key: str, value: str | None
+    ) -> str | None:
+        """Normalize ``country_of_origin`` to uppercase ISO 3166-1 alpha-2.
+
+        Accepts mixed case input ("fr", "Fr", "FR") and stores uppercase.
+        Rejects non-letter characters at the ORM layer so junk like
+        ``"!!"`` or ``"12"`` cannot reach the DB even though it would
+        pass the length-only CHECK constraint. ISO 3166-1 alpha-2 codes
+        are always two ASCII letters by specification.
+        """
+        if value is None:
+            return value
+        if len(value) != 2 or not value.isalpha():
+            raise ValueError(
+                f"Beer.country_of_origin must be a 2-letter ISO code, "
+                f"got {value!r}"
+            )
+        return value.upper()

--- a/packages/beer-encyclopedia/db/models/legal_denomination.py
+++ b/packages/beer-encyclopedia/db/models/legal_denomination.py
@@ -1,0 +1,105 @@
+"""French legal denomination reference model.
+
+Backed by the French regulatory framework on beer composition and
+labelling — primarily decree 92-307 of 31 March 1992, modified by decree
+2016-1531 of 15 November 2016. Each row maps a controlled vocabulary
+code (snake_case) to its canonical label, the discriminating criterion
+that defines the denomination, and a pointer to the source text. Used
+to populate UI dropdowns and to validate ``Beer.legal_denomination``
+against an authoritative whitelist.
+
+The ``label`` column stores the French wording because this is the
+French-locale reference table. Internationalisation (German, English,
+…) will be handled by a future ``LegalDenominationLabel(locale, label)``
+sibling table rather than by suffixing column names.
+
+Scope is intentionally France-only for v0.2; other locales (Belgium,
+Germany, etc.) will get sibling rows or sibling tables in later iterations.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import CheckConstraint, Numeric, SmallInteger, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.models.base import Base, TimestampMixin, UUIDMixin
+
+# The ten canonical legal denominations defined by the French decree
+# 92-307 modified by 2016-1531. Kept as a module-level constant so the
+# migration CHECK constraint, the seed script, and the validator stay in
+# sync. Codes use the original French snake_case form because there is
+# no English equivalent in the French regulation.
+#
+# Order mirrors the structure of the decree itself: the generic
+# definition first, then categorisation by alcohol content, then by
+# composition, then by process, then by additives, then derived
+# products, and finally the producer-qualifying mention. Keeping the
+# list in this order helps any reader cross-reference with the decree.
+LEGAL_DENOMINATION_VALUES: tuple[str, ...] = (
+    # Generic definition (Art. 1)
+    "biere",
+    # By alcohol content
+    "biere_sans_alcool",
+    "biere_forte",
+    # By composition
+    "pur_malt",
+    # By process
+    "biere_de_garde",
+    "biere_fermentation_lactique",
+    # By additives
+    "biere_a_ingredient",
+    "biere_aromatisee",
+    # Derived product
+    "panache",
+    # Producer-qualifying mention
+    "biere_artisanale",
+)
+
+
+class LegalDenomination(Base, UUIDMixin, TimestampMixin):
+    """Reference entry for a French legal beer denomination.
+
+    Each row maps a canonical snake_case ``code`` (e.g. ``biere_de_garde``)
+    to its French ``label`` and the discriminating criterion that the
+    decree attaches to it. Consumed by:
+
+    - the ``Beer.legal_denomination`` CHECK constraint (whitelist
+      enforcement at the DB level)
+    - the mobile UI dropdowns and explanatory tooltips (queries the
+      ``label`` and ``description`` columns)
+    - the future PR3 community-validation flow (uses ``min_aging_days``
+      and ``max_alcohol_pct`` to flag inconsistent claims)
+
+    See ADR-0002 for the rationale (dedicated table vs. enum, no FK to
+    keep the reference re-seedable, French snake_case for traceability
+    with the regulation).
+    """
+
+    __tablename__ = "legal_denominations"
+    __table_args__ = (
+        CheckConstraint(
+            "code IN ({})".format(
+                ", ".join(f"'{v}'" for v in LEGAL_DENOMINATION_VALUES)
+            ),
+            name="ck_legal_denominations_code_valid",
+        ),
+        CheckConstraint(
+            "min_aging_days IS NULL OR min_aging_days >= 0",
+            name="ck_legal_denominations_min_aging_positive",
+        ),
+        CheckConstraint(
+            "max_alcohol_pct IS NULL OR max_alcohol_pct >= 0",
+            name="ck_legal_denominations_max_alcohol_positive",
+        ),
+    )
+
+    code: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    label: Mapped[str] = mapped_column(String(100), nullable=False)
+    description: Mapped[str] = mapped_column(Text, nullable=False)
+    legal_reference: Mapped[str] = mapped_column(String(255), nullable=False)
+    min_aging_days: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    max_alcohol_pct: Mapped[Decimal | None] = mapped_column(
+        Numeric(4, 2), nullable=True
+    )

--- a/packages/beer-encyclopedia/docs/adr/ADR-0002-french-legal-reference.md
+++ b/packages/beer-encyclopedia/docs/adr/ADR-0002-french-legal-reference.md
@@ -1,0 +1,130 @@
+# ADR-0002: French legal reference for beer denominations and labels
+
+- Status: Accepted
+- Date: 2026-05-01
+
+## Context
+
+The encyclopedia stores beer rows that the mobile app surfaces to French
+consumers. Until now the schema had no anchor on the regulatory framework
+that governs beer composition and labelling in France, so the data layer
+could not enforce — or even express — the categories defined by the law.
+
+The applicable framework is:
+
+- Decree n°92-307 of 31 March 1992, modified by decree n°2016-1531 of
+  15 November 2016 — beer composition and labelling
+- EU regulation 1169/2011 — consumer information on food
+- Order of 2 October 2006 — mandatory health message on alcoholic
+  drinks above 1.2 %vol
+- Article L-3321-1 of the French Code de la santé publique — five-group
+  alcohol classification (group 2 was historically merged into group 3)
+- Article 16 of the decree-law of 30 July 1935 — capacity etching on
+  beer glassware (out of scope for the data layer; tracked for UI later)
+
+We need this knowledge represented in the schema for three reasons:
+
+1. **Validation** — the brewer-facing flow (and later the community
+   contribution flow) must reject claims that violate the law (e.g. a
+   beer labelled `pur_malt` while the recipe contains adjuncts).
+2. **Discovery** — users want to filter on legal categories that are
+   familiar to them in France ("bière de garde", "panaché"), not only
+   on BJCP-style taxonomies that come from the homebrewing world.
+3. **Compliance trail** — every regulatory field (allergens, country of
+   origin, alcohol group) must be queryable independently for export
+   and for future moderation tooling.
+
+## Decision
+
+Introduce a dedicated `legal_denominations` reference table holding the
+ten canonical French denominations, plus four nullable regulatory
+columns on `beers` (`legal_denomination`, `country_of_origin`,
+`allergens`, `alcohol_group`).
+
+Specifically:
+
+1. **`legal_denominations` table** — controlled vocabulary table with a
+   unique `code`, a `label` (French wording, displayed in the FR
+   mobile UI), the discriminating `description`, the `legal_reference`
+   text, and two category-specific structured fields (`min_aging_days`,
+   `max_alcohol_pct`). Seeded by `scripts/seed_legal_denominations.py`
+   (idempotent upsert). Internationalisation will be handled later by
+   a `LegalDenominationLabel(locale, label)` sibling table rather than
+   by suffixing column names — keeps the table aligned with the rest of
+   the package (`Style.name`, `Brewery.name`, etc. carry no language
+   suffix).
+2. **`beers.legal_denomination`** — nullable `VARCHAR(50)`, CHECK
+   constrained to the same ten codes. Cross-referenced with the
+   reference table by application code, not by foreign key, so historical
+   rows without a denomination remain valid and the table can be
+   re-seeded without the FK getting in the way.
+3. **`beers.country_of_origin`** — nullable `CHAR(2)`, ISO 3166-1
+   alpha-2; uppercased at the ORM layer.
+4. **`beers.allergens`** — nullable JSONB on PostgreSQL (JSON elsewhere)
+   storing a normalised string array.
+5. **`beers.alcohol_group`** — nullable `SMALLINT`, CHECK in (1, 3, 4, 5)
+   (group 2 explicitly excluded, see context).
+
+All four columns on `beers` are nullable. Pre-existing rows and rows
+imported from non-FR sources legitimately leave them blank.
+
+### Rejected alternatives
+
+- **Pure enum on `Beer.legal_denomination`** (no reference table).
+  Rejected because the enum cannot carry the discriminating criterion,
+  the legal reference text, or the per-category structured fields
+  (`min_aging_days`, `max_alcohol_pct`). Those need a row.
+- **Foreign key from `beers.legal_denomination` to
+  `legal_denominations.code`**. Rejected to avoid coupling a slow-moving
+  reference table to the high-volume beer table; the CHECK constraint
+  gives the same correctness guarantee at lower migration cost.
+- **One row per regulation in a generic `regulations` table**. Rejected
+  as premature generalisation — denominations and labelling rules have
+  distinct shapes and lifecycles; a single table would force a JSON
+  blob and lose the value of typed columns.
+- **Encode the regulation in code only (no table)**. Rejected because
+  the mobile UI and the future moderation flow both need to render the
+  list and explain each category to non-expert users; that data has to
+  live somewhere queryable.
+
+## Rationale
+
+- The reference table makes the regulation a first-class artefact,
+  versioned alongside the schema and usable from any client.
+- Nullable columns on `beers` keep the migration non-breaking and let
+  non-FR data coexist without a kludgy `country = "FR"` toggle.
+- Storing values in their original French snake_case (`biere_de_garde`,
+  `panache`) preserves traceability with the regulation; there is no
+  English equivalent that carries the same legal meaning.
+- The duplication of `LEGAL_DENOMINATION_VALUES` between the model and
+  the migration mirrors the convention introduced by ADR-0001 work and
+  by migration 002 — historical migrations stay runnable even if the
+  model evolves.
+
+## Consequences
+
+### Positive
+
+- Beers can carry their regulated category and be queried, filtered,
+  and validated against it.
+- Allergens and country of origin are explicit columns rather than
+  buried inside a description string; both are required by the EU
+  regulation for any beer sold in France.
+- The reference table is queryable from the mobile app for dropdowns
+  and explanatory tooltips without bundling the regulation client-side.
+- The Open Food Facts importer (next PR) can populate
+  `country_of_origin` and `allergens` directly from its `countries_tags`
+  and `allergens_tags` payload.
+
+### Trade-offs
+
+- Scope is France-only for now. Belgium, Germany, etc. will require a
+  parallel table or a discriminator column when we expand. Documented
+  here so the next iteration is intentional.
+- The values are opinionated French snake_case strings; consumers
+  outside the FR locale will see them as opaque codes unless the UI
+  joins on `label_fr`. Acceptable: the mobile UI is already French.
+- A foreign key would have prevented the rare drift case (a `Beer.legal_denomination`
+  pointing to a code that was later removed from the reference). We
+  accept this trade-off in exchange for migration simplicity and seed
+  re-runnability; a later integrity sweep can detect orphans cheaply.

--- a/packages/beer-encyclopedia/migrations/versions/003_legal_reference_fr.py
+++ b/packages/beer-encyclopedia/migrations/versions/003_legal_reference_fr.py
@@ -1,0 +1,176 @@
+"""Add French legal reference (denominations table + beer regulatory fields).
+
+Introduces the regulatory layer required to keep the encyclopedia
+compliant with the French framework for beer composition and labelling:
+
+- New ``legal_denominations`` table — controlled vocabulary of the ten
+  legal beer denominations defined by decree 92-307 of 31 March 1992,
+  modified by decree 2016-1531 of 15 November 2016. The table is
+  populated by ``scripts/seed_legal_denominations.py``.
+- Four new columns on ``beers``:
+  - ``legal_denomination`` (nullable VARCHAR(50), CHECK against the ten
+    canonical codes) — the regulated category claimed by the brewer.
+  - ``country_of_origin`` (nullable CHAR(2), CHECK on length) — ISO
+    3166-1 alpha-2 code. Required by EU regulation 1169/2011 Art. 26
+    only when its omission would mislead the consumer (not systematic).
+  - ``allergens`` (nullable JSONB on PostgreSQL, JSON elsewhere) — the
+    list of allergens that must be highlighted on the label per EU
+    regulation 1169/2011 (cereals containing gluten, sulfites > 10 mg/L,
+    etc.). Stored as a normalised string array.
+  - ``alcohol_group`` (nullable SMALLINT, CHECK in (1, 3, 4, 5)) — group
+    classification under article L-3321-1 of the French Code de la santé
+    publique. Beer falls in group 3.
+
+All four ``beers`` columns are nullable so the migration is non-breaking
+for existing rows imported from non-FR sources.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-05-01
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "003"
+down_revision: str | None = "002"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+# Canonical legal denomination codes. Mirrors LEGAL_DENOMINATION_VALUES
+# in db/models/legal_denomination.py — kept duplicated here (instead of
+# imported) so historical migrations remain runnable even if the model
+# evolves. Same convention as migration 002 for BEER_SOURCE_VALUES.
+LEGAL_DENOMINATION_VALUES: tuple[str, ...] = (
+    "biere",
+    "biere_sans_alcool",
+    "biere_forte",
+    "pur_malt",
+    "biere_de_garde",
+    "biere_fermentation_lactique",
+    "biere_a_ingredient",
+    "biere_aromatisee",
+    "panache",
+    "biere_artisanale",
+)
+
+ALCOHOL_GROUP_VALUES: tuple[int, ...] = (1, 3, 4, 5)
+
+LEGAL_DENOMINATION_CHECK_EXPR: str = "code IN ({})".format(
+    ", ".join(f"'{v}'" for v in LEGAL_DENOMINATION_VALUES)
+)
+
+BEER_LEGAL_DENOMINATION_CHECK_EXPR: str = (
+    "legal_denomination IS NULL OR legal_denomination IN ({})".format(
+        ", ".join(f"'{v}'" for v in LEGAL_DENOMINATION_VALUES)
+    )
+)
+
+BEER_ALCOHOL_GROUP_CHECK_EXPR: str = (
+    "alcohol_group IS NULL OR alcohol_group IN ({})".format(
+        ", ".join(str(v) for v in ALCOHOL_GROUP_VALUES)
+    )
+)
+
+
+def upgrade() -> None:
+    """Create ``legal_denominations`` and add four columns on ``beers``."""
+
+    # --- legal_denominations -----------------------------------------------
+    op.create_table(
+        "legal_denominations",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("code", sa.String(length=50), nullable=False),
+        sa.Column("label", sa.String(length=100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column("legal_reference", sa.String(length=255), nullable=False),
+        sa.Column("min_aging_days", sa.SmallInteger(), nullable=True),
+        sa.Column("max_alcohol_pct", sa.Numeric(precision=4, scale=2), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("code"),
+        sa.CheckConstraint(
+            LEGAL_DENOMINATION_CHECK_EXPR,
+            name="ck_legal_denominations_code_valid",
+        ),
+        sa.CheckConstraint(
+            "min_aging_days IS NULL OR min_aging_days >= 0",
+            name="ck_legal_denominations_min_aging_positive",
+        ),
+        sa.CheckConstraint(
+            "max_alcohol_pct IS NULL OR max_alcohol_pct >= 0",
+            name="ck_legal_denominations_max_alcohol_positive",
+        ),
+    )
+
+    # --- beers regulatory columns ------------------------------------------
+    # ``batch_alter_table`` keeps the migration portable across PostgreSQL
+    # (production) and SQLite (tests). SQLite cannot ``ALTER TABLE ADD
+    # CONSTRAINT`` directly — batch mode rewrites the table transparently.
+    with op.batch_alter_table("beers") as batch_op:
+        batch_op.add_column(
+            sa.Column("legal_denomination", sa.String(length=50), nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column("country_of_origin", sa.String(length=2), nullable=True),
+        )
+        batch_op.add_column(
+            sa.Column(
+                "allergens",
+                sa.JSON().with_variant(
+                    postgresql.JSONB(astext_type=sa.Text()), "postgresql"
+                ),
+                nullable=True,
+            ),
+        )
+        batch_op.add_column(
+            sa.Column("alcohol_group", sa.SmallInteger(), nullable=True),
+        )
+
+        batch_op.create_check_constraint(
+            "ck_beers_legal_denomination_valid",
+            BEER_LEGAL_DENOMINATION_CHECK_EXPR,
+        )
+        batch_op.create_check_constraint(
+            "ck_beers_alcohol_group_valid",
+            BEER_ALCOHOL_GROUP_CHECK_EXPR,
+        )
+        batch_op.create_check_constraint(
+            "ck_beers_country_of_origin_iso2",
+            "country_of_origin IS NULL OR length(country_of_origin) = 2",
+        )
+
+
+def downgrade() -> None:
+    """Drop the four ``beers`` columns + the ``legal_denominations`` table."""
+
+    with op.batch_alter_table("beers") as batch_op:
+        batch_op.drop_constraint(
+            "ck_beers_country_of_origin_iso2", type_="check"
+        )
+        batch_op.drop_constraint("ck_beers_alcohol_group_valid", type_="check")
+        batch_op.drop_constraint(
+            "ck_beers_legal_denomination_valid", type_="check"
+        )
+        batch_op.drop_column("alcohol_group")
+        batch_op.drop_column("allergens")
+        batch_op.drop_column("country_of_origin")
+        batch_op.drop_column("legal_denomination")
+
+    op.drop_table("legal_denominations")

--- a/packages/beer-encyclopedia/scripts/seed_legal_denominations.py
+++ b/packages/beer-encyclopedia/scripts/seed_legal_denominations.py
@@ -1,0 +1,214 @@
+"""Seed the ``legal_denominations`` table with the French regulatory catalog.
+
+The ten denominations seeded here implement the controlled vocabulary
+defined by decree 92-307 of 31 March 1992, modified by decree 2016-1531
+of 15 November 2016 (composition and labelling of beers in France).
+
+Each row carries the discriminating criterion that defines the
+denomination, plus a pointer back to the source text. The ``label`` and
+``description`` columns are written in French because this is the
+French-locale reference table; the column names themselves remain in
+English, in line with the package conventions.
+
+This script is idempotent: running it multiple times updates existing
+rows in place (matched by ``code``) and inserts only what is missing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.engine import create_engine, create_session_factory, get_database_url
+from db.models import LegalDenomination
+
+# code, label, description, legal_reference,
+# min_aging_days, max_alcohol_pct
+DenominationSeed = tuple[
+    str, str, str, str,
+    int | None, Decimal | None,
+]
+
+DECREE_REF: str = (
+    "Décret n°92-307 du 31 mars 1992 modifié par le décret n°2016-1531 "
+    "du 15 novembre 2016"
+)
+
+# Order mirrors LEGAL_DENOMINATION_VALUES (db/models/legal_denomination.py)
+# which itself follows the structure of decree 92-307: generic definition,
+# then alcohol content, composition, process, additives, derived product,
+# producer-qualifying mention.
+DENOMINATIONS: list[DenominationSeed] = [
+    # Generic definition (Art. 1)
+    (
+        "biere",
+        "Bière",
+        "Boisson obtenue par fermentation alcoolique d'un moût préparé "
+        "à partir de malt de céréales (au moins 50 % du poids des "
+        "matières amylacées), de matières premières céréalières, de "
+        "sucres alimentaires, de houblon et d'eau potable.",
+        DECREE_REF,
+        None,
+        None,
+    ),
+    # By alcohol content
+    (
+        "biere_sans_alcool",
+        "Bière sans alcool",
+        "Bière dont le titre alcoométrique acquis est inférieur ou égal "
+        "à 1,2 %vol.",
+        DECREE_REF,
+        None,
+        Decimal("1.20"),
+    ),
+    (
+        "biere_forte",
+        "Bière forte",
+        "Bière dont la densité primitive du moût et le titre "
+        "alcoométrique dépassent les seuils définis par le décret "
+        "92-307. Catégorie réservée aux bières à degré élevé.",
+        DECREE_REF,
+        None,
+        None,
+    ),
+    # By composition
+    (
+        "pur_malt",
+        "Pur malt",
+        "Bière dont la fermentation est obtenue exclusivement à "
+        "partir de malt de céréales, sans ajout de sucres ni de "
+        "matières amylacées non maltées.",
+        DECREE_REF,
+        None,
+        None,
+    ),
+    # By process
+    (
+        "biere_de_garde",
+        "Bière de garde",
+        "Bière soumise à une période de garde minimale de 21 jours "
+        "après la fermentation principale, permettant la maturation "
+        "des arômes.",
+        DECREE_REF,
+        21,
+        None,
+    ),
+    (
+        "biere_fermentation_lactique",
+        "Bière de fermentation lactique",
+        "Bière ayant subi une fermentation lactique au cours de son "
+        "élaboration. Inclut notamment la gueuze et les bières acides "
+        "traditionnelles.",
+        DECREE_REF,
+        None,
+        None,
+    ),
+    # By additives
+    (
+        "biere_a_ingredient",
+        "Bière à [ingrédient]",
+        "Bière obtenue par addition ou macération de matières "
+        "végétales (fruits, plantes, épices) représentant au maximum "
+        "10 % du volume du moût initial.",
+        DECREE_REF,
+        None,
+        None,
+    ),
+    (
+        "biere_aromatisee",
+        "Bière aromatisée",
+        "Bière à laquelle ont été ajoutés des arômes, naturels ou non, "
+        "sans modification substantielle de la base brassicole.",
+        DECREE_REF,
+        None,
+        None,
+    ),
+    # Derived product
+    (
+        "panache",
+        "Panaché",
+        "Mélange de bière et de boisson gazeuse sans alcool dont le "
+        "titre alcoométrique acquis est inférieur ou égal à 1,2 %vol.",
+        DECREE_REF,
+        None,
+        Decimal("1.20"),
+    ),
+    # Producer-qualifying mention
+    (
+        "biere_artisanale",
+        "Bière artisanale",
+        "Bière brassée par un opérateur immatriculé en tant que "
+        "brasseur et disposant de la qualification professionnelle "
+        "correspondante. Mention valorisante encadrée par la DGCCRF.",
+        DECREE_REF,
+        None,
+        None,
+    ),
+]
+
+
+async def seed_legal_denominations(
+    session: AsyncSession,
+) -> tuple[int, int]:
+    """Upsert the legal denomination catalog. Returns (created, updated)."""
+
+    created = 0
+    updated = 0
+
+    for (
+        code,
+        label,
+        description,
+        legal_reference,
+        min_aging_days,
+        max_alcohol_pct,
+    ) in DENOMINATIONS:
+        existing = (
+            await session.execute(
+                select(LegalDenomination).where(LegalDenomination.code == code)
+            )
+        ).scalar_one_or_none()
+
+        if existing is None:
+            session.add(
+                LegalDenomination(
+                    code=code,
+                    label=label,
+                    description=description,
+                    legal_reference=legal_reference,
+                    min_aging_days=min_aging_days,
+                    max_alcohol_pct=max_alcohol_pct,
+                )
+            )
+            created += 1
+        else:
+            existing.label = label
+            existing.description = description
+            existing.legal_reference = legal_reference
+            existing.min_aging_days = min_aging_days
+            existing.max_alcohol_pct = max_alcohol_pct
+            updated += 1
+
+    await session.commit()
+    return created, updated
+
+
+async def main() -> None:
+    engine = create_engine(get_database_url())
+    factory = create_session_factory(engine)
+    try:
+        async with factory() as session:
+            created, updated = await seed_legal_denominations(session)
+            print(
+                f"Legal denominations seeded: {created} created, "
+                f"{updated} updated."
+            )
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/beer-encyclopedia/tests/test_db/test_beer_legal_fields.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_beer_legal_fields.py
@@ -1,0 +1,137 @@
+"""Behavior tests for the four French regulatory fields on ``Beer``.
+
+Covers happy path (every accepted shape persists), sad path (invalid
+values are rejected at the ORM validator level before flush), and edge
+cases (case normalisation on country code, JSON list round-trip).
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Beer, Brewery
+from db.models.beer import ALCOHOL_GROUP_VALUES
+from db.models.legal_denomination import LEGAL_DENOMINATION_VALUES
+
+
+async def _make_brewery(session: AsyncSession, slug: str = "test-brewery") -> Brewery:
+    brewery = Brewery(name=slug.replace("-", " ").title(), slug=slug)
+    session.add(brewery)
+    await session.commit()
+    return brewery
+
+
+async def test_beer_persists_full_legal_payload(db_session: AsyncSession) -> None:
+    brewery = await _make_brewery(db_session)
+
+    db_session.add(
+        Beer(
+            name="Test Beer",
+            slug="test-beer",
+            brewery_id=brewery.id,
+            legal_denomination="biere_de_garde",
+            country_of_origin="FR",
+            allergens=["gluten", "sulfites"],
+            alcohol_group=3,
+        )
+    )
+    await db_session.commit()
+
+    loaded = (
+        await db_session.execute(select(Beer).where(Beer.slug == "test-beer"))
+    ).scalar_one()
+    assert loaded.legal_denomination == "biere_de_garde"
+    assert loaded.country_of_origin == "FR"
+    assert loaded.allergens == ["gluten", "sulfites"]
+    assert loaded.alcohol_group == 3
+
+
+async def test_beer_accepts_null_legal_fields(db_session: AsyncSession) -> None:
+    # Non-FR beers (and pre-existing rows) leave every regulatory field NULL.
+    db_session.add(Beer(name="Plain", slug="plain"))
+    await db_session.commit()
+
+    loaded = (
+        await db_session.execute(select(Beer).where(Beer.slug == "plain"))
+    ).scalar_one()
+    assert loaded.legal_denomination is None
+    assert loaded.country_of_origin is None
+    assert loaded.allergens is None
+    assert loaded.alcohol_group is None
+
+
+@pytest.mark.parametrize("value", LEGAL_DENOMINATION_VALUES)
+async def test_beer_accepts_every_canonical_denomination(
+    db_session: AsyncSession, value: str
+) -> None:
+    db_session.add(Beer(name=f"Beer {value}", slug=value, legal_denomination=value))
+    await db_session.commit()
+
+
+def test_beer_rejects_unknown_denomination_at_orm_layer() -> None:
+    # The ``@validates`` hook fires at assignment time — no flush needed.
+    with pytest.raises(ValueError, match="legal_denomination"):
+        Beer(name="X", slug="x", legal_denomination="not_a_real_one")
+
+
+@pytest.mark.parametrize("value", ALCOHOL_GROUP_VALUES)
+async def test_beer_accepts_every_alcohol_group(
+    db_session: AsyncSession, value: int
+) -> None:
+    db_session.add(Beer(name=f"Beer g{value}", slug=f"g{value}", alcohol_group=value))
+    await db_session.commit()
+
+
+def test_beer_rejects_alcohol_group_two() -> None:
+    # Group 2 was historically merged into group 3 — it is not part of
+    # the current nomenclature under article L-3321-1.
+    with pytest.raises(ValueError, match="alcohol_group"):
+        Beer(name="X", slug="x", alcohol_group=2)
+
+
+async def test_beer_country_code_is_uppercased(db_session: AsyncSession) -> None:
+    db_session.add(Beer(name="Lowercase Country", slug="lc", country_of_origin="fr"))
+    await db_session.commit()
+
+    loaded = (
+        await db_session.execute(select(Beer).where(Beer.slug == "lc"))
+    ).scalar_one()
+    assert loaded.country_of_origin == "FR"
+
+
+def test_beer_rejects_country_code_with_wrong_length() -> None:
+    with pytest.raises(ValueError, match="country_of_origin"):
+        Beer(name="X", slug="x", country_of_origin="FRA")
+
+
+def test_beer_rejects_non_letter_country_code() -> None:
+    # Length-only check would let "12" or "!!" through to the DB; the
+    # ORM validator rejects these at assignment time so the error is
+    # actionable from the caller side.
+    with pytest.raises(ValueError, match="country_of_origin"):
+        Beer(name="X", slug="x", country_of_origin="12")
+    with pytest.raises(ValueError, match="country_of_origin"):
+        Beer(name="X", slug="x", country_of_origin="!!")
+
+
+async def test_beer_db_check_blocks_raw_sql_invalid_denomination(
+    db_session: AsyncSession,
+) -> None:
+    # Last line of defence: even if the ORM validator is bypassed (e.g.
+    # via ``execute(insert(...))``), the DB CHECK constraint must reject
+    # invalid values. Going through the ORM but skipping the validator by
+    # using ``__dict__`` would be brittle — instead drive a raw insert.
+    from sqlalchemy import insert
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            insert(Beer).values(
+                name="Bypass",
+                slug="bypass",
+                legal_denomination="not_valid",
+            )
+        )
+        await db_session.commit()

--- a/packages/beer-encyclopedia/tests/test_db/test_legal_denomination.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_legal_denomination.py
@@ -1,0 +1,129 @@
+"""Behavior tests for the ``LegalDenomination`` model.
+
+Covers the three invariants this reference table must hold:
+- ``code`` is unique and constrained to the canonical whitelist
+- numeric guards reject negative values
+- happy-path persistence round-trips every column correctly
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import LegalDenomination
+from db.models.legal_denomination import LEGAL_DENOMINATION_VALUES
+
+
+async def test_create_and_round_trip(db_session: AsyncSession) -> None:
+    db_session.add(
+        LegalDenomination(
+            code="biere_de_garde",
+            label="Bière de garde",
+            description="Période de garde minimale de 21 jours.",
+            legal_reference="Décret 92-307",
+            min_aging_days=21,
+            max_alcohol_pct=None,
+        )
+    )
+    await db_session.commit()
+
+    loaded = (
+        await db_session.execute(
+            select(LegalDenomination).where(
+                LegalDenomination.code == "biere_de_garde"
+            )
+        )
+    ).scalar_one()
+
+    assert loaded.label == "Bière de garde"
+    assert loaded.min_aging_days == 21
+    assert loaded.created_at is not None
+    assert loaded.updated_at is not None
+
+
+async def test_code_is_unique(db_session: AsyncSession) -> None:
+    db_session.add(
+        LegalDenomination(
+            code="biere",
+            label="Bière",
+            description="Dénomination générique.",
+            legal_reference="Décret 92-307",
+        )
+    )
+    await db_session.commit()
+
+    db_session.add(
+        LegalDenomination(
+            code="biere",
+            label="Bière (doublon)",
+            description="Tentative de doublon.",
+            legal_reference="Décret 92-307",
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_invalid_code_is_rejected_by_check_constraint(
+    db_session: AsyncSession,
+) -> None:
+    db_session.add(
+        LegalDenomination(
+            code="not_a_real_denomination",
+            label="Invalide",
+            description="Devrait être rejeté.",
+            legal_reference="(none)",
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_negative_min_aging_days_is_rejected(
+    db_session: AsyncSession,
+) -> None:
+    db_session.add(
+        LegalDenomination(
+            code="biere_de_garde",
+            label="Bière de garde",
+            description="Devrait être rejeté.",
+            legal_reference="Décret 92-307",
+            min_aging_days=-1,
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_negative_max_alcohol_pct_is_rejected(
+    db_session: AsyncSession,
+) -> None:
+    db_session.add(
+        LegalDenomination(
+            code="biere_sans_alcool",
+            label="Bière sans alcool",
+            description="Devrait être rejeté.",
+            legal_reference="Décret 92-307",
+            max_alcohol_pct=Decimal("-0.1"),
+        )
+    )
+
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+def test_canonical_values_tuple_has_ten_entries() -> None:
+    # Sanity check: the regulatory catalog must hold exactly the ten
+    # denominations defined by decree 92-307 modified by 2016-1531.
+    # Drift here means the ORM, the migration, and the seed script will
+    # disagree about what is valid.
+    assert len(LEGAL_DENOMINATION_VALUES) == 10
+    assert len(set(LEGAL_DENOMINATION_VALUES)) == 10  # no duplicates

--- a/packages/beer-encyclopedia/tests/test_db/test_seed_legal_denominations.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_seed_legal_denominations.py
@@ -1,0 +1,87 @@
+"""Behavior tests for ``scripts/seed_legal_denominations.py``.
+
+Mirrors the structure of ``test_seed_styles.py``: full population on a
+blank DB, idempotence on re-run, and field refresh on drift. Adds a
+specific check that every code listed in ``LEGAL_DENOMINATION_VALUES``
+is actually seeded — drift between the canonical tuple and the seed
+catalog would silently break ``Beer.legal_denomination`` validation.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import LegalDenomination
+from db.models.legal_denomination import LEGAL_DENOMINATION_VALUES
+from scripts.seed_legal_denominations import (
+    DENOMINATIONS,
+    seed_legal_denominations,
+)
+
+
+async def test_seed_creates_full_catalog_on_empty_db(
+    db_session: AsyncSession,
+) -> None:
+    created, updated = await seed_legal_denominations(db_session)
+
+    assert created == len(DENOMINATIONS)
+    assert updated == 0
+
+    count = (
+        await db_session.execute(select(func.count()).select_from(LegalDenomination))
+    ).scalar_one()
+    assert count == len(DENOMINATIONS)
+
+
+async def test_seed_covers_every_canonical_code(
+    db_session: AsyncSession,
+) -> None:
+    await seed_legal_denominations(db_session)
+
+    rows = (
+        await db_session.execute(select(LegalDenomination.code))
+    ).scalars().all()
+    assert set(rows) == set(LEGAL_DENOMINATION_VALUES)
+
+
+async def test_seed_is_idempotent(db_session: AsyncSession) -> None:
+    await seed_legal_denominations(db_session)
+
+    created, updated = await seed_legal_denominations(db_session)
+    assert created == 0
+    assert updated == len(DENOMINATIONS)
+
+    count = (
+        await db_session.execute(select(func.count()).select_from(LegalDenomination))
+    ).scalar_one()
+    assert count == len(DENOMINATIONS)
+
+
+async def test_seed_updates_changed_fields_on_rerun(
+    db_session: AsyncSession,
+) -> None:
+    await seed_legal_denominations(db_session)
+
+    garde = (
+        await db_session.execute(
+            select(LegalDenomination).where(
+                LegalDenomination.code == "biere_de_garde"
+            )
+        )
+    ).scalar_one()
+    assert garde.min_aging_days == 21  # sanity check
+    garde.label = "Drifted label"
+    garde.min_aging_days = 1
+    await db_session.commit()
+
+    await seed_legal_denominations(db_session)
+    refreshed = (
+        await db_session.execute(
+            select(LegalDenomination).where(
+                LegalDenomination.code == "biere_de_garde"
+            )
+        )
+    ).scalar_one()
+    assert refreshed.label == "Bière de garde"
+    assert refreshed.min_aging_days == 21


### PR DESCRIPTION
## Summary

Adds the French legal denomination reference table and four nullable
regulatory columns on `Beer`, as the first step of the encyclopedia
data-enrichment plan (PR1 of 3 — Open Food Facts connector and
community-scan loop will land in subsequent PRs). Architectural rationale
and rejected alternatives documented in `ADR-0002`.

- New `legal_denominations` table seeded with the ten denominations
  defined by decree 92-307 of 31 March 1992 modified by 2016-1531
- `Beer.legal_denomination` CHECK-constrained to the same ten codes
  (no FK so the reference table stays re-seedable)
- `Beer.country_of_origin` auto-uppercased ISO 3166-1 alpha-2 (validator
  rejects non-letter input)
- `Beer.allergens` JSONB on PostgreSQL (JSON elsewhere)
- `Beer.alcohol_group` SMALLINT in (1, 3, 4, 5) per Code de la santé
  publique Art. L-3321-1 (group 2 historically merged into 3)
- Idempotent seed script aligned with the existing `seed_styles.py`
  pattern

All four columns are nullable so the migration is non-breaking for
existing rows imported from non-FR sources.

## Checklist

- [x] Happy path + sad path + edge cases covered (32 new tests)
- [x] Migration runs on a fresh SQLite (\`alembic upgrade head\` 001 → 003)
- [x] Seed script idempotent (10 created on first run, 0/10 updated on second)
- [x] \`pytest -q tests/\` green (96/96, no regression)
- [x] \`ruff check\` clean on all new/modified files
- [x] No \`any\`, no inline styles introduced
- [x] ADR-0002 documents the architecture decision