### PR TITLE
fix(beer-encyclopedia): DB-first lookup in POST /beers/import-by-ean

### DIFF
--- a/packages/beer-encyclopedia/api/routers/beers.py
+++ b/packages/beer-encyclopedia/api/routers/beers.py
@@ -104,15 +104,36 @@ async def import_beer_by_ean(
 ) -> BeerRead:
     """Bootstrap or refresh a beer row from an Open Food Facts lookup.
 
-    Idempotent on the supplied ``ean``: a first call inserts a new row
-    (HTTP 201) and a subsequent call refreshes the same row in place
-    (HTTP 200) while bumping ``EntitySource.last_synced_at`` so the
-    audit trail records the new fetch.
+    **DB-first.** When the EAN is already known in the encyclopedia the
+    handler returns the existing row immediately with HTTP 200 and
+    never calls OFF — saving a network round-trip (~200–500 ms) and
+    keeping the endpoint usable when OFF is down for an EAN we already
+    have. The Open Food Facts call only fires on a database miss.
 
-    Returns 404 when OFF reports no product for the EAN — distinct from
-    a 503 (transport / payload-level failure) so a client can branch on
-    "unknown product" vs "service hiccup".
+    Status semantics:
+
+    - ``200 OK`` — the EAN matched an existing ``Beer`` row (no OFF
+      call) **or** OFF returned a payload that refreshed an existing
+      row matched by ``ean_code`` inside ``upsert_beer_from_snapshot``.
+    - ``201 Created`` — the EAN was unknown to the encyclopedia, OFF
+      returned a payload, and a new row was inserted.
+    - ``404 Not Found`` — the EAN is unknown both to the DB and to OFF.
+    - ``503 Service Unavailable`` — OFF transport / payload / seed-state
+      failure. Distinct from 404 so a client can branch on "unknown
+      product" vs "service hiccup".
     """
+
+    # DB-first: skip OFF entirely when the encyclopedia already has the
+    # row. Two upsides: (1) zero network call on the warm path, (2) the
+    # endpoint stays available even when OFF is degraded for a code we
+    # have on file. The cold path (DB miss) preserves the original
+    # OFF → upsert flow below.
+    existing = (
+        await session.execute(select(Beer).where(Beer.ean_code == payload.ean))
+    ).scalar_one_or_none()
+    if existing is not None:
+        response.status_code = status.HTTP_200_OK
+        return BeerRead.model_validate(existing)
 
     try:
         snapshot = await off_client.fetch_by_ean(payload.ean)

--- a/packages/beer-encyclopedia/api/routers/beers.py
+++ b/packages/beer-encyclopedia/api/routers/beers.py
@@ -85,13 +85,31 @@ async def _validate_fks(
     "/import-by-ean",
     response_model=BeerRead,
     responses={
-        200: {"description": "Existing beer refreshed from Open Food Facts."},
-        201: {"description": "Beer created from Open Food Facts."},
-        404: {"description": "Open Food Facts has no product for this EAN."},
+        200: {
+            "description": (
+                "Beer already known to the encyclopedia. Returned either "
+                "from a direct DB hit on `Beer.ean_code` (no Open Food "
+                "Facts call) or after Open Food Facts refreshed an "
+                "existing row matched downstream by EAN."
+            )
+        },
+        201: {
+            "description": (
+                "Beer was unknown to the encyclopedia and has been "
+                "created from the Open Food Facts payload."
+            )
+        },
+        404: {
+            "description": (
+                "EAN is unknown both to the local database and to "
+                "Open Food Facts."
+            )
+        },
         503: {
             "description": (
                 "Open Food Facts is unavailable or returned an unexpected "
-                "payload. Try again later."
+                "payload, and the EAN was not in the local database. "
+                "Try again later."
             )
         },
     },

--- a/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
@@ -250,7 +250,7 @@ async def test_second_import_is_idempotent_and_returns_200(
     stub_off_factory,  # type: ignore[no-untyped-def]
     seeded_source: Source,
 ) -> None:
-    stub_off_factory(lambda _: _build_pelforth_snapshot())
+    stub = stub_off_factory(lambda _: _build_pelforth_snapshot())
 
     first = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
     assert first.status_code == 201
@@ -260,7 +260,13 @@ async def test_second_import_is_idempotent_and_returns_200(
     assert second.status_code == 200
     assert second.json()["id"] == first_id
 
-    # Still exactly one beer + one audit row, last_synced_at refreshed.
+    # DB-first: the second call must short-circuit to the existing row
+    # WITHOUT touching OFF. Only the first call should appear in the
+    # stub's recorded calls.
+    assert stub.calls == [EAN_PELFORTH]
+
+    # Still exactly one beer + one audit row (the first import created
+    # both; the second short-circuit added neither).
     beers = (
         await db_session.execute(
             select(Beer).where(Beer.ean_code == EAN_PELFORTH)
@@ -276,6 +282,62 @@ async def test_second_import_is_idempotent_and_returns_200(
         )
     ).scalars().all()
     assert len(audits) == 1
+
+
+async def test_db_hit_returns_existing_beer_without_calling_off(
+    client: TestClient,
+    db_session: AsyncSession,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    """Pre-existing rows short-circuit the import route entirely.
+
+    Demonstrates the warm-path optimisation: when the EAN already lives
+    in the encyclopedia (regardless of how it got there — manual seed,
+    prior OFF import, future community contribution), we serve it from
+    the DB and never call OFF.
+    """
+
+    db_session.add(
+        Beer(
+            name="Pre-seeded Pelforth",
+            slug="pre-seeded-pelforth",
+            ean_code=EAN_PELFORTH,
+        )
+    )
+    await db_session.commit()
+
+    # The stub would explode if called — the route must not reach OFF.
+    stub = stub_off_factory(
+        lambda _: pytest.fail("OFF must not be called on a DB hit")  # type: ignore[arg-type,return-value]
+    )
+
+    response = client.post(
+        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ean_code"] == EAN_PELFORTH
+    assert response.json()["name"] == "Pre-seeded Pelforth"
+    assert stub.calls == []
+
+
+async def test_db_miss_still_falls_back_to_off(
+    client: TestClient,
+    db_session: AsyncSession,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    """Sanity check: when the EAN is unknown to the DB, OFF is queried."""
+
+    stub = stub_off_factory(lambda _: _build_pelforth_snapshot())
+
+    response = client.post(
+        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
+    )
+
+    assert response.status_code == 201
+    assert stub.calls == [EAN_PELFORTH]
 
 
 async def test_import_with_snapshot_missing_brand_skips_brewery(


### PR DESCRIPTION
## Summary

Skip the Open Food Facts call when the EAN is already known to the encyclopedia. **Two upsides on the warm path :**

- **Zero network round-trip** when a previously-imported beer (or a manual seed, or a future community contribution) is asked for again. Saves ~200–500 ms per request.
- **The endpoint stays available** even when OFF is degraded for an EAN we already have on file.

The cold path (DB miss) is unchanged: OFF → snapshot → upsert + 201.

Follow-up of PR #847 (\`5ad8b92\`) — addresses the design issue surfaced during pre-merge review of #847 (the original endpoint always queried OFF, even when the EAN was in the DB).

## Updated status semantics

| Code | When | OFF call ? |
|---|---|---|
| **200** | DB hit (existing row returned as-is) | **No** |
| **200** | DB miss + OFF refresh (rare; upsert matches downstream by \`ean_code\`) | Yes |
| **201** | DB miss + OFF first-time insert | Yes |
| **404** | EAN unknown to both DB and OFF | Yes |
| **503** | OFF transport / payload / seed-state failure | Yes |

## Tests (139 passing, +2 vs baseline 137)

- \`test_db_hit_returns_existing_beer_without_calling_off\` — pre-seeds a \`Beer\` with the target EAN, then asserts the route returns 200, exposes the existing fields, and the OFF stub records zero calls. The stub is wired with \`pytest.fail\` so any reach into OFF would surface immediately.
- \`test_db_miss_still_falls_back_to_off\` — sanity guard on the cold path: no pre-seed, OFF is called exactly once, route returns 201.
- Updated \`test_second_import_is_idempotent_and_returns_200\` to assert \`stub.calls == [EAN_PELFORTH]\` after both calls (now explicit that the second call short-circuits — was implicit before).

## Manual verification

\`\`\`bash
cd packages/beer-encyclopedia
pytest -q tests/test_api/test_import_by_ean.py     # 12 → 14 passing
pytest -q tests/                                    # 139 passing total
ruff check api/routers/beers.py tests/test_api/test_import_by_ean.py
\`\`\`

## Notes

- Helper logic is intentionally inline in the route (~5 lines: \`select(Beer).where(Beer.ean_code == ...)\`). PR2.5 (the larger \`/scan\` wiring) will extract it into a shared helper if reuse becomes meaningful.
- No schema change. No new migration.
- No breaking change on existing API contracts.

## Checklist

- [x] Tests cover happy / sad / edge paths
- [x] \`pytest -q tests/\` passes (139 / 139)
- [x] \`ruff check\` clean on touched files
- [x] No \`Any\`, no inline styles introduced
- [x] Existing tests still green (no regression)