### PR TITLE
chore(beer-encyclopedia): add scan-photos local folder for manual /scan testing

### DIFF
--- a/packages/beer-encyclopedia/scan-photos/.gitignore
+++ b/packages/beer-encyclopedia/scan-photos/.gitignore
@@ -1,0 +1,8 @@
+# Local-only beer label photos used for manual /scan endpoint testing.
+# Photos are heavy (1-5 MB each) and personal — never commit them to the
+# repo. The folder structure, the README, this .gitignore and the
+# findings log are kept under version control.
+*
+!.gitignore
+!README.md
+!findings.md

--- a/packages/beer-encyclopedia/scan-photos/README.md
+++ b/packages/beer-encyclopedia/scan-photos/README.md
@@ -1,0 +1,90 @@
+# scan-photos — local manual test photos
+
+Local-only directory for **real beer label photos** used to manually
+exercise the `POST /scan` endpoint end-to-end. Photos themselves are
+**never committed** (1–5 MB each, personal data, low repository value);
+only the folder structure + this README + the findings log are version
+controlled.
+
+## Why this exists
+
+Until a YOLO checkpoint is trained and a mobile barcode scanner ships
+(see issue #803 and the PR2.5a chantier), the only way to validate the
+full ML pipeline (`infer.py` → `ocr.py` → `extract.py` → `recommender.py`)
+on real-world input is to capture photos by hand and feed them to the
+`/scan` route locally. This folder centralises those photos so they
+are easy to find, easy to re-run after pipeline changes, and easy to
+augment over time.
+
+## Convention de nommage suggérée
+
+Pas d'enforcement, mais pour s'y retrouver après plusieurs sessions :
+
+```
+YYYY-MM-DD_<beer-slug>_<face>.jpg
+```
+
+Examples :
+
+```
+2026-05-02_pelforth-brune_front.jpg
+2026-05-02_chouffe-blonde_back.jpg
+2026-05-02_unknown-craft-no-name.jpg
+```
+
+Where:
+
+- `YYYY-MM-DD` — capture date, helps sort the folder chronologically.
+- `<beer-slug>` — descriptive name; use `unknown-...` when the goal of
+  the test is precisely to see what the OCR pipeline guesses.
+- `<face>` — `front`, `back`, `top` or `macro`.
+
+## Workflow
+
+1. Take a photo on a phone (Android: JPEG by default; iPhone: configure
+   *Settings → Camera → Formats → Most Compatible* to get JPEG instead
+   of HEIC, otherwise convert before transfer).
+2. Transfer the photo into this folder by any means (USB, KDE Connect,
+   Telegram desktop, Quick Share, …).
+3. Tell the assistant: *"new photo added"* or *"check the scan-photos
+   folder"*. The assistant will `ls` the folder, run `curl -X POST
+   /scan -F file=@<path>` for each fresh entry, parse the JSON
+   response, and compare against the human-readable label.
+4. Findings are appended to [`findings.md`](./findings.md) as a session
+   log: ground truth (what the label actually says), pipeline output,
+   delta, observations.
+
+## What is `.gitignore`d
+
+Everything in this directory **except**:
+
+- `.gitignore`
+- `README.md` (this file)
+- `findings.md` (the persistent test log)
+
+Verify with `git check-ignore -v packages/beer-encyclopedia/scan-photos/<filename>`.
+
+## Cleanup policy
+
+Photos accumulate over time. Manage manually for now: once `findings.md`
+references the relevant takeaways, the source photo can usually be
+deleted. The folder is not meant to grow into a long-term archive — for
+that, ingest curated entries into the encyclopedia DB (see the
+upcoming book-ingestion pipeline in issue #857).
+
+## Out of scope
+
+- **Test fixtures committed to the repo for CI**: a separate pattern
+  (small, license-clear photos under `tests/fixtures/`) handled in a
+  later issue when the YOLO training dataset workflow lands.
+- **Photo storage as `Media` rows in the DB**: that is the responsibility
+  of the community contribution loop (PR3, issue #803), not this manual
+  testing folder.
+
+## References
+
+- [`api/routers/scan.py`](../api/routers/scan.py) — endpoint we exercise
+- [`ml/pipeline.py`](../ml/pipeline.py) — orchestration
+- [`ml/schemas.py`](../ml/schemas.py) — `ScanResponse` shape
+- [`docs/dataset/DATASET_STRATEGY_SPRINT1.md`](../docs/dataset/DATASET_STRATEGY_SPRINT1.md)
+  — broader dataset strategy this folder is a stepping stone toward

--- a/packages/beer-encyclopedia/scan-photos/README.md
+++ b/packages/beer-encyclopedia/scan-photos/README.md
@@ -16,15 +16,15 @@ on real-world input is to capture photos by hand and feed them to the
 are easy to find, easy to re-run after pipeline changes, and easy to
 augment over time.
 
-## Convention de nommage suggérée
+## Suggested naming convention
 
-Pas d'enforcement, mais pour s'y retrouver après plusieurs sessions :
+No enforcement, but to navigate the folder after several sessions:
 
 ```
 YYYY-MM-DD_<beer-slug>_<face>.jpg
 ```
 
-Examples :
+Examples:
 
 ```
 2026-05-02_pelforth-brune_front.jpg

--- a/packages/beer-encyclopedia/scan-photos/findings.md
+++ b/packages/beer-encyclopedia/scan-photos/findings.md
@@ -1,0 +1,45 @@
+# scan-photos — manual test session log
+
+Persistent log of `/scan` endpoint test sessions against real beer
+label photos collected in this folder. Each session captures **what
+was tested**, **what the pipeline returned**, and **what we learned**
+— so future contributors can see how the ML accuracy evolves over
+time and what the recurring failure modes are.
+
+## Format
+
+One H2 section per test session, dated. Within a session, one H3 per
+photo. Within a photo, three subsections:
+
+- **Ground truth** — what a human reading the label sees (for
+  comparison).
+- **`/scan` output** — relevant fields from the JSON response.
+- **Observations** — what worked, what failed, hypotheses, follow-up
+  issues to open.
+
+Sessions are append-only — never edit past entries, only add new
+ones. Treat this file like an experimental notebook.
+
+## Sessions
+
+<!-- Add new sessions below this line, most recent on top. -->
+
+---
+
+## 2026-05-02 — Session 1 (template)
+
+First test session against the live `/scan` endpoint after merging
+PR #847 (Open Food Facts connector) and PR #848 (DB-first lookup).
+The encyclopedia pipeline runs in **full-image fallback** mode (no
+YOLO checkpoint trained yet), so detection is the entire frame and
+EasyOCR is asked to read everything.
+
+Goal: surface the regex extractor's weak spots on real-world labels
+before committing time to PR2.5a (live barcode scanner).
+
+### Photo 1 — pending
+
+- **File**: `<filename to be added>`
+- **Ground truth**: _(to fill after capture)_
+- **`/scan` output**: _(to fill after running the endpoint)_
+- **Observations**: _(to fill after analysis)_


### PR DESCRIPTION
## Summary

Centralises real beer-label photos used to manually exercise the \`POST /scan\` endpoint end-to-end. Until a YOLO checkpoint is trained and the live mobile barcode scanner ships (issue #803, PR2.5a chantier), hand-captured photos are the only way to validate the full ML pipeline (\`infer\` -> \`ocr\` -> \`extract\` -> \`recommender\`) on real-world input.

## Changes

| File | Status | Purpose |
|---|---|---|
| \`scan-photos/.gitignore\` | NEW (committed) | Exclude every file in the folder except the 3 anchor files |
| \`scan-photos/README.md\` | NEW (committed) | Purpose, naming convention, workflow, OS notes (HEIC), retention policy |
| \`scan-photos/findings.md\` | NEW (committed) | Append-only test session log |

Photo files (jpg/png/heic/webp) are intentionally **not committed**: heavy, personal, low repository value. The folder structure + README + findings log stay under version control so the folder is self-documenting and the test history persists across machines.

## Naming convention (suggested)

\`\`\`
YYYY-MM-DD_<beer-slug>_<face>.jpg
\`\`\`

Examples: \`2026-05-02_pelforth-brune_front.jpg\`, \`2026-05-02_chouffe-blonde_back.jpg\`, \`2026-05-02_unknown-craft-no-name.jpg\`.

## .gitignore pattern

The folder uses a local \`.gitignore\` rather than adding to the package-level \`.gitignore\` so the rules are co-located with the data they govern (more discoverable for future contributors):

\`\`\`gitignore
*
!.gitignore
!README.md
!findings.md
\`\`\`

Verified manually: a \`fake-photo.jpg\` dropped in the folder is correctly ignored, while the 3 anchor files stay tracked.

## Why now

Manual /scan validation is needed **before** committing time to PR2.5a (live barcode mobile scanner). The first session today (2026-05-02) immediately surfaced an OCR pipeline bug (paragraph=True silently dropped all results on dispersed-text labels) — fixed in PR coming next.

## Checklist

- [x] Folder structure committed
- [x] .gitignore pattern verified manually
- [x] README documents the workflow + naming + OS notes
- [x] findings.md ready to be appended in subsequent test sessions
- [x] No \`Any\`, no inline styles introduced