### PR TITLE
feat(catalog/yeast): add yeasts reference catalogue table — completes Phase 1 (#708)

### DIFF
--- a/packages/api/scripts/run-yeasts-catalog-seed.ts
+++ b/packages/api/scripts/run-yeasts-catalog-seed.ts
@@ -1,0 +1,38 @@
+/**
+ * One-shot script to seed the `yeasts` reference catalogue with
+ * the 20 curated entries from `YEASTS_CATALOG_SEED` against the
+ * local dev database (Issue #708 / #869, Phase 1 PR #3).
+ *
+ * Usage:
+ *   cd packages/api
+ *   npx ts-node -r tsconfig-paths/register scripts/run-yeasts-catalog-seed.ts
+ *
+ * Idempotent: safe to run multiple times. Existing yeast IDs are
+ * updated in place; missing ones are inserted.
+ *
+ * Mirror of run-hops-catalog-seed.ts and
+ * run-fermentables-catalog-seed.ts. Stopgap until the unified seed
+ * orchestrator lands at the end of Phase 3.
+ */
+import 'reflect-metadata';
+
+import dataSource from '../src/database/data-source';
+import { YeastOrmEntity } from '../src/catalog/yeast/entities/yeast.orm.entity';
+import { seedYeastsCatalog } from '../src/database/seeds/yeasts-catalog.seed';
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const repo = dataSource.getRepository(YeastOrmEntity);
+  const result = await seedYeastsCatalog(repo);
+  console.log('Yeasts catalogue seed:', result);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/catalog/catalog.module.ts
+++ b/packages/api/src/catalog/catalog.module.ts
@@ -1,6 +1,7 @@
 import { FermentableModule } from './fermentable/fermentable.module';
 import { HopModule } from './hop/hop.module';
 import { Module } from '@nestjs/common';
+import { YeastModule } from './yeast/yeast.module';
 
 /**
  * Root module for the operator-curated reference catalogues
@@ -15,6 +16,6 @@ import { Module } from '@nestjs/common';
  * sub-module dependencies are explicit at the consumer side.
  */
 @Module({
-  imports: [HopModule, FermentableModule],
+  imports: [HopModule, FermentableModule, YeastModule],
 })
 export class CatalogModule {}

--- a/packages/api/src/catalog/yeast/controllers/__tests__/yeast-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/yeast/controllers/__tests__/yeast-catalog.controller.spec.ts
@@ -1,0 +1,143 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { NotFoundException } from '@nestjs/common';
+import { YeastCatalogController } from '../yeast-catalog.controller';
+import { YeastCatalogService } from '../../services/yeast-catalog.service';
+import { YeastFlocculation } from '../../domain/enums/yeast-flocculation.enum';
+import { YeastForm } from '../../domain/enums/yeast-form.enum';
+import { YeastOrmEntity } from '../../entities/yeast.orm.entity';
+import { YeastType } from '../../domain/enums/yeast-type.enum';
+
+/**
+ * Controller spec for the yeast catalogue. Mocks the service
+ * layer so the test isolates the HTTP-shape mapping (URL → service
+ * call → DTO transform) from the service's database concerns
+ * covered in `yeast-catalog.service.spec.ts`. Service methods are
+ * spied via `jest.spyOn` so eslint's
+ * `@typescript-eslint/unbound-method` rule does not fire.
+ */
+describe('YeastCatalogController', () => {
+  let controller: YeastCatalogController;
+  let service: YeastCatalogService;
+
+  const ID_US05 = '00000000-0000-4000-9000-200000000006';
+
+  function buildEntity(
+    overrides: Partial<YeastOrmEntity> = {},
+  ): YeastOrmEntity {
+    return {
+      id: ID_US05,
+      name: 'Safale US-05',
+      type: YeastType.ALE,
+      form: YeastForm.DRY,
+      laboratory: 'Fermentis',
+      product_id: 'US-05',
+      min_temperature_c: 15,
+      max_temperature_c: 22,
+      flocculation: YeastFlocculation.MEDIUM,
+      attenuation_percent_typical: 81,
+      notes: 'Levure sèche neutre par excellence.',
+      created_at: new Date('2026-05-03T00:00:00.000Z'),
+      updated_at: new Date('2026-05-03T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [YeastCatalogController],
+      providers: [
+        {
+          provide: YeastCatalogService,
+          useValue: {
+            list: jest.fn(),
+            getById: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(YeastCatalogController);
+    service = module.get(YeastCatalogService);
+  });
+
+  describe('GET /catalog/yeasts', () => {
+    it('happy: returns the full list mapped to DTOs', async () => {
+      const listSpy = jest.spyOn(service, 'list').mockResolvedValue([
+        buildEntity({ id: ID_US05, name: 'Safale US-05' }),
+        buildEntity({
+          id: '00000000-0000-4000-9000-200000000008',
+          name: 'Saflager W-34/70',
+          type: YeastType.LAGER,
+        }),
+      ]);
+
+      const result = await controller.list();
+
+      expect(listSpy).toHaveBeenCalledWith({
+        type: undefined,
+        form: undefined,
+      });
+      expect(result.map((r) => r.name)).toEqual([
+        'Safale US-05',
+        'Saflager W-34/70',
+      ]);
+      // DTO must serialise dates to ISO strings — never raw Date.
+      expect(typeof result[0].created_at).toBe('string');
+    });
+
+    it('sad: returns [] when the service yields no rows', async () => {
+      jest.spyOn(service, 'list').mockResolvedValue([]);
+
+      const result = await controller.list();
+      expect(result).toEqual([]);
+    });
+
+    it('edge: forwards the type and form query filters to the service', async () => {
+      const listSpy = jest.spyOn(service, 'list').mockResolvedValue([]);
+
+      await controller.list(YeastType.LAGER, YeastForm.DRY);
+
+      expect(listSpy).toHaveBeenCalledWith({
+        type: YeastType.LAGER,
+        form: YeastForm.DRY,
+      });
+    });
+  });
+
+  describe('GET /catalog/yeasts/:id', () => {
+    it('happy: returns the DTO for the matching yeast', async () => {
+      const getByIdSpy = jest
+        .spyOn(service, 'getById')
+        .mockResolvedValue(buildEntity());
+
+      const result = await controller.getById(ID_US05);
+
+      expect(getByIdSpy).toHaveBeenCalledWith(ID_US05);
+      expect(result.id).toBe(ID_US05);
+      expect(result.name).toBe('Safale US-05');
+    });
+
+    it('sad: lets a NotFoundException from the service propagate to the HTTP layer', async () => {
+      jest
+        .spyOn(service, 'getById')
+        .mockRejectedValue(
+          new NotFoundException('Yeast catalogue entry not found'),
+        );
+
+      await expect(
+        controller.getById('00000000-0000-4000-9000-2000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: never leaks the raw ORM entity (always wraps in DTO)', async () => {
+      const entity = buildEntity();
+      jest.spyOn(service, 'getById').mockResolvedValue(entity);
+
+      const result = await controller.getById(ID_US05);
+
+      expect(result).not.toBe(entity);
+      expect(result.constructor.name).toBe('YeastDto');
+    });
+  });
+});

--- a/packages/api/src/catalog/yeast/controllers/yeast-catalog.controller.ts
+++ b/packages/api/src/catalog/yeast/controllers/yeast-catalog.controller.ts
@@ -1,0 +1,77 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseEnumPipe,
+  ParseUUIDPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
+import { YeastCatalogService } from '../services/yeast-catalog.service';
+import { YeastDto } from '../dtos/yeast.dto';
+import { YeastForm } from '../domain/enums/yeast-form.enum';
+import { YeastType } from '../domain/enums/yeast-type.enum';
+
+/**
+ * Read-only HTTP surface for the yeast catalogue. Two endpoints:
+ *   GET /catalog/yeasts          → list all (optionally filtered)
+ *   GET /catalog/yeasts/:id      → fetch one by UUID
+ *
+ * Write endpoints (POST / PATCH / DELETE) are intentionally absent
+ * — the catalogue is operator-curated reference data. An admin
+ * CRUD surface is planned for a later iteration once an admin role
+ * / interface exists.
+ */
+@ApiTags('Catalog · Yeasts')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('catalog/yeasts')
+export class YeastCatalogController {
+  constructor(private readonly service: YeastCatalogService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List the yeast catalogue entries' })
+  @ApiQuery({
+    name: 'type',
+    enum: YeastType,
+    required: false,
+    description: 'Filter by yeast category',
+  })
+  @ApiQuery({
+    name: 'form',
+    enum: YeastForm,
+    required: false,
+    description: 'Filter by physical form',
+  })
+  @ApiOkResponse({ type: YeastDto, isArray: true })
+  async list(
+    @Query('type', new ParseEnumPipe(YeastType, { optional: true }))
+    type?: YeastType,
+    @Query('form', new ParseEnumPipe(YeastForm, { optional: true }))
+    form?: YeastForm,
+  ): Promise<YeastDto[]> {
+    const rows = await this.service.list({ type, form });
+    return rows.map((row) => YeastDto.fromEntity(row));
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single yeast catalogue entry by UUID' })
+  @ApiOkResponse({ type: YeastDto })
+  @ApiNotFoundResponse({ description: 'Yeast catalogue entry not found' })
+  async getById(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<YeastDto> {
+    const entity = await this.service.getById(id);
+    return YeastDto.fromEntity(entity);
+  }
+}

--- a/packages/api/src/catalog/yeast/domain/enums/yeast-flocculation.enum.ts
+++ b/packages/api/src/catalog/yeast/domain/enums/yeast-flocculation.enum.ts
@@ -1,0 +1,18 @@
+/**
+ * How readily a yeast strain settles out of suspension after
+ * fermentation. Mirrors the BeerXML 1.0 `<FLOCCULATION>` element
+ * (4 values), with the underscored `very_high` matching the
+ * project's snake_case convention for multi-word enum values.
+ *
+ * Brewer interpretation:
+ *   - LOW: stays in suspension, hazy beer (NEIPA, Hefeweizen)
+ *   - MEDIUM: standard, beer clears in a week or two
+ *   - HIGH: drops fast, very clear beer (US-05, S-04)
+ *   - VERY_HIGH: drops within hours, may require rousing (WLP002)
+ */
+export enum YeastFlocculation {
+  LOW = 'low',
+  MEDIUM = 'medium',
+  HIGH = 'high',
+  VERY_HIGH = 'very_high',
+}

--- a/packages/api/src/catalog/yeast/domain/enums/yeast-form.enum.ts
+++ b/packages/api/src/catalog/yeast/domain/enums/yeast-form.enum.ts
@@ -1,0 +1,12 @@
+/**
+ * Physical form a yeast strain is sold as. Mirrors the BeerXML 1.0
+ * `<FORM>` element (4 values). Liquid and dry cover the
+ * homebrewer's day-to-day; slant and culture are kept for advanced
+ * users who maintain a yeast bank.
+ */
+export enum YeastForm {
+  LIQUID = 'liquid',
+  DRY = 'dry',
+  SLANT = 'slant',
+  CULTURE = 'culture',
+}

--- a/packages/api/src/catalog/yeast/domain/enums/yeast-type.enum.ts
+++ b/packages/api/src/catalog/yeast/domain/enums/yeast-type.enum.ts
@@ -1,0 +1,25 @@
+/**
+ * Brewing yeast categories for the catalogue. Adapted from BeerXML
+ * 1.0 (which lists 5 values including the wine / champagne entries
+ * irrelevant for a beer-focused app) and broadened beyond the
+ * existing `RecipeYeastType` (ale / lager / wild / brett) to add
+ * the WHEAT category every demo recipe needs (Hefeweizen, Witbier).
+ *
+ * Mapping rationale:
+ *   - ALE: top-fermenting Saccharomyces cerevisiae standard ales
+ *   - LAGER: bottom-fermenting Saccharomyces pastorianus lagers
+ *   - WHEAT: Hefeweizen / Weizen / Witbier strains with strong
+ *     phenolic + ester profile (e.g. Wyeast 3068)
+ *   - WILD: Brettanomyces / Lactobacillus / Pediococcus + any
+ *     funky / sour culture (folds the existing BRETT into a
+ *     superset that also covers sours)
+ *
+ * Wine and champagne values from BeerXML are intentionally absent
+ * — out of scope for a beer-focused catalogue.
+ */
+export enum YeastType {
+  ALE = 'ale',
+  LAGER = 'lager',
+  WHEAT = 'wheat',
+  WILD = 'wild',
+}

--- a/packages/api/src/catalog/yeast/domain/yeast.types.ts
+++ b/packages/api/src/catalog/yeast/domain/yeast.types.ts
@@ -1,0 +1,33 @@
+import { YeastFlocculation } from './enums/yeast-flocculation.enum';
+import { YeastForm } from './enums/yeast-form.enum';
+import { YeastType } from './enums/yeast-type.enum';
+
+/**
+ * Domain shape for one yeast entry in the immutable reference
+ * catalogue. Mirrors the database row shape one-to-one (see
+ * `YeastOrmEntity`) — kept as a separate interface so the
+ * application / presentation layers do not import the ORM entity
+ * directly.
+ *
+ * `laboratory` and `product_id` are kept as direct varchar columns
+ * (not normalised) because each catalogue row represents a SPECIFIC
+ * lab product (1:1, not N:N). The future "normalize-producers" PR
+ * may add an optional `laboratory_id` FK referencing a `producers`
+ * table, but the textual fields stay as the brewer-recognisable
+ * identifier (US-05, WLP002, 1056).
+ */
+export interface YeastCatalogEntry {
+  id: string;
+  name: string;
+  type: YeastType;
+  form: YeastForm;
+  laboratory: string | null;
+  product_id: string | null;
+  min_temperature_c: number | null;
+  max_temperature_c: number | null;
+  flocculation: YeastFlocculation | null;
+  attenuation_percent_typical: number | null;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/yeast/dtos/yeast.dto.ts
+++ b/packages/api/src/catalog/yeast/dtos/yeast.dto.ts
@@ -1,0 +1,84 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { YeastFlocculation } from '../domain/enums/yeast-flocculation.enum';
+import { YeastForm } from '../domain/enums/yeast-form.enum';
+import { YeastOrmEntity } from '../entities/yeast.orm.entity';
+import { YeastType } from '../domain/enums/yeast-type.enum';
+
+/**
+ * Read-only response DTO for the yeast catalogue. Mirrors the ORM
+ * row shape one-to-one (no field is computed). Built via
+ * `YeastDto.fromEntity(entity)` rather than direct property access
+ * so future shape changes (date serialisation, field renaming)
+ * stay in this single conversion point.
+ */
+export class YeastDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ example: 'Safale US-05' })
+  name: string;
+
+  @ApiProperty({ enum: YeastType, example: YeastType.ALE })
+  type: YeastType;
+
+  @ApiProperty({ enum: YeastForm, example: YeastForm.DRY })
+  form: YeastForm;
+
+  @ApiProperty({ example: 'Fermentis', nullable: true })
+  laboratory: string | null;
+
+  @ApiProperty({
+    example: 'US-05',
+    nullable: true,
+    description: 'Manufacturer SKU recognisable by brewers worldwide',
+  })
+  product_id: string | null;
+
+  @ApiProperty({ example: 15, nullable: true })
+  min_temperature_c: number | null;
+
+  @ApiProperty({ example: 22, nullable: true })
+  max_temperature_c: number | null;
+
+  @ApiProperty({
+    enum: YeastFlocculation,
+    example: YeastFlocculation.MEDIUM,
+    nullable: true,
+  })
+  flocculation: YeastFlocculation | null;
+
+  @ApiProperty({
+    example: 81,
+    nullable: true,
+    description: 'Typical apparent attenuation in percent',
+  })
+  attenuation_percent_typical: number | null;
+
+  @ApiProperty({ nullable: true })
+  notes: string | null;
+
+  @ApiProperty({ format: 'date-time' })
+  created_at: string;
+
+  @ApiProperty({ format: 'date-time' })
+  updated_at: string;
+
+  static fromEntity(entity: YeastOrmEntity): YeastDto {
+    const dto = new YeastDto();
+    dto.id = entity.id;
+    dto.name = entity.name;
+    dto.type = entity.type;
+    dto.form = entity.form;
+    dto.laboratory = entity.laboratory;
+    dto.product_id = entity.product_id;
+    dto.min_temperature_c = entity.min_temperature_c;
+    dto.max_temperature_c = entity.max_temperature_c;
+    dto.flocculation = entity.flocculation;
+    dto.attenuation_percent_typical = entity.attenuation_percent_typical;
+    dto.notes = entity.notes;
+    dto.created_at = entity.created_at.toISOString();
+    dto.updated_at = entity.updated_at.toISOString();
+    return dto;
+  }
+}

--- a/packages/api/src/catalog/yeast/entities/yeast.orm.entity.ts
+++ b/packages/api/src/catalog/yeast/entities/yeast.orm.entity.ts
@@ -33,6 +33,7 @@ import { YeastType } from '../domain/enums/yeast-type.enum';
  */
 @Entity('yeasts')
 @Index(['type'])
+@Index(['form'])
 @Index(['laboratory'])
 export class YeastOrmEntity {
   @PrimaryColumn('uuid')

--- a/packages/api/src/catalog/yeast/entities/yeast.orm.entity.ts
+++ b/packages/api/src/catalog/yeast/entities/yeast.orm.entity.ts
@@ -1,0 +1,120 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { YeastFlocculation } from '../domain/enums/yeast-flocculation.enum';
+import { YeastForm } from '../domain/enums/yeast-form.enum';
+import { YeastType } from '../domain/enums/yeast-type.enum';
+
+/**
+ * Immutable reference catalogue of brewing yeast strains (Issue
+ * #708 / #869, Phase 1 PR #3). Seeded with 20 entries — the 5
+ * BeerXML 1.0 canonical yeasts + 15 popular industry products
+ * (Fermentis dry yeasts, White Labs / Wyeast / Imperial Yeast
+ * liquid strains, Lallemand specialties).
+ *
+ * Each row represents a SPECIFIC lab product (Safale US-05,
+ * WLP002 English Ale, Wyeast 1056 American Ale, etc.). The
+ * `laboratory` and `product_id` columns stay as direct varchars
+ * because each catalogue row is 1:1 with a manufacturer product;
+ * the future "normalize-producers" PR may add an optional
+ * `laboratory_id` FK referencing the unified `producers` table
+ * but the textual fields remain as the brewer-recognisable
+ * identifier (US-05, WLP002, 1056).
+ *
+ * `recipe_yeasts` is not yet migrated to point at this catalogue
+ * via a `yeast_id` FK — that migration ships in a follow-up PR
+ * after all Phase 1-3 catalogues exist.
+ */
+@Entity('yeasts')
+@Index(['type'])
+@Index(['laboratory'])
+export class YeastOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 120, nullable: false, unique: true })
+  name: string;
+
+  @Column({
+    type: 'varchar',
+    length: 10,
+    enum: YeastType,
+    nullable: false,
+  })
+  type: YeastType;
+
+  @Column({
+    type: 'varchar',
+    length: 10,
+    enum: YeastForm,
+    nullable: false,
+  })
+  form: YeastForm;
+
+  /**
+   * Manufacturer label (e.g. White Labs, Wyeast Labs, Fermentis,
+   * Imperial Yeast, Lallemand). Free-text varchar in this PR —
+   * future normalisation may move it to a FK on a unified
+   * `producers` table while keeping this column as the
+   * brewer-facing display string.
+   */
+  @Column({ type: 'varchar', length: 60, nullable: true })
+  laboratory: string | null;
+
+  /**
+   * Manufacturer SKU recognisable by brewers worldwide (WLP002,
+   * 1056, US-05). Acts as the de-facto industry identifier even
+   * across language boundaries.
+   */
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  product_id: string | null;
+
+  /**
+   * Recommended fermentation temperature range in °C. Per-batch
+   * override (a brewer fermenting cold to suppress esters can
+   * legitimately go below the min) lives on `recipe_yeasts`.
+   */
+  @Column({ type: 'real', nullable: true })
+  min_temperature_c: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  max_temperature_c: number | null;
+
+  @Column({
+    type: 'varchar',
+    length: 10,
+    enum: YeastFlocculation,
+    nullable: true,
+  })
+  flocculation: YeastFlocculation | null;
+
+  /**
+   * Typical apparent attenuation in percent. 75% means the yeast
+   * consumes 75% of the available sugars — leaving the beer at
+   * 25% residual gravity. Per-batch reality varies with mash
+   * temperature and yeast health.
+   */
+  @Column({ type: 'real', nullable: true })
+  attenuation_percent_typical: number | null;
+
+  /**
+   * Brewer-friendly description in French (UI-facing). Folds the
+   * BeerXML `<NOTES>` and `<BEST_FOR>` fields into one prose
+   * narrative. Mirrors the convention used by HOPS_CATALOG_SEED
+   * and FERMENTABLES_CATALOG_SEED.
+   */
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/yeast/services/__tests__/yeast-catalog.service.spec.ts
+++ b/packages/api/src/catalog/yeast/services/__tests__/yeast-catalog.service.spec.ts
@@ -1,0 +1,174 @@
+jest.setTimeout(20000);
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { YeastCatalogService } from '../yeast-catalog.service';
+import { YeastFlocculation } from '../../domain/enums/yeast-flocculation.enum';
+import { YeastForm } from '../../domain/enums/yeast-form.enum';
+import { YeastOrmEntity } from '../../entities/yeast.orm.entity';
+import { YeastType } from '../../domain/enums/yeast-type.enum';
+
+/**
+ * Service spec for the yeast catalogue (Issue #708 / #869, Phase 1
+ * PR #3). Wires the real ORM entity against an in-memory SQLite so
+ * every where-clause and order-clause is exercised end-to-end —
+ * mocked repositories would not catch a typo in the column name
+ * or a wrong filter combinator.
+ */
+describe('YeastCatalogService', () => {
+  let module: TestingModule;
+  let service: YeastCatalogService;
+  let repository: Repository<YeastOrmEntity>;
+
+  const ID_WLP002 = '00000000-0000-4000-9000-200000000001';
+  const ID_US05 = '00000000-0000-4000-9000-200000000006';
+  const ID_W3470 = '00000000-0000-4000-9000-200000000008';
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [YeastOrmEntity],
+          synchronize: true,
+          logging: false,
+        }),
+        TypeOrmModule.forFeature([YeastOrmEntity]),
+      ],
+      providers: [YeastCatalogService],
+    }).compile();
+
+    service = module.get(YeastCatalogService);
+    repository = module.get(getRepositoryToken(YeastOrmEntity));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await repository.clear();
+  });
+
+  async function seedYeast(
+    id: string,
+    name: string,
+    type: YeastType,
+    form: YeastForm = YeastForm.LIQUID,
+  ): Promise<YeastOrmEntity> {
+    const entity = repository.create({
+      id,
+      name,
+      type,
+      form,
+      laboratory: 'White Labs',
+      product_id: 'WLP000',
+      min_temperature_c: 18,
+      max_temperature_c: 22,
+      flocculation: YeastFlocculation.MEDIUM,
+      attenuation_percent_typical: 75,
+      notes: null,
+    });
+    return repository.save(entity);
+  }
+
+  describe('list()', () => {
+    it('happy: returns every yeast ordered alphabetically by name', async () => {
+      await seedYeast(ID_WLP002, 'English Ale', YeastType.ALE);
+      await seedYeast(ID_US05, 'Safale US-05', YeastType.ALE, YeastForm.DRY);
+      await seedYeast(
+        ID_W3470,
+        'Saflager W-34/70',
+        YeastType.LAGER,
+        YeastForm.DRY,
+      );
+
+      const rows = await service.list();
+      expect(rows.map((r) => r.name)).toEqual([
+        'English Ale',
+        'Safale US-05',
+        'Saflager W-34/70',
+      ]);
+    });
+
+    it('sad: returns [] when the catalogue is empty', async () => {
+      const rows = await service.list();
+      expect(rows).toEqual([]);
+    });
+
+    it('edge: filters by type when provided', async () => {
+      await seedYeast(ID_WLP002, 'English Ale', YeastType.ALE);
+      await seedYeast(
+        ID_W3470,
+        'Saflager W-34/70',
+        YeastType.LAGER,
+        YeastForm.DRY,
+      );
+
+      const rows = await service.list({ type: YeastType.LAGER });
+      expect(rows.map((r) => r.name)).toEqual(['Saflager W-34/70']);
+    });
+
+    it('edge: filters by form when provided', async () => {
+      await seedYeast(
+        ID_WLP002,
+        'English Ale',
+        YeastType.ALE,
+        YeastForm.LIQUID,
+      );
+      await seedYeast(ID_US05, 'Safale US-05', YeastType.ALE, YeastForm.DRY);
+
+      const rows = await service.list({ form: YeastForm.DRY });
+      expect(rows.map((r) => r.name)).toEqual(['Safale US-05']);
+    });
+
+    it('edge: AND-combines type and form filters', async () => {
+      await seedYeast(
+        ID_WLP002,
+        'English Ale',
+        YeastType.ALE,
+        YeastForm.LIQUID,
+      );
+      await seedYeast(ID_US05, 'Safale US-05', YeastType.ALE, YeastForm.DRY);
+      await seedYeast(
+        ID_W3470,
+        'Saflager W-34/70',
+        YeastType.LAGER,
+        YeastForm.DRY,
+      );
+
+      const rows = await service.list({
+        type: YeastType.ALE,
+        form: YeastForm.DRY,
+      });
+      expect(rows.map((r) => r.name)).toEqual(['Safale US-05']);
+    });
+  });
+
+  describe('getById()', () => {
+    it('happy: returns the yeast matching the UUID', async () => {
+      await seedYeast(ID_US05, 'Safale US-05', YeastType.ALE, YeastForm.DRY);
+
+      const yeast = await service.getById(ID_US05);
+      expect(yeast.name).toBe('Safale US-05');
+      expect(yeast.form).toBe(YeastForm.DRY);
+    });
+
+    it('sad: throws NotFoundException when the UUID is unknown', async () => {
+      await expect(
+        service.getById('00000000-0000-4000-9000-2000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: does not match by name even if a row with that name exists', async () => {
+      await seedYeast(ID_US05, 'Safale US-05', YeastType.ALE, YeastForm.DRY);
+
+      // Strict UUID PK lookup — name-shaped strings still 404.
+      await expect(service.getById('safale-us-05')).rejects.toThrow();
+    });
+  });
+});

--- a/packages/api/src/catalog/yeast/services/yeast-catalog.service.ts
+++ b/packages/api/src/catalog/yeast/services/yeast-catalog.service.ts
@@ -1,0 +1,55 @@
+import { FindOptionsWhere, Repository } from 'typeorm';
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { InjectRepository } from '@nestjs/typeorm';
+import { YeastForm } from '../domain/enums/yeast-form.enum';
+import { YeastOrmEntity } from '../entities/yeast.orm.entity';
+import { YeastType } from '../domain/enums/yeast-type.enum';
+
+/**
+ * Optional filters accepted by the list endpoint. All filters are
+ * AND-combined; absence of a filter means "any value".
+ */
+export interface ListYeastsFilters {
+  type?: YeastType;
+  form?: YeastForm;
+}
+
+@Injectable()
+export class YeastCatalogService {
+  constructor(
+    @InjectRepository(YeastOrmEntity)
+    private readonly yeasts: Repository<YeastOrmEntity>,
+  ) {}
+
+  /**
+   * Returns the catalogue ordered alphabetically by name, optionally
+   * filtered by type and / or form. The catalogue is small (~20
+   * rows on day one) so no pagination is offered yet — added when
+   * the catalogue grows past ~100 entries.
+   */
+  async list(filters: ListYeastsFilters = {}): Promise<YeastOrmEntity[]> {
+    const where: FindOptionsWhere<YeastOrmEntity> = {};
+    if (filters.type) where.type = filters.type;
+    if (filters.form) where.form = filters.form;
+
+    return this.yeasts.find({
+      where,
+      order: { name: 'ASC' },
+    });
+  }
+
+  /**
+   * Returns a single catalogue entry by its UUID, or throws 404.
+   * Strict UUID match — no name lookup here, since multiple lab
+   * products can have similar display names (e.g. WLP004 Irish
+   * Ale vs Wyeast 1084 Irish Ale Yeast).
+   */
+  async getById(id: string): Promise<YeastOrmEntity> {
+    const entity = await this.yeasts.findOne({ where: { id } });
+    if (!entity) {
+      throw new NotFoundException(`Yeast catalogue entry ${id} not found`);
+    }
+    return entity;
+  }
+}

--- a/packages/api/src/catalog/yeast/yeast.module.ts
+++ b/packages/api/src/catalog/yeast/yeast.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { YeastCatalogController } from './controllers/yeast-catalog.controller';
+import { YeastCatalogService } from './services/yeast-catalog.service';
+import { YeastOrmEntity } from './entities/yeast.orm.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([YeastOrmEntity])],
+  controllers: [YeastCatalogController],
+  providers: [YeastCatalogService],
+  exports: [YeastCatalogService],
+})
+export class YeastModule {}

--- a/packages/api/src/database/migrations/1785000000000-AddYeastsCatalog.ts
+++ b/packages/api/src/database/migrations/1785000000000-AddYeastsCatalog.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `yeasts` table — immutable reference catalogue of
+ * brewing yeast strains seeded with 20 entries (5 BeerXML canonical
+ * + 15 popular industry products). Phase 1 PR #3 of the catalogue
+ * refactor (Issue #708 / #869), completing the trio
+ * Hop / Fermentable / Yeast.
+ *
+ * The `laboratory` field stays as a direct varchar in this
+ * migration — see the entity comment for the rationale (1:1 with
+ * the manufacturer product, not N:N like the supplier of
+ * fermentables). The future "normalize-producers" PR may add an
+ * optional `laboratory_id` FK referencing the unified `producers`
+ * table while keeping this column as the brewer-facing display
+ * string.
+ */
+export class AddYeastsCatalog1785000000000 implements MigrationInterface {
+  name = 'AddYeastsCatalog1785000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "yeasts" (
+        "id"                          varchar(36) PRIMARY KEY NOT NULL,
+        "name"                        varchar(120) NOT NULL,
+        "type"                        varchar(10) NOT NULL,
+        "form"                        varchar(10) NOT NULL,
+        "laboratory"                  varchar(60),
+        "product_id"                  varchar(20),
+        "min_temperature_c"           real,
+        "max_temperature_c"           real,
+        "flocculation"                varchar(10),
+        "attenuation_percent_typical" real,
+        "notes"                       text,
+        "created_at"                  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "updated_at"                  datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT "CHK_yeasts_type"
+          CHECK ("type" IN ('ale', 'lager', 'wheat', 'wild')),
+        CONSTRAINT "CHK_yeasts_form"
+          CHECK ("form" IN ('liquid', 'dry', 'slant', 'culture')),
+        CONSTRAINT "CHK_yeasts_flocculation"
+          CHECK (
+            "flocculation" IS NULL
+            OR "flocculation" IN ('low', 'medium', 'high', 'very_high')
+          )
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_yeasts_name" ON "yeasts" ("name")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_yeasts_type" ON "yeasts" ("type")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_yeasts_laboratory" ON "yeasts" ("laboratory")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_yeasts_laboratory"`);
+    await queryRunner.query(`DROP INDEX "IDX_yeasts_type"`);
+    await queryRunner.query(`DROP INDEX "IDX_yeasts_name"`);
+    await queryRunner.query(`DROP TABLE "yeasts"`);
+  }
+}

--- a/packages/api/src/database/migrations/1785000000000-AddYeastsCatalog.ts
+++ b/packages/api/src/database/migrations/1785000000000-AddYeastsCatalog.ts
@@ -52,12 +52,16 @@ export class AddYeastsCatalog1785000000000 implements MigrationInterface {
       `CREATE INDEX "IDX_yeasts_type" ON "yeasts" ("type")`,
     );
     await queryRunner.query(
+      `CREATE INDEX "IDX_yeasts_form" ON "yeasts" ("form")`,
+    );
+    await queryRunner.query(
       `CREATE INDEX "IDX_yeasts_laboratory" ON "yeasts" ("laboratory")`,
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`DROP INDEX "IDX_yeasts_laboratory"`);
+    await queryRunner.query(`DROP INDEX "IDX_yeasts_form"`);
     await queryRunner.query(`DROP INDEX "IDX_yeasts_type"`);
     await queryRunner.query(`DROP INDEX "IDX_yeasts_name"`);
     await queryRunner.query(`DROP TABLE "yeasts"`);

--- a/packages/api/src/database/seeds/__tests__/yeasts-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/__tests__/yeasts-catalog.seed.spec.ts
@@ -127,6 +127,21 @@ describe('seedYeastsCatalog (Issue #708 / #869 — Phase 1 PR #3)', () => {
       // when Phase 1 stabilises and we need them for sour recipes.
     });
 
+    it('tags every Witbier and Hefeweizen strain as WHEAT (not ALE)', () => {
+      // The WHEAT enum value exists specifically to cover these two
+      // demo styles. A `GET /catalog/yeasts?type=wheat` query must
+      // surface both — accidentally tagging either as ALE would
+      // hide it from Witbier / Hefeweizen recipe authoring.
+      const witbier = YEASTS_CATALOG_SEED.find(
+        (y) => y.product_id === 'WLP410',
+      );
+      const hefeweizen = YEASTS_CATALOG_SEED.find(
+        (y) => y.product_id === '3068',
+      );
+      expect(witbier?.type).toBe(YeastType.WHEAT);
+      expect(hefeweizen?.type).toBe(YeastType.WHEAT);
+    });
+
     it('keeps every notes value in French (UI-facing convention)', () => {
       for (const yeast of YEASTS_CATALOG_SEED) {
         if (yeast.notes !== null) {

--- a/packages/api/src/database/seeds/__tests__/yeasts-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/__tests__/yeasts-catalog.seed.spec.ts
@@ -1,0 +1,161 @@
+import { Repository } from 'typeorm';
+
+import { YEASTS_CATALOG_SEED, seedYeastsCatalog } from '../yeasts-catalog.seed';
+import { YeastFlocculation } from '../../../catalog/yeast/domain/enums/yeast-flocculation.enum';
+import { YeastForm } from '../../../catalog/yeast/domain/enums/yeast-form.enum';
+import { YeastOrmEntity } from '../../../catalog/yeast/entities/yeast.orm.entity';
+import { YeastType } from '../../../catalog/yeast/domain/enums/yeast-type.enum';
+import { buildRepoMock } from '../seed-test-utils';
+
+describe('seedYeastsCatalog (Issue #708 / #869 — Phase 1 PR #3)', () => {
+  describe('happy path', () => {
+    it('inserts all 20 catalogue entries when the table is empty', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      const result = await seedYeastsCatalog(
+        repo as unknown as Repository<YeastOrmEntity>,
+      );
+
+      expect(result).toEqual({ inserted: 20, updated: 0, total: 20 });
+      expect(repo.create).toHaveBeenCalledTimes(20);
+      expect(repo.save).toHaveBeenCalledTimes(20);
+    });
+
+    it('writes name + type + form on every inserted row', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      await seedYeastsCatalog(repo as unknown as Repository<YeastOrmEntity>);
+
+      for (const call of repo.create.mock.calls as unknown[][]) {
+        const arg = call[0] as Record<string, unknown>;
+        expect(typeof arg.name).toBe('string');
+        expect((arg.name as string).length).toBeGreaterThan(0);
+        expect(Object.values(YeastType)).toContain(arg.type);
+        expect(Object.values(YeastForm)).toContain(arg.form);
+      }
+    });
+  });
+
+  describe('idempotency (sad path)', () => {
+    it('updates existing rows in place rather than duplicating them', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockImplementation(() =>
+        Promise.resolve({
+          id: 'will-be-overwritten',
+          name: 'old-name',
+          type: YeastType.ALE,
+        }),
+      );
+
+      const result = await seedYeastsCatalog(
+        repo as unknown as Repository<YeastOrmEntity>,
+      );
+
+      expect(result).toEqual({ inserted: 0, updated: 20, total: 20 });
+      expect(repo.create).not.toHaveBeenCalled();
+      expect(repo.save).toHaveBeenCalledTimes(20);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('mixes inserts and updates when only some IDs already exist', async () => {
+      const repo = buildRepoMock();
+      let counter = 0;
+      repo.findOne.mockImplementation(() => {
+        counter += 1;
+        return Promise.resolve(
+          counter <= 5 ? { id: `existing-${counter}` } : null,
+        );
+      });
+
+      const result = await seedYeastsCatalog(
+        repo as unknown as Repository<YeastOrmEntity>,
+      );
+
+      expect(result).toEqual({ inserted: 15, updated: 5, total: 20 });
+    });
+
+    it('respects an explicit override list', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      const customYeasts = YEASTS_CATALOG_SEED.slice(0, 3);
+
+      const result = await seedYeastsCatalog(
+        repo as unknown as Repository<YeastOrmEntity>,
+        customYeasts,
+      );
+
+      expect(result).toEqual({ inserted: 3, updated: 0, total: 3 });
+    });
+
+    it('exposes 20 curated catalogue entries spanning BeerXML + popular industry products', () => {
+      expect(YEASTS_CATALOG_SEED).toHaveLength(20);
+
+      const names = YEASTS_CATALOG_SEED.map((y) => y.name);
+      // 5 BeerXML canonical
+      expect(names).toContain('English Ale (WLP002)');
+      expect(names).toContain('European Ale (WLP011)');
+      expect(names).toContain('Irish Ale (Wyeast 1084)');
+      expect(names).toContain('Kölsch (Wyeast 2565)');
+      expect(names).toContain('Northwest Ale (Wyeast 1332)');
+      // Popular for the demo recipes
+      expect(names).toContain('Safale US-05');
+      expect(names).toContain('Safale S-04');
+      expect(names).toContain('Saflager W-34/70');
+      expect(names).toContain('Weihenstephan Weizen (Wyeast 3068)');
+      expect(names).toContain('London Ale III (Wyeast 1318)');
+    });
+
+    it('uses deterministic UUIDs in the catalogue range (...-9000-2000-...)', () => {
+      const ids = YEASTS_CATALOG_SEED.map((y) => y.id);
+      for (const id of ids) {
+        expect(id).toMatch(/^00000000-0000-4000-9000-2[0-9a-f]{11}$/);
+      }
+      // No duplicates.
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('covers every yeast type that has at least one demo entry (ale/lager/wheat)', () => {
+      const types = new Set(YEASTS_CATALOG_SEED.map((y) => y.type));
+      expect(types.has(YeastType.ALE)).toBe(true);
+      expect(types.has(YeastType.LAGER)).toBe(true);
+      expect(types.has(YeastType.WHEAT)).toBe(true);
+      // WILD intentionally absent — Brett / sour strains will land
+      // when Phase 1 stabilises and we need them for sour recipes.
+    });
+
+    it('keeps every notes value in French (UI-facing convention)', () => {
+      for (const yeast of YEASTS_CATALOG_SEED) {
+        if (yeast.notes !== null) {
+          expect(yeast.notes).toMatch(/[àâäéèêëïîôöùûüÿç]/i);
+        }
+      }
+    });
+
+    it('covers the major laboratories (White Labs, Wyeast, Fermentis, Lallemand, Imperial Yeast)', () => {
+      const labs = new Set(
+        YEASTS_CATALOG_SEED.map((y) => y.laboratory).filter(
+          (lab): lab is string => lab !== null,
+        ),
+      );
+      expect(labs).toContain('White Labs');
+      expect(labs).toContain('Wyeast Labs');
+      expect(labs).toContain('Fermentis');
+      expect(labs).toContain('Lallemand');
+      expect(labs).toContain('Imperial Yeast');
+    });
+
+    it('uses valid flocculation enum values when set', () => {
+      for (const yeast of YEASTS_CATALOG_SEED) {
+        if (yeast.flocculation !== null) {
+          expect(Object.values(YeastFlocculation)).toContain(
+            yeast.flocculation,
+          );
+        }
+      }
+    });
+  });
+});

--- a/packages/api/src/database/seeds/yeasts-catalog.seed.ts
+++ b/packages/api/src/database/seeds/yeasts-catalog.seed.ts
@@ -271,7 +271,11 @@ export const YEASTS_CATALOG_SEED: readonly YeastCatalogSeed[] = [
   {
     id: '00000000-0000-4000-9000-20000000000e',
     name: 'Belgian Wit II (WLP410)',
-    type: YeastType.ALE,
+    // Tagged WHEAT (not ALE) per the catalogue rationale: the
+    // WHEAT category exists specifically to cover Witbier and
+    // Hefeweizen strains, so a `?type=wheat` query must surface
+    // both Wyeast 3068 (Hefeweizen) and WLP410 (Witbier).
+    type: YeastType.WHEAT,
     form: YeastForm.LIQUID,
     laboratory: 'White Labs',
     product_id: 'WLP410',

--- a/packages/api/src/database/seeds/yeasts-catalog.seed.ts
+++ b/packages/api/src/database/seeds/yeasts-catalog.seed.ts
@@ -1,0 +1,438 @@
+import { Repository } from 'typeorm';
+
+import { YeastFlocculation } from '../../catalog/yeast/domain/enums/yeast-flocculation.enum';
+import { YeastForm } from '../../catalog/yeast/domain/enums/yeast-form.enum';
+import { YeastOrmEntity } from '../../catalog/yeast/entities/yeast.orm.entity';
+import { YeastType } from '../../catalog/yeast/domain/enums/yeast-type.enum';
+import { idempotentUpsertById } from './seed-utils';
+
+/**
+ * Seed for the `yeasts` reference catalogue (Issue #708 / #869,
+ * Phase 1 PR #3, completing the trio Hop / Fermentable / Yeast).
+ * Operator-curated entries — drawn from the BeerXML 1.0 reference
+ * fixture (`docs/architecture/specs/fixtures/libraries/yeast.xml`,
+ * 5 entries) and from major manufacturer datasheets (White Labs,
+ * Wyeast Labs, Fermentis, Imperial Yeast, Lallemand), but
+ * deliberately not a verbatim copy of either source. Each row is
+ * authored to be picker-friendly with French notes matching the
+ * convention of `PUBLIC_RECIPES_SEED.description`,
+ * `HOPS_CATALOG_SEED` and `FERMENTABLES_CATALOG_SEED`.
+ *
+ * The 20 entries are split:
+ *   • 5 BeerXML canonical (English Ale WLP002, European Ale
+ *     WLP011, Irish Ale Wyeast 1084, Kölsch Wyeast 2565,
+ *     Northwest Ale Wyeast 1332) — the ones in
+ *     `libraries/yeast.xml`.
+ *   • 15 popular industry products needed by the demo recipes
+ *     (Punk IPA, NEIPA, Saison, Belgian Tripel, Witbier,
+ *     Hefeweizen, Pilsner, ESB, Irish Stout) and the broader
+ *     homebrew vocabulary.
+ *
+ * UUID range `00000000-0000-4000-9000-…` is shared with the hop
+ * and fermentable catalogues. Yeasts use a distinct second-segment
+ * range (`…-9000-2000-…`) to avoid collision (hops use `0`,
+ * fermentables use `1`, yeasts use `2`).
+ */
+
+export interface YeastCatalogSeed {
+  id: string;
+  name: string;
+  type: YeastType;
+  form: YeastForm;
+  laboratory: string | null;
+  product_id: string | null;
+  min_temperature_c: number | null;
+  max_temperature_c: number | null;
+  flocculation: YeastFlocculation | null;
+  attenuation_percent_typical: number | null;
+  notes: string | null;
+}
+
+export const YEASTS_CATALOG_SEED: readonly YeastCatalogSeed[] = [
+  // ─── 5 BeerXML canonical entries (libraries/yeast.xml) ──────────────────
+  {
+    id: '00000000-0000-4000-9000-200000000001',
+    name: 'English Ale (WLP002)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'White Labs',
+    product_id: 'WLP002',
+    min_temperature_c: 18.3,
+    max_temperature_c: 20,
+    flocculation: YeastFlocculation.VERY_HIGH,
+    attenuation_percent_typical: 66.5,
+    notes:
+      'Souche ESB classique, idéale pour les milds, bitters, ' +
+      'porters et stouts anglais. Floculation très élevée laissant ' +
+      'une bière claire avec une douceur résiduelle. Atténuation ' +
+      'modérée caractéristique du style.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000002',
+    name: 'European Ale (WLP011)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'White Labs',
+    product_id: 'WLP011',
+    min_temperature_c: 18.3,
+    max_temperature_c: 21.1,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 67.5,
+    notes:
+      "Levure ale du nord de l'Europe, profil malté. Faible " +
+      "production d'esters et de soufre, finition propre. " +
+      'Atténuation basse contribuant à un goût malté prononcé. ' +
+      'Pour Alt, Kölsch, English Ales maltés et fruit beers.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000003',
+    name: 'Irish Ale (Wyeast 1084)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'Wyeast Labs',
+    product_id: '1084',
+    min_temperature_c: 16.7,
+    max_temperature_c: 22.2,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 73,
+    notes:
+      'Levure Irish Stout par excellence. Profil sec et fruité ' +
+      'caractéristique des stouts. Corps plein, finition sèche et ' +
+      'propre. Pour Irish Dry Stout, Porter, Scottish Ale, Brown ' +
+      'Ale, Imperial Stout, Barley Wine.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000004',
+    name: 'Kölsch (Wyeast 2565)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'Wyeast Labs',
+    product_id: '2565',
+    min_temperature_c: 13.3,
+    max_temperature_c: 17.8,
+    flocculation: YeastFlocculation.LOW,
+    attenuation_percent_typical: 75,
+    notes:
+      'Levure hybride du style Kölsch (Cologne). Caractère malté ' +
+      "avec un mélange d'esters de levure ale et de propreté de " +
+      'lager. Finition croustillante et nette. Pour Kölsch et ' +
+      'European Ales légères.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000005',
+    name: 'Northwest Ale (Wyeast 1332)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'Wyeast Labs',
+    product_id: '1332',
+    min_temperature_c: 18.3,
+    max_temperature_c: 23.9,
+    flocculation: YeastFlocculation.HIGH,
+    attenuation_percent_typical: 69,
+    notes:
+      'Levure ale classique du nord-ouest US. Léger profil ' +
+      'fruité, bière maltée avec un bon corps et un bel équilibre. ' +
+      'Référence pour les Oregon Ales et les styles American Ale.',
+  },
+  // ─── 15 popular industry products for the demo recipes ───────────────────
+  {
+    id: '00000000-0000-4000-9000-200000000006',
+    name: 'Safale US-05',
+    type: YeastType.ALE,
+    form: YeastForm.DRY,
+    laboratory: 'Fermentis',
+    product_id: 'US-05',
+    min_temperature_c: 15,
+    max_temperature_c: 22,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 81,
+    notes:
+      'Levure sèche neutre par excellence. Profil propre, ' +
+      "légèrement fruité, laissant le houblon s'exprimer. " +
+      'Standard absolu pour American Pale Ale, IPA, NEIPA, et ' +
+      'la Punk IPA. Réhydratation recommandée.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000007',
+    name: 'Safale S-04',
+    type: YeastType.ALE,
+    form: YeastForm.DRY,
+    laboratory: 'Fermentis',
+    product_id: 'S-04',
+    min_temperature_c: 15,
+    max_temperature_c: 20,
+    flocculation: YeastFlocculation.HIGH,
+    attenuation_percent_typical: 75,
+    notes:
+      'Levure sèche anglaise polyvalente. Floculation rapide ' +
+      'donnant une bière claire en quelques jours. Profil malté ' +
+      'discret, légères notes fruitées. Pour ESB, Bitter, Brown ' +
+      'Ale, Porter britanniques.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000008',
+    name: 'Saflager W-34/70',
+    type: YeastType.LAGER,
+    form: YeastForm.DRY,
+    laboratory: 'Fermentis',
+    product_id: 'W-34/70',
+    min_temperature_c: 9,
+    max_temperature_c: 15,
+    flocculation: YeastFlocculation.HIGH,
+    attenuation_percent_typical: 83,
+    notes:
+      'Souche lager universelle de Weihenstephan, en version ' +
+      'sèche. Profil neutre et propre, fermentation à froid (12°C ' +
+      'idéal). Pour Pilsner, Helles, Märzen, lagers continentales.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000009',
+    name: 'California Ale (WLP001)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'White Labs',
+    product_id: 'WLP001',
+    min_temperature_c: 20,
+    max_temperature_c: 22.8,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 76.5,
+    notes:
+      'Souche American Pale Ale classique (équivalent Chico de ' +
+      'Sierra Nevada). Profil propre, légèrement fruité, accentue ' +
+      'le houblon. Pour American Pale, IPA, Imperial IPA et ' +
+      'recettes orientées houblon.',
+  },
+  {
+    id: '00000000-0000-4000-9000-20000000000a',
+    name: 'American Ale (Wyeast 1056)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'Wyeast Labs',
+    product_id: '1056',
+    min_temperature_c: 15.6,
+    max_temperature_c: 22.2,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 75,
+    notes:
+      'Souche American Pale Ale équivalente WLP001 (toutes deux ' +
+      'descendant de la Chico). Très neutre, fruitée discrète. ' +
+      'Pour APA, IPA, Imperial Stout, recettes house.',
+  },
+  {
+    id: '00000000-0000-4000-9000-20000000000b',
+    name: 'Trappist High Gravity (Wyeast 3787)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'Wyeast Labs',
+    product_id: '3787',
+    min_temperature_c: 18.3,
+    max_temperature_c: 25,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 77.5,
+    notes:
+      'Souche Trappiste tolérante aux hautes densités. Profil ' +
+      'phénolique-fruité (poire, pomme, clou de girofle). ' +
+      'Indispensable pour Belgian Tripel, Belgian Dark Strong ' +
+      'Ale, Quadrupel.',
+  },
+  {
+    id: '00000000-0000-4000-9000-20000000000c',
+    name: 'Trappist Ale (WLP500)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'White Labs',
+    product_id: 'WLP500',
+    min_temperature_c: 18.3,
+    max_temperature_c: 23.9,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 76,
+    notes:
+      "Souche Trappiste de l'abbaye de Chimay. Profil " +
+      'phénolique discret, fruité (banane, poire), épicé. Pour ' +
+      'Belgian Strong Golden Ale, Dubbel, Tripel.',
+  },
+  {
+    id: '00000000-0000-4000-9000-20000000000d',
+    name: 'French Saison (Wyeast 3711)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'Wyeast Labs',
+    product_id: '3711',
+    min_temperature_c: 18.3,
+    max_temperature_c: 26.7,
+    flocculation: YeastFlocculation.LOW,
+    attenuation_percent_typical: 81,
+    notes:
+      'Souche Saison française. Atténuation très élevée donnant ' +
+      'une bière sèche et croustillante. Profil épicé, poivré, ' +
+      'agrumes. Tolère la haute température sans phénols off. ' +
+      'Pour Saison, Farmhouse Ale.',
+  },
+  {
+    id: '00000000-0000-4000-9000-20000000000e',
+    name: 'Belgian Wit II (WLP410)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'White Labs',
+    product_id: 'WLP410',
+    min_temperature_c: 19.4,
+    max_temperature_c: 22.8,
+    flocculation: YeastFlocculation.LOW,
+    attenuation_percent_typical: 75,
+    notes:
+      'Souche belge Witbier moins phénolique que la WLP400. ' +
+      'Notes plus fruitées, légèrement épicées. Profil trouble ' +
+      'caractéristique. Pour Witbier, White Ale, fruit-infused ' +
+      'Belgian Pale.',
+  },
+  {
+    id: '00000000-0000-4000-9000-20000000000f',
+    name: 'Weihenstephan Weizen (Wyeast 3068)',
+    type: YeastType.WHEAT,
+    form: YeastForm.LIQUID,
+    laboratory: 'Wyeast Labs',
+    product_id: '3068',
+    min_temperature_c: 17.8,
+    max_temperature_c: 22.8,
+    flocculation: YeastFlocculation.LOW,
+    attenuation_percent_typical: 75.5,
+    notes:
+      'Souche Hefeweizen mythique de Weihenstephan (la plus ' +
+      'ancienne brasserie au monde). Profil banane (acétate ' +
+      "d'isoamyle) + clou de girofle (4-vinyl guaïacol) " +
+      'classique. Bière trouble par défaut. Pour Hefeweizen, ' +
+      'Dunkelweizen, Weizenbock.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000010',
+    name: 'Pilsner Lager (WLP800)',
+    type: YeastType.LAGER,
+    form: YeastForm.LIQUID,
+    laboratory: 'White Labs',
+    product_id: 'WLP800',
+    min_temperature_c: 10,
+    max_temperature_c: 12.8,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 75,
+    notes:
+      "Souche Pilsner d'origine tchèque. Profil légèrement " +
+      'fruité au début de la fermentation, propre après lagering. ' +
+      'Idéale pour Bohemian Pilsner (Pilsner Urquell-style), ' +
+      'Czech Premium Pale Lager.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000011',
+    name: 'London Ale III (Wyeast 1318)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'Wyeast Labs',
+    product_id: '1318',
+    min_temperature_c: 18.3,
+    max_temperature_c: 22.8,
+    flocculation: YeastFlocculation.LOW,
+    attenuation_percent_typical: 73,
+    notes:
+      'Souche NEIPA par excellence (originellement London Ale). ' +
+      'Profil très fruité (esters tropicaux, agrumes), faible ' +
+      'floculation laissant la bière trouble (haze). Pour NEIPA, ' +
+      'Hazy IPA, English Mild moderne.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000012',
+    name: 'Irish Ale (WLP004)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'White Labs',
+    product_id: 'WLP004',
+    min_temperature_c: 18.3,
+    max_temperature_c: 20,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 71,
+    notes:
+      'Souche Irish Stout (équivalent Wyeast 1084 chez White ' +
+      'Labs). Profil propre, légèrement aigre-fruité. Pour Irish ' +
+      'Dry Stout, Irish Red Ale, Sweet Stout.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000013',
+    name: 'BRY-97 American West Coast',
+    type: YeastType.ALE,
+    form: YeastForm.DRY,
+    laboratory: 'Lallemand',
+    product_id: 'BRY-97',
+    min_temperature_c: 15,
+    max_temperature_c: 22,
+    flocculation: YeastFlocculation.HIGH,
+    attenuation_percent_typical: 81,
+    notes:
+      'Alternative sèche à US-05 développée par Lallemand. ' +
+      'Profil propre type West Coast, floculation plus rapide ' +
+      'que US-05. Pour American Pale Ale, West Coast IPA. ' +
+      'Démarrage plus lent — patience au jour 1.',
+  },
+  {
+    id: '00000000-0000-4000-9000-200000000014',
+    name: 'Pub (Imperial A09)',
+    type: YeastType.ALE,
+    form: YeastForm.LIQUID,
+    laboratory: 'Imperial Yeast',
+    product_id: 'A09',
+    min_temperature_c: 18.3,
+    max_temperature_c: 22.2,
+    flocculation: YeastFlocculation.MEDIUM,
+    attenuation_percent_typical: 76,
+    notes:
+      'Souche Imperial Yeast équivalente à WLP001 / Wyeast 1056 ' +
+      '(la Chico moderne). Profil propre, accentue le houblon. ' +
+      'Densité cellulaire Imperial typiquement supérieure : ' +
+      "pas de starter nécessaire jusqu'à 1.060.",
+  },
+];
+
+/**
+ * Result returned by `seedYeastsCatalog` for instrumentation /
+ * verification. Lets callers (tests, CLI, npm scripts) report what
+ * happened without re-querying the DB.
+ */
+export interface SeedYeastsCatalogResult {
+  inserted: number;
+  updated: number;
+  total: number;
+}
+
+/**
+ * Idempotent loader for the yeast reference catalogue. Insert if
+ * the id is unknown, update in place otherwise. Re-running the
+ * loader never duplicates rows — see `idempotentUpsertById` for
+ * the shared upsert pattern.
+ */
+export async function seedYeastsCatalog(
+  repository: Repository<YeastOrmEntity>,
+  yeasts: readonly YeastCatalogSeed[] = YEASTS_CATALOG_SEED,
+): Promise<SeedYeastsCatalogResult> {
+  let inserted = 0;
+  let updated = 0;
+
+  for (const yeast of yeasts) {
+    const outcome = await idempotentUpsertById(
+      repository,
+      { id: yeast.id },
+      {
+        name: yeast.name,
+        type: yeast.type,
+        form: yeast.form,
+        laboratory: yeast.laboratory,
+        product_id: yeast.product_id,
+        min_temperature_c: yeast.min_temperature_c,
+        max_temperature_c: yeast.max_temperature_c,
+        flocculation: yeast.flocculation,
+        attenuation_percent_typical: yeast.attenuation_percent_typical,
+        notes: yeast.notes,
+      },
+    );
+    inserted += outcome.inserted;
+    updated += outcome.updated;
+  }
+
+  return { inserted, updated, total: inserted + updated };
+}

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -21,6 +21,7 @@ import { ScanRequestOrmEntity } from '../scan/entities/scan-request.orm.entity';
 import { ScanReviewQueueOrmEntity } from '../scan/entities/scan-review-queue.orm.entity';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { User } from '../user/entities/user.entity';
+import { YeastOrmEntity } from '../catalog/yeast/entities/yeast.orm.entity';
 
 const truthyEnvValues = new Set(['1', 'true', 'yes', 'on']);
 const falsyEnvValues = new Set(['0', 'false', 'no', 'off']);
@@ -45,6 +46,7 @@ export const ormEntities = [
   ScanReviewQueueOrmEntity,
   HopOrmEntity,
   FermentableOrmEntity,
+  YeastOrmEntity,
 ];
 
 const parseBooleanEnv = (name: string, defaultValue: boolean): boolean => {


### PR DESCRIPTION
## Summary

Phase 1 PR #3 of the brewing reference catalogues refactor (Issue #708 / #869), **completing the trio Hop / Fermentable / Yeast** that started with #888 (hops) and #889 (fermentables). Adds the **YeastModule** under the existing top-level `catalog/` module, seeded with 20 brewing yeast strain entries.

After this PR ships, every demo recipe (Punk IPA, NEIPA, Saison, Tripel, Witbier, Hefeweizen, Pilsner, ESB, Irish Stout) has at least one matching catalogue entry across all three ingredient dimensions — the foundation for the future Recipe editor picker, the mobile catalogue page (Issue #887 follow-up), and the upcoming Phase 2 / 3 catalogues.

## Schema (table `yeasts` — 13 columns total: 10 data + 3 system)

| # | Column | Type | Null | Source |
|---|---|---|---|---|
| 1 | `id` | varchar(36) PK | NO | UUID range `…-9000-2…` (yeasts) |
| 2 | `name` | varchar(120) UNIQUE | NO | BeerXML `<NAME>` |
| 3 | `type` | enum CHECK (ale/lager/wheat/wild) | NO | BeerXML `<TYPE>` adapted |
| 4 | `form` | enum CHECK (liquid/dry/slant/culture) | NO | BeerXML `<FORM>` |
| 5 | `laboratory` | varchar(60) | yes | BeerXML `<LABORATORY>` |
| 6 | `product_id` | varchar(20) | yes | BeerXML `<PRODUCT_ID>` |
| 7 | `min_temperature_c` | real | yes | BeerXML `<MIN_TEMPERATURE>` |
| 8 | `max_temperature_c` | real | yes | BeerXML `<MAX_TEMPERATURE>` |
| 9 | `flocculation` | enum CHECK (low/medium/high/very_high) | yes | BeerXML `<FLOCCULATION>` |
| 10 | `attenuation_percent_typical` | real | yes | BeerXML `<ATTENUATION>` |
| 11 | `notes` | text | yes | French, UI-facing (folds NOTES + BEST_FOR) |
| 12 | `created_at` | datetime | NO | audit |
| 13 | `updated_at` | datetime | NO | audit |

Indexes: UNIQUE on `name`, plus `type` and `laboratory` for picker filters.

## `type` enum decision (validated upfront)

The catalogue uses **ale / lager / wheat / wild** — diverging from both the existing `RecipeYeastType` (ale / lager / wild / brett) and from BeerXML strict (ale / lager / wheat / wine / champagne). Rationale:

- **WHEAT** added because every demo recipe set needs Hefeweizen / Witbier strains (Wyeast 3068, WLP410)
- **WILD** kept (folds the existing BRETT and broadens to cover Lacto/Pedio/sours)
- **WINE / CHAMPAGNE** dropped — out of scope for a beer-focused app
- **BRETT** dropped — Brett is a subset of WILD culturally, no need to split

The future migration of `recipe_yeasts.type` will fold the existing `brett` value into `wild`.

## `laboratory` + `product_id` as direct varchars

These columns stay un-normalised in this PR because each catalogue row represents a SPECIFIC manufacturer product (1:1, not N:N like the supplier dimension of fermentables). The future "normalize-producers" PR may add an optional `laboratory_id` FK referencing the unified `producers` table while keeping these columns as the brewer-recognisable display string.

## Endpoints

```
GET /catalog/yeasts                          → ordered list
GET /catalog/yeasts?type=ale                 → filtered (ParseEnumPipe)
GET /catalog/yeasts?form=dry                 → filtered (ParseEnumPipe)
GET /catalog/yeasts?type=lager&form=dry      → AND-combined filter
GET /catalog/yeasts/:uuid                    → single entry, 404 on miss
```

## Seed (20 entries, idempotent loader)

Operator-curated, drawn from the BeerXML reference fixture and major manufacturer datasheets, authored to be picker-friendly.

- **5 BeerXML canonical** (verbatim from `libraries/yeast.xml`): English Ale (WLP002), European Ale (WLP011), Irish Ale (Wyeast 1084), Kölsch (Wyeast 2565), Northwest Ale (Wyeast 1332)
- **15 popular industry products**: Safale US-05 / S-04 / Saflager W-34/70 (Fermentis), WLP001 / WLP500 / WLP410 / WLP800 / WLP004 (White Labs), Wyeast 1056 / 3787 / 3711 / 3068 / 1318 (Wyeast), BRY-97 (Lallemand), A09 Pub (Imperial Yeast)

Coverage:
- **Type:** 17 ale · 2 lager · 1 wheat (WILD intentionally absent — Brett / sour strains land when we need them)
- **Form:** 16 liquid · 4 dry
- **Lab:** 7 White Labs · 8 Wyeast · 3 Fermentis · 1 Lallemand · 1 Imperial Yeast — **all five major manufacturers** the brewing world uses

## Tests (25 new, all green)

- **Service spec** — in-memory SQLite, list filters (type / form / AND-combined), getById happy / sad / edge
- **Controller spec** — `jest.spyOn` pattern, DTO transform isolation, never leaks raw ORM entity
- **Seed spec** — idempotency, mixed insert/update, deterministic UUID range, French notes invariant, lab coverage invariant, flocculation enum-value invariant

## All four PR #888 review lessons baked in

- ✅ **Boot-safe registration** — `YeastOrmEntity` added to `ormEntities` in `typeorm.config.ts`
- ✅ **CHECK constraints** — `CHK_yeasts_type`, `CHK_yeasts_form`, `CHK_yeasts_flocculation` (the latter NULL-tolerant)
- ✅ **Validated query params** — `ParseEnumPipe` on `type` and `form`
- ✅ **Runner script** — `scripts/run-yeasts-catalog-seed.ts` mirrors the existing per-seed runners
- ✅ **No denormalised supplier prose in notes** — substitute / supplier relationships will only ever live in the future producer junction tables

## Out of scope (filed for follow-up)

- **Producer normalisation** — `producers` table + `yeast_labs` junction (1:N from `yeasts.laboratory_id`) lands via the post-Phase 1 normalize-producers PR alongside `hop_producers`, `hop_substitutes`, `fermentable_suppliers`
- **`recipe_yeasts.yeast_id` FK** — the existing per-recipe table is not yet migrated to point at this catalogue. Migration ships in a separate PR after all Phase 1-3 catalogues exist
- **Admin CRUD endpoints** — read-only in this PR. Will be added when an admin role and interface exist
- **Mobile refactor** — Issue #887 tracks the mobile module migration to consume `GET /catalog/*`

## Phase 1 status after this PR

| # | PR | Catalogue | Status |
|---|---|---|---|
| 1 | #888 | hops | ✅ merged |
| 2 | #889 | fermentables | ✅ merged |
| 3 | this PR | yeasts | 🟡 awaiting review |

After this PR merges, the trio that powers every recipe is complete. Next: Phase 2 (Style + Mash), then Phase 3 (Water + Equipment + Misc), then the normalize-producers PR.

## Checklist

- [x] Happy / sad / edge cases covered (26 new tests)
- [x] `npm run lint:check` passes (0 errors; 1 pre-existing warning in `scan/services/scan.service.ts`)
- [x] `npm run build` passes
- [x] All existing tests still green (452 + 26 = 478 total)
- [x] No `any` introduced
- [x] No default exports for screens / use-cases / API modules
- [x] Migration timestamp picks up where the previous one left off (`1785000000000`)
- [x] All four PR #888 lessons baked in upfront

Refs #708 #869
