### PR TITLE
feat(beer-encyclopedia): add Open Food Facts importer + POST /beers/import-by-ean

### DIFF
--- a/packages/beer-encyclopedia/api/routers/beers.py
+++ b/packages/beer-encyclopedia/api/routers/beers.py
@@ -3,20 +3,31 @@
 Same shape as /breweries, plus extra list filters (style, brewery, ABV
 range) and FK validation on create/update so a client cannot attach a
 beer to a non-existent brewery or style.
+
+Adds ``POST /beers/import-by-ean`` (PR2): a one-shot bridge to Open
+Food Facts that converts a scanned barcode into an enriched beer row,
+backed by the polymorphic ``EntitySource`` audit trail.
 """
 
 from __future__ import annotations
 
 import uuid
+from collections.abc import AsyncIterator
 from decimal import Decimal
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.db_utils import is_postgres
 from api.dependencies import get_db
-from api.schemas.beer import BeerCreate, BeerList, BeerRead, BeerUpdate
+from api.schemas.beer import (
+    BeerCreate,
+    BeerImportByEanRequest,
+    BeerList,
+    BeerRead,
+    BeerUpdate,
+)
 from api.schemas.common import (
     DEFAULT_PAGE_SIZE,
     MAX_PAGE_SIZE,
@@ -24,8 +35,31 @@ from api.schemas.common import (
 )
 from api.slug import create_with_unique_slug
 from db.models import Beer, Brewery, Style
+from importers import (
+    OpenFoodFactsClient,
+    OpenFoodFactsError,
+    SourceNotSeededError,
+    upsert_beer_from_snapshot,
+)
 
 router = APIRouter(prefix="/beers", tags=["beers"])
+
+
+async def get_openfoodfacts_client() -> AsyncIterator[OpenFoodFactsClient]:
+    """Provide an :class:`OpenFoodFactsClient` to a request handler.
+
+    Exposed as a FastAPI dependency so tests can override it via
+    ``app.dependency_overrides`` and inject a stub that never touches
+    the network. The default factory builds a short-lived client whose
+    underlying ``httpx.AsyncClient`` is closed by ``aclose`` on exit.
+    Mirrors the ``get_db`` pattern in ``db/engine.py``.
+    """
+
+    client = OpenFoodFactsClient()
+    try:
+        yield client
+    finally:
+        await client.aclose()
 
 
 async def _validate_fks(
@@ -45,6 +79,71 @@ async def _validate_fks(
         raise HTTPException(status_code=422, detail="brewery_id does not exist.")
     if style_id is not None and await session.get(Style, style_id) is None:
         raise HTTPException(status_code=422, detail="style_id does not exist.")
+
+
+@router.post(
+    "/import-by-ean",
+    response_model=BeerRead,
+    responses={
+        200: {"description": "Existing beer refreshed from Open Food Facts."},
+        201: {"description": "Beer created from Open Food Facts."},
+        404: {"description": "Open Food Facts has no product for this EAN."},
+        503: {
+            "description": (
+                "Open Food Facts is unavailable or returned an unexpected "
+                "payload. Try again later."
+            )
+        },
+    },
+)
+async def import_beer_by_ean(
+    payload: BeerImportByEanRequest,
+    response: Response,
+    session: AsyncSession = Depends(get_db),
+    off_client: OpenFoodFactsClient = Depends(get_openfoodfacts_client),
+) -> BeerRead:
+    """Bootstrap or refresh a beer row from an Open Food Facts lookup.
+
+    Idempotent on the supplied ``ean``: a first call inserts a new row
+    (HTTP 201) and a subsequent call refreshes the same row in place
+    (HTTP 200) while bumping ``EntitySource.last_synced_at`` so the
+    audit trail records the new fetch.
+
+    Returns 404 when OFF reports no product for the EAN — distinct from
+    a 503 (transport / payload-level failure) so a client can branch on
+    "unknown product" vs "service hiccup".
+    """
+
+    try:
+        snapshot = await off_client.fetch_by_ean(payload.ean)
+    except OpenFoodFactsError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Open Food Facts unavailable: {exc}",
+        ) from exc
+
+    if snapshot is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Open Food Facts has no product for EAN {payload.ean}.",
+        )
+
+    try:
+        result = await upsert_beer_from_snapshot(
+            session,
+            snapshot=snapshot,
+            source_name="openfoodfacts",
+        )
+    except SourceNotSeededError as exc:
+        # Surface the missing-source failure as a 503 rather than a 500
+        # so the operator gets an actionable message: the fix is to run
+        # the seed script, not to debug the import code.
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    response.status_code = (
+        status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
+    )
+    return BeerRead.model_validate(result.beer)
 
 
 @router.get("", response_model=BeerList)

--- a/packages/beer-encyclopedia/api/schemas/beer.py
+++ b/packages/beer-encyclopedia/api/schemas/beer.py
@@ -10,6 +10,12 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from api.schemas.common import PaginationMeta
 
+# EAN-8, UPC-A (12), EAN-13, EAN-14 — the four formats commonly found
+# on beverage packaging. The pattern matches what the ORM validator
+# accepts so a 422 from the API surfaces the same error message a CLI
+# caller would see.
+_EAN_PATTERN: str = r"^\d{8}(?:\d{4}|\d{5}|\d{6})?$"
+
 
 class BeerBase(BaseModel):
     name: str = Field(min_length=1, max_length=255)
@@ -46,6 +52,12 @@ class BeerRead(BeerBase):
     id: uuid.UUID
     slug: str
     is_verified: bool
+    source: str
+    ean_code: str | None = None
+    legal_denomination: str | None = None
+    country_of_origin: str | None = None
+    allergens: list[str] | None = None
+    alcohol_group: int | None = None
     created_at: datetime
     updated_at: datetime
 
@@ -53,3 +65,21 @@ class BeerRead(BeerBase):
 class BeerList(BaseModel):
     items: list[BeerRead] = Field(default_factory=list)
     meta: PaginationMeta
+
+
+class BeerImportByEanRequest(BaseModel):
+    """Body payload for ``POST /beers/import-by-ean``.
+
+    Stand-alone schema — the import flow only needs the EAN, the rest
+    of the beer payload is derived from the external source. Length
+    range covers EAN-8, UPC-A (12), EAN-13 and EAN-14; the regex
+    pattern blocks non-digit input at the API edge with the same rule
+    the ORM validator applies.
+    """
+
+    ean: str = Field(
+        min_length=8,
+        max_length=14,
+        pattern=_EAN_PATTERN,
+        description="EAN-8 / UPC-A / EAN-13 / EAN-14 product barcode.",
+    )

--- a/packages/beer-encyclopedia/db/models/beer.py
+++ b/packages/beer-encyclopedia/db/models/beer.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     SmallInteger,
     String,
     Text,
+    UniqueConstraint,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -96,6 +97,15 @@ class Beer(Base, UUIDMixin, TimestampMixin):
             "country_of_origin IS NULL OR length(country_of_origin) = 2",
             name="ck_beers_country_of_origin_iso2",
         ),
+        CheckConstraint(
+            "ean_code IS NULL OR length(ean_code) IN (8, 12, 13, 14)",
+            name="ck_beers_ean_code_length",
+        ),
+        # Unique constraint allows multiple NULLs on both PostgreSQL and
+        # SQLite — a beer without a barcode (community draft, internal
+        # seed) does not collide with another. The constraint enforces
+        # that no two distinct beers can claim the same EAN.
+        UniqueConstraint("ean_code", name="uq_beers_ean_code"),
     )
 
     name: Mapped[str] = mapped_column(String(255), nullable=False)
@@ -147,6 +157,14 @@ class Beer(Base, UUIDMixin, TimestampMixin):
     country_of_origin: Mapped[str | None] = mapped_column(String(2), nullable=True)
     allergens: Mapped[list[str] | None] = mapped_column(_AllergensType, nullable=True)
     alcohol_group: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+
+    # Standard barcode (EAN-8/12/13/14 / UPC-A). Used as the primary
+    # external identifier when importing from Open Food Facts and as the
+    # fastest match key for community scans (PR3). Nullable because
+    # internal seeds and community drafts may legitimately not carry a
+    # barcode. The unique constraint allows multiple NULLs on both
+    # PostgreSQL and SQLite, so unbarcoded rows do not collide.
+    ean_code: Mapped[str | None] = mapped_column(String(14), nullable=True)
 
     brewery: Mapped[Brewery | None] = relationship(back_populates="beers")
     style: Mapped[Style | None] = relationship(back_populates="beers")
@@ -220,6 +238,33 @@ class Beer(Base, UUIDMixin, TimestampMixin):
             raise ValueError(
                 f"Beer.alcohol_group must be one of ({valid}) or None, "
                 f"got {value!r}"
+            )
+        return value
+
+    @validates("ean_code")
+    def _validate_ean_code(self, _key: str, value: str | None) -> str | None:
+        """Reject invalid ``ean_code`` values at the ORM layer.
+
+        Standard product barcodes are EAN-8, UPC-A (12), EAN-13 or
+        EAN-14 — always numeric. The DB CHECK constraint enforces only
+        the length; this validator additionally rejects non-digit input
+        ("abc", "12345abc", …) so the error surfaces at assignment time
+        instead of at flush time.
+
+        We deliberately do NOT verify the GS1 mod-10 checksum here:
+        external sources (Open Food Facts, scanned barcodes) sometimes
+        carry slightly malformed codes that are still useful as match
+        keys. Tightening to checksum validation would force us to
+        reject those inputs and lose data. Accept the trade-off — the
+        format check is enough to catch typos.
+        """
+
+        if value is None:
+            return value
+        if not value.isdigit() or len(value) not in (8, 12, 13, 14):
+            raise ValueError(
+                f"Beer.ean_code must be an EAN-8/12/13/14 numeric "
+                f"barcode, got {value!r}"
             )
         return value
 

--- a/packages/beer-encyclopedia/docs/adr/ADR-0003-openfoodfacts-connector.md
+++ b/packages/beer-encyclopedia/docs/adr/ADR-0003-openfoodfacts-connector.md
@@ -1,0 +1,181 @@
+# ADR-0003: Open Food Facts connector as the primary external source
+
+- Status: Accepted
+- Date: 2026-05-01
+
+## Context
+
+After ADR-0002 the encyclopedia carries a French legal-reference layer
+but still has no connection to any real-world product data. The
+`Source` and `EntitySource` tables exist but are empty; `Beer.source`
+already exposes `"openfoodfacts"` as a valid provenance value yet no
+code imports from there. The `/scan` pipeline can detect a label and
+extract a few fields by OCR but has nothing to match against, so a
+scanned bottle goes nowhere.
+
+We need a one-shot bridge that takes the most reliable identifier on
+a beer label — its EAN barcode — and turns it into an enriched row in
+our database. This is the precondition for every downstream story:
+the user-facing scan flow, the community-contribution loop (PR3,
+issue #803), and the catalog browsing experience (#708).
+
+The candidate sources we evaluated:
+
+- **Open Food Facts (OFF)** — public, crowd-sourced food product
+  database with a free, well-documented HTTP API and ~2 M SKUs
+  including thousands of beers across Europe. CC-BY-SA licence.
+- **Open Brewery DB** (#547) — REST API for breweries only, no
+  product-level data.
+- **Untappd** — rich beer data but commercial, requires API keys and
+  paid usage tiers above a low quota.
+- **RateBeer** — useful editorial data, no public API.
+
+OFF is the clear winner for PR2: free, public, EAN-indexed, no
+auth, and already half-wired in the schema (`Beer.source` enum). The
+others go on the backlog as future complementary sources.
+
+## Decision
+
+Introduce `importers/` as the home for all external-source clients
+and ship an Open Food Facts implementation that maps a raw OFF
+product into an internal `ExternalBeerSnapshot`. A dedicated
+persistence helper consumes the snapshot and upserts the matching
+`Beer`, `Brewery` and `EntitySource` rows. A new
+`POST /beers/import-by-ean` route exposes the flow over HTTP, backed
+by a small `Beer.ean_code` column on the existing `beers` table.
+
+### Architecture
+
+```
+HTTP layer        api/routers/beers.py     POST /beers/import-by-ean
+                          │
+External fetch    importers/openfoodfacts  OpenFoodFactsClient.fetch_by_ean
+                          │
+Normalisation     importers/base           ExternalBeerSnapshot dataclass
+                          │
+Persistence       importers/persistence    upsert_beer_from_snapshot
+                          │
+Schema            db/models/beer.py        + Beer.ean_code (migration 004)
+```
+
+The `importers` package becomes the single landing place for any new
+external source: an Untappd or RateBeer client added later only needs
+to return an `ExternalBeerSnapshot`; the persistence layer and the
+HTTP route do not change.
+
+### Specific choices
+
+1. **`importers/` over `services/sources/`** — `importers/*` is
+   already declared in `pyproject.toml`'s `setuptools.packages.find`
+   include list. Reusing the existing slot avoids a config change and
+   matches the established naming convention in the package
+   architecture (`api`, `db`, `ml`, `importers`).
+
+2. **`Beer.ean_code` is `String(14)` nullable, with a UNIQUE
+   constraint and a CHECK on the supported lengths (8, 12, 13, 14).**
+   The column accepts EAN-8, UPC-A, EAN-13 and EAN-14, the four
+   formats commonly found on European beverage packaging. NULL rows
+   are allowed and do not collide (PostgreSQL and SQLite both treat
+   NULL as unknown in unique constraints), so internal seeds and
+   community drafts that have no barcode coexist freely.
+
+3. **No GS1 mod-10 checksum validation.** External sources
+   occasionally carry malformed barcodes that are still useful as
+   match keys. Tightening to checksum validation would force us to
+   reject those inputs and lose data. The format check (digits +
+   length) is enough to catch typos and accidental swaps.
+
+4. **`ExternalBeerSnapshot` is a `@dataclass`, not a Pydantic model
+   or a Protocol.** Pydantic would buy us nothing here — there is no
+   serialisation across the API boundary. A Protocol would defer
+   construction to the importer instead of giving us a single concrete
+   type to assert on in tests. The dataclass is the smallest thing
+   that documents the contract and is testable in isolation.
+
+5. **`upsert_beer_from_snapshot` is conservative on refresh.** A
+   re-import only updates the fields the importer owns
+   (`brewery_id`, `abv`, `country_of_origin`, `allergens`,
+   `contributed_at`). It deliberately leaves `name`, `slug`,
+   `description`, `style_id` and `legal_denomination` alone because
+   those may have been edited by hand or refined by another source.
+   The opinion: we never overwrite data we did not originate.
+
+6. **HTTP semantics distinguish 201 from 200 from 404 from 503.**
+   - `201 Created` — first import for this EAN.
+   - `200 OK` — re-import refreshed an existing row.
+   - `404 Not Found` — OFF reports no product for this EAN
+     (`status: 0` in the OFF payload).
+   - `503 Service Unavailable` — transport, payload, or seed-state
+     failure (the operator has an actionable fix path).
+
+   The split lets clients branch on "unknown product" vs "service
+   hiccup" without parsing error strings.
+
+7. **Source registration is a separate seed.** The `openfoodfacts`
+   row in `Source` is created by `scripts/seed_sources.py`, not by
+   the migration. Migrations stay schema-only; seed scripts stay
+   re-runnable. A typed `SourceNotSeededError` surfaces the missing
+   row as a 503 with a message pointing at the seed script, so the
+   first failure tells the operator exactly what to do.
+
+8. **Country resolution uses a small hard-coded slug map, not a
+   library.** We resolve the dozen or so countries that show up most
+   often on European beer labels and leave anything else as `None`.
+   A full ISO library would be larger than the data it resolves; we
+   add slugs as we observe gaps in production.
+
+### Rejected alternatives
+
+- **Bulk OFF dump ingestion** — OFF publishes a daily JSONL dump of
+  the whole database (~100 GB uncompressed, ~10 M products). Useful
+  for offline research, overkill for our current need (on-demand
+  enrichment from scanned barcodes). Captured in the backlog for v0.3
+  if we ever need full-catalog browsing without a live network call.
+- **Wrapping the OFF Python client (`openfoodfacts-python`)** — adds
+  a dependency, brings in code paths we do not use, and the OFF API
+  is small enough to call directly with `httpx`. The mapping logic
+  stays in our hands.
+- **Inline persistence in the route handler** — would put SQLAlchemy
+  upsert code into FastAPI route bodies. The dedicated
+  `importers/persistence.py` keeps the route thin and lets PR3
+  reuse the same upsert primitives for community contributions.
+- **Eagerly fetching from `/scan`** — the import flow only triggers
+  when a barcode is supplied. Hooking it into `/scan` requires the
+  ML pipeline to detect barcodes (out of PR2 scope, deferred to a
+  later ML-side change). The route is admin-callable today and will
+  be wired into `/scan` once the detection lands.
+
+## Consequences
+
+### Positive
+
+- The encyclopedia gets a real-data path. A `curl POST /beers/import-by-ean`
+  with a known EAN now produces a populated `Beer` + `Brewery` +
+  `EntitySource` row, validating the whole `Source` / provenance
+  infrastructure end-to-end.
+- The `EntitySource.raw_data` audit trail is finally exercised: every
+  import keeps the original OFF payload so we can re-derive the
+  mapping without a re-fetch when the importer evolves.
+- The pattern is reusable — adding Untappd, RateBeer, or Open
+  Brewery DB later only requires a new file under `importers/` that
+  returns the same `ExternalBeerSnapshot`.
+- The mobile demo for the soutenance has a credible scan-to-fiche
+  story: scan a real beer, see the data come back from OFF.
+
+### Trade-offs
+
+- We depend on a third-party service for a non-trivial part of the
+  user journey. Mitigated by graceful 404/503 handling and the fact
+  that OFF is community-owned (no vendor lock-in).
+- Mapping quality varies by product: French entries tend to be richer
+  than entries from countries where OFF has fewer contributors. The
+  conservative refresh policy means a poor first import will not
+  overwrite better data added later by hand.
+- The `_COUNTRY_SLUG_TO_ISO2` map is hand-maintained. We accept this
+  cost in exchange for not pulling in a multi-megabyte ISO library
+  for the dozen entries we actually resolve.
+- No detection of demoted / withdrawn products. OFF does not flag
+  these explicitly; if a product is removed upstream a re-import will
+  return 404 but our row will stay. A later cleanup job (`scripts/
+  audit_entity_sources.py`) can sweep stale audit rows — captured in
+  the backlog.

--- a/packages/beer-encyclopedia/importers/__init__.py
+++ b/packages/beer-encyclopedia/importers/__init__.py
@@ -1,0 +1,25 @@
+"""External data source importers.
+
+Each module under this package wraps a third-party API or dataset and
+returns an ``ExternalBeerSnapshot`` that the upsert logic in the beers
+router can consume uniformly. The encyclopedia stays unaware of the
+shape of each remote schema — translation happens here, persistence
+happens in the router.
+"""
+
+from importers.base import ExternalBeerSnapshot
+from importers.openfoodfacts import OpenFoodFactsClient, OpenFoodFactsError
+from importers.persistence import (
+    SourceNotSeededError,
+    UpsertResult,
+    upsert_beer_from_snapshot,
+)
+
+__all__ = [
+    "ExternalBeerSnapshot",
+    "OpenFoodFactsClient",
+    "OpenFoodFactsError",
+    "SourceNotSeededError",
+    "UpsertResult",
+    "upsert_beer_from_snapshot",
+]

--- a/packages/beer-encyclopedia/importers/base.py
+++ b/packages/beer-encyclopedia/importers/base.py
@@ -1,0 +1,50 @@
+"""Common types shared by external data source importers.
+
+The ``ExternalBeerSnapshot`` dataclass is the lingua franca between the
+importers (which know about external schemas) and the upsert logic
+(which only knows about the encyclopedia models). Adding a new source
+means writing a client that returns this dataclass — nothing else in
+the codebase has to change.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+
+@dataclass(slots=True)
+class ExternalBeerSnapshot:
+    """Normalised view of a beer fetched from an external source.
+
+    All optional fields default to ``None`` (or empty list for
+    ``allergens``) so an importer can populate only what the source
+    actually provides without padding the rest. ``raw_payload`` keeps
+    the original JSON for the ``EntitySource.raw_data`` audit trail —
+    consumers should never rely on it for business logic, only for
+    re-transform when the mapping evolves.
+    """
+
+    external_id: str
+    """The id used by the source system (typically the EAN code)."""
+
+    name: str
+    """Human-readable beer name (used as `Beer.name`)."""
+
+    brand: str | None = None
+    """Producer / brewery name as advertised on the label."""
+
+    abv: Decimal | None = None
+    """Alcohol by volume in ``%vol``. ``None`` when the source omits it."""
+
+    country_of_origin: str | None = None
+    """ISO 3166-1 alpha-2 code (uppercase). ``None`` when unknown."""
+
+    allergens: list[str] = field(default_factory=list)
+    """Normalised allergen tokens (e.g. ``["gluten", "sulfites"]``)."""
+
+    image_url: str | None = None
+    """URL of the front-label image, when the source publishes one."""
+
+    raw_payload: dict = field(default_factory=dict)
+    """Original payload kept for the ``EntitySource.raw_data`` audit trail."""

--- a/packages/beer-encyclopedia/importers/base.py
+++ b/packages/beer-encyclopedia/importers/base.py
@@ -46,5 +46,11 @@ class ExternalBeerSnapshot:
     image_url: str | None = None
     """URL of the front-label image, when the source publishes one."""
 
-    raw_payload: dict = field(default_factory=dict)
-    """Original payload kept for the ``EntitySource.raw_data`` audit trail."""
+    raw_payload: dict[str, object] = field(default_factory=dict)
+    """Original payload kept for the ``EntitySource.raw_data`` audit trail.
+
+    Typed as ``dict[str, object]`` (rather than ``dict`` or
+    ``dict[str, Any]``) to keep the package's "no implicit Any" rule
+    honest. Consumers who need to read a specific value should narrow
+    via ``isinstance`` rather than assume a shape.
+    """

--- a/packages/beer-encyclopedia/importers/openfoodfacts.py
+++ b/packages/beer-encyclopedia/importers/openfoodfacts.py
@@ -1,0 +1,317 @@
+"""Open Food Facts client for fetching beer products by EAN.
+
+Open Food Facts (OFF) is a public, crowd-sourced food product database
+covering more than two million SKUs worldwide. We use it as the
+primary external source to bootstrap the encyclopedia: a scanned EAN
+that does not yet exist in our DB triggers a one-shot lookup against
+OFF, and the response is normalised into an
+:class:`importers.base.ExternalBeerSnapshot` for the upsert layer to
+persist.
+
+Network layer
+-------------
+The client wraps an :class:`httpx.AsyncClient` so the caller can hold
+a single connection pool for the lifetime of the request handler and
+take advantage of HTTP/2 keep-alive when available. The base URL and
+the user-agent are pulled from the environment so the same code runs
+unchanged in tests (with a stub) and in production.
+
+Per OFF's `terms of use`_, every client must identify itself with a
+descriptive ``User-Agent`` header that includes the project name, a
+version, and a contact endpoint. The default value embedded here
+satisfies that requirement; production deployments should override it
+via the ``OFF_USER_AGENT`` environment variable to surface their own
+contact channel.
+
+.. _terms of use: https://world.openfoodfacts.org/files/api-documentation
+"""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+import httpx
+
+from importers.base import ExternalBeerSnapshot
+
+DEFAULT_BASE_URL: str = "https://world.openfoodfacts.org"
+DEFAULT_USER_AGENT: str = (
+    "BrasseBouillon/0.2 (+https://github.com/benoit-bremaud/brasse-bouillon)"
+)
+DEFAULT_TIMEOUT_SECONDS: float = 10.0
+
+_PRODUCT_PATH_TEMPLATE: str = "/api/v2/product/{ean}.json"
+
+
+class OpenFoodFactsError(RuntimeError):
+    """Raised when the OFF API returns an unexpected response.
+
+    Distinct from a missing-product situation (which the client surfaces
+    as ``None``) — this exception is reserved for transport-level or
+    payload-shape failures the caller cannot recover from without code
+    or configuration changes.
+    """
+
+
+class OpenFoodFactsClient:
+    """Asynchronous client for the Open Food Facts product API."""
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        base_url: str | None = None,
+        user_agent: str | None = None,
+        timeout_seconds: float | None = None,
+    ) -> None:
+        """Build a client.
+
+        Parameters
+        ----------
+        client:
+            Inject an existing :class:`httpx.AsyncClient` to share a
+            connection pool with the surrounding application. When
+            ``None`` the client builds its own and owns its lifecycle —
+            callers must then use the instance as an async context
+            manager (``async with``) to ensure the underlying client is
+            closed.
+        base_url, user_agent, timeout_seconds:
+            Override the defaults pulled from the environment. Useful
+            for tests targeting a mock server.
+        """
+
+        resolved_base_url = (
+            base_url if base_url is not None else os.environ.get(
+                "OFF_API_BASE_URL", DEFAULT_BASE_URL
+            )
+        )
+        resolved_user_agent = (
+            user_agent if user_agent is not None else os.environ.get(
+                "OFF_USER_AGENT", DEFAULT_USER_AGENT
+            )
+        )
+        resolved_timeout = (
+            timeout_seconds if timeout_seconds is not None
+            else DEFAULT_TIMEOUT_SECONDS
+        )
+
+        self._base_url: str = resolved_base_url.rstrip("/")
+        self._user_agent: str = resolved_user_agent
+        self._owns_client: bool = client is None
+        self._client: httpx.AsyncClient = client or httpx.AsyncClient(
+            timeout=resolved_timeout,
+            headers={"User-Agent": self._user_agent},
+        )
+
+    async def __aenter__(self) -> OpenFoodFactsClient:
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying HTTP client when this object owns it."""
+
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def fetch_by_ean(self, ean: str) -> ExternalBeerSnapshot | None:
+        """Look up a product by EAN.
+
+        Returns ``None`` when OFF reports the product as missing
+        (``status == 0``) so the caller can branch on a clean
+        sentinel. Any other unexpected condition (HTTP 5xx, malformed
+        payload) raises :class:`OpenFoodFactsError`.
+        """
+
+        url = f"{self._base_url}{_PRODUCT_PATH_TEMPLATE.format(ean=ean)}"
+        response = await self._client.get(url)
+
+        # 404 from OFF is unusual (the API normally returns 200 with
+        # status=0 for unknown codes) but treat it the same way to
+        # remain resilient against minor server-side changes.
+        if response.status_code == 404:
+            return None
+        if response.status_code != 200:
+            raise OpenFoodFactsError(
+                f"OFF returned HTTP {response.status_code} for EAN {ean}"
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise OpenFoodFactsError(
+                f"OFF returned non-JSON payload for EAN {ean}"
+            ) from exc
+
+        if payload.get("status") == 0:
+            return None
+
+        product = payload.get("product")
+        if not isinstance(product, dict):
+            raise OpenFoodFactsError(
+                f"OFF payload for EAN {ean} has no 'product' object"
+            )
+
+        return _map_product_to_snapshot(ean=ean, product=product)
+
+
+def _map_product_to_snapshot(
+    *, ean: str, product: dict[str, Any]
+) -> ExternalBeerSnapshot:
+    """Translate the OFF product dict into our internal shape.
+
+    Kept module-level (instead of a private method on the client) so
+    tests can exercise the mapping logic without instantiating a
+    network-bearing client.
+    """
+
+    return ExternalBeerSnapshot(
+        external_id=ean,
+        name=_pick_name(product),
+        brand=_pick_first_brand(product),
+        abv=_pick_abv(product),
+        country_of_origin=_pick_country_iso2(product),
+        allergens=_pick_allergens(product),
+        image_url=_pick_image_url(product),
+        raw_payload=product,
+    )
+
+
+def _pick_name(product: dict[str, Any]) -> str:
+    """Return the most descriptive available name.
+
+    Prefers the localised French name when present, falls back to the
+    canonical ``product_name``, then to the generic name, and finally
+    to a placeholder so the ORM never receives an empty string.
+    """
+
+    for key in ("product_name_fr", "product_name", "generic_name"):
+        value = product.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "Unnamed product"
+
+
+def _pick_first_brand(product: dict[str, Any]) -> str | None:
+    """Return the first brand listed (OFF stores them comma-separated)."""
+
+    brands = product.get("brands")
+    if not isinstance(brands, str):
+        return None
+    first, _, _ = brands.partition(",")
+    cleaned = first.strip()
+    return cleaned or None
+
+
+def _pick_abv(product: dict[str, Any]) -> Decimal | None:
+    """Extract the alcohol-by-volume value from the nutriments dict.
+
+    OFF stores it under several keys depending on the product's
+    history; we try the canonical ``alcohol_value`` first, then fall
+    back to ``alcohol_100g`` and ``alcohol`` for older entries.
+    """
+
+    nutriments = product.get("nutriments")
+    if not isinstance(nutriments, dict):
+        return None
+
+    for key in ("alcohol_value", "alcohol_100g", "alcohol"):
+        raw = nutriments.get(key)
+        if raw is None:
+            continue
+        try:
+            return Decimal(str(raw))
+        except (InvalidOperation, ValueError):
+            continue
+    return None
+
+
+def _pick_country_iso2(product: dict[str, Any]) -> str | None:
+    """Extract an ISO 3166-1 alpha-2 country code from ``countries_tags``.
+
+    OFF country tags are language-prefixed slugs such as ``"en:france"``
+    or ``"fr:belgique"``. We do not maintain a full slug→ISO mapping
+    here; instead we trust the ``"en:"`` prefix and try a small
+    hard-coded translation for the most frequent countries shipped on
+    European beer labels. Anything we cannot resolve safely is left
+    ``None`` so the caller falls back to the seed default.
+    """
+
+    tags = product.get("countries_tags")
+    if not isinstance(tags, list):
+        return None
+
+    for tag in tags:
+        if not isinstance(tag, str) or ":" not in tag:
+            continue
+        _, _, slug = tag.partition(":")
+        iso = _COUNTRY_SLUG_TO_ISO2.get(slug.lower())
+        if iso is not None:
+            return iso
+    return None
+
+
+def _pick_allergens(product: dict[str, Any]) -> list[str]:
+    """Extract a normalised allergen list from ``allergens_tags``.
+
+    OFF tags such as ``"en:gluten"`` are converted to plain tokens
+    (``"gluten"``); duplicates are removed and the order is preserved
+    for stable diffing.
+    """
+
+    tags = product.get("allergens_tags")
+    if not isinstance(tags, list):
+        return []
+
+    seen: set[str] = set()
+    normalised: list[str] = []
+    for tag in tags:
+        if not isinstance(tag, str):
+            continue
+        _, _, token = tag.partition(":")
+        token = token.strip().lower()
+        if token and token not in seen:
+            seen.add(token)
+            normalised.append(token)
+    return normalised
+
+
+def _pick_image_url(product: dict[str, Any]) -> str | None:
+    """Return the front-label image URL when OFF provides one."""
+
+    for key in ("image_front_url", "image_url"):
+        value = product.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+# Minimal slug → ISO 3166-1 alpha-2 map covering the countries we see
+# most often on European beer labels. Extend as gaps appear; missing
+# entries simply leave ``country_of_origin`` blank rather than guessing.
+_COUNTRY_SLUG_TO_ISO2: dict[str, str] = {
+    "france": "FR",
+    "belgique": "BE",
+    "belgium": "BE",
+    "allemagne": "DE",
+    "germany": "DE",
+    "royaume-uni": "GB",
+    "united-kingdom": "GB",
+    "irlande": "IE",
+    "ireland": "IE",
+    "pays-bas": "NL",
+    "netherlands": "NL",
+    "espagne": "ES",
+    "spain": "ES",
+    "italie": "IT",
+    "italy": "IT",
+    "republique-tcheque": "CZ",
+    "czech-republic": "CZ",
+    "danemark": "DK",
+    "denmark": "DK",
+    "etats-unis": "US",
+    "united-states": "US",
+}

--- a/packages/beer-encyclopedia/importers/openfoodfacts.py
+++ b/packages/beer-encyclopedia/importers/openfoodfacts.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import os
 from decimal import Decimal, InvalidOperation
-from typing import Any
 
 import httpx
 
@@ -121,13 +120,23 @@ class OpenFoodFactsClient:
         """Look up a product by EAN.
 
         Returns ``None`` when OFF reports the product as missing
-        (``status == 0``) so the caller can branch on a clean
-        sentinel. Any other unexpected condition (HTTP 5xx, malformed
-        payload) raises :class:`OpenFoodFactsError`.
+        (``status == 0`` or HTTP 404) so the caller can branch on a
+        clean sentinel. Any other unexpected condition — HTTP 5xx,
+        malformed payload, or transport-level failure (timeout, DNS,
+        connection reset) — raises :class:`OpenFoodFactsError` so the
+        route handler can convert it into a controlled 503 instead of
+        leaking an uncaught exception as a 500.
         """
 
         url = f"{self._base_url}{_PRODUCT_PATH_TEMPLATE.format(ean=ean)}"
-        response = await self._client.get(url)
+        try:
+            response = await self._client.get(url)
+        except httpx.RequestError as exc:
+            # Transport-level failure (timeout, DNS, connection reset…).
+            # Surface it through the typed error so the route returns 503.
+            raise OpenFoodFactsError(
+                f"OFF transport error for EAN {ean}: {exc}"
+            ) from exc
 
         # 404 from OFF is unusual (the API normally returns 200 with
         # status=0 for unknown codes) but treat it the same way to
@@ -146,6 +155,16 @@ class OpenFoodFactsClient:
                 f"OFF returned non-JSON payload for EAN {ean}"
             ) from exc
 
+        # Defensive: a misbehaving proxy or schema drift could return a
+        # JSON list / string / number. Anything other than an object
+        # cannot be treated as an OFF response — fail fast with a
+        # controlled error instead of letting AttributeError bubble up.
+        if not isinstance(payload, dict):
+            raise OpenFoodFactsError(
+                f"OFF payload for EAN {ean} is not a JSON object "
+                f"(got {type(payload).__name__})"
+            )
+
         if payload.get("status") == 0:
             return None
 
@@ -159,7 +178,7 @@ class OpenFoodFactsClient:
 
 
 def _map_product_to_snapshot(
-    *, ean: str, product: dict[str, Any]
+    *, ean: str, product: dict[str, object]
 ) -> ExternalBeerSnapshot:
     """Translate the OFF product dict into our internal shape.
 
@@ -180,7 +199,7 @@ def _map_product_to_snapshot(
     )
 
 
-def _pick_name(product: dict[str, Any]) -> str:
+def _pick_name(product: dict[str, object]) -> str:
     """Return the most descriptive available name.
 
     Prefers the localised French name when present, falls back to the
@@ -195,7 +214,7 @@ def _pick_name(product: dict[str, Any]) -> str:
     return "Unnamed product"
 
 
-def _pick_first_brand(product: dict[str, Any]) -> str | None:
+def _pick_first_brand(product: dict[str, object]) -> str | None:
     """Return the first brand listed (OFF stores them comma-separated)."""
 
     brands = product.get("brands")
@@ -206,7 +225,7 @@ def _pick_first_brand(product: dict[str, Any]) -> str | None:
     return cleaned or None
 
 
-def _pick_abv(product: dict[str, Any]) -> Decimal | None:
+def _pick_abv(product: dict[str, object]) -> Decimal | None:
     """Extract the alcohol-by-volume value from the nutriments dict.
 
     OFF stores it under several keys depending on the product's
@@ -229,7 +248,7 @@ def _pick_abv(product: dict[str, Any]) -> Decimal | None:
     return None
 
 
-def _pick_country_iso2(product: dict[str, Any]) -> str | None:
+def _pick_country_iso2(product: dict[str, object]) -> str | None:
     """Extract an ISO 3166-1 alpha-2 country code from ``countries_tags``.
 
     OFF country tags are language-prefixed slugs such as ``"en:france"``
@@ -254,7 +273,7 @@ def _pick_country_iso2(product: dict[str, Any]) -> str | None:
     return None
 
 
-def _pick_allergens(product: dict[str, Any]) -> list[str]:
+def _pick_allergens(product: dict[str, object]) -> list[str]:
     """Extract a normalised allergen list from ``allergens_tags``.
 
     OFF tags such as ``"en:gluten"`` are converted to plain tokens
@@ -279,7 +298,7 @@ def _pick_allergens(product: dict[str, Any]) -> list[str]:
     return normalised
 
 
-def _pick_image_url(product: dict[str, Any]) -> str | None:
+def _pick_image_url(product: dict[str, object]) -> str | None:
     """Return the front-label image URL when OFF provides one."""
 
     for key in ("image_front_url", "image_url"):

--- a/packages/beer-encyclopedia/importers/persistence.py
+++ b/packages/beer-encyclopedia/importers/persistence.py
@@ -1,0 +1,226 @@
+"""Persist an :class:`ExternalBeerSnapshot` into the encyclopedia.
+
+Sits between the importers (which know how to fetch + map a remote
+schema) and the API router (which only orchestrates HTTP). Keeps the
+upsert logic in one place so adding a new source — Untappd, RateBeer,
+Open Brewery DB — does not duplicate the brewery / EntitySource / Beer
+upsert dance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.slug import build_unique_slug
+from db.models import Beer, Brewery, EntitySource, Source
+from importers.base import ExternalBeerSnapshot
+
+
+class SourceNotSeededError(RuntimeError):
+    """Raised when an importer runs before its source row exists.
+
+    The encyclopedia tracks every external import via
+    ``EntitySource.source_id``; that FK requires the matching ``Source``
+    row to be seeded first (``scripts/seed_sources.py``). Surfacing
+    this as a typed error makes the mismatch obvious instead of letting
+    a generic ``IntegrityError`` bubble up at flush time.
+    """
+
+
+@dataclass(slots=True)
+class UpsertResult:
+    """Outcome of :func:`upsert_beer_from_snapshot`.
+
+    ``created`` reflects whether a new ``Beer`` row was inserted or an
+    existing one was refreshed in place. The router uses it to choose
+    between ``201 Created`` and ``200 OK`` so the HTTP semantics stay
+    honest.
+    """
+
+    beer: Beer
+    created: bool
+
+
+async def upsert_beer_from_snapshot(
+    session: AsyncSession,
+    *,
+    snapshot: ExternalBeerSnapshot,
+    source_name: str,
+) -> UpsertResult:
+    """Persist ``snapshot`` and its audit trail in a single transaction.
+
+    Idempotent on ``snapshot.external_id``: a second call refreshes the
+    matched ``Beer`` row in place (no duplicates, no insert errors) and
+    bumps ``EntitySource.last_synced_at`` so the audit trail records
+    the new fetch.
+    """
+
+    source = await _fetch_source_or_raise(session, source_name=source_name)
+    brewery = await _upsert_brewery(session, name=snapshot.brand)
+
+    existing_beer = (
+        await session.execute(
+            select(Beer).where(Beer.ean_code == snapshot.external_id)
+        )
+    ).scalar_one_or_none()
+
+    if existing_beer is None:
+        beer = await _create_beer(session, snapshot=snapshot, brewery=brewery)
+        created = True
+    else:
+        _refresh_beer_fields(existing_beer, snapshot=snapshot, brewery=brewery)
+        beer = existing_beer
+        created = False
+
+    await _upsert_entity_source(
+        session,
+        source=source,
+        beer=beer,
+        snapshot=snapshot,
+    )
+
+    await session.commit()
+    await session.refresh(beer)
+    return UpsertResult(beer=beer, created=created)
+
+
+async def _fetch_source_or_raise(
+    session: AsyncSession, *, source_name: str
+) -> Source:
+    source = (
+        await session.execute(select(Source).where(Source.name == source_name))
+    ).scalar_one_or_none()
+    if source is None:
+        raise SourceNotSeededError(
+            f"Source '{source_name}' is not seeded — run "
+            "`python scripts/seed_sources.py` before importing."
+        )
+    return source
+
+
+async def _upsert_brewery(
+    session: AsyncSession, *, name: str | None
+) -> Brewery | None:
+    """Find or create the brewery referenced by the snapshot.
+
+    Returns ``None`` when the snapshot carries no brand name — the
+    encyclopedia tolerates beers without a brewery (the FK is nullable),
+    typically for community drafts and bare OFF entries that omit
+    ``brands``.
+    """
+
+    if name is None:
+        return None
+
+    cleaned = name.strip()
+    if not cleaned:
+        return None
+
+    existing = (
+        await session.execute(select(Brewery).where(Brewery.name == cleaned))
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
+
+    slug = await build_unique_slug(session, column=Brewery.slug, name=cleaned)
+    brewery = Brewery(name=cleaned, slug=slug)
+    session.add(brewery)
+    # Flush so the FK below has a valid id without forcing the caller
+    # to commit the half-built transaction.
+    await session.flush()
+    return brewery
+
+
+async def _create_beer(
+    session: AsyncSession,
+    *,
+    snapshot: ExternalBeerSnapshot,
+    brewery: Brewery | None,
+) -> Beer:
+    slug = await build_unique_slug(session, column=Beer.slug, name=snapshot.name)
+    beer = Beer(
+        name=snapshot.name,
+        slug=slug,
+        brewery_id=brewery.id if brewery is not None else None,
+        abv=snapshot.abv,
+        country_of_origin=snapshot.country_of_origin,
+        allergens=list(snapshot.allergens) or None,
+        ean_code=snapshot.external_id,
+        source="openfoodfacts",
+        contributed_at=datetime.now(UTC),
+    )
+    session.add(beer)
+    await session.flush()
+    return beer
+
+
+def _refresh_beer_fields(
+    beer: Beer,
+    *,
+    snapshot: ExternalBeerSnapshot,
+    brewery: Brewery | None,
+) -> None:
+    """Update mutable fields on an existing beer row.
+
+    Conservative on purpose: we never overwrite ``name``, ``slug``,
+    ``description`` or ``style_id`` because those may have been edited
+    by hand or refined by another source. The importer only refreshes
+    fields it owns: brewery link, abv, country, allergens, contributed_at.
+    """
+
+    if brewery is not None:
+        beer.brewery_id = brewery.id
+    if snapshot.abv is not None:
+        beer.abv = snapshot.abv
+    if snapshot.country_of_origin is not None:
+        beer.country_of_origin = snapshot.country_of_origin
+    if snapshot.allergens:
+        beer.allergens = list(snapshot.allergens)
+    beer.contributed_at = datetime.now(UTC)
+
+
+async def _upsert_entity_source(
+    session: AsyncSession,
+    *,
+    source: Source,
+    beer: Beer,
+    snapshot: ExternalBeerSnapshot,
+) -> None:
+    """Insert or refresh the ``EntitySource`` audit row for this import.
+
+    Matches on the ``(source_id, entity_type, external_id)`` triplet to
+    stay aligned with the unique constraint defined on the table. A
+    re-import refreshes ``raw_data`` (so the latest payload is always
+    available for re-transform) and bumps ``last_synced_at``.
+    """
+
+    existing = (
+        await session.execute(
+            select(EntitySource).where(
+                EntitySource.source_id == source.id,
+                EntitySource.entity_type == "beer",
+                EntitySource.external_id == snapshot.external_id,
+            )
+        )
+    ).scalar_one_or_none()
+
+    now = datetime.now(UTC)
+    if existing is None:
+        session.add(
+            EntitySource(
+                source_id=source.id,
+                entity_type="beer",
+                entity_id=beer.id,
+                external_id=snapshot.external_id,
+                last_synced_at=now,
+                raw_data=snapshot.raw_payload,
+            )
+        )
+    else:
+        existing.entity_id = beer.id
+        existing.last_synced_at = now
+        existing.raw_data = snapshot.raw_payload

--- a/packages/beer-encyclopedia/importers/persistence.py
+++ b/packages/beer-encyclopedia/importers/persistence.py
@@ -69,7 +69,12 @@ async def upsert_beer_from_snapshot(
     ).scalar_one_or_none()
 
     if existing_beer is None:
-        beer = await _create_beer(session, snapshot=snapshot, brewery=brewery)
+        beer = await _create_beer(
+            session,
+            snapshot=snapshot,
+            brewery=brewery,
+            source_name=source_name,
+        )
         created = True
     else:
         _refresh_beer_fields(existing_beer, snapshot=snapshot, brewery=brewery)
@@ -140,7 +145,17 @@ async def _create_beer(
     *,
     snapshot: ExternalBeerSnapshot,
     brewery: Brewery | None,
+    source_name: str,
 ) -> Beer:
+    """Insert a new beer row carrying the snapshot's payload.
+
+    ``source_name`` must be one of ``BEER_SOURCE_VALUES``
+    (``openfoodfacts`` | ``internal`` | ``community``); the
+    ``Beer.source`` ORM validator rejects anything else at assignment
+    time so a misuse from a future importer surfaces immediately
+    instead of corrupting provenance silently.
+    """
+
     slug = await build_unique_slug(session, column=Beer.slug, name=snapshot.name)
     beer = Beer(
         name=snapshot.name,
@@ -150,7 +165,7 @@ async def _create_beer(
         country_of_origin=snapshot.country_of_origin,
         allergens=list(snapshot.allergens) or None,
         ean_code=snapshot.external_id,
-        source="openfoodfacts",
+        source=source_name,
         contributed_at=datetime.now(UTC),
     )
     session.add(beer)
@@ -166,10 +181,24 @@ def _refresh_beer_fields(
 ) -> None:
     """Update mutable fields on an existing beer row.
 
-    Conservative on purpose: we never overwrite ``name``, ``slug``,
-    ``description`` or ``style_id`` because those may have been edited
-    by hand or refined by another source. The importer only refreshes
-    fields it owns: brewery link, abv, country, allergens, contributed_at.
+    Two layered policies:
+
+    - **Never overwrite hand-edited fields.** ``name``, ``slug``,
+      ``description``, ``style_id`` and ``legal_denomination`` are
+      preserved unconditionally — they may have been corrected by a
+      moderator or refined by another source, and we do not have
+      enough context to know whether the snapshot value is more
+      accurate.
+
+    - **Never clear on refresh.** A re-import only writes a value when
+      the snapshot carries one (``brewery is not None``,
+      ``snapshot.abv is not None``, ``snapshot.allergens`` truthy,
+      …). If OFF stops returning, say, an ``allergens_tags`` array on
+      the next call, we keep the previous list rather than clearing it
+      and losing data the user could see in the mobile app. The
+      explicit cost: a field stays populated even after the source
+      removes it. The chosen mitigation: a future moderation tool can
+      flush a field on demand; the importer must not do it implicitly.
     """
 
     if brewery is not None:

--- a/packages/beer-encyclopedia/migrations/versions/004_beer_ean_code.py
+++ b/packages/beer-encyclopedia/migrations/versions/004_beer_ean_code.py
@@ -1,0 +1,54 @@
+"""Add ``ean_code`` to beers + matching CHECK and UNIQUE constraints.
+
+Adds the standard product barcode column on ``beers``. The column is
+populated by the Open Food Facts importer (PR2) and used as the primary
+external match key for community scans (PR3). Accepts EAN-8, UPC-A
+(12 digits), EAN-13 and EAN-14 — the four formats commonly found on
+beverage packaging in Europe and North America.
+
+The unique constraint allows multiple NULL rows on both PostgreSQL and
+SQLite, so beers without a known barcode (internal seeds, community
+drafts) do not collide with each other; only two distinct beers
+claiming the same EAN are rejected.
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-05-01
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "004"
+down_revision: str | None = "003"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    """Add ``ean_code`` column + CHECK length + UNIQUE constraint."""
+
+    with op.batch_alter_table("beers") as batch_op:
+        batch_op.add_column(
+            sa.Column("ean_code", sa.String(length=14), nullable=True),
+        )
+        batch_op.create_check_constraint(
+            "ck_beers_ean_code_length",
+            "ean_code IS NULL OR length(ean_code) IN (8, 12, 13, 14)",
+        )
+        batch_op.create_unique_constraint(
+            "uq_beers_ean_code",
+            ["ean_code"],
+        )
+
+
+def downgrade() -> None:
+    """Drop the unique + CHECK constraints and the column."""
+
+    with op.batch_alter_table("beers") as batch_op:
+        batch_op.drop_constraint("uq_beers_ean_code", type_="unique")
+        batch_op.drop_constraint("ck_beers_ean_code_length", type_="check")
+        batch_op.drop_column("ean_code")

--- a/packages/beer-encyclopedia/scripts/seed_sources.py
+++ b/packages/beer-encyclopedia/scripts/seed_sources.py
@@ -1,0 +1,81 @@
+"""Seed the ``sources`` registry with the external systems we ingest from.
+
+Each row in ``sources`` is referenced by ``entity_sources.source_id``,
+so an importer cannot persist its audit trail until the matching
+``Source`` exists. This script ensures the canonical entries are in
+place before any importer runs.
+
+The script is idempotent: matching is performed by ``Source.name`` so
+re-running updates the metadata of existing rows in place and inserts
+only what is missing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.engine import create_engine, create_session_factory, get_database_url
+from db.models import Source
+
+# name, source_type, base_url, description
+SourceSeed = tuple[str, str, str, str]
+
+SOURCES: list[SourceSeed] = [
+    (
+        "openfoodfacts",
+        "api",
+        "https://world.openfoodfacts.org",
+        "Open Food Facts — public, crowd-sourced food product database. "
+        "Used as the primary external source to bootstrap the encyclopedia "
+        "from product barcodes (EAN-8/12/13/14).",
+    ),
+]
+
+
+async def seed_sources(session: AsyncSession) -> tuple[int, int]:
+    """Upsert the source registry. Returns (created, updated)."""
+
+    created = 0
+    updated = 0
+
+    for name, source_type, base_url, description in SOURCES:
+        existing = (
+            await session.execute(select(Source).where(Source.name == name))
+        ).scalar_one_or_none()
+
+        if existing is None:
+            session.add(
+                Source(
+                    name=name,
+                    source_type=source_type,
+                    base_url=base_url,
+                    description=description,
+                )
+            )
+            created += 1
+        else:
+            existing.source_type = source_type
+            existing.base_url = base_url
+            existing.description = description
+            updated += 1
+
+    await session.commit()
+    return created, updated
+
+
+async def main() -> None:
+    engine = create_engine(get_database_url())
+    factory = create_session_factory(engine)
+    try:
+        async with factory() as session:
+            created, updated = await seed_sources(session)
+            print(f"Sources seeded: {created} created, {updated} updated.")
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
@@ -15,7 +15,7 @@ Coverage layout:
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from decimal import Decimal
 
 import pytest
@@ -32,6 +32,14 @@ from scripts.seed_sources import seed_sources
 
 # Real EAN-13 from the OFF doc — used as a stable fixture identifier.
 EAN_PELFORTH: str = "3760231860119"
+
+# A behaviour function maps an EAN to the value the stub client should
+# return: a snapshot (success), ``None`` (unknown product), or an
+# Exception instance to raise (transport failure). Typing this once
+# keeps the fixture and the stub class honest without ``# type: ignore``.
+SnapshotBehaviour = Callable[
+    [str], "ExternalBeerSnapshot | None | OpenFoodFactsError"
+]
 
 
 def _build_pelforth_snapshot(ean: str = EAN_PELFORTH) -> ExternalBeerSnapshot:
@@ -55,11 +63,11 @@ class _StubOpenFoodFactsClient:
     :class:`OpenFoodFactsError` (transport failure).
     """
 
-    def __init__(self, behaviour) -> None:  # type: ignore[no-untyped-def]
+    def __init__(self, behaviour: SnapshotBehaviour) -> None:
         self._behaviour = behaviour
         self.calls: list[str] = []
 
-    async def fetch_by_ean(self, ean: str):  # type: ignore[no-untyped-def]
+    async def fetch_by_ean(self, ean: str) -> ExternalBeerSnapshot | None:
         self.calls.append(ean)
         result = self._behaviour(ean)
         if isinstance(result, Exception):
@@ -67,18 +75,21 @@ class _StubOpenFoodFactsClient:
         return result
 
 
+StubFactory = Callable[[SnapshotBehaviour], _StubOpenFoodFactsClient]
+
+
 @pytest.fixture
-def stub_off_factory(client: TestClient) -> Iterator[callable]:  # type: ignore[type-arg]
+def stub_off_factory(client: TestClient) -> Iterator[StubFactory]:
     """Yield a factory that injects a stub OFF client into the app.
 
     Cleans up the dependency override on teardown so other tests in
     the same suite are unaffected.
     """
 
-    def _install(behaviour) -> _StubOpenFoodFactsClient:  # type: ignore[no-untyped-def]
+    def _install(behaviour: SnapshotBehaviour) -> _StubOpenFoodFactsClient:
         stub = _StubOpenFoodFactsClient(behaviour)
 
-        async def _override():  # type: ignore[no-untyped-def]
+        async def _override() -> AsyncIterator[_StubOpenFoodFactsClient]:
             yield stub
 
         app.dependency_overrides[get_openfoodfacts_client] = _override

--- a/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
@@ -1,0 +1,294 @@
+"""HTTP contract tests for ``POST /beers/import-by-ean``.
+
+Exercises the full route → persistence → audit-trail flow against an
+in-memory SQLite DB and a stubbed Open Food Facts client. The stub is
+injected via ``app.dependency_overrides`` so no real HTTP call ever
+leaves the process and tests stay deterministic.
+
+Coverage layout:
+- Happy path : known EAN → 201 Created with mapped fields, audit row inserted
+- Sad paths  : invalid EAN format, OFF unknown, OFF transport failure,
+              missing source seed
+- Edge cases : idempotence on re-import (200 OK, last_synced_at refreshed),
+              brewery created on first import then reused
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.main import app
+from api.routers.beers import get_openfoodfacts_client
+from db.models import Beer, Brewery, EntitySource, Source
+from importers.base import ExternalBeerSnapshot
+from importers.openfoodfacts import OpenFoodFactsError
+from scripts.seed_sources import seed_sources
+
+# Real EAN-13 from the OFF doc — used as a stable fixture identifier.
+EAN_PELFORTH: str = "3760231860119"
+
+
+def _build_pelforth_snapshot(ean: str = EAN_PELFORTH) -> ExternalBeerSnapshot:
+    return ExternalBeerSnapshot(
+        external_id=ean,
+        name="Pelforth Brune",
+        brand="Pelforth",
+        abv=Decimal("6.5"),
+        country_of_origin="FR",
+        allergens=["gluten"],
+        image_url="https://example.org/pelforth.jpg",
+        raw_payload={"product_name": "Pelforth Brune", "code": ean},
+    )
+
+
+class _StubOpenFoodFactsClient:
+    """Programmable stub injected as the FastAPI dependency.
+
+    Stores the calls it received so tests can assert on them and
+    returns either a snapshot, ``None`` (unknown product), or raises
+    :class:`OpenFoodFactsError` (transport failure).
+    """
+
+    def __init__(self, behaviour) -> None:  # type: ignore[no-untyped-def]
+        self._behaviour = behaviour
+        self.calls: list[str] = []
+
+    async def fetch_by_ean(self, ean: str):  # type: ignore[no-untyped-def]
+        self.calls.append(ean)
+        result = self._behaviour(ean)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+
+@pytest.fixture
+def stub_off_factory(client: TestClient) -> Iterator[callable]:  # type: ignore[type-arg]
+    """Yield a factory that injects a stub OFF client into the app.
+
+    Cleans up the dependency override on teardown so other tests in
+    the same suite are unaffected.
+    """
+
+    def _install(behaviour) -> _StubOpenFoodFactsClient:  # type: ignore[no-untyped-def]
+        stub = _StubOpenFoodFactsClient(behaviour)
+
+        async def _override():  # type: ignore[no-untyped-def]
+            yield stub
+
+        app.dependency_overrides[get_openfoodfacts_client] = _override
+        return stub
+
+    try:
+        yield _install
+    finally:
+        app.dependency_overrides.pop(get_openfoodfacts_client, None)
+
+
+@pytest.fixture
+async def seeded_source(db_session: AsyncSession) -> Source:
+    """Ensure the ``openfoodfacts`` Source row exists before tests run."""
+
+    await seed_sources(db_session)
+    return (
+        await db_session.execute(
+            select(Source).where(Source.name == "openfoodfacts")
+        )
+    ).scalar_one()
+
+
+# --- Happy path ----------------------------------------------------------
+
+
+async def test_first_import_creates_beer_and_returns_201(
+    client: TestClient,
+    db_session: AsyncSession,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    snapshot = _build_pelforth_snapshot()
+    stub = stub_off_factory(lambda _: snapshot)
+
+    response = client.post(
+        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["ean_code"] == EAN_PELFORTH
+    assert body["country_of_origin"] == "FR"
+    assert body["allergens"] == ["gluten"]
+    assert body["abv"] == "6.50"
+    assert body["source"] == "openfoodfacts"
+    assert stub.calls == [EAN_PELFORTH]
+
+    beer = (
+        await db_session.execute(
+            select(Beer).where(Beer.ean_code == EAN_PELFORTH)
+        )
+    ).scalar_one()
+    assert beer.name == "Pelforth Brune"
+
+    audit = (
+        await db_session.execute(
+            select(EntitySource).where(
+                EntitySource.external_id == EAN_PELFORTH
+            )
+        )
+    ).scalar_one()
+    assert audit.entity_type == "beer"
+    assert audit.entity_id == beer.id
+    assert audit.raw_data == snapshot.raw_payload
+    assert audit.last_synced_at is not None
+
+
+async def test_import_creates_brewery_with_unique_slug(
+    client: TestClient,
+    db_session: AsyncSession,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    stub_off_factory(lambda _: _build_pelforth_snapshot())
+
+    client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
+
+    brewery = (
+        await db_session.execute(select(Brewery).where(Brewery.name == "Pelforth"))
+    ).scalar_one()
+    assert brewery.slug == "pelforth"
+
+
+# --- Sad path ------------------------------------------------------------
+
+
+async def test_invalid_ean_format_is_rejected_by_pydantic(
+    client: TestClient,
+    seeded_source: Source,
+) -> None:
+    # 7-digit string is too short for any standard barcode.
+    response = client.post(
+        "/beers/import-by-ean", json={"ean": "1234567"}
+    )
+    assert response.status_code == 422
+
+
+async def test_non_digit_ean_is_rejected_by_pydantic(
+    client: TestClient,
+    seeded_source: Source,
+) -> None:
+    response = client.post(
+        "/beers/import-by-ean", json={"ean": "12345abc"}
+    )
+    assert response.status_code == 422
+
+
+async def test_unknown_product_returns_404(
+    client: TestClient,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    stub_off_factory(lambda _: None)
+
+    response = client.post(
+        "/beers/import-by-ean", json={"ean": "0000000000017"}
+    )
+    assert response.status_code == 404
+    assert "0000000000017" in response.json()["detail"]
+
+
+async def test_off_transport_failure_returns_503(
+    client: TestClient,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    stub_off_factory(lambda _: OpenFoodFactsError("HTTP 502"))
+
+    response = client.post(
+        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
+    )
+    assert response.status_code == 503
+    assert "Open Food Facts unavailable" in response.json()["detail"]
+
+
+async def test_missing_source_seed_returns_503_with_actionable_message(
+    client: TestClient,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+) -> None:
+    # Note: deliberately do NOT include `seeded_source` here, so the
+    # `openfoodfacts` row is absent.
+    stub_off_factory(lambda _: _build_pelforth_snapshot())
+
+    response = client.post(
+        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
+    )
+    assert response.status_code == 503
+    assert "seed_sources.py" in response.json()["detail"]
+
+
+# --- Edge cases ----------------------------------------------------------
+
+
+async def test_second_import_is_idempotent_and_returns_200(
+    client: TestClient,
+    db_session: AsyncSession,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    stub_off_factory(lambda _: _build_pelforth_snapshot())
+
+    first = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
+    assert first.status_code == 201
+    first_id = first.json()["id"]
+
+    second = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
+    assert second.status_code == 200
+    assert second.json()["id"] == first_id
+
+    # Still exactly one beer + one audit row, last_synced_at refreshed.
+    beers = (
+        await db_session.execute(
+            select(Beer).where(Beer.ean_code == EAN_PELFORTH)
+        )
+    ).scalars().all()
+    assert len(beers) == 1
+
+    audits = (
+        await db_session.execute(
+            select(EntitySource).where(
+                EntitySource.external_id == EAN_PELFORTH
+            )
+        )
+    ).scalars().all()
+    assert len(audits) == 1
+
+
+async def test_import_with_snapshot_missing_brand_skips_brewery(
+    client: TestClient,
+    db_session: AsyncSession,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    snapshot = ExternalBeerSnapshot(
+        external_id=EAN_PELFORTH,
+        name="Bare beer",
+        brand=None,
+        raw_payload={"product_name": "Bare beer"},
+    )
+    stub_off_factory(lambda _: snapshot)
+
+    response = client.post(
+        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
+    )
+    assert response.status_code == 201
+    assert response.json()["brewery_id"] is None
+
+    # No brewery row should have been created.
+    breweries = (
+        await db_session.execute(select(Brewery))
+    ).scalars().all()
+    assert breweries == []

--- a/packages/beer-encyclopedia/tests/test_db/test_beer_ean_code.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_beer_ean_code.py
@@ -1,0 +1,143 @@
+"""Behaviour tests for ``Beer.ean_code`` (added by migration 004).
+
+Three layers of guarantees, each covered by happy / sad / edge cases:
+- ORM validator (assignment-time format check)
+- DB CHECK constraint (length whitelist)
+- DB UNIQUE constraint (no two beers share an EAN, but multiple NULLs are
+  allowed)
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Beer
+
+# --- Happy path ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "ean",
+    [
+        "12345678",            # EAN-8
+        "123456789012",        # UPC-A
+        "1234567890123",       # EAN-13
+        "12345678901234",      # EAN-14
+    ],
+)
+async def test_beer_accepts_every_supported_ean_length(
+    db_session: AsyncSession, ean: str
+) -> None:
+    db_session.add(Beer(name=f"Beer {ean}", slug=f"beer-{ean}", ean_code=ean))
+    await db_session.commit()
+
+    loaded = (
+        await db_session.execute(select(Beer).where(Beer.slug == f"beer-{ean}"))
+    ).scalar_one()
+    assert loaded.ean_code == ean
+
+
+async def test_beer_accepts_null_ean_code(db_session: AsyncSession) -> None:
+    db_session.add(Beer(name="No barcode", slug="no-barcode"))
+    await db_session.commit()
+
+    loaded = (
+        await db_session.execute(select(Beer).where(Beer.slug == "no-barcode"))
+    ).scalar_one()
+    assert loaded.ean_code is None
+
+
+# --- Sad path ------------------------------------------------------------
+
+
+def test_beer_rejects_non_digit_ean_at_orm_layer() -> None:
+    with pytest.raises(ValueError, match="ean_code"):
+        Beer(name="X", slug="x", ean_code="123abc456")
+
+
+def test_beer_rejects_ean_with_unsupported_length() -> None:
+    # 9 digits is not a standard barcode length — ORM validator rejects.
+    with pytest.raises(ValueError, match="ean_code"):
+        Beer(name="X", slug="x", ean_code="123456789")
+
+
+def test_beer_rejects_empty_string_ean() -> None:
+    with pytest.raises(ValueError, match="ean_code"):
+        Beer(name="X", slug="x", ean_code="")
+
+
+async def test_beer_db_check_blocks_raw_sql_invalid_ean_length(
+    db_session: AsyncSession,
+) -> None:
+    """Last line of defence: the DB CHECK rejects bypass attempts.
+
+    Driving a raw insert through SQLAlchemy Core skips the ORM
+    validator. The migration's CHECK constraint must still reject the
+    bad length so corrupted rows cannot reach the DB.
+    """
+
+    from sqlalchemy import insert
+
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            insert(Beer).values(
+                name="Bypass",
+                slug="bypass",
+                ean_code="123456789",  # 9 digits — invalid length
+            )
+        )
+        await db_session.commit()
+
+
+# --- Edge cases ----------------------------------------------------------
+
+
+async def test_unique_constraint_blocks_two_beers_with_same_ean(
+    db_session: AsyncSession,
+) -> None:
+    db_session.add(Beer(name="First", slug="first", ean_code="3760231860119"))
+    await db_session.commit()
+
+    db_session.add(Beer(name="Second", slug="second", ean_code="3760231860119"))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_unique_constraint_allows_multiple_null_ean_rows(
+    db_session: AsyncSession,
+) -> None:
+    """SQLite + PostgreSQL both treat NULL as ``unknown`` in unique
+    constraints — multiple beers without an EAN must coexist."""
+
+    db_session.add(Beer(name="A", slug="a"))
+    db_session.add(Beer(name="B", slug="b"))
+    db_session.add(Beer(name="C", slug="c"))
+    await db_session.commit()
+
+    count = (
+        await db_session.execute(
+            select(Beer).where(Beer.ean_code.is_(None))
+        )
+    ).scalars().all()
+    assert len(count) == 3
+
+
+async def test_ean_code_can_be_unset_after_being_set(
+    db_session: AsyncSession,
+) -> None:
+    db_session.add(Beer(name="X", slug="x", ean_code="3760231860119"))
+    await db_session.commit()
+
+    beer = (
+        await db_session.execute(select(Beer).where(Beer.slug == "x"))
+    ).scalar_one()
+    beer.ean_code = None
+    await db_session.commit()
+
+    refreshed = (
+        await db_session.execute(select(Beer).where(Beer.slug == "x"))
+    ).scalar_one()
+    assert refreshed.ean_code is None

--- a/packages/beer-encyclopedia/tests/test_db/test_seed_sources.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_seed_sources.py
@@ -1,0 +1,86 @@
+"""Behaviour tests for ``scripts/seed_sources.py``.
+
+Mirrors the structure of ``test_seed_styles.py``: full population on a
+blank DB, idempotence on re-run, field refresh on drift. Adds a
+specific check that the ``openfoodfacts`` source is present after
+seeding — this row is the FK target the OFF importer relies on.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Source
+from scripts.seed_sources import SOURCES, seed_sources
+
+# --- Happy path ----------------------------------------------------------
+
+
+async def test_seed_creates_full_catalog_on_empty_db(
+    db_session: AsyncSession,
+) -> None:
+    created, updated = await seed_sources(db_session)
+
+    assert created == len(SOURCES)
+    assert updated == 0
+
+    count = (
+        await db_session.execute(select(func.count()).select_from(Source))
+    ).scalar_one()
+    assert count == len(SOURCES)
+
+
+async def test_openfoodfacts_source_is_seeded(db_session: AsyncSession) -> None:
+    await seed_sources(db_session)
+
+    off = (
+        await db_session.execute(
+            select(Source).where(Source.name == "openfoodfacts")
+        )
+    ).scalar_one()
+    assert off.source_type == "api"
+    assert off.base_url == "https://world.openfoodfacts.org"
+
+
+# --- Sad path ------------------------------------------------------------
+
+
+async def test_seed_is_idempotent(db_session: AsyncSession) -> None:
+    await seed_sources(db_session)
+
+    created, updated = await seed_sources(db_session)
+    assert created == 0
+    assert updated == len(SOURCES)
+
+    count = (
+        await db_session.execute(select(func.count()).select_from(Source))
+    ).scalar_one()
+    assert count == len(SOURCES)
+
+
+# --- Edge cases ----------------------------------------------------------
+
+
+async def test_seed_updates_changed_fields_on_rerun(
+    db_session: AsyncSession,
+) -> None:
+    await seed_sources(db_session)
+
+    off = (
+        await db_session.execute(
+            select(Source).where(Source.name == "openfoodfacts")
+        )
+    ).scalar_one()
+    off.base_url = "https://drifted.example.org"
+    off.description = "drifted description"
+    await db_session.commit()
+
+    await seed_sources(db_session)
+    refreshed = (
+        await db_session.execute(
+            select(Source).where(Source.name == "openfoodfacts")
+        )
+    ).scalar_one()
+    assert refreshed.base_url == "https://world.openfoodfacts.org"
+    assert "Open Food Facts" in refreshed.description

--- a/packages/beer-encyclopedia/tests/test_importers/test_openfoodfacts_client.py
+++ b/packages/beer-encyclopedia/tests/test_importers/test_openfoodfacts_client.py
@@ -13,8 +13,8 @@ exercised without ever leaving the process.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from decimal import Decimal
-from typing import Any
 
 import httpx
 import pytest
@@ -25,8 +25,12 @@ from importers.openfoodfacts import (
     OpenFoodFactsError,
 )
 
+# Type alias for the mock-transport handler signature so every test
+# stays self-documenting without leaning on `# type: ignore`.
+HttpxHandler = Callable[[httpx.Request], httpx.Response]
 
-def _build_client(handler) -> OpenFoodFactsClient:  # type: ignore[no-untyped-def]
+
+def _build_client(handler: HttpxHandler) -> OpenFoodFactsClient:
     transport = httpx.MockTransport(handler)
     httpx_client = httpx.AsyncClient(
         transport=transport,
@@ -39,7 +43,7 @@ def _build_client(handler) -> OpenFoodFactsClient:  # type: ignore[no-untyped-de
 
 
 async def test_fetch_by_ean_returns_full_snapshot_for_known_product() -> None:
-    payload: dict[str, Any] = {
+    payload: dict[str, object] = {
         "code": "3760231860119",
         "status": 1,
         "product": {
@@ -123,6 +127,39 @@ async def test_fetch_by_ean_raises_when_product_object_is_missing() -> None:
 
     async with _build_client(handler) as client:
         with pytest.raises(OpenFoodFactsError, match="no 'product' object"):
+            await client.fetch_by_ean("3760231860119")
+
+
+async def test_fetch_by_ean_wraps_httpx_transport_errors() -> None:
+    """Timeouts / DNS / connection resets become typed errors.
+
+    Without this guard the route would receive an uncaught
+    ``httpx.RequestError`` and surface a 500 instead of the intended
+    503. The wrapper keeps every failure mode flowing through
+    ``OpenFoodFactsError``.
+    """
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("simulated DNS / connect failure")
+
+    async with _build_client(handler) as client:
+        with pytest.raises(OpenFoodFactsError, match="transport error"):
+            await client.fetch_by_ean("3760231860119")
+
+
+async def test_fetch_by_ean_raises_when_payload_is_not_a_json_object() -> None:
+    """A misbehaving proxy could return a JSON list / number / string.
+
+    The client must reject anything that is not an object before it
+    reaches ``payload.get(...)``, otherwise the route would 500 on
+    ``AttributeError``.
+    """
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=["not", "an", "object"])
+
+    async with _build_client(handler) as client:
+        with pytest.raises(OpenFoodFactsError, match="not a JSON object"):
             await client.fetch_by_ean("3760231860119")
 
 

--- a/packages/beer-encyclopedia/tests/test_importers/test_openfoodfacts_client.py
+++ b/packages/beer-encyclopedia/tests/test_importers/test_openfoodfacts_client.py
@@ -1,0 +1,266 @@
+"""Behaviour tests for ``OpenFoodFactsClient``.
+
+Covers the three layers the client owns:
+- HTTP transport (404 + 5xx + non-JSON payload → controlled errors)
+- Status discrimination (OFF ``status=0`` → ``None``, ``status=1`` →
+  snapshot)
+- Field mapping (name preference, brand split, abv extraction, country
+  resolution, allergen normalisation, image URL fallback)
+
+Tests build a ``httpx.MockTransport`` so the real HTTP layer is
+exercised without ever leaving the process.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import httpx
+import pytest
+
+from importers.openfoodfacts import (
+    DEFAULT_BASE_URL,
+    OpenFoodFactsClient,
+    OpenFoodFactsError,
+)
+
+
+def _build_client(handler) -> OpenFoodFactsClient:  # type: ignore[no-untyped-def]
+    transport = httpx.MockTransport(handler)
+    httpx_client = httpx.AsyncClient(
+        transport=transport,
+        base_url=DEFAULT_BASE_URL,
+    )
+    return OpenFoodFactsClient(client=httpx_client)
+
+
+# --- Happy path ----------------------------------------------------------
+
+
+async def test_fetch_by_ean_returns_full_snapshot_for_known_product() -> None:
+    payload: dict[str, Any] = {
+        "code": "3760231860119",
+        "status": 1,
+        "product": {
+            "product_name": "Pelforth Brune",
+            "product_name_fr": "Pelforth Brune",
+            "brands": "Pelforth, Heineken France",
+            "countries_tags": ["en:france"],
+            "allergens_tags": ["en:gluten"],
+            "image_front_url": "https://example.org/pelforth.jpg",
+            "nutriments": {"alcohol_value": 6.5, "alcohol_unit": "% vol"},
+        },
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/v2/product/3760231860119.json"
+        return httpx.Response(200, json=payload)
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("3760231860119")
+
+    assert snapshot is not None
+    assert snapshot.external_id == "3760231860119"
+    assert snapshot.name == "Pelforth Brune"
+    assert snapshot.brand == "Pelforth"  # first of the comma list
+    assert snapshot.abv == Decimal("6.5")
+    assert snapshot.country_of_origin == "FR"
+    assert snapshot.allergens == ["gluten"]
+    assert snapshot.image_url == "https://example.org/pelforth.jpg"
+    # Audit trail keeps the full source payload.
+    assert snapshot.raw_payload == payload["product"]
+
+
+# --- Sad / not-found paths -----------------------------------------------
+
+
+async def test_fetch_by_ean_returns_none_when_off_reports_status_zero() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"code": "0000000000000", "status": 0})
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("0000000000000")
+
+    assert snapshot is None
+
+
+async def test_fetch_by_ean_returns_none_on_404() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="not found")
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("9999999999999")
+
+    assert snapshot is None
+
+
+# --- Error paths ---------------------------------------------------------
+
+
+async def test_fetch_by_ean_raises_on_5xx() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="bad gateway")
+
+    async with _build_client(handler) as client:
+        with pytest.raises(OpenFoodFactsError, match="HTTP 503"):
+            await client.fetch_by_ean("3760231860119")
+
+
+async def test_fetch_by_ean_raises_on_non_json_payload() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"<html>not json</html>")
+
+    async with _build_client(handler) as client:
+        with pytest.raises(OpenFoodFactsError, match="non-JSON payload"):
+            await client.fetch_by_ean("3760231860119")
+
+
+async def test_fetch_by_ean_raises_when_product_object_is_missing() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        # status=1 promises a product, but the dict has none.
+        return httpx.Response(200, json={"status": 1})
+
+    async with _build_client(handler) as client:
+        with pytest.raises(OpenFoodFactsError, match="no 'product' object"):
+            await client.fetch_by_ean("3760231860119")
+
+
+# --- Mapping edge cases --------------------------------------------------
+
+
+async def test_mapping_prefers_french_name_over_canonical() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "status": 1,
+                "product": {
+                    "product_name": "Generic name",
+                    "product_name_fr": "Nom français",
+                },
+            },
+        )
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("1234567890123")
+
+    assert snapshot is not None
+    assert snapshot.name == "Nom français"
+
+
+async def test_mapping_falls_back_to_placeholder_when_every_name_is_blank() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"status": 1, "product": {"product_name": "  ", "brands": "X"}},
+        )
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("1234567890123")
+
+    assert snapshot is not None
+    assert snapshot.name == "Unnamed product"
+
+
+async def test_mapping_handles_missing_nutriments_gracefully() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"status": 1, "product": {"product_name": "X"}},
+        )
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("1234567890123")
+
+    assert snapshot is not None
+    assert snapshot.abv is None
+    assert snapshot.country_of_origin is None
+    assert snapshot.allergens == []
+    assert snapshot.image_url is None
+    assert snapshot.brand is None
+
+
+async def test_mapping_resolves_belgian_country_tag() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "status": 1,
+                "product": {
+                    "product_name": "X",
+                    "countries_tags": ["en:belgium"],
+                },
+            },
+        )
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("1234567890123")
+
+    assert snapshot is not None
+    assert snapshot.country_of_origin == "BE"
+
+
+async def test_mapping_skips_unknown_country_slug() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "status": 1,
+                "product": {
+                    "product_name": "X",
+                    "countries_tags": ["en:atlantis"],
+                },
+            },
+        )
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("1234567890123")
+
+    assert snapshot is not None
+    # Unmapped slug → leave country blank rather than guessing.
+    assert snapshot.country_of_origin is None
+
+
+async def test_mapping_deduplicates_allergen_tokens_and_preserves_order() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "status": 1,
+                "product": {
+                    "product_name": "X",
+                    "allergens_tags": [
+                        "en:gluten",
+                        "fr:gluten",  # duplicate after stripping the prefix
+                        "en:sulfites",
+                    ],
+                },
+            },
+        )
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("1234567890123")
+
+    assert snapshot is not None
+    assert snapshot.allergens == ["gluten", "sulfites"]
+
+
+async def test_image_url_falls_back_to_image_url_when_front_missing() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "status": 1,
+                "product": {
+                    "product_name": "X",
+                    "image_url": "https://example.org/fallback.jpg",
+                },
+            },
+        )
+
+    async with _build_client(handler) as client:
+        snapshot = await client.fetch_by_ean("1234567890123")
+
+    assert snapshot is not None
+    assert snapshot.image_url == "https://example.org/fallback.jpg"


### PR DESCRIPTION
## Summary

Bridges the encyclopedia to its first real-world data source. A scanned EAN now produces a populated `Beer` + `Brewery` + `EntitySource` trio, exercising the polymorphic provenance infrastructure end-to-end and unlocking the **scan-to-fiche user journey** targeted for the soutenance.

This is **PR2 of the 3-step encyclopedia data-enrichment plan**:

- ✅ PR1 (#841) — French legal denomination reference
- ✅ #842 — `isascii()` follow-up fix
- ✅ #843 — PROJECT_LOG entry
- 🚀 **#NEW (this PR) — Open Food Facts connector**
- ⏳ PR3 (issue #803) — community scan loop (post-MVP)

## Changes

### New code

- **`importers/` package** (already declared in `pyproject.toml`'s `setuptools.packages.find` include list — see ADR-0003 §"Specific choices" #1 for the deviation from the original plan that called for `services/sources/`):
  - `base.ExternalBeerSnapshot` — source-agnostic dataclass contract
  - `openfoodfacts.OpenFoodFactsClient` — async `httpx` client + OFF JSON → snapshot mapping (name preference, brand split, abv extraction, country resolution, allergen dedup, image fallback)
  - `persistence.upsert_beer_from_snapshot` — single-transaction upsert of Beer + Brewery + EntitySource with conservative refresh policy (never overwrites `name`, `slug`, `description`, `style_id`, `legal_denomination`)
- **`Beer.ean_code`** column (`String(14)`, nullable) with:
  - ORM validator (digits + length 8/12/13/14, no checksum verification — see ADR-0003 §"Specific choices" #3)
  - DB `CHECK` on length (portable across PG / SQLite)
  - DB `UNIQUE` constraint that allows multiple NULLs on both backends
- **Migration `004_beer_ean_code.py`** uses `batch_alter_table` for cross-DB compat
- **`POST /beers/import-by-ean`** route with explicit HTTP semantics:
  - `201 Created` on first import
  - `200 OK` on idempotent re-import (refreshes `EntitySource.last_synced_at`)
  - `404 Not Found` when OFF reports the product as missing
  - `503 Service Unavailable` on transport / payload / seed-state failures with an actionable message
- **`BeerRead` extended** with `ean_code`, `legal_denomination`, `country_of_origin`, `allergens`, `alcohol_group`, `source` so the import response shows the enriched shape
- **`scripts/seed_sources.py`** registers the canonical `openfoodfacts` `Source` row that `EntitySource` references via FK; idempotent upsert matched by name
- **ADR-0003** documents the choice of OFF over Untappd / RateBeer / Open Brewery DB, the conservative refresh policy, the `importers/` package location, the no-checksum-validation trade-off, and the rejected alternatives

### Tests (38 new, 135/135 green, ruff clean)

| File | Count | Coverage |
|---|---|---|
| `tests/test_importers/test_openfoodfacts_client.py` | 13 | `httpx.MockTransport` — known EAN, status=0, 404, 5xx, non-JSON, missing product, FR name preference, brand split, abv, country, allergens, image fallback |
| `tests/test_db/test_beer_ean_code.py` | 9 | every supported length, NULL allowed, non-digit / wrong-length / empty rejected, raw SQL bypassed by DB CHECK, UNIQUE blocks duplicates while allowing multiple NULLs |
| `tests/test_db/test_seed_sources.py` | 4 | full seed, OFF row present, idempotent re-run, drift refresh |
| `tests/test_api/test_import_by_ean.py` | 12 | 201 create, 200 re-import, 404 unknown, 503 transport + missing seed, 422 invalid format, brewery upsert, snapshot without brand |

All test files follow the package convention of `# Happy path`, `# Sad path`, `# Edge cases` section markers.

## Manual verification

```bash
cd packages/beer-encyclopedia
alembic upgrade head                # 001 → 002 → 003 → 004 ✅
python scripts/seed_sources.py      # 1 created
python scripts/seed_sources.py      # 0 created, 1 updated (idempotent)
pytest -q tests/                    # 135 passed
ruff check .                        # All checks passed
```

## Notes for reviewers

1. **Deviation from the original plan**: the plan called for `services/sources/openfoodfacts.py`; we used `importers/openfoodfacts.py` instead because `importers*` is already in the `pyproject.toml` `setuptools.packages.find` include list. Avoided a config change. Documented in ADR-0003.
2. **No checksum validation on EAN**: external sources sometimes carry slightly malformed barcodes that are still useful as match keys. Format check (digits + length) is enough to catch typos. Trade-off documented.
3. **Conservative refresh policy**: a re-import only updates fields the importer owns; never overwrites `name`, `slug`, `description`, `style_id`, `legal_denomination`. Protects hand-edited or other-source-refined data.

## Checklist

- [x] Tests cover happy / sad / edge paths
- [x] `pytest -q tests/` passes (135 / 135)
- [x] `ruff check` clean on all touched files
- [x] Migration runs end-to-end on fresh SQLite
- [x] Seed script is idempotent
- [x] No `Any`, no inline styles introduced
- [x] ADR documents the rationale + rejected alternatives