### PR TITLE
fix(beer-encyclopedia): use paragraph=False in EasyOCR readtext to surface dispersed label text

### DIFF
--- a/packages/beer-encyclopedia/ml/ocr.py
+++ b/packages/beer-encyclopedia/ml/ocr.py
@@ -53,12 +53,23 @@ def _read_text(crop: np.ndarray, languages: Sequence[str]) -> tuple[str, float, 
                 confs.append(conf)
         return texts, confs
 
-    raw_results = reader.readtext(crop, detail=1, paragraph=True)
+    # ``paragraph=False`` (the EasyOCR default) returns one item per
+    # detected text region with its individual confidence. ``paragraph=True``
+    # tries to group regions into coherent blocks first and silently
+    # returns nothing when it cannot — which happens systematically on
+    # beer labels where the text is dispersed (name in the middle, slogan
+    # in an arc, ABV diagonally in a corner, capacity sideways). The
+    # downstream extractor (``extract.py``) operates on per-region text
+    # already and benefits from seeing every fragment, even low-confidence
+    # ones. Empirically, ``paragraph=True`` returned 0 results on every
+    # one of nine real bottle photos that ``paragraph=False`` parsed into
+    # 10–13 text fragments each. Stay with ``False``.
+    raw_results = reader.readtext(crop, detail=1, paragraph=False)
     texts, confs = parse(raw_results)
 
     if not texts:
         preprocessed = _preprocess_for_ocr(crop)
-        pre_results = reader.readtext(preprocessed, detail=1, paragraph=True)
+        pre_results = reader.readtext(preprocessed, detail=1, paragraph=False)
         texts, confs = parse(pre_results)
         if texts:
             notes.append("OCR succeeded after preprocessing.")

--- a/packages/beer-encyclopedia/ml/ocr.py
+++ b/packages/beer-encyclopedia/ml/ocr.py
@@ -56,14 +56,14 @@ def _read_text(crop: np.ndarray, languages: Sequence[str]) -> tuple[str, float, 
     # ``paragraph=False`` (the EasyOCR default) returns one item per
     # detected text region with its individual confidence. ``paragraph=True``
     # tries to group regions into coherent blocks first and silently
-    # returns nothing when it cannot — which happens systematically on
-    # beer labels where the text is dispersed (name in the middle, slogan
-    # in an arc, ABV diagonally in a corner, capacity sideways). The
-    # downstream extractor (``extract.py``) operates on per-region text
-    # already and benefits from seeing every fragment, even low-confidence
-    # ones. Empirically, ``paragraph=True`` returned 0 results on every
-    # one of nine real bottle photos that ``paragraph=False`` parsed into
-    # 10–13 text fragments each. Stay with ``False``.
+    # returns an empty list when it cannot — which happens systematically
+    # on beer labels where the text is dispersed (name in the middle,
+    # slogan in an arc, ABV diagonally in a corner, capacity sideways).
+    # The downstream extractor (``ml/extract.py``) operates on per-region
+    # text already and benefits from seeing every fragment, even at low
+    # confidence. Empirically, ``paragraph=True`` returned 0 results on
+    # every one of nine real bottle photos that ``paragraph=False`` parsed
+    # into 10–13 text fragments each. Stay with ``False``.
     raw_results = reader.readtext(crop, detail=1, paragraph=False)
     texts, confs = parse(raw_results)
 

--- a/packages/beer-encyclopedia/tests/test_ml/test_ocr.py
+++ b/packages/beer-encyclopedia/tests/test_ml/test_ocr.py
@@ -1,0 +1,123 @@
+"""Regression tests for ``ml/ocr.py``.
+
+The single most important behavioural property guarded here is that
+EasyOCR is called with ``paragraph=False``. Setting it to ``True`` (the
+historical state of the file before #861) silently dropped every
+result on real-world dispersed beer-label photos. Anyone who later
+re-enables ``paragraph=True`` thinking it looks cleaner must trip
+these tests immediately, not discover the regression in production by
+seeing scans return ``detected_text=""``.
+
+Tests stub ``ml.ocr._get_reader`` with a ``MagicMock`` so the real
+EasyOCR model never loads — they verify the ``readtext`` argument
+contract, not the ML output.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from ml.ocr import _read_text
+
+
+def _make_easyocr_result(text: str, conf: float) -> list:
+    """Return a value shaped like EasyOCR's ``readtext`` output."""
+
+    bbox = [[0, 0], [10, 0], [10, 10], [0, 10]]
+    return [(bbox, text, conf)]
+
+
+def _build_crop() -> np.ndarray:
+    """Return a small non-empty crop the function will accept."""
+
+    return np.zeros((20, 20, 3), dtype=np.uint8) + 1
+
+
+def test_read_text_calls_easyocr_with_paragraph_false_on_first_pass() -> None:
+    """The raw read must use ``paragraph=False``.
+
+    This is the regression guard that closes the original bug fixed in
+    PR #861. Forcing ``paragraph=True`` regroups EasyOCR's per-region
+    results into "paragraphs" — a heuristic that fails systematically
+    on dispersed beer-label text and silently returns an empty list.
+    """
+
+    fake_reader = MagicMock()
+    fake_reader.readtext.return_value = _make_easyocr_result("hello", 0.85)
+
+    with patch("ml.ocr._get_reader", return_value=fake_reader):
+        text, conf, notes = _read_text(_build_crop(), ("en", "fr"))
+
+    fake_reader.readtext.assert_called_once()
+    call_kwargs = fake_reader.readtext.call_args.kwargs
+    assert call_kwargs.get("paragraph") is False, (
+        "ml/ocr.py must call readtext with paragraph=False — see the "
+        "comment in _read_text for the empirical justification."
+    )
+    assert text == "hello"
+    assert conf == 0.85
+    assert notes == []
+
+
+def test_read_text_uses_paragraph_false_in_preprocessed_retry() -> None:
+    """The preprocessed retry must also use ``paragraph=False``.
+
+    When the raw read returns no text, the OCR layer falls back to a
+    bilateral-filtered + adaptive-thresholded crop and tries again. If
+    only one of the two ``readtext`` call sites is fixed to
+    ``paragraph=False``, real photos that need preprocessing would
+    silently regress.
+    """
+
+    fake_reader = MagicMock()
+    fake_reader.readtext.side_effect = [
+        [],  # raw pass: empty
+        _make_easyocr_result("found-after-preprocess", 0.7),  # retry hits
+    ]
+
+    with patch("ml.ocr._get_reader", return_value=fake_reader):
+        text, conf, notes = _read_text(_build_crop(), ("en", "fr"))
+
+    assert fake_reader.readtext.call_count == 2
+    for call in fake_reader.readtext.call_args_list:
+        assert call.kwargs.get("paragraph") is False, (
+            "Both the raw and preprocessed readtext calls in "
+            "ml/ocr.py must use paragraph=False."
+        )
+    assert text == "found-after-preprocess"
+    assert "OCR succeeded after preprocessing." in notes
+
+
+def test_read_text_returns_empty_when_both_passes_find_nothing() -> None:
+    """The two-pass fallback returns a typed empty result, not None.
+
+    Defensive guard so callers can always rely on the
+    ``(str, float, list[str])`` shape regardless of what EasyOCR did.
+    """
+
+    fake_reader = MagicMock()
+    fake_reader.readtext.side_effect = [[], []]
+
+    with patch("ml.ocr._get_reader", return_value=fake_reader):
+        text, conf, notes = _read_text(_build_crop(), ("en", "fr"))
+
+    assert text == ""
+    assert conf == 0.0
+    assert "No OCR text extracted." in notes
+
+
+def test_read_text_short_circuits_on_empty_crop() -> None:
+    """An empty crop bypasses EasyOCR entirely with a recorded note."""
+
+    empty = np.zeros((0, 0, 3), dtype=np.uint8)
+    fake_reader = MagicMock()
+
+    with patch("ml.ocr._get_reader", return_value=fake_reader):
+        text, conf, notes = _read_text(empty, ("en", "fr"))
+
+    fake_reader.readtext.assert_not_called()
+    assert text == ""
+    assert conf == 0.0
+    assert "Empty crop for OCR." in notes


### PR DESCRIPTION
## Summary

The OCR layer called \`reader.readtext(crop, detail=1, paragraph=True)\`, which silently returned no results on every one of nine real bottle photos used in a manual /scan validation session today. Setting \`paragraph\` to \`False\` (the EasyOCR default) recovered 10–13 text fragments per photo on the same inputs.

## Why the bug bites beer labels specifically

\`paragraph=True\` asks EasyOCR to **group** its detected text regions into coherent blocks before returning. The grouping heuristic assumes regions live on roughly aligned baselines, the way they do in a document scan.

**Beer labels almost never look like that.** The brand name sits in the middle, the slogan curves around the perimeter, the ABV is angled in a corner, the capacity is sideways elsewhere. The grouper cannot form any block, returns an empty list, and the downstream extractor sees \`detected_text = \"\"\` even though EasyOCR did detect text individually.

## Empirical evidence

Manual /scan test on 9 real bottle photos (in PR #860 \`scan-photos/\` folder):

| State | Photos with non-empty \`detected_text\` | Photos with extracted \`name\` / \`style\` / \`abv\` |
|---|---|---|
| **Before** (\`paragraph=True\`) | 0 / 9 | 0 / 9 |
| **After** (\`paragraph=False\`) | **9 / 9** | 4 / 9 names, 3 / 9 styles, 2 / 9 ABV (best-of-class beers gave correct extraction; decorative cursive labels gave fragmented but non-empty text) |

Direct EasyOCR test on the same photo (bypassing our pipeline):

\`\`\`python
reader.readtext(img, detail=1)  # no paragraph argument => default False
# returns 13 text fragments: 'Goudale', 'Ambree', 'Alc720', etc.
\`\`\`

Same call with \`paragraph=True\` returns \`[]\` on the exact same image.

## Changes

- \`packages/beer-encyclopedia/ml/ocr.py\` — both call sites updated (raw read + preprocessed retry):
  \`\`\`diff
  - reader.readtext(crop, detail=1, paragraph=True)
  + reader.readtext(crop, detail=1, paragraph=False)
  \`\`\`
- A 9-line comment captures the empirical evidence so a future contributor does not silently re-enable \`paragraph=True\` thinking it looks cleaner.

## Why this is the right default for our use case

- The downstream extractor (\`extract.py\`) operates on **per-region text already** and prefers more fragments to fewer, even at low confidence.
- Beer labels are visually dispersed by design (branding > readability priority).
- EasyOCR's \`paragraph=False\` is its native default — we were the ones overriding it without justification.

## Out of scope (captured separately)

- Improvements to the regex extractor (\`extract.py\`) to better handle:
  - ABV in formats like \`Alc720 |\` (lit as 720 instead of 7.2)
  - Name extraction blacklist (currently picks generic words like \`Ingredients\`, \`MÉDAILLE\`)
  - French-language style keywords (e.g. \`ambrée\` -> \`amber_ale\`)

  → These deserve their own issue — observed during the same /scan session.

- Mobile-side photo capture quality improvements — issue #858.
- Visual recognition fallback when OCR fails entirely on decorative labels — issue #859.

## Tests

- Existing OCR test suite passes unchanged (it does not exercise dispersed-text labels yet — would benefit from a fixture-based addition once we have license-clear test images).
- Manual end-to-end validation: 9 real bottle photos, 9 / 9 returned non-empty text after the fix.

## References

- PR #860 — \`scan-photos/\` folder where the test session lives
- Issue #858 — mobile capture quality (complementary)
- Issue #859 — visual recognition fallback (complementary)

## Checklist

- [x] Bug reproduced in production-equivalent conditions
- [x] Fix verified on all 9 test photos
- [x] Comment explains the why (with empirical numbers) so the change is not undone later
- [x] Existing tests still green
- [x] No \`Any\`, no inline styles introduced