### PR TITLE
feat(mobile-app): wire Python beer-encyclopedia as fallback for /scan/lookup 404 + ADR-0005 backend split

### DIFF
--- a/docs/architecture/decisions/0002-centralized-nestjs-backend.md
+++ b/docs/architecture/decisions/0002-centralized-nestjs-backend.md
@@ -1,6 +1,6 @@
 # ADR-0002 — Centralized NestJS backend for all external data sources
 
-**Status**  Accepted
+**Status**  Accepted (partially superseded by ADR-0005 for the beer-data axis)
 **Date**    2026-04-24
 **Owners**  @benoit-bremaud
 

--- a/docs/architecture/decisions/0005-backend-split-encyclopedia-vs-product.md
+++ b/docs/architecture/decisions/0005-backend-split-encyclopedia-vs-product.md
@@ -16,20 +16,22 @@
 
 Two backends have evolved in parallel inside this monorepo:
 
-- **NestJS API** (`packages/api/`) — TypeORM, Postgres. Owns auth,
-  user accounts, user-submitted recettes, brassins, academy progress,
-  feedback, and (until now) a `scan_catalog_items` table that caches
-  beer data fetched from Open Food Facts on barcode scan.
+- **NestJS API** (`packages/api/`) — TypeORM, SQLite (`better-sqlite3`)
+  in dev/CI, Postgres-ready for production. Owns auth, user accounts,
+  user-submitted recettes, brassins, academy progress, feedback, and
+  (until now) a `scan_catalog_items` table that caches beer data
+  fetched from Open Food Facts on barcode scan.
 - **Python beer-encyclopedia** (`packages/beer-encyclopedia/`) —
-  FastAPI, async SQLAlchemy, Postgres. Owns a richer beer/brewery
-  domain (`beers`, `breweries`, `styles`, `legal_denominations`,
-  `sources`, `entity_sources`, `tasting_profiles`, `ingredients`,
+  FastAPI, async SQLAlchemy, SQLite (`aiosqlite`) in dev/CI,
+  Postgres-ready for production. Owns a richer beer/brewery domain
+  (`beers`, `breweries`, `styles`, `legal_denominations`, `sources`,
+  `entity_sources`, `tasting_profiles`, `ingredients`,
   `community_corrections`, `media`) plus the ML pipeline
   (YOLOv8 + EasyOCR) and an Open Food Facts importer.
 
 Both backends ended up implementing roughly the same "barcode → beer
 fiche" flow with their own Open Food Facts client, their own cache,
-and their own Postgres table. The mobile app today only talks to
+and their own table. The mobile app today only talks to
 NestJS for that flow; the Python backend, despite shipping a complete
 solution in PR #847 + #848, is consumed by no production code path.
 
@@ -163,10 +165,10 @@ migration on either side.
 
 ### Trade-offs
 
-- **Two backends to operate**: both must run, both have their own
-  Postgres database (or at least their own schema), both have CI.
-  Mitigated by: NestJS already exists and is mature; Python is small
-  and self-contained.
+- **Two backends to operate**: both must run, both maintain their own
+  schema and migrations (SQLite in dev/CI, Postgres-ready for
+  production), both have CI. Mitigated by: NestJS already exists and
+  is mature; Python is small and self-contained.
 - **Mobile app speaks two HTTP base URLs**: a small amount of plumbing
   in `core/http/http-client.ts` to support a `baseUrl` override. Done
   in the PR that ships this ADR.

--- a/docs/architecture/decisions/0005-backend-split-encyclopedia-vs-product.md
+++ b/docs/architecture/decisions/0005-backend-split-encyclopedia-vs-product.md
@@ -1,0 +1,205 @@
+# ADR-0005 — Backend split: Python beer-encyclopedia is the knowledge base, NestJS is the product
+
+**Status**  Accepted
+**Date**    2026-05-02
+**Owners**  @benoit-bremaud
+
+> **Supersedes the implicit "single backend" assumption** that ADR-0002
+> ("Centralized NestJS backend for all external data sources") relied
+> on. ADR-0002 itself stays valid for the **product** APIs it describes
+> (auth, recettes utilisateurs, academy, feedback) — only the part
+> covering external beer-data sources is replaced by this ADR.
+
+---
+
+## Context
+
+Two backends have evolved in parallel inside this monorepo:
+
+- **NestJS API** (`packages/api/`) — TypeORM, Postgres. Owns auth,
+  user accounts, user-submitted recettes, brassins, academy progress,
+  feedback, and (until now) a `scan_catalog_items` table that caches
+  beer data fetched from Open Food Facts on barcode scan.
+- **Python beer-encyclopedia** (`packages/beer-encyclopedia/`) —
+  FastAPI, async SQLAlchemy, Postgres. Owns a richer beer/brewery
+  domain (`beers`, `breweries`, `styles`, `legal_denominations`,
+  `sources`, `entity_sources`, `tasting_profiles`, `ingredients`,
+  `community_corrections`, `media`) plus the ML pipeline
+  (YOLOv8 + EasyOCR) and an Open Food Facts importer.
+
+Both backends ended up implementing roughly the same "barcode → beer
+fiche" flow with their own Open Food Facts client, their own cache,
+and their own Postgres table. The mobile app today only talks to
+NestJS for that flow; the Python backend, despite shipping a complete
+solution in PR #847 + #848, is consumed by no production code path.
+
+We discovered this duplication while planning to wire the mobile app
+to the Python backend. Continuing to evolve both in parallel would
+double the maintenance cost forever and silently fork the data: the
+same beer could exist independently in `scan_catalog_items` (NestJS)
+and `beers` (Python) with no synchronisation between the two.
+
+---
+
+## Decision
+
+**One concern per backend.** The two backends keep coexisting, but
+each owns a **clearly distinct domain** with no overlap.
+
+### Python beer-encyclopedia = the **knowledge base**
+
+> *"The world's beer reference, started in France."*
+
+Owns every fact about beers, breweries, styles, regulatory metadata,
+ingredients, and tasting profiles. Multi-source by design (OFF today,
+Untappd / RateBeer / AI-research / community / printed books later,
+all unified by `Source` + `EntitySource`). Carries no user data.
+**Public-facing in vocation**: could one day be queried by other
+products beyond Brasse-Bouillon.
+
+Owns:
+
+- `beers`, `breweries`, `styles`, `legal_denominations`
+- `sources`, `entity_sources` (audit trail of ingestions)
+- `tasting_profiles`, `ingredients`, `beer_ingredients`
+- `community_corrections`, `media`
+- The OFF importer + future Untappd / RateBeer / AI-research importers
+- The ML pipeline (YOLO + EasyOCR + extractors)
+
+### NestJS API = the **product backend**
+
+> *"The Brasse-Bouillon app: users, their recettes, their brassins, their academy."*
+
+Owns everything that belongs to a single user or to the Brasse-Bouillon
+product specifically. Stays as the authentication + sessions + user-data
+backend. Calls the Python knowledge base **read-only** when it needs
+factual beer data inside a user-facing flow.
+
+Owns:
+
+- `users`, sessions, OAuth, password hashing
+- `recipes` (user-submitted), `brassins` (brewing day calendar)
+- `academy` articles + per-user progression
+- Feedback, ratings, social features
+- All other product-specific concerns
+- **Will lose** the `scan_catalog_items` table and the `scan/` module,
+  which become Python's responsibility (deprecation roadmap below).
+
+### Mobile app
+
+The mobile app is allowed to talk to **both** backends:
+
+- **NestJS** for everything user-related (login, the user's recettes,
+  the user's brassins, the academy progress, feedback).
+- **Python beer-encyclopedia** for everything beer-fact related (the
+  scan→fiche flow, beer detail browse, future catalog search).
+
+This explicitly relaxes ADR-0002's "mobile talks only to NestJS"
+constraint **for the knowledge-base axis only**. The principle
+ADR-0002 defended (one integration surface for cross-source data)
+still applies, just delegated to Python instead of NestJS for the
+beer-data axis.
+
+---
+
+## Why the previous duplication is not wasted work
+
+Both backends shipped working code. Neither effort is thrown away:
+
+- **NestJS scan module** (`scan_catalog_items`, OFF client, `GET /scan/lookup/:ean`,
+  rate limiter, "not a beer" detection) made it possible to ship the
+  mobile scan UX **before** Python beer-encyclopedia was production-ready.
+  It is a transitional layer that will be retired.
+- **Python beer-encyclopedia** (`beers`, `breweries`, `legal_denominations`,
+  `Source`/`EntitySource` audit trail, OFF importer, conservative
+  refresh, regression tests around `paragraph=False`, …) is the
+  long-term home. PRs #841 → #861 are **exactly** what we want;
+  they were just isolated until this ADR.
+
+The duplication is the cost of two parallel sprints discovering they
+solved the same problem independently. The fix is consolidation, not
+rewrite.
+
+---
+
+## Roadmap (deprecation of NestJS scan module)
+
+Sequenced over post-soutenance, no soutenance blocker:
+
+1. **Wire the mobile fallback** (this PR): when NestJS `GET /scan/lookup/:ean`
+   returns 404, the mobile app calls Python `POST /beers/import-by-ean`.
+   First mobile↔Python connection in production.
+2. **Promote Python to primary** (separate PR, post-soutenance):
+   the mobile app calls Python first, NestJS only as a transitional
+   read-through cache while data migrates.
+3. **ETL** (separate PR): script that copies every `scan_catalog_items`
+   row from NestJS into Python `beers` (idempotent, source-tagged).
+4. **Retire** (separate PR): remove the `scan/` module from NestJS
+   along with its database table, OFF client, controller, service,
+   and tests. NestJS `EXPO_PUBLIC_API_URL` continues to serve
+   everything else.
+
+The mobile app evolves in lockstep across these steps; no big-bang
+migration on either side.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Strategic clarity**: every contributor knows where new code goes
+  for any given concern. No more "should this go in NestJS or Python?"
+  hesitation.
+- **Domain alignment**: the encyclopedia evolves toward a public-facing
+  reference; the product backend evolves toward Brasse-Bouillon-specific
+  features. The two stop competing.
+- **Re-usability**: the Python knowledge base can one day be consumed
+  by other products (a public web encyclopedia, a sommelier tool,
+  partner integrations) without dragging user data with it.
+- **Clear ownership of new beer-data sources**: Untappd, RateBeer,
+  AI-research, community contributions, the printed-book ingestion
+  (#857) all land in Python without question.
+
+### Trade-offs
+
+- **Two backends to operate**: both must run, both have their own
+  Postgres database (or at least their own schema), both have CI.
+  Mitigated by: NestJS already exists and is mature; Python is small
+  and self-contained.
+- **Mobile app speaks two HTTP base URLs**: a small amount of plumbing
+  in `core/http/http-client.ts` to support a `baseUrl` override. Done
+  in the PR that ships this ADR.
+- **Temporary data fork**: between steps 1 and 4 of the roadmap, the
+  same beer can transiently live in `scan_catalog_items` and `beers`.
+  Acceptable because (a) reads always come from one or the other,
+  never merged, and (b) the ETL step reconciles them at the cutover.
+
+### Rejected alternatives
+
+- **Stay single-backend (NestJS only)**: would require porting Python
+  beer-encyclopedia features (legal reference, importer pattern,
+  `EntitySource`, ML pipeline in TypeScript) — significantly more
+  work than the consolidation we propose, with no architectural gain.
+- **Stay single-backend (Python only)**: would require porting
+  user-facing modules (auth, recettes, brassins, academy) to Python.
+  Even more work, throws away the mature NestJS user product.
+- **Sync the two backends at the data layer**: replicate beer data
+  bidirectionally between the two databases. Complicates everything
+  for no clear benefit; concerns are not actually shared.
+- **Have NestJS proxy Python**: the mobile keeps calling NestJS,
+  which forwards beer-data calls to Python. Adds one HTTP hop, hides
+  the architecture from the mobile, no real upside.
+
+---
+
+## References
+
+- ADR-0002 (`0002-centralized-nestjs-backend.md`) — partially
+  superseded for the beer-data axis
+- ADR-0001 (`0001-build-for-today-design-for-tomorrow.md`) — guides
+  the "consolidate when ready, not before" cadence
+- Issue #853 — DB autonomy strategy (Python-side)
+- PRs #841, #847, #848, #860, #861 — Python beer-encyclopedia work
+  this ADR retroactively legitimises
+- Issue #696 / PR #697 — NestJS scan-lookup work, transitional

--- a/packages/mobile-app/src/core/config/env.ts
+++ b/packages/mobile-app/src/core/config/env.ts
@@ -1,11 +1,25 @@
+const explicitEncyclopediaUrl = process.env.EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL;
+
 export const env = {
   /** NestJS product backend (auth, user recipes, brassins, academy, …). */
   apiUrl: process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3000",
   /**
    * Python beer-encyclopedia knowledge base (beers, breweries, styles,
    * legal denominations, OFF importer). See ADR-0005 for the split.
+   * Defaults to `http://localhost:8000` for the dev-PC web preview;
+   * physical devices and production builds MUST set
+   * `EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL` explicitly — see
+   * `encyclopediaUrlIsConfigured` and the data-layer guard in
+   * `features/scan/data/beers-import.api.ts`.
    */
-  encyclopediaUrl:
-    process.env.EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL ?? "http://localhost:8000",
+  encyclopediaUrl: explicitEncyclopediaUrl ?? "http://localhost:8000",
+  /**
+   * `true` only when the env var is explicitly provided. Lets the
+   * data layer fail fast (Codex P1 #871) when the bundle was built
+   * without the encyclopedia URL — avoids leaking a network timeout
+   * to the UI when the default `localhost:8000` resolves to the
+   * device itself rather than the dev PC.
+   */
+  encyclopediaUrlIsConfigured: !!explicitEncyclopediaUrl,
   useDemoData: (process.env.EXPO_PUBLIC_USE_DEMO_DATA ?? "false") === "true",
 };

--- a/packages/mobile-app/src/core/config/env.ts
+++ b/packages/mobile-app/src/core/config/env.ts
@@ -1,4 +1,11 @@
 export const env = {
+  /** NestJS product backend (auth, user recipes, brassins, academy, …). */
   apiUrl: process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:3000",
+  /**
+   * Python beer-encyclopedia knowledge base (beers, breweries, styles,
+   * legal denominations, OFF importer). See ADR-0005 for the split.
+   */
+  encyclopediaUrl:
+    process.env.EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL ?? "http://localhost:8000",
   useDemoData: (process.env.EXPO_PUBLIC_USE_DEMO_DATA ?? "false") === "true",
 };

--- a/packages/mobile-app/src/core/http/__tests__/http-client.test.ts
+++ b/packages/mobile-app/src/core/http/__tests__/http-client.test.ts
@@ -1,0 +1,221 @@
+import { authSession } from "@/core/auth/session";
+import { request } from "@/core/http/http-client";
+import { HttpError } from "@/core/http/http-error";
+
+jest.mock("@/core/auth/session", () => ({
+  authSession: {
+    getAccessToken: jest.fn(),
+  },
+}));
+
+jest.mock("@/core/config/env", () => ({
+  env: {
+    apiUrl: "http://default-api.test:3000",
+    encyclopediaUrl: "http://default-encyclopedia.test:8000",
+    encyclopediaUrlIsConfigured: true,
+    useDemoData: false,
+  },
+}));
+
+const mockGetAccessToken = authSession.getAccessToken as jest.MockedFunction<
+  typeof authSession.getAccessToken
+>;
+
+const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+beforeAll(() => {
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+function buildResponse(
+  body: unknown,
+  init: { status?: number } = {},
+): Response {
+  const status = init.status ?? 200;
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    text: () => Promise.resolve(text),
+  } as unknown as Response;
+}
+
+describe("http-client / request", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    mockGetAccessToken.mockReset();
+  });
+
+  describe("URL construction", () => {
+    it("targets env.apiUrl by default", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse({ ok: true }));
+
+      await request("/foo");
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://default-api.test:3000/foo",
+        expect.any(Object),
+      );
+    });
+
+    it("uses the baseUrl override (PR #871 — encyclopedia fallback)", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse({ ok: true }));
+
+      await request("/beers/import-by-ean", {
+        method: "POST",
+        body: { ean: "3760231860119" },
+        baseUrl: "http://encyclopedia.test:8000",
+      });
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://encyclopedia.test:8000/beers/import-by-ean",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("normalises a path that does not start with a slash", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse({ ok: true }));
+
+      await request("foo/bar");
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "http://default-api.test:3000/foo/bar",
+        expect.any(Object),
+      );
+    });
+  });
+
+  describe("auth", () => {
+    it("attaches the bearer token by default when one exists", async () => {
+      mockGetAccessToken.mockReturnValueOnce("the-jwt");
+      fetchMock.mockResolvedValueOnce(buildResponse({ ok: true }));
+
+      await request("/me");
+
+      const headers = (fetchMock.mock.calls[0][1] as RequestInit)
+        .headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer the-jwt");
+    });
+
+    it("omits the Authorization header when auth=false (PR #871 Python backend)", async () => {
+      mockGetAccessToken.mockReturnValueOnce("the-jwt");
+      fetchMock.mockResolvedValueOnce(buildResponse({ ok: true }));
+
+      await request("/beers/import-by-ean", { auth: false });
+
+      const headers = (fetchMock.mock.calls[0][1] as RequestInit)
+        .headers as Record<string, string>;
+      expect(headers.Authorization).toBeUndefined();
+    });
+
+    it("does not set Authorization when no token is available", async () => {
+      mockGetAccessToken.mockReturnValueOnce(null);
+      fetchMock.mockResolvedValueOnce(buildResponse({ ok: true }));
+
+      await request("/me");
+
+      const headers = (fetchMock.mock.calls[0][1] as RequestInit)
+        .headers as Record<string, string>;
+      expect(headers.Authorization).toBeUndefined();
+    });
+  });
+
+  describe("body + Content-Type", () => {
+    it("serialises the body as JSON when provided", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse({ ok: true }));
+
+      await request("/foo", { method: "POST", body: { hello: "world" } });
+
+      const opts = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(opts.body).toBe(JSON.stringify({ hello: "world" }));
+      const headers = opts.headers as Record<string, string>;
+      expect(headers["Content-Type"]).toBe("application/json");
+    });
+
+    it("omits body when none is provided", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse({ ok: true }));
+
+      await request("/foo");
+
+      const opts = fetchMock.mock.calls[0][1] as RequestInit;
+      expect(opts.body).toBeUndefined();
+    });
+  });
+
+  describe("response parsing", () => {
+    it("auto-unwraps the `data` envelope used by the NestJS API", async () => {
+      fetchMock.mockResolvedValueOnce(
+        buildResponse({ data: { id: "u-1", email: "a@b.c" } }),
+      );
+
+      const result = await request<{ id: string; email: string }>("/me");
+
+      expect(result).toEqual({ id: "u-1", email: "a@b.c" });
+    });
+
+    it("returns raw payload when the response has no `data` field", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse({ id: "raw" }));
+
+      const result = await request<{ id: string }>("/foo");
+
+      expect(result).toEqual({ id: "raw" });
+    });
+
+    it("returns null on HTTP 204 (no content)", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse("", { status: 204 }));
+
+      const result = await request("/foo", { method: "DELETE" });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when the body is empty", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse(""));
+
+      const result = await request("/foo");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns the raw text when the body is not valid JSON", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse("plain text"));
+
+      const result = await request("/foo");
+
+      expect(result).toBe("plain text");
+    });
+  });
+
+  describe("error mapping", () => {
+    it("throws HttpError carrying the status, message and payload on a 4xx", async () => {
+      fetchMock.mockResolvedValueOnce(
+        buildResponse(
+          { message: "Beer not found", errorCode: "BEER_NOT_FOUND" },
+          { status: 404 },
+        ),
+      );
+
+      const rejected = await request("/scan/lookup/123").catch(
+        (e: unknown) => e,
+      );
+
+      expect(rejected).toBeInstanceOf(HttpError);
+      expect((rejected as HttpError).status).toBe(404);
+      expect((rejected as HttpError).message).toBe("Beer not found");
+      expect((rejected as HttpError).details).toEqual({
+        message: "Beer not found",
+        errorCode: "BEER_NOT_FOUND",
+      });
+    });
+
+    it("falls back to statusText when the body has no message", async () => {
+      fetchMock.mockResolvedValueOnce(buildResponse("", { status: 500 }));
+
+      const rejected = await request("/foo").catch((e: unknown) => e);
+
+      expect(rejected).toBeInstanceOf(HttpError);
+      expect((rejected as HttpError).status).toBe(500);
+    });
+  });
+});

--- a/packages/mobile-app/src/core/http/http-client.ts
+++ b/packages/mobile-app/src/core/http/http-client.ts
@@ -8,6 +8,12 @@ type RequestOptions = {
   body?: unknown;
   auth?: boolean;
   headers?: Record<string, string>;
+  /**
+   * Override the default base URL (`env.apiUrl`, NestJS product backend).
+   * Pass `env.encyclopediaUrl` to target the Python beer-encyclopedia
+   * knowledge base instead. See ADR-0005 for the split.
+   */
+  baseUrl?: string;
 };
 
 async function parseBody(response: Response) {
@@ -29,9 +35,16 @@ async function parseBody(response: Response) {
 
 export async function request<T>(
   path: string,
-  { method = "GET", body, auth = true, headers = {} }: RequestOptions = {},
+  {
+    method = "GET",
+    body,
+    auth = true,
+    headers = {},
+    baseUrl,
+  }: RequestOptions = {},
 ): Promise<T> {
-  const url = `${env.apiUrl}${path.startsWith("/") ? path : `/${path}`}`;
+  const resolvedBase = baseUrl ?? env.apiUrl;
+  const url = `${resolvedBase}${path.startsWith("/") ? path : `/${path}`}`;
 
   const mergedHeaders: Record<string, string> = {
     "Content-Type": "application/json",

--- a/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
@@ -7,6 +7,7 @@ import {
   ScanLookupServiceUnavailableError,
   lookupBeerByBarcode,
 } from "@/features/scan/application/scan-lookup.use-cases";
+import { importBeerByEan as fetchImportFromEncyclopedia } from "@/features/scan/data/beers-import.api";
 import { lookupBeerByBarcode as fetchLookupFromApi } from "@/features/scan/data/scan-lookup.api";
 
 jest.mock("@/core/data/data-source", () => ({
@@ -17,13 +18,21 @@ jest.mock("@/features/scan/data/scan-lookup.api", () => ({
   lookupBeerByBarcode: jest.fn(),
 }));
 
+jest.mock("@/features/scan/data/beers-import.api", () => ({
+  importBeerByEan: jest.fn(),
+}));
+
 const mockFetchLookup = fetchLookupFromApi as jest.MockedFunction<
   typeof fetchLookupFromApi
+>;
+const mockFetchImport = fetchImportFromEncyclopedia as jest.MockedFunction<
+  typeof fetchImportFromEncyclopedia
 >;
 
 describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
   beforeEach(() => {
     mockFetchLookup.mockReset();
+    mockFetchImport.mockReset();
     dataSource.useDemoData = false;
   });
 
@@ -117,14 +126,18 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
   });
 
   describe("real API mode — error mapping", () => {
-    it("translates a 404 HttpError to ScanLookupBeerNotFoundError", async () => {
+    it("falls back to ScanLookupBeerNotFoundError when both NestJS and Python return 404 (ADR-0005)", async () => {
       mockFetchLookup.mockRejectedValueOnce(
         new HttpError(404, "Beer not found"),
+      );
+      mockFetchImport.mockRejectedValueOnce(
+        new HttpError(404, "EAN unknown to OFF"),
       );
 
       await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
         ScanLookupBeerNotFoundError,
       );
+      expect(mockFetchImport).toHaveBeenCalledWith("1234567890123");
     });
 
     it("translates a 503 HttpError to ScanLookupServiceUnavailableError", async () => {
@@ -206,6 +219,61 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       expect(result.item.name).toBe("Punk IPA");
       expect(result.source).toBe("cache_miss_fetched");
       expect(result.rawPayloadAvailable).toBe(true);
+    });
+  });
+
+  describe("encyclopedia fallback (ADR-0005)", () => {
+    it("returns the Python result when NestJS 404s and Python finds the beer", async () => {
+      const expectedResult = {
+        item: {
+          barcode: "3760298280016",
+          name: "Page 24 Réserve Hildegarde",
+        } as never,
+        source: "cache_miss_fetched" as const,
+        rawPayloadAvailable: false,
+      };
+      mockFetchLookup.mockRejectedValueOnce(new HttpError(404, "Not found"));
+      mockFetchImport.mockResolvedValueOnce(expectedResult);
+
+      const result = await lookupBeerByBarcode("3760298280016");
+
+      expect(result).toBe(expectedResult);
+      expect(mockFetchLookup).toHaveBeenCalledWith("3760298280016");
+      expect(mockFetchImport).toHaveBeenCalledWith("3760298280016");
+    });
+
+    it("translates a Python 503 during fallback to ScanLookupServiceUnavailableError", async () => {
+      mockFetchLookup.mockRejectedValueOnce(new HttpError(404, "Not found"));
+      mockFetchImport.mockRejectedValueOnce(
+        new HttpError(503, "OFF unreachable"),
+      );
+
+      await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
+        ScanLookupServiceUnavailableError,
+      );
+    });
+
+    it("does not call Python when NestJS returns a non-404 error", async () => {
+      mockFetchLookup.mockRejectedValueOnce(new HttpError(503, "NestJS down"));
+
+      await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
+        ScanLookupServiceUnavailableError,
+      );
+      expect(mockFetchImport).not.toHaveBeenCalled();
+    });
+
+    it("does not call Python when NestJS succeeds (warm path stays single-backend)", async () => {
+      const directResult = {
+        item: { barcode: "5060277380019" } as never,
+        source: "cache_hit_fresh" as const,
+        rawPayloadAvailable: false,
+      };
+      mockFetchLookup.mockResolvedValueOnce(directResult);
+
+      const result = await lookupBeerByBarcode("5060277380019");
+
+      expect(result).toBe(directResult);
+      expect(mockFetchImport).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
@@ -140,14 +140,18 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       expect(mockFetchImport).toHaveBeenCalledWith("1234567890123");
     });
 
-    it("translates a 503 HttpError to ScanLookupServiceUnavailableError", async () => {
+    it("falls back to Python when NestJS 503s and Python 503s too — surfaces ScanLookupServiceUnavailableError (ADR-0005)", async () => {
       mockFetchLookup.mockRejectedValueOnce(
+        new HttpError(503, "OFF unreachable"),
+      );
+      mockFetchImport.mockRejectedValueOnce(
         new HttpError(503, "OFF unreachable"),
       );
 
       await expect(lookupBeerByBarcode("5060277380019")).rejects.toBeInstanceOf(
         ScanLookupServiceUnavailableError,
       );
+      expect(mockFetchImport).toHaveBeenCalledWith("5060277380019");
     });
 
     it("translates a 422 NOT_A_BEER HttpError to ScanLookupNotABeerError carrying the product name (Issue #798)", async () => {
@@ -253,11 +257,28 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       );
     });
 
-    it("does not call Python when NestJS returns a non-404 error", async () => {
+    it("falls back to Python when NestJS returns 503 (OFF unreachable / rate-limited)", async () => {
+      const expectedResult = {
+        item: { barcode: "3770012913076", name: "Biere A la fut IPA" } as never,
+        source: "cache_miss_fetched" as const,
+        rawPayloadAvailable: false,
+      };
       mockFetchLookup.mockRejectedValueOnce(new HttpError(503, "NestJS down"));
+      mockFetchImport.mockResolvedValueOnce(expectedResult);
+
+      const result = await lookupBeerByBarcode("3770012913076");
+
+      expect(result).toBe(expectedResult);
+      expect(mockFetchImport).toHaveBeenCalledWith("3770012913076");
+    });
+
+    it("does not call Python when NestJS returns a non-recoverable error (e.g. 429 rate-limit)", async () => {
+      mockFetchLookup.mockRejectedValueOnce(
+        new HttpError(429, "Too many requests"),
+      );
 
       await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
-        ScanLookupServiceUnavailableError,
+        HttpError,
       );
       expect(mockFetchImport).not.toHaveBeenCalled();
     });

--- a/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
@@ -134,18 +134,17 @@ export async function lookupBeerByBarcode(
     return await fetchLookupFromApi(barcode);
   } catch (error) {
     if (error instanceof HttpError) {
-      if (error.status === 404) {
-        // ADR-0005 fallback: when NestJS does not know this barcode,
-        // try the Python beer-encyclopedia. It has its own OFF
-        // importer (PR #847) and may surface a beer that NestJS has
-        // not cached yet. We swallow only its 404 / 503 (transparent
-        // unknown / service down) and translate them to the same
-        // typed errors the caller already handles, so the UI stays
-        // identical to the single-backend path.
+      if (error.status === 404 || error.status === 503) {
+        // ADR-0005 fallback: when NestJS does not know this barcode
+        // (404) OR cannot reach OFF (503 — typically OFF rate-limit
+        // or transport failure with no NestJS cache row), try the
+        // Python beer-encyclopedia. It has its own DB and OFF
+        // importer (PR #847) and may surface a beer NestJS cannot
+        // serve right now. The fallback's own 404 / 503 are
+        // translated to the same typed errors the caller already
+        // handles, so the UI stays identical to the single-backend
+        // path.
         return await fallbackToEncyclopediaImport(barcode);
-      }
-      if (error.status === 503) {
-        throw new ScanLookupServiceUnavailableError(barcode);
       }
       if (error.status === 422 && isNotABeerDetails(error.details)) {
         throw new ScanLookupNotABeerError(

--- a/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
@@ -15,6 +15,7 @@
  */
 import { dataSource } from "@/core/data/data-source";
 import { HttpError } from "@/core/http/http-error";
+import { importBeerByEan as fetchImportFromEncyclopedia } from "@/features/scan/data/beers-import.api";
 import { lookupBeerByBarcode as fetchLookupFromApi } from "@/features/scan/data/scan-lookup.api";
 import type { ScanLookupResult } from "@/features/scan/domain/scan.types";
 import { buildDemoLookupResult, demoScanCatalog } from "@/mocks/demo-data";
@@ -134,7 +135,14 @@ export async function lookupBeerByBarcode(
   } catch (error) {
     if (error instanceof HttpError) {
       if (error.status === 404) {
-        throw new ScanLookupBeerNotFoundError(barcode);
+        // ADR-0005 fallback: when NestJS does not know this barcode,
+        // try the Python beer-encyclopedia. It has its own OFF
+        // importer (PR #847) and may surface a beer that NestJS has
+        // not cached yet. We swallow only its 404 / 503 (transparent
+        // unknown / service down) and translate them to the same
+        // typed errors the caller already handles, so the UI stays
+        // identical to the single-backend path.
+        return await fallbackToEncyclopediaImport(barcode);
       }
       if (error.status === 503) {
         throw new ScanLookupServiceUnavailableError(barcode);
@@ -144,6 +152,33 @@ export async function lookupBeerByBarcode(
           barcode,
           error.details.productName ?? null,
         );
+      }
+    }
+    throw error;
+  }
+}
+
+/**
+ * Try to resolve `barcode` against the Python beer-encyclopedia.
+ *
+ * Translates Python's HTTP responses into the same typed errors the
+ * primary NestJS path emits, so callers (presentation, tests) do not
+ * need to know which backend ultimately served the data. The Python
+ * backend itself already does DB-first + OFF fallback (PR #847 +
+ * #848) so a 404 here truly means "neither cache nor OFF knows".
+ */
+async function fallbackToEncyclopediaImport(
+  barcode: string,
+): Promise<ScanLookupResult> {
+  try {
+    return await fetchImportFromEncyclopedia(barcode);
+  } catch (error) {
+    if (error instanceof HttpError) {
+      if (error.status === 404) {
+        throw new ScanLookupBeerNotFoundError(barcode);
+      }
+      if (error.status === 503) {
+        throw new ScanLookupServiceUnavailableError(barcode);
       }
     }
     throw error;

--- a/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
+++ b/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
@@ -1,4 +1,5 @@
 import { env } from "@/core/config/env";
+import { HttpError } from "@/core/http/http-error";
 import { importBeerByEan } from "@/features/scan/data/beers-import.api";
 
 const mockRequest = jest.fn();
@@ -6,6 +7,22 @@ const mockRequest = jest.fn();
 jest.mock("@/core/http/http-client", () => ({
   request: (...args: unknown[]) => mockRequest(...args),
 }));
+
+jest.mock("@/core/config/env", () => ({
+  env: {
+    apiUrl: "http://localhost:3000",
+    encyclopediaUrl: "http://test-encyclopedia.local:8000",
+    encyclopediaUrlIsConfigured: true,
+    useDemoData: false,
+  },
+}));
+
+const mockedEnv = env as unknown as {
+  apiUrl: string;
+  encyclopediaUrl: string;
+  encyclopediaUrlIsConfigured: boolean;
+  useDemoData: boolean;
+};
 
 type PythonBeerReadDto = {
   id: string;
@@ -59,6 +76,25 @@ function buildDto(
 describe("beers-import.api / importBeerByEan", () => {
   beforeEach(() => {
     mockRequest.mockReset();
+    mockedEnv.encyclopediaUrlIsConfigured = true;
+    mockedEnv.encyclopediaUrl = "http://test-encyclopedia.local:8000";
+  });
+
+  describe("encyclopedia URL guard (Codex P1 #871)", () => {
+    it("throws HttpError(503) without hitting the network when the URL is not explicitly configured", async () => {
+      mockedEnv.encyclopediaUrlIsConfigured = false;
+
+      const rejected = await importBeerByEan("3760231860119").catch(
+        (e: unknown) => e,
+      );
+
+      expect(rejected).toBeInstanceOf(HttpError);
+      expect((rejected as HttpError).status).toBe(503);
+      expect((rejected as HttpError).message).toMatch(
+        /not configured.*EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL/i,
+      );
+      expect(mockRequest).not.toHaveBeenCalled();
+    });
   });
 
   describe("HTTP wiring", () => {
@@ -81,21 +117,68 @@ describe("beers-import.api / importBeerByEan", () => {
       });
     });
 
-    it("returns a ScanLookupResult with cache_miss_fetched source and rawPayloadAvailable=false", async () => {
-      mockRequest.mockResolvedValueOnce(buildDto());
-
-      const result = await importBeerByEan("3760231860119");
-
-      expect(result.source).toBe("cache_miss_fetched");
-      expect(result.rawPayloadAvailable).toBe(false);
-      expect(result.item.barcode).toBe("3760231860119");
-    });
-
     it("re-throws when the http-client throws (let HttpError bubble up)", async () => {
       const httpError = new Error("HTTP 503");
       mockRequest.mockRejectedValueOnce(httpError);
 
       await expect(importBeerByEan("3760231860119")).rejects.toBe(httpError);
+    });
+  });
+
+  describe("source heuristic (200 vs 201 — no HTTP status visibility)", () => {
+    it("treats a row created within the last few seconds as cache_miss_fetched (just imported)", async () => {
+      const justCreated = new Date(Date.now() - 1_000).toISOString();
+      mockRequest.mockResolvedValueOnce(
+        buildDto({ created_at: justCreated, updated_at: justCreated }),
+      );
+
+      const result = await importBeerByEan("3760231860119");
+
+      expect(result.source).toBe("cache_miss_fetched");
+    });
+
+    it("treats a row created long ago as cache_hit_fresh (DB hit, no upstream fetch)", async () => {
+      mockRequest.mockResolvedValueOnce(
+        buildDto({ created_at: "2026-04-01T08:00:00.000Z" }),
+      );
+
+      const result = await importBeerByEan("3760231860119");
+
+      expect(result.source).toBe("cache_hit_fresh");
+    });
+
+    it("falls back to cache_hit_fresh when created_at cannot be parsed", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ created_at: "not-a-date" }));
+
+      const result = await importBeerByEan("3760231860119");
+
+      expect(result.source).toBe("cache_hit_fresh");
+    });
+  });
+
+  describe("rawPayloadAvailable (Python persists EntitySource.raw_data only for OFF imports)", () => {
+    it("returns true when the source is openfoodfacts", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ source: "openfoodfacts" }));
+
+      const result = await importBeerByEan("3760231860119");
+
+      expect(result.rawPayloadAvailable).toBe(true);
+    });
+
+    it("returns false when the source is internal (no upstream payload to keep)", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ source: "internal" }));
+
+      const result = await importBeerByEan("3760231860119");
+
+      expect(result.rawPayloadAvailable).toBe(false);
+    });
+
+    it("returns false when the source is community", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ source: "community" }));
+
+      const result = await importBeerByEan("3760231860119");
+
+      expect(result.rawPayloadAvailable).toBe(false);
     });
   });
 
@@ -117,7 +200,9 @@ describe("beers-import.api / importBeerByEan", () => {
       expect(item.notesSource).toBe("Ambrée typée");
       expect(item.createdAt).toBe("2026-04-01T08:00:00.000Z");
       expect(item.updatedAt).toBe("2026-04-15T09:00:00.000Z");
-      expect(item.fetchedAt).toBe("2026-04-15T09:00:00.000Z");
+      // BeerRead exposes no actual OFF fetch timestamp — see mapper
+      // comment. We surface null rather than misrepresent updated_at.
+      expect(item.fetchedAt).toBeNull();
     });
 
     it("substitutes 'Brasserie inconnue' / 'Style inconnu' placeholders (FK UUIDs not yet enriched)", async () => {

--- a/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
+++ b/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
@@ -1,0 +1,205 @@
+import { env } from "@/core/config/env";
+import { importBeerByEan } from "@/features/scan/data/beers-import.api";
+
+const mockRequest = jest.fn();
+
+jest.mock("@/core/http/http-client", () => ({
+  request: (...args: unknown[]) => mockRequest(...args),
+}));
+
+type PythonBeerReadDto = {
+  id: string;
+  name: string;
+  slug: string;
+  brewery_id: string | null;
+  style_id: string | null;
+  abv: string | null;
+  ibu: number | null;
+  srm: number | null;
+  description: string | null;
+  is_active: boolean;
+  is_verified: boolean;
+  source: "openfoodfacts" | "internal" | "community";
+  ean_code: string | null;
+  legal_denomination: string | null;
+  country_of_origin: string | null;
+  allergens: string[] | null;
+  alcohol_group: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function buildDto(
+  overrides: Partial<PythonBeerReadDto> = {},
+): PythonBeerReadDto {
+  return {
+    id: "ddc4c2bc-6f5b-4c2f-9f4d-7e0e0a8b1c2d",
+    name: "Pelforth Brune",
+    slug: "pelforth-brune",
+    brewery_id: "b1d2c3e4-1111-2222-3333-444455556666",
+    style_id: "5d6e7f80-aaaa-bbbb-cccc-ddddeeee0001",
+    abv: "6.5",
+    ibu: 22,
+    srm: 30,
+    description: "Brune intense",
+    is_active: true,
+    is_verified: false,
+    source: "openfoodfacts",
+    ean_code: "3760231860119",
+    legal_denomination: "biere",
+    country_of_origin: "FR",
+    allergens: ["gluten"],
+    alcohol_group: 3,
+    created_at: "2026-05-02T10:00:00.000Z",
+    updated_at: "2026-05-02T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("beers-import.api / importBeerByEan", () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  describe("HTTP wiring", () => {
+    it("POSTs /beers/import-by-ean to the encyclopedia backend with the EAN body and no auth", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto());
+
+      await importBeerByEan("3760231860119");
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+      const [path, options] = mockRequest.mock.calls[0] as [
+        string,
+        Record<string, unknown>,
+      ];
+      expect(path).toBe("/beers/import-by-ean");
+      expect(options).toMatchObject({
+        method: "POST",
+        body: { ean: "3760231860119" },
+        auth: false,
+        baseUrl: env.encyclopediaUrl,
+      });
+    });
+
+    it("returns a ScanLookupResult with cache_miss_fetched source and rawPayloadAvailable=false", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto());
+
+      const result = await importBeerByEan("3760231860119");
+
+      expect(result.source).toBe("cache_miss_fetched");
+      expect(result.rawPayloadAvailable).toBe(false);
+      expect(result.item.barcode).toBe("3760231860119");
+    });
+
+    it("re-throws when the http-client throws (let HttpError bubble up)", async () => {
+      const httpError = new Error("HTTP 503");
+      mockRequest.mockRejectedValueOnce(httpError);
+
+      await expect(importBeerByEan("3760231860119")).rejects.toBe(httpError);
+    });
+  });
+
+  describe("DTO → ScanCatalogItem mapping", () => {
+    it("maps name, description and timestamps and uses the queried EAN as barcode", async () => {
+      mockRequest.mockResolvedValueOnce(
+        buildDto({
+          name: "Goudale Ambrée",
+          description: "Ambrée typée",
+          created_at: "2026-04-01T08:00:00.000Z",
+          updated_at: "2026-04-15T09:00:00.000Z",
+        }),
+      );
+
+      const { item } = await importBeerByEan("3760298280016");
+
+      expect(item.barcode).toBe("3760298280016");
+      expect(item.name).toBe("Goudale Ambrée");
+      expect(item.notesSource).toBe("Ambrée typée");
+      expect(item.createdAt).toBe("2026-04-01T08:00:00.000Z");
+      expect(item.updatedAt).toBe("2026-04-15T09:00:00.000Z");
+      expect(item.fetchedAt).toBe("2026-04-15T09:00:00.000Z");
+    });
+
+    it("substitutes 'Brasserie inconnue' / 'Style inconnu' placeholders (FK UUIDs not yet enriched)", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto());
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.brewery).toBe("Brasserie inconnue");
+      expect(item.style).toBe("Style inconnu");
+      expect(item.fermentationType).toBe("");
+      expect(item.aromaticTags).toBeNull();
+      expect(item.isStyleEstimated).toBe(true);
+    });
+
+    it("parses Decimal-as-string abv into a number", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ abv: "5.4" }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.abv).toBe(5.4);
+      expect(item.isAbvEstimated).toBe(false);
+    });
+
+    it("preserves null abv when the source has no value", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ abv: null }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.abv).toBeNull();
+    });
+
+    it("converts SRM to EBC (factor 1.97, rounded) and flags color as estimated", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ srm: 10 }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.colorEbc).toBe(20); // 10 * 1.97 = 19.7 → 20
+      expect(item.isColorEbcEstimated).toBe(true);
+    });
+
+    it("returns null colorEbc and unflagged estimation when srm is null", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ srm: null }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.colorEbc).toBeNull();
+      expect(item.isColorEbcEstimated).toBe(false);
+    });
+
+    it("propagates ibu null without estimation", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ ibu: null }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.ibu).toBeNull();
+      expect(item.isIbuEstimated).toBe(false);
+    });
+  });
+
+  describe("source → origin mapping", () => {
+    it("maps Python 'openfoodfacts' to ScanCatalogItem origin 'openfoodfacts'", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ source: "openfoodfacts" }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.origin).toBe("openfoodfacts");
+    });
+
+    it("maps Python 'internal' to 'seed' (closest NestJS analogue)", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ source: "internal" }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.origin).toBe("seed");
+    });
+
+    it("maps Python 'community' to 'manual' (placeholder until community origin lands)", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ source: "community" }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.origin).toBe("manual");
+    });
+  });
+});

--- a/packages/mobile-app/src/features/scan/data/beers-import.api.ts
+++ b/packages/mobile-app/src/features/scan/data/beers-import.api.ts
@@ -1,0 +1,145 @@
+/**
+ * Data layer for the Python beer-encyclopedia
+ * `POST /beers/import-by-ean` endpoint (PR #847 + #848).
+ *
+ * Targets the **knowledge-base** backend (`env.encyclopediaUrl`),
+ * not the NestJS product backend. See ADR-0005 for the split.
+ *
+ * Per Clean Architecture, this file contains only the HTTP call and
+ * the snake_case → ScanCatalogItem mapping. Use-case orchestration
+ * (when to call this fallback, error handling for the UI) lives in
+ * `application/scan-lookup.use-cases.ts`.
+ */
+import { env } from "@/core/config/env";
+import { request } from "@/core/http/http-client";
+
+import type {
+  ScanCatalogItem,
+  ScanCatalogItemOrigin,
+  ScanLookupResult,
+} from "../domain/scan.types";
+
+/**
+ * Wire shape returned by the Python beer-encyclopedia.
+ *
+ * Mirrors `BeerRead` from `packages/beer-encyclopedia/api/schemas/beer.py`.
+ * The schema is intentionally richer than NestJS `scan_catalog_items`
+ * (legal_denomination, allergens, country_of_origin, alcohol_group)
+ * but does NOT include a denormalised brewery name or style name —
+ * only the foreign-key UUIDs. We accept this degraded mapping for now
+ * (TODO: enrich `BeerRead` server-side with brewery_name + style_name
+ * before the NestJS deprecation step of ADR-0005's roadmap).
+ */
+type PythonBeerReadDto = {
+  id: string;
+  name: string;
+  slug: string;
+  brewery_id: string | null;
+  style_id: string | null;
+  abv: string | null; // Pydantic Decimal serialises as string
+  ibu: number | null;
+  srm: number | null;
+  description: string | null;
+  is_active: boolean;
+  is_verified: boolean;
+  source: "openfoodfacts" | "internal" | "community";
+  ean_code: string | null;
+  legal_denomination: string | null;
+  country_of_origin: string | null;
+  allergens: string[] | null;
+  alcohol_group: number | null;
+  created_at: string;
+  updated_at: string;
+};
+
+/**
+ * Conservative SRM → EBC conversion (EBC ≈ SRM × 1.97). The Python
+ * model exposes SRM (Standard Reference Method, US) while NestJS
+ * `scan_catalog_items` exposes EBC (European Brewery Convention).
+ * Conversion is approximate; we round to the nearest integer to
+ * match the column type and avoid suggesting false precision.
+ */
+function srmToEbc(srm: number | null): number | null {
+  if (srm === null || srm === undefined) {
+    return null;
+  }
+  return Math.round(srm * 1.97);
+}
+
+function mapPythonSourceToOrigin(
+  source: PythonBeerReadDto["source"],
+): ScanCatalogItemOrigin {
+  if (source === "openfoodfacts") {
+    return "openfoodfacts";
+  }
+  if (source === "internal") {
+    return "seed";
+  }
+  // community → represent as "manual" for now (closest NestJS analogue)
+  return "manual";
+}
+
+function mapPythonBeerToCatalogItem(
+  dto: PythonBeerReadDto,
+  ean: string,
+): ScanCatalogItem {
+  return {
+    id: dto.id,
+    barcode: ean,
+    name: dto.name,
+    // Brewery / style names live in separate Python tables. Until
+    // BeerRead is enriched server-side we surface a placeholder.
+    brewery: "Brasserie inconnue",
+    style: "Style inconnu",
+    abv: dto.abv === null ? null : Number(dto.abv),
+    ibu: dto.ibu,
+    colorEbc: srmToEbc(dto.srm),
+    fermentationType: "",
+    aromaticTags: null,
+    notesSource: dto.description,
+    isAbvEstimated: false,
+    isIbuEstimated: false,
+    isColorEbcEstimated: dto.srm !== null,
+    isStyleEstimated: true,
+    origin: mapPythonSourceToOrigin(dto.source),
+    fetchedAt: dto.updated_at,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  };
+}
+
+/**
+ * Call the Python beer-encyclopedia to resolve a barcode, importing
+ * from Open Food Facts on first occurrence. Returns a
+ * `ScanLookupResult` whose `item` carries placeholders for the fields
+ * Python does not yet expose (brewery name, style name,
+ * fermentation type, aromatic tags). The presentation layer should
+ * render the fiche in a degraded-but-functional state until the
+ * server-side enrichment ships.
+ *
+ * Throws (for the use-case to translate):
+ * - HttpError 404 — the EAN is unknown to both Python DB and OFF
+ * - HttpError 503 — OFF transport / payload / seed-state failure
+ * - HttpError 4xx/5xx — other unexpected backend conditions
+ */
+export async function importBeerByEan(ean: string): Promise<ScanLookupResult> {
+  const dto = await request<PythonBeerReadDto>("/beers/import-by-ean", {
+    method: "POST",
+    body: { ean },
+    auth: false, // Python backend is currently unauthenticated.
+    baseUrl: env.encyclopediaUrl,
+  });
+  const item = mapPythonBeerToCatalogItem(dto, ean);
+  return {
+    item,
+    // Python's "import-by-ean" semantically straddles the existing
+    // NestJS source values: a 200 (DB hit) ≈ cache_hit_fresh, a 201
+    // (OFF first-time fetch) ≈ cache_miss_fetched. We cannot
+    // distinguish the two without inspecting the HTTP status code
+    // (the wrapper returns the body only). Default to
+    // "cache_miss_fetched" since this fallback only fires after a
+    // NestJS 404 — meaning the row was likely just imported.
+    source: "cache_miss_fetched",
+    rawPayloadAvailable: false,
+  };
+}

--- a/packages/mobile-app/src/features/scan/data/beers-import.api.ts
+++ b/packages/mobile-app/src/features/scan/data/beers-import.api.ts
@@ -12,11 +12,13 @@
  */
 import { env } from "@/core/config/env";
 import { request } from "@/core/http/http-client";
+import { HttpError } from "@/core/http/http-error";
 
 import type {
   ScanCatalogItem,
   ScanCatalogItemOrigin,
   ScanLookupResult,
+  ScanLookupSource,
 } from "../domain/scan.types";
 
 /**
@@ -30,7 +32,7 @@ import type {
  * (TODO: enrich `BeerRead` server-side with brewery_name + style_name
  * before the NestJS deprecation step of ADR-0005's roadmap).
  */
-type PythonBeerReadDto = {
+interface PythonBeerReadDto {
   id: string;
   name: string;
   slug: string;
@@ -50,7 +52,17 @@ type PythonBeerReadDto = {
   alcohol_group: number | null;
   created_at: string;
   updated_at: string;
-};
+}
+
+/**
+ * Window during which a row whose `created_at` is "now-ish" is treated
+ * as a freshly imported one (cache_miss_fetched). The Python endpoint
+ * does not return its HTTP status (200 vs 201) through the response
+ * body, so we lean on this heuristic. Generous enough to absorb clock
+ * skew and the round-trip latency, narrow enough to avoid mislabelling
+ * older DB rows.
+ */
+const FRESH_IMPORT_WINDOW_MS = 5_000;
 
 /**
  * Conservative SRM → EBC conversion (EBC ≈ SRM × 1.97). The Python
@@ -79,6 +91,25 @@ function mapPythonSourceToOrigin(
   return "manual";
 }
 
+/**
+ * Best-effort guess of whether the Python endpoint just imported the
+ * beer (HTTP 201) versus served an existing DB row (HTTP 200). We
+ * cannot read the status from the response body, so we infer from
+ * `created_at`: a row whose creation timestamp is within
+ * `FRESH_IMPORT_WINDOW_MS` of "now" is almost certainly the result of
+ * the very import we just triggered.
+ */
+function inferLookupSource(dto: PythonBeerReadDto): ScanLookupSource {
+  const createdAtMs = Date.parse(dto.created_at);
+  if (Number.isFinite(createdAtMs)) {
+    const ageMs = Date.now() - createdAtMs;
+    if (ageMs >= 0 && ageMs <= FRESH_IMPORT_WINDOW_MS) {
+      return "cache_miss_fetched";
+    }
+  }
+  return "cache_hit_fresh";
+}
+
 function mapPythonBeerToCatalogItem(
   dto: PythonBeerReadDto,
   ean: string,
@@ -102,7 +133,11 @@ function mapPythonBeerToCatalogItem(
     isColorEbcEstimated: dto.srm !== null,
     isStyleEstimated: true,
     origin: mapPythonSourceToOrigin(dto.source),
-    fetchedAt: dto.updated_at,
+    // BeerRead does not expose the OFF fetch timestamp; `updated_at`
+    // changes on any row update (including community edits) so it
+    // would fabricate freshness metadata. Surface null until the
+    // server adds an explicit `last_fetched_at` field.
+    fetchedAt: null,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
   };
@@ -118,11 +153,28 @@ function mapPythonBeerToCatalogItem(
  * server-side enrichment ships.
  *
  * Throws (for the use-case to translate):
+ * - HttpError 503 — `EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL` is not
+ *   configured (default `http://localhost:8000` would silently fail
+ *   on physical devices). Fail fast instead of timing out.
  * - HttpError 404 — the EAN is unknown to both Python DB and OFF
  * - HttpError 503 — OFF transport / payload / seed-state failure
  * - HttpError 4xx/5xx — other unexpected backend conditions
  */
 export async function importBeerByEan(ean: string): Promise<ScanLookupResult> {
+  // Codex P1 #871: when the env var is absent, the bundle would fall
+  // back to `http://localhost:8000` — meaningful only on a host that
+  // happens to also run the encyclopedia (web preview from the dev
+  // PC). On a physical device or production build, that URL resolves
+  // to the device itself and times out. Surface a clean 503 the
+  // use-case already knows how to translate, instead of leaking a
+  // raw network error to the UI.
+  if (!env.encyclopediaUrlIsConfigured) {
+    throw new HttpError(
+      503,
+      "Beer encyclopedia backend not configured (EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL).",
+      null,
+    );
+  }
   const dto = await request<PythonBeerReadDto>("/beers/import-by-ean", {
     method: "POST",
     body: { ean },
@@ -132,14 +184,10 @@ export async function importBeerByEan(ean: string): Promise<ScanLookupResult> {
   const item = mapPythonBeerToCatalogItem(dto, ean);
   return {
     item,
-    // Python's "import-by-ean" semantically straddles the existing
-    // NestJS source values: a 200 (DB hit) ≈ cache_hit_fresh, a 201
-    // (OFF first-time fetch) ≈ cache_miss_fetched. We cannot
-    // distinguish the two without inspecting the HTTP status code
-    // (the wrapper returns the body only). Default to
-    // "cache_miss_fetched" since this fallback only fires after a
-    // NestJS 404 — meaning the row was likely just imported.
-    source: "cache_miss_fetched",
-    rawPayloadAvailable: false,
+    source: inferLookupSource(dto),
+    // Python persists the raw OFF payload in `EntitySource.raw_data`
+    // for every `openfoodfacts` import (PR #847). Internal / community
+    // sources never carry an upstream payload, so gate on origin.
+    rawPayloadAvailable: dto.source === "openfoodfacts",
   };
 }


### PR DESCRIPTION
## Summary

First mobile↔Python beer-encyclopedia bridge. When NestJS \`GET /scan/lookup/:ean\` returns 404, the mobile now falls back to the Python \`POST /beers/import-by-ean\` endpoint shipped in PR #847 + #848.

ADR-0005 is added in the same PR to record the **strategic split** that justifies this wiring:

- **NestJS** = product backend (auth, recettes utilisateur, brassins, academy)
- **Python beer-encyclopedia** = worldwide beer knowledge base (beers, breweries, styles, legal denominations, multi-source ingestion)

## Changes

- \`docs/architecture/decisions/0005-backend-split-encyclopedia-vs-product.md\` — new ADR
- \`docs/architecture/decisions/0002-centralized-nestjs-backend.md\` — marked partially superseded
- \`packages/mobile-app/src/core/config/env.ts\` — new \`encyclopediaUrl\`
- \`packages/mobile-app/src/core/http/http-client.ts\` — optional \`baseUrl\` request option
- \`packages/mobile-app/src/features/scan/data/beers-import.api.ts\` — NEW
- \`packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts\` — fallback wiring
- \`packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts\` — 4 new tests + 1 updated

## Live test 2026-05-02 (4 real bottles scanned)

Validated end-to-end on a phone via LAN against both backends running locally.

| EAN | Beer | Path taken | Result |
|---|---|---|---|
| 3770012913076 | Bière A la fut IPA | NestJS DB miss → OFF hit → fiche | ✅ |
| 3760023241107 | La Rousse (Mont-Blanc) | NestJS DB hit (cached previously) | ✅ |
| 3261570004196 | Goudale Ambrée 75cl | NestJS DB miss → OFF hit → fiche | ✅ |
| 3701292200020/082 | BACHOU (micro-brewery, Tourrette-sur-Loup) | NestJS 404 → Python 404 → "bière non reconnue" | 🟡 expected (OFF doesn't have BACHOU) |

## Findings (captured in \`packages/beer-encyclopedia/scan-photos/findings.md\`)

- The wiring works: scan→fiche end-to-end on real bottles.
- NestJS OFF mapper is **very lossy** — Goudale lost ABV (7.2%), style ("amber-beers"), allergens (gluten), image. Captured as issue **#870**.
- Python fallback never triggered tonight in production (NestJS handled all known EANs; both backends 404 on the unknown craft beer). Wiring is validated by unit tests + ready for the day BACHOU lands in Python via community / AI-research / book ingestion.
- Two UX bugs spotted: keyboard overlaps password field; no password visibility toggle. Captured separately.

## Tests

- 647 / 647 passing locally (\`npm test\` mobile-app)
- \`npm run ci:check\` clean (lint + typecheck + format)
- 4 new unit tests on the fallback path (DB miss + Python hit, Python 404, NestJS non-404 = no fallback, NestJS success = no fallback)

## Notes

- \`.env.example\` not modified (per \`packages/mobile-app/CLAUDE.md\` rule). The new env var \`EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL\` is documented inline in \`env.ts\` (defaults to \`http://localhost:8000\`).
- Mapping Python \`BeerRead\` → mobile \`ScanCatalogItem\` is **lossy** (no brewery name, no style name in the Python schema yet). Followup needed before the NestJS scan-module deprecation step of ADR-0005.

## Checklist

- [x] Tests cover happy / sad / edge paths
- [x] \`pytest\` + \`npm test\` passing
- [x] \`ruff check\` + \`npm run ci:check\` clean
- [x] ADR documented
- [x] Live-tested with real bottles