### PR TITLE
fix(beer-encyclopedia): reject non-ASCII letters in country_of_origin validator

### DIFF
--- a/packages/beer-encyclopedia/db/models/beer.py
+++ b/packages/beer-encyclopedia/db/models/beer.py
@@ -232,14 +232,17 @@ class Beer(Base, UUIDMixin, TimestampMixin):
         Accepts mixed case input ("fr", "Fr", "FR") and stores uppercase.
         Rejects non-letter characters at the ORM layer so junk like
         ``"!!"`` or ``"12"`` cannot reach the DB even though it would
-        pass the length-only CHECK constraint. ISO 3166-1 alpha-2 codes
-        are always two ASCII letters by specification.
+        pass the length-only CHECK constraint. ``isascii()`` is required
+        in addition to ``isalpha()`` because Python treats Latin-extended
+        letters such as ``"Å"`` as alphabetical, but ISO 3166-1 alpha-2
+        codes are always two ASCII letters by specification — accepting
+        ``"ÅB"`` would persist invalid data.
         """
         if value is None:
             return value
-        if len(value) != 2 or not value.isalpha():
+        if len(value) != 2 or not value.isalpha() or not value.isascii():
             raise ValueError(
-                f"Beer.country_of_origin must be a 2-letter ISO code, "
-                f"got {value!r}"
+                f"Beer.country_of_origin must be a 2-letter ASCII ISO "
+                f"code, got {value!r}"
             )
         return value.upper()

--- a/packages/beer-encyclopedia/tests/test_db/test_beer_legal_fields.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_beer_legal_fields.py
@@ -117,6 +117,18 @@ def test_beer_rejects_non_letter_country_code() -> None:
         Beer(name="X", slug="x", country_of_origin="!!")
 
 
+def test_beer_rejects_non_ascii_letter_country_code() -> None:
+    # Python's str.isalpha() returns True for Latin-extended letters
+    # such as "Å" or "Ñ", but ISO 3166-1 alpha-2 codes are defined as
+    # ASCII letters only. Without an explicit isascii() check the
+    # validator would let "ÅB" or "ÑO" through and persist invalid
+    # country codes.
+    with pytest.raises(ValueError, match="country_of_origin"):
+        Beer(name="X", slug="x", country_of_origin="ÅB")
+    with pytest.raises(ValueError, match="country_of_origin"):
+        Beer(name="X", slug="x", country_of_origin="ÑO")
+
+
 async def test_beer_db_check_blocks_raw_sql_invalid_denomination(
     db_session: AsyncSession,
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up of PR #841 — addresses the [Copilot review comment](https://github.com/benoit-bremaud/brasse-bouillon/pull/841#discussion_r0) on `db/models/beer.py:245`.

The previous validator relied on `str.isalpha()` which returns `True` for Latin-extended letters such as `"Å"` or `"Ñ"`. ISO 3166-1 alpha-2 codes are defined as two **ASCII** letters only, so accepting `"ÅB"` or `"ÑO"` would have persisted invalid country codes (passes both ORM check and DB CHECK constraint).

- Added `isascii()` guard alongside `isalpha()` in the validator
- Updated the docstring + error message to surface the ASCII requirement
- New regression test `test_beer_rejects_non_ascii_letter_country_code` covering `"ÅB"` and `"ÑO"`

## Checklist

- [x] Regression test added covering the bug
- [x] \`pytest -q tests/\` green (97/97, +1 new test)
- [x] \`ruff check\` clean on modified files
- [x] No \`any\`, no inline styles introduced