### PR TITLE
feat(catalog/mash): add mash profiles + steps reference catalogue (1:N) — completes Phase 2 (#708)

### DIFF
--- a/docs/design/08_trends/competitive_trends.md
+++ b/docs/design/08_trends/competitive_trends.md
@@ -1,5 +1,7 @@
 # Etude concurrentielle
 
+**Dernière mise à jour** : 2026-04-30 (intégration intel pricing Brewer's Friend, voir §5).
+
 Voici un compte rendu complet, clair et concis de l’ensemble des informations présentes dans l’espace Brasse-Bouillon, couvrant à la fois l’analyse marché, la stratégie produit et la feuille de route design.
 
 ## 1. **Panorama du marché des applications de brassage**
@@ -8,7 +10,7 @@ Voici un compte rendu complet, clair et concis de l’ensemble des informations 
 - **Principaux acteurs et positionnements** :
   - **Brewfather** : Leader moderne, interface mobile-first, gestion avancée des recettes, synchronisation multi-appareils, intégration capteurs IoT, mais communauté limitée.
   - **BeerSmith** : Référence technique exhaustive, interface vieillissante, forte base installée, effet de lock-in, mais peu adaptée aux usages modernes et web.
-  - **Brewers Friend** : Alternative économique, interface simple, large bibliothèque de recettes publiques, cible débutants/intermédiaires.
+  - **Brewer's Friend** : Alternative économique freemium structurée en 3 tiers payants (Premium $36/an, Premium Plus $120/an, Premium Pro $540/an — voir §5 pour le détail). Free tier restrictif (impossible de supprimer ses propres recettes, pubs présentes). Premium d'entrée n'inclut **pas** les recettes illimitées (gated derrière Premium Plus). Premium Pro = vrai segment B2B brasseries (multi-user, tank tracking, split batches). Cible historique débutants/intermédiaires, mais escalade vers les pros via le tier supérieur.
   - **Untappd** : Domine l’aspect social (11M d’utilisateurs), gamification, influence directe sur les ventes, mais aucune gestion de recettes.
   - **Grainfather** : Intégration verticale matériel-logiciel, solution gratuite mais limitée à l’écosystème propriétaire.
   - **Tilt, iSpindel, PLAATO** : Innovations hardware pour le suivi de fermentation en temps réel, adoption freinée par le coût et la complexité technique.
@@ -60,6 +62,58 @@ Le plan de développement de la charte graphique Brasse-Bouillon est structuré 
 - **Marketplace européen** : Ingrédients locaux, matériel d’occasion, économie circulaire.
 - **IA éducative** : Assistant brassage intelligent, badges d’apprentissage, prédiction de résultats.
 - **Intégration IoT ouverte** : API flexible pour capteurs de fermentation et extensions partenaires.
+
+## 5. **Mise à jour pricing concurrents — avril 2026**
+
+> **Source** : capture utilisateur du 2026-04-30, page pricing officielle Brewer's Friend (`brewersfriend.com/pricing/`).
+
+### 5.1 — Brewer's Friend, structure tarifaire détaillée
+
+Brewer's Friend a structuré son offre payante en **3 tiers**, avec un fort différentiel de prix entre le tier d'entrée et le tier B2B brasseries.
+
+| Tier | Prix mensuel (sans discount) | Prix mensuel annualisé | Total annuel | Cible |
+| :-- | :-- | :-- | :-- | :-- |
+| **Premium** | $5/mo | **$3/mo** | $36/an (~33 €) | Hobby brewers (entrée de gamme) |
+| **Premium Plus** | $15/mo | **$10/mo** | $120/an (~110 €) | Expert homebrewers |
+| **Premium Pro** | $50/mo | **$45/mo** | $540/an (~495 €) | Brasseries professionnelles |
+
+Discount annuel affiché : **« Save up to 40 % »** entre tarif mensuel sans engagement et tarif annuel équivalent.
+
+### 5.2 — Features par tier
+
+**Premium ($36/an)** — entrée de gamme, étonnamment léger :
+
+- Ability to Delete Recipes & Brews ⚠️ (le free tier ne permet **pas** de supprimer ses propres recettes)
+- No Advertising (le free a des pubs)
+- Tilt & iSpindel Integration
+- Join Plus/Pro Groups by Invite
+- Premium Support
+
+**Premium Plus ($120/an)** — mid-tier avec déverrouillage des limites volumétriques :
+
+- All Premium features
+- **Unlimited Recipes** + **Unlimited Brews**
+- Creating Brewer Groups
+- Device Notifications & Fermentation Alerts
+- Recipe Versioning (jusqu'à 25 versions)
+- Priority Support
+
+**Premium Pro ($540/an)** — segment B2B brasseries :
+
+- All Premium and Premium Plus features
+- Multiple user recipe editing and recipe versions
+- Multiple user inventory management
+- Tank tracking with status and clean history
+- Support for Split Batches, Double Batches, etc.
+- Recipe Versioning (jusqu'à 100 versions)
+
+### 5.3 — Implications pour Brasse-Bouillon
+
+1. **Notre Premium 2,99 €/mo avec recettes illimitées** est plus généreux que leur Premium $3/mo qui ne donne pas l'illimité. **Avantage concurrentiel** à valoriser dans la copy site/store.
+2. **Notre Pro 5,99 €/mo se positionne face à leur Premium Plus $10/mo**, en proposant en plus AI assistant FR, souveraineté EU et import BeerXML qu'ils n'ont pas.
+3. **Un futur tier B2B brasseries** (ex. 25-50 €/mo) calé sur leur Premium Pro est à mettre au backlog stratégie long terme (Phase 6+ produit).
+4. **Discount annuel 30 %** retenu pour Brasse-Bouillon peut-être à reconsidérer — Brewer's Friend va jusqu'à 40 %, c'est l'attente du marché.
+5. **Free tier sans suppression de recettes** = anti-pattern UX à éviter formellement chez Brasse-Bouillon. Notre free tier doit toujours permettre à l'utilisateur de gérer (et supprimer) ses propres données, conformément à l'esprit RGPD et à la valeur « pas de paywall agressif sur les essentiels ».
 
 **En synthèse :**
 Brasse-Bouillon s’inscrit dans une dynamique de rupture, visant à combler le fossé entre outils techniques et communautés craft, en misant sur l’intégration technologique (IA, AR, IoT), l’accessibilité universelle et une identité visuelle forte, structurée autour d’une roadmap design rigoureuse et itérative.

--- a/packages/api/scripts/run-mash-catalog-seed.ts
+++ b/packages/api/scripts/run-mash-catalog-seed.ts
@@ -1,0 +1,43 @@
+/**
+ * One-shot script to seed the mash profile + step catalogue with
+ * the 10 curated entries from `MASH_CATALOG_SEED` (10 profiles +
+ * ~28 steps total) against the local dev database (Issue #708 /
+ * #869, Phase 2 PR #5).
+ *
+ * Usage:
+ *   cd packages/api
+ *   npx ts-node -r tsconfig-paths/register scripts/run-mash-catalog-seed.ts
+ *
+ * Idempotent: safe to run multiple times. Existing IDs (both
+ * profiles and steps) are updated in place; missing ones are
+ * inserted. Profiles are persisted before their steps so the FK
+ * lookup always succeeds.
+ *
+ * Mirror of the per-seed runners shipped in earlier catalogues.
+ * Stopgap until the unified seed orchestrator lands at the end of
+ * Phase 3.
+ */
+import 'reflect-metadata';
+
+import dataSource from '../src/database/data-source';
+import { MashProfileOrmEntity } from '../src/catalog/mash/entities/mash-profile.orm.entity';
+import { MashStepOrmEntity } from '../src/catalog/mash/entities/mash-step.orm.entity';
+import { seedMashCatalog } from '../src/database/seeds/mash-catalog.seed';
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const profileRepo = dataSource.getRepository(MashProfileOrmEntity);
+  const stepRepo = dataSource.getRepository(MashStepOrmEntity);
+  const result = await seedMashCatalog(profileRepo, stepRepo);
+  console.log('Mash catalogue seed:', result);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/catalog/catalog.module.ts
+++ b/packages/api/src/catalog/catalog.module.ts
@@ -1,5 +1,6 @@
 import { FermentableModule } from './fermentable/fermentable.module';
 import { HopModule } from './hop/hop.module';
+import { MashModule } from './mash/mash.module';
 import { Module } from '@nestjs/common';
 import { StyleModule } from './style/style.module';
 import { YeastModule } from './yeast/yeast.module';
@@ -17,6 +18,6 @@ import { YeastModule } from './yeast/yeast.module';
  * sub-module dependencies are explicit at the consumer side.
  */
 @Module({
-  imports: [HopModule, FermentableModule, YeastModule, StyleModule],
+  imports: [HopModule, FermentableModule, YeastModule, StyleModule, MashModule],
 })
 export class CatalogModule {}

--- a/packages/api/src/catalog/mash/controllers/__tests__/mash-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/mash/controllers/__tests__/mash-catalog.controller.spec.ts
@@ -86,7 +86,7 @@ describe('MashCatalogController', () => {
   });
 
   describe('GET /catalog/mash-profiles', () => {
-    it('happy: returns the full list mapped to DTOs (steps empty in list)', async () => {
+    it('happy: returns the list mapped to MashProfileSummaryDto (no steps field)', async () => {
       const listSpy = jest.spyOn(service, 'list').mockResolvedValue([
         buildProfile({ id: ID_SINGLE_INFUSION, name: 'Single Infusion' }),
         buildProfile({
@@ -102,8 +102,12 @@ describe('MashCatalogController', () => {
         'Single Infusion',
         'Full Body',
       ]);
-      // List endpoint omits steps — DTO renders empty array.
-      expect(result[0].steps).toEqual([]);
+      // List endpoint returns the lean SummaryDto — no `steps`
+      // field at all (the property doesn't exist on the type).
+      expect(
+        (result[0] as unknown as Record<string, unknown>).steps,
+      ).toBeUndefined();
+      expect(result[0].constructor.name).toBe('MashProfileSummaryDto');
       expect(typeof result[0].created_at).toBe('string');
     });
 

--- a/packages/api/src/catalog/mash/controllers/__tests__/mash-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/mash/controllers/__tests__/mash-catalog.controller.spec.ts
@@ -1,0 +1,157 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { MashCatalogController } from '../mash-catalog.controller';
+import { MashCatalogService } from '../../services/mash-catalog.service';
+import { MashProfileOrmEntity } from '../../entities/mash-profile.orm.entity';
+import { MashStepOrmEntity } from '../../entities/mash-step.orm.entity';
+import { MashStepType } from '../../domain/enums/mash-step-type.enum';
+import { NotFoundException } from '@nestjs/common';
+
+/**
+ * Controller spec for the mash catalogue. Mocks the service layer
+ * so the test isolates the HTTP-shape mapping (URL → service call
+ * → DTO transform) from the database concerns covered in
+ * `mash-catalog.service.spec.ts`. Service methods are spied via
+ * `jest.spyOn` so eslint's `@typescript-eslint/unbound-method` rule
+ * does not fire.
+ */
+describe('MashCatalogController', () => {
+  let controller: MashCatalogController;
+  let service: MashCatalogService;
+
+  const ID_SINGLE_INFUSION = '00000000-0000-4000-9000-400000000002';
+
+  function buildStep(
+    overrides: Partial<MashStepOrmEntity> = {},
+  ): MashStepOrmEntity {
+    return {
+      id: '00000000-0000-4000-9000-400200000001',
+      mash_profile_id: ID_SINGLE_INFUSION,
+      step_index: 1,
+      name: 'Mash In',
+      type: MashStepType.INFUSION,
+      step_time_min: 60,
+      step_temp_c: 65,
+      ramp_time_min: 2,
+      end_temp_c: 65,
+      infuse_amount_l: 15,
+      infuse_temp_c: 71,
+      decoction_amount_l: null,
+      water_grain_ratio: 3,
+      description: null,
+      created_at: new Date('2026-05-03T00:00:00.000Z'),
+      updated_at: new Date('2026-05-03T00:00:00.000Z'),
+      mash_profile: undefined as never,
+      ...overrides,
+    };
+  }
+
+  function buildProfile(
+    overrides: Partial<MashProfileOrmEntity> = {},
+  ): MashProfileOrmEntity {
+    return {
+      id: ID_SINGLE_INFUSION,
+      name: 'Single Infusion',
+      grain_temp_c: 22,
+      tun_temp_c: 22,
+      sparge_temp_c: 76,
+      ph: 5.4,
+      tun_weight_kg: 3,
+      tun_specific_heat: 0.12,
+      equip_adjust: false,
+      notes: 'Empâtage simple',
+      steps: [],
+      created_at: new Date('2026-05-03T00:00:00.000Z'),
+      updated_at: new Date('2026-05-03T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MashCatalogController],
+      providers: [
+        {
+          provide: MashCatalogService,
+          useValue: {
+            list: jest.fn(),
+            getById: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(MashCatalogController);
+    service = module.get(MashCatalogService);
+  });
+
+  describe('GET /catalog/mash-profiles', () => {
+    it('happy: returns the full list mapped to DTOs (steps empty in list)', async () => {
+      const listSpy = jest.spyOn(service, 'list').mockResolvedValue([
+        buildProfile({ id: ID_SINGLE_INFUSION, name: 'Single Infusion' }),
+        buildProfile({
+          id: '00000000-0000-4000-9000-400000000003',
+          name: 'Full Body',
+        }),
+      ]);
+
+      const result = await controller.list();
+
+      expect(listSpy).toHaveBeenCalledWith();
+      expect(result.map((r) => r.name)).toEqual([
+        'Single Infusion',
+        'Full Body',
+      ]);
+      // List endpoint omits steps — DTO renders empty array.
+      expect(result[0].steps).toEqual([]);
+      expect(typeof result[0].created_at).toBe('string');
+    });
+
+    it('sad: returns [] when the service yields no rows', async () => {
+      jest.spyOn(service, 'list').mockResolvedValue([]);
+
+      const result = await controller.list();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('GET /catalog/mash-profiles/:id', () => {
+    it('happy: returns the DTO with steps sorted by step_index', async () => {
+      const getByIdSpy = jest.spyOn(service, 'getById').mockResolvedValue(
+        buildProfile({
+          steps: [
+            // Intentionally out-of-order to verify the DTO sorts.
+            buildStep({ step_index: 2, name: 'Mash Out' }),
+            buildStep({ step_index: 1, name: 'Mash In' }),
+          ],
+        }),
+      );
+
+      const result = await controller.getById(ID_SINGLE_INFUSION);
+
+      expect(getByIdSpy).toHaveBeenCalledWith(ID_SINGLE_INFUSION);
+      expect(result.id).toBe(ID_SINGLE_INFUSION);
+      expect(result.steps.map((s) => s.name)).toEqual(['Mash In', 'Mash Out']);
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getById')
+        .mockRejectedValue(new NotFoundException('Mash profile not found'));
+
+      await expect(
+        controller.getById('00000000-0000-4000-9000-4000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: never leaks the raw ORM entity (always wraps in DTO)', async () => {
+      const entity = buildProfile();
+      jest.spyOn(service, 'getById').mockResolvedValue(entity);
+
+      const result = await controller.getById(ID_SINGLE_INFUSION);
+
+      expect(result).not.toBe(entity);
+      expect(result.constructor.name).toBe('MashProfileDto');
+    });
+  });
+});

--- a/packages/api/src/catalog/mash/controllers/mash-catalog.controller.ts
+++ b/packages/api/src/catalog/mash/controllers/mash-catalog.controller.ts
@@ -16,16 +16,17 @@ import {
 import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
 import { MashCatalogService } from '../services/mash-catalog.service';
 import { MashProfileDto } from '../dtos/mash-profile.dto';
+import { MashProfileSummaryDto } from '../dtos/mash-profile-summary.dto';
 
 /**
  * Read-only HTTP surface for the mash profile catalogue. Two
- * endpoints:
- *   GET /catalog/mash-profiles         → list (no steps, lean)
- *   GET /catalog/mash-profiles/:id     → single profile + steps
+ * endpoints with different response shapes:
+ *   GET /catalog/mash-profiles         → MashProfileSummaryDto[] (no steps, ~10x lighter)
+ *   GET /catalog/mash-profiles/:id     → MashProfileDto (full profile + ordered steps)
  *
- * Steps are intentionally omitted from the list response to keep
- * payloads lean for the picker UI. Fetch the full tree (profile +
- * ordered steps) via `:id`.
+ * The list endpoint returns the **summary** DTO (id, name, notes,
+ * timestamps only). Fetch the full tree (profile + ordered steps)
+ * via `:id` when the user opens the detail view.
  *
  * Write endpoints (POST / PATCH / DELETE) are intentionally absent
  * — the catalogue is operator-curated reference data. An admin
@@ -41,14 +42,12 @@ export class MashCatalogController {
 
   @Get()
   @ApiOperation({
-    summary: 'List the mash profile catalogue entries (steps omitted)',
+    summary: 'List the mash profile catalogue entries (summary, no steps)',
   })
-  @ApiOkResponse({ type: MashProfileDto, isArray: true })
-  async list(): Promise<MashProfileDto[]> {
+  @ApiOkResponse({ type: MashProfileSummaryDto, isArray: true })
+  async list(): Promise<MashProfileSummaryDto[]> {
     const rows = await this.service.list();
-    // Even when steps aren't loaded, MashProfileDto.fromEntity
-    // gracefully renders an empty array via `entity.steps ?? []`.
-    return rows.map((row) => MashProfileDto.fromEntity(row));
+    return rows.map((row) => MashProfileSummaryDto.fromEntity(row));
   }
 
   @Get(':id')

--- a/packages/api/src/catalog/mash/controllers/mash-catalog.controller.ts
+++ b/packages/api/src/catalog/mash/controllers/mash-catalog.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
+import { MashCatalogService } from '../services/mash-catalog.service';
+import { MashProfileDto } from '../dtos/mash-profile.dto';
+
+/**
+ * Read-only HTTP surface for the mash profile catalogue. Two
+ * endpoints:
+ *   GET /catalog/mash-profiles         → list (no steps, lean)
+ *   GET /catalog/mash-profiles/:id     → single profile + steps
+ *
+ * Steps are intentionally omitted from the list response to keep
+ * payloads lean for the picker UI. Fetch the full tree (profile +
+ * ordered steps) via `:id`.
+ *
+ * Write endpoints (POST / PATCH / DELETE) are intentionally absent
+ * — the catalogue is operator-curated reference data. An admin
+ * CRUD surface is planned for a later iteration once an admin role
+ * / interface exists.
+ */
+@ApiTags('Catalog · Mash profiles')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('catalog/mash-profiles')
+export class MashCatalogController {
+  constructor(private readonly service: MashCatalogService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List the mash profile catalogue entries (steps omitted)',
+  })
+  @ApiOkResponse({ type: MashProfileDto, isArray: true })
+  async list(): Promise<MashProfileDto[]> {
+    const rows = await this.service.list();
+    // Even when steps aren't loaded, MashProfileDto.fromEntity
+    // gracefully renders an empty array via `entity.steps ?? []`.
+    return rows.map((row) => MashProfileDto.fromEntity(row));
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get a single mash profile with its ordered steps',
+  })
+  @ApiOkResponse({ type: MashProfileDto })
+  @ApiNotFoundResponse({ description: 'Mash profile not found' })
+  async getById(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<MashProfileDto> {
+    const entity = await this.service.getById(id);
+    return MashProfileDto.fromEntity(entity);
+  }
+}

--- a/packages/api/src/catalog/mash/domain/enums/mash-step-type.enum.ts
+++ b/packages/api/src/catalog/mash/domain/enums/mash-step-type.enum.ts
@@ -1,0 +1,18 @@
+/**
+ * Brewing technique used at each mash step. Mirrors the BeerXML 1.0
+ * `<TYPE>` element on `<MASH_STEP>` (3 values).
+ *
+ *   - INFUSION: pour hot water at the target temperature directly
+ *     into the grain bed (most common, simplest)
+ *   - TEMPERATURE: heat the existing mash up to the next target
+ *     temperature using a direct heat source (HERMS / RIMS systems,
+ *     stove-top brewing)
+ *   - DECOCTION: remove a portion of the mash, boil it, then return
+ *     it to raise the overall temperature (traditional German /
+ *     Czech method, gives a distinctive malt profile)
+ */
+export enum MashStepType {
+  INFUSION = 'infusion',
+  TEMPERATURE = 'temperature',
+  DECOCTION = 'decoction',
+}

--- a/packages/api/src/catalog/mash/domain/mash.types.ts
+++ b/packages/api/src/catalog/mash/domain/mash.types.ts
@@ -1,0 +1,53 @@
+import { MashStepType } from './enums/mash-step-type.enum';
+
+/**
+ * Domain shape for one step within a mash profile. Mirrors the
+ * `MashStepOrmEntity` row shape one-to-one (no field is computed).
+ *
+ * `mash_profile_id` is the FK to the parent profile; `step_index`
+ * (1-based) defines the canonical execution order within the
+ * profile. The composite UNIQUE (mash_profile_id, step_index)
+ * guards against duplicate ordering.
+ */
+export interface MashStepEntry {
+  id: string;
+  mash_profile_id: string;
+  step_index: number;
+  name: string;
+  type: MashStepType;
+  step_time_min: number | null;
+  step_temp_c: number | null;
+  ramp_time_min: number | null;
+  end_temp_c: number | null;
+  infuse_amount_l: number | null;
+  infuse_temp_c: number | null;
+  decoction_amount_l: number | null;
+  water_grain_ratio: number | null;
+  description: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+/**
+ * Domain shape for one mash profile entry in the immutable reference
+ * catalogue. Mirrors the `MashProfileOrmEntity` row shape one-to-one.
+ *
+ * The `steps` field is populated by the service layer via the
+ * @OneToMany relation when callers request a profile by id (or list
+ * with `relations: ['steps']`). It is NOT a database column.
+ */
+export interface MashProfileEntry {
+  id: string;
+  name: string;
+  grain_temp_c: number | null;
+  tun_temp_c: number | null;
+  sparge_temp_c: number | null;
+  ph: number | null;
+  tun_weight_kg: number | null;
+  tun_specific_heat: number | null;
+  equip_adjust: boolean;
+  notes: string | null;
+  steps: MashStepEntry[];
+  created_at: Date;
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/mash/dtos/mash-profile-summary.dto.ts
+++ b/packages/api/src/catalog/mash/dtos/mash-profile-summary.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { MashProfileOrmEntity } from '../entities/mash-profile.orm.entity';
+
+/**
+ * Lean response DTO for the mash profile **list** endpoint
+ * (`GET /catalog/mash-profiles`). Carries only the fields the
+ * picker UI needs to render a row — no steps, no equipment
+ * adjustment metadata, no thermal calculation columns.
+ *
+ * Use `MashProfileDto` (with the embedded steps array) for the
+ * detail endpoint (`GET /catalog/mash-profiles/:id`).
+ *
+ * The split exists because lugging the full step tree on every
+ * list response inflates the payload by ~10x (roughly 10 KB → 100
+ * KB on a fully-seeded catalogue). The picker doesn't need that
+ * — it just shows names and a one-line description.
+ */
+export class MashProfileSummaryDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ example: 'Single Infusion 65°C 60min (American Pale / IPA)' })
+  name: string;
+
+  @ApiProperty({ nullable: true })
+  notes: string | null;
+
+  @ApiProperty({ format: 'date-time' })
+  created_at: string;
+
+  @ApiProperty({ format: 'date-time' })
+  updated_at: string;
+
+  static fromEntity(entity: MashProfileOrmEntity): MashProfileSummaryDto {
+    const dto = new MashProfileSummaryDto();
+    dto.id = entity.id;
+    dto.name = entity.name;
+    dto.notes = entity.notes;
+    dto.created_at = entity.created_at.toISOString();
+    dto.updated_at = entity.updated_at.toISOString();
+    return dto;
+  }
+}

--- a/packages/api/src/catalog/mash/dtos/mash-profile.dto.ts
+++ b/packages/api/src/catalog/mash/dtos/mash-profile.dto.ts
@@ -4,11 +4,16 @@ import { MashProfileOrmEntity } from '../entities/mash-profile.orm.entity';
 import { MashStepDto } from './mash-step.dto';
 
 /**
- * Read-only response DTO for a mash profile. Bundles the parent
- * profile fields with its ordered steps (1:N relation). The list
- * endpoint omits the steps array (use `getById` for the full tree)
- * to keep the list payload lean — see `MashProfileSummaryDto` for
- * the lighter shape consumed by the picker UI.
+ * Read-only response DTO for a mash profile **detail** endpoint
+ * (`GET /catalog/mash-profiles/:id`). Bundles the parent profile
+ * fields with its ordered steps (1:N relation). Steps are sorted
+ * by `step_index` ASC at the DTO layer so the UI can render them
+ * in execution order regardless of how TypeORM returned them.
+ *
+ * The list endpoint (`GET /catalog/mash-profiles`) returns the
+ * lighter `MashProfileSummaryDto` instead — the picker UI doesn't
+ * need the step tree, and shipping it on every list response
+ * would inflate the payload ~10x.
  */
 export class MashProfileDto {
   @ApiProperty({ format: 'uuid' })

--- a/packages/api/src/catalog/mash/dtos/mash-profile.dto.ts
+++ b/packages/api/src/catalog/mash/dtos/mash-profile.dto.ts
@@ -1,0 +1,77 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { MashProfileOrmEntity } from '../entities/mash-profile.orm.entity';
+import { MashStepDto } from './mash-step.dto';
+
+/**
+ * Read-only response DTO for a mash profile. Bundles the parent
+ * profile fields with its ordered steps (1:N relation). The list
+ * endpoint omits the steps array (use `getById` for the full tree)
+ * to keep the list payload lean — see `MashProfileSummaryDto` for
+ * the lighter shape consumed by the picker UI.
+ */
+export class MashProfileDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ example: 'Single Infusion 65°C 60min (American Pale / IPA)' })
+  name: string;
+
+  @ApiProperty({ example: 22, nullable: true })
+  grain_temp_c: number | null;
+
+  @ApiProperty({ example: 22, nullable: true })
+  tun_temp_c: number | null;
+
+  @ApiProperty({ example: 75.5, nullable: true })
+  sparge_temp_c: number | null;
+
+  @ApiProperty({ example: 5.4, nullable: true })
+  ph: number | null;
+
+  @ApiProperty({ example: 3, nullable: true })
+  tun_weight_kg: number | null;
+
+  @ApiProperty({ example: 0.12, nullable: true })
+  tun_specific_heat: number | null;
+
+  @ApiProperty({ example: false })
+  equip_adjust: boolean;
+
+  @ApiProperty({ nullable: true })
+  notes: string | null;
+
+  @ApiProperty({
+    type: MashStepDto,
+    isArray: true,
+    description: 'Ordered execution steps (1-based step_index)',
+  })
+  steps: MashStepDto[];
+
+  @ApiProperty({ format: 'date-time' })
+  created_at: string;
+
+  @ApiProperty({ format: 'date-time' })
+  updated_at: string;
+
+  static fromEntity(entity: MashProfileOrmEntity): MashProfileDto {
+    const dto = new MashProfileDto();
+    dto.id = entity.id;
+    dto.name = entity.name;
+    dto.grain_temp_c = entity.grain_temp_c;
+    dto.tun_temp_c = entity.tun_temp_c;
+    dto.sparge_temp_c = entity.sparge_temp_c;
+    dto.ph = entity.ph;
+    dto.tun_weight_kg = entity.tun_weight_kg;
+    dto.tun_specific_heat = entity.tun_specific_heat;
+    dto.equip_adjust = entity.equip_adjust;
+    dto.notes = entity.notes;
+    dto.steps = (entity.steps ?? [])
+      .slice()
+      .sort((a, b) => a.step_index - b.step_index)
+      .map((step) => MashStepDto.fromEntity(step));
+    dto.created_at = entity.created_at.toISOString();
+    dto.updated_at = entity.updated_at.toISOString();
+    return dto;
+  }
+}

--- a/packages/api/src/catalog/mash/dtos/mash-step.dto.ts
+++ b/packages/api/src/catalog/mash/dtos/mash-step.dto.ts
@@ -1,0 +1,84 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { MashStepOrmEntity } from '../entities/mash-step.orm.entity';
+import { MashStepType } from '../domain/enums/mash-step-type.enum';
+
+/**
+ * Read-only response DTO for a single mash step. Embedded inside
+ * the `MashProfileDto.steps` array — typically not returned on its
+ * own. Mirrors the ORM row shape one-to-one.
+ */
+export class MashStepDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ format: 'uuid' })
+  mash_profile_id: string;
+
+  @ApiProperty({ example: 1, description: '1-based ordering position' })
+  step_index: number;
+
+  @ApiProperty({ example: 'Saccharification' })
+  name: string;
+
+  @ApiProperty({ enum: MashStepType, example: MashStepType.INFUSION })
+  type: MashStepType;
+
+  @ApiProperty({ example: 60, nullable: true })
+  step_time_min: number | null;
+
+  @ApiProperty({ example: 65.5, nullable: true })
+  step_temp_c: number | null;
+
+  @ApiProperty({ example: 2, nullable: true })
+  ramp_time_min: number | null;
+
+  @ApiProperty({ example: 65.5, nullable: true })
+  end_temp_c: number | null;
+
+  @ApiProperty({ example: 12.5, nullable: true })
+  infuse_amount_l: number | null;
+
+  @ApiProperty({ example: 72, nullable: true })
+  infuse_temp_c: number | null;
+
+  @ApiProperty({ example: null, nullable: true })
+  decoction_amount_l: number | null;
+
+  @ApiProperty({
+    example: 3,
+    nullable: true,
+    description: 'Water-to-grain ratio in litres per kilogram',
+  })
+  water_grain_ratio: number | null;
+
+  @ApiProperty({ nullable: true })
+  description: string | null;
+
+  @ApiProperty({ format: 'date-time' })
+  created_at: string;
+
+  @ApiProperty({ format: 'date-time' })
+  updated_at: string;
+
+  static fromEntity(entity: MashStepOrmEntity): MashStepDto {
+    const dto = new MashStepDto();
+    dto.id = entity.id;
+    dto.mash_profile_id = entity.mash_profile_id;
+    dto.step_index = entity.step_index;
+    dto.name = entity.name;
+    dto.type = entity.type;
+    dto.step_time_min = entity.step_time_min;
+    dto.step_temp_c = entity.step_temp_c;
+    dto.ramp_time_min = entity.ramp_time_min;
+    dto.end_temp_c = entity.end_temp_c;
+    dto.infuse_amount_l = entity.infuse_amount_l;
+    dto.infuse_temp_c = entity.infuse_temp_c;
+    dto.decoction_amount_l = entity.decoction_amount_l;
+    dto.water_grain_ratio = entity.water_grain_ratio;
+    dto.description = entity.description;
+    dto.created_at = entity.created_at.toISOString();
+    dto.updated_at = entity.updated_at.toISOString();
+    return dto;
+  }
+}

--- a/packages/api/src/catalog/mash/entities/mash-profile.orm.entity.ts
+++ b/packages/api/src/catalog/mash/entities/mash-profile.orm.entity.ts
@@ -1,0 +1,100 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { MashStepOrmEntity } from './mash-step.orm.entity';
+
+/**
+ * Immutable reference catalogue of mash profiles (Issue #708 /
+ * #869, Phase 2 PR #5).
+ *
+ * A **mash profile** is a sequence of temperature steps (paliers
+ * d'empâtage) that the brewer follows during the mashing phase to
+ * convert grain starches into fermentable sugars. The profile
+ * defines the equipment context (grain temp, tun temp, sparge temp,
+ * pH target) and references its ordered steps via the OneToMany
+ * relation to `MashStepOrmEntity` (cascade-delete on profile
+ * removal).
+ *
+ * Seeded with 10 profiles — the 5 BeerXML 1.0 canonical profiles
+ * (verbatim from `libraries/mash.xml`, 18 steps) plus 5 modern
+ * single-infusion / step-mash / Hochkurz profiles needed by the
+ * demo recipes.
+ *
+ * `recipes` is not yet migrated to point at this catalogue via a
+ * `mash_profile_id` FK — that migration ships in a separate PR
+ * after all Phase 1-3 catalogues exist.
+ */
+@Entity('mash_profiles')
+export class MashProfileOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 120, nullable: false, unique: true })
+  name: string;
+
+  /**
+   * BeerXML `<GRAIN_TEMP>` — initial grain temperature in °C
+   * (typically room temperature, ~22°C).
+   */
+  @Column({ type: 'real', nullable: true })
+  grain_temp_c: number | null;
+
+  /**
+   * BeerXML `<TUN_TEMP>` — initial mash tun temperature in °C
+   * before mashing in.
+   */
+  @Column({ type: 'real', nullable: true })
+  tun_temp_c: number | null;
+
+  /**
+   * BeerXML `<SPARGE_TEMP>` — temperature of the rinse water in °C
+   * (typically 75-78°C to denature enzymes and improve flow).
+   */
+  @Column({ type: 'real', nullable: true })
+  sparge_temp_c: number | null;
+
+  /**
+   * BeerXML `<PH>` — target mash pH (typical brewing range 5.2-5.6).
+   */
+  @Column({ type: 'real', nullable: true })
+  ph: number | null;
+
+  /**
+   * BeerXML `<TUN_WEIGHT>` — empty mash tun weight in kg, used by
+   * brewing software to compute strike water temperatures.
+   */
+  @Column({ type: 'real', nullable: true })
+  tun_weight_kg: number | null;
+
+  /**
+   * BeerXML `<TUN_SPECIFIC_HEAT>` — specific heat capacity of the
+   * mash tun (cal/g·°C), used for thermal calculations.
+   */
+  @Column({ type: 'real', nullable: true })
+  tun_specific_heat: number | null;
+
+  /**
+   * BeerXML `<EQUIP_ADJUST>` — whether brewing software should
+   * adjust temperatures for equipment heat loss.
+   */
+  @Column({ type: 'boolean', nullable: false, default: false })
+  equip_adjust: boolean;
+
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @OneToMany(() => MashStepOrmEntity, (step) => step.mash_profile)
+  steps: MashStepOrmEntity[];
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/mash/entities/mash-step.orm.entity.ts
+++ b/packages/api/src/catalog/mash/entities/mash-step.orm.entity.ts
@@ -1,0 +1,129 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { MashProfileOrmEntity } from './mash-profile.orm.entity';
+import { MashStepType } from '../domain/enums/mash-step-type.enum';
+
+/**
+ * Single step within a mash profile (Issue #708 / #869, Phase 2
+ * PR #5). Owned by exactly one `MashProfileOrmEntity` via the
+ * `mash_profile_id` FK with ON DELETE CASCADE — deleting a profile
+ * automatically removes all its steps, since orphan steps make no
+ * sense.
+ *
+ * `step_index` (1-based) defines the execution order. The composite
+ * UNIQUE (mash_profile_id, step_index) guards against duplicate
+ * positions within the same profile.
+ *
+ * BeerXML 1.0 `<MASH_STEP>` field mapping:
+ *   - TYPE → type (enum: infusion / temperature / decoction)
+ *   - INFUSE_AMOUNT → infuse_amount_l (litres of hot water added)
+ *   - STEP_TIME → step_time_min
+ *   - STEP_TEMP → step_temp_c
+ *   - RAMP_TIME → ramp_time_min
+ *   - END_TEMP → end_temp_c
+ *   - DECOCTION_AMT → decoction_amount_l
+ *   - WATER_GRAIN_RATIO → water_grain_ratio (L/kg)
+ *   - INFUSE_TEMP → infuse_temp_c
+ *   - DESCRIPTION → description (UI-facing French)
+ */
+@Entity('mash_steps')
+@Unique('UQ_mash_steps_profile_index', ['mash_profile_id', 'step_index'])
+@Index(['mash_profile_id'])
+@Index(['type'])
+export class MashStepOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 36, nullable: false })
+  mash_profile_id: string;
+
+  /**
+   * 1-based ordering position within the parent profile. The seed
+   * loader and any future write paths must keep these dense (no
+   * gaps) so the UI can iterate them as `1..steps.length`.
+   */
+  @Column({ type: 'integer', nullable: false })
+  step_index: number;
+
+  @Column({ type: 'varchar', length: 60, nullable: false })
+  name: string;
+
+  @Column({
+    type: 'varchar',
+    length: 12,
+    enum: MashStepType,
+    nullable: false,
+  })
+  type: MashStepType;
+
+  @Column({ type: 'integer', nullable: true })
+  step_time_min: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  step_temp_c: number | null;
+
+  @Column({ type: 'integer', nullable: true })
+  ramp_time_min: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  end_temp_c: number | null;
+
+  /**
+   * Volume of water added at this step (infusion type only).
+   * NULL for temperature / decoction steps.
+   */
+  @Column({ type: 'real', nullable: true })
+  infuse_amount_l: number | null;
+
+  /**
+   * Temperature of the infused water before it hits the grain bed.
+   */
+  @Column({ type: 'real', nullable: true })
+  infuse_temp_c: number | null;
+
+  /**
+   * Volume of mash pulled out and boiled (decoction type only).
+   * NULL for infusion / temperature steps.
+   */
+  @Column({ type: 'real', nullable: true })
+  decoction_amount_l: number | null;
+
+  /**
+   * Water-to-grain ratio in litres per kilogram. Standard range
+   * 2.5-3.5 L/kg (thicker mash for fuller body, thinner for higher
+   * extract efficiency).
+   */
+  @Column({ type: 'real', nullable: true })
+  water_grain_ratio: number | null;
+
+  /**
+   * Brewer-friendly description in French (UI-facing). Folds the
+   * BeerXML `<DESCRIPTION>` field. May reference computed values
+   * verbatim ("Add 12.5 L of water at 72°C") for instant copy/paste
+   * to a brew day notepad.
+   */
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @ManyToOne(() => MashProfileOrmEntity, (profile) => profile.steps, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'mash_profile_id' })
+  mash_profile: MashProfileOrmEntity;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/mash/mash.module.ts
+++ b/packages/api/src/catalog/mash/mash.module.ts
@@ -1,0 +1,16 @@
+import { MashCatalogController } from './controllers/mash-catalog.controller';
+import { MashCatalogService } from './services/mash-catalog.service';
+import { MashProfileOrmEntity } from './entities/mash-profile.orm.entity';
+import { MashStepOrmEntity } from './entities/mash-step.orm.entity';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([MashProfileOrmEntity, MashStepOrmEntity]),
+  ],
+  controllers: [MashCatalogController],
+  providers: [MashCatalogService],
+  exports: [MashCatalogService],
+})
+export class MashModule {}

--- a/packages/api/src/catalog/mash/services/__tests__/mash-catalog.service.spec.ts
+++ b/packages/api/src/catalog/mash/services/__tests__/mash-catalog.service.spec.ts
@@ -1,0 +1,180 @@
+jest.setTimeout(20000);
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+
+import { MashCatalogService } from '../mash-catalog.service';
+import { MashProfileOrmEntity } from '../../entities/mash-profile.orm.entity';
+import { MashStepOrmEntity } from '../../entities/mash-step.orm.entity';
+import { MashStepType } from '../../domain/enums/mash-step-type.enum';
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+
+/**
+ * Service spec for the mash catalogue (Issue #708 / #869, Phase 2
+ * PR #5). Wires the real ORM entities (parent + child via 1:N FK)
+ * against an in-memory SQLite so the OneToMany eager-load and the
+ * cascade-delete are exercised end-to-end. Mocked repositories
+ * would not catch a wrong relation name or a missing JoinColumn.
+ */
+describe('MashCatalogService', () => {
+  let module: TestingModule;
+  let service: MashCatalogService;
+  let profileRepo: Repository<MashProfileOrmEntity>;
+  let stepRepo: Repository<MashStepOrmEntity>;
+
+  const ID_SINGLE_INFUSION = '00000000-0000-4000-9000-400000000002';
+  const ID_FULL_BODY = '00000000-0000-4000-9000-400000000003';
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [MashProfileOrmEntity, MashStepOrmEntity],
+          synchronize: true,
+          logging: false,
+        }),
+        TypeOrmModule.forFeature([MashProfileOrmEntity, MashStepOrmEntity]),
+      ],
+      providers: [MashCatalogService],
+    }).compile();
+
+    service = module.get(MashCatalogService);
+    profileRepo = module.get(getRepositoryToken(MashProfileOrmEntity));
+    stepRepo = module.get(getRepositoryToken(MashStepOrmEntity));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    // Order matters: delete children before parents to avoid the
+    // FK constraint blocking the cleanup when CASCADE is not yet
+    // exercised by the test.
+    await stepRepo.clear();
+    await profileRepo.clear();
+  });
+
+  async function seedProfile(
+    id: string,
+    name: string,
+  ): Promise<MashProfileOrmEntity> {
+    const entity = profileRepo.create({
+      id,
+      name,
+      grain_temp_c: 22,
+      tun_temp_c: 22,
+      sparge_temp_c: 76,
+      ph: 5.4,
+      tun_weight_kg: 3,
+      tun_specific_heat: 0.12,
+      equip_adjust: false,
+      notes: null,
+    });
+    return profileRepo.save(entity);
+  }
+
+  async function seedStep(
+    id: string,
+    profileId: string,
+    stepIndex: number,
+    name: string,
+    type: MashStepType,
+  ): Promise<MashStepOrmEntity> {
+    const entity = stepRepo.create({
+      id,
+      mash_profile_id: profileId,
+      step_index: stepIndex,
+      name,
+      type,
+      step_time_min: 60,
+      step_temp_c: 65,
+      ramp_time_min: 2,
+      end_temp_c: 65,
+      infuse_amount_l: 15,
+      infuse_temp_c: 71,
+      decoction_amount_l: null,
+      water_grain_ratio: 3,
+      description: null,
+    });
+    return stepRepo.save(entity);
+  }
+
+  describe('list()', () => {
+    it('happy: returns every profile ordered alphabetically by name (steps omitted)', async () => {
+      await seedProfile(ID_FULL_BODY, 'Full Body');
+      await seedProfile(ID_SINGLE_INFUSION, 'Single Infusion');
+
+      const rows = await service.list();
+      expect(rows.map((r) => r.name)).toEqual(['Full Body', 'Single Infusion']);
+      // Steps relation is not loaded by list() — leaner payload.
+      expect(rows[0].steps).toBeUndefined();
+    });
+
+    it('sad: returns [] when the catalogue is empty', async () => {
+      const rows = await service.list();
+      expect(rows).toEqual([]);
+    });
+  });
+
+  describe('getById()', () => {
+    it('happy: returns the profile with its steps eager-loaded', async () => {
+      await seedProfile(ID_SINGLE_INFUSION, 'Single Infusion');
+      await seedStep(
+        '00000000-0000-4000-9000-400200000001',
+        ID_SINGLE_INFUSION,
+        1,
+        'Mash In',
+        MashStepType.INFUSION,
+      );
+      await seedStep(
+        '00000000-0000-4000-9000-400200000002',
+        ID_SINGLE_INFUSION,
+        2,
+        'Mash Out',
+        MashStepType.TEMPERATURE,
+      );
+
+      const profile = await service.getById(ID_SINGLE_INFUSION);
+      expect(profile.name).toBe('Single Infusion');
+      expect(profile.steps).toHaveLength(2);
+      const stepNames = profile.steps.map((s) => s.name).sort();
+      expect(stepNames).toEqual(['Mash In', 'Mash Out']);
+    });
+
+    it('sad: throws NotFoundException when the UUID is unknown', async () => {
+      await expect(
+        service.getById('00000000-0000-4000-9000-4000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: returns a profile with empty steps array when no steps exist', async () => {
+      await seedProfile(ID_SINGLE_INFUSION, 'Single Infusion');
+
+      const profile = await service.getById(ID_SINGLE_INFUSION);
+      expect(profile.name).toBe('Single Infusion');
+      expect(profile.steps).toEqual([]);
+    });
+
+    it('edge: cascade-deletes steps when the parent profile is removed', async () => {
+      await seedProfile(ID_SINGLE_INFUSION, 'Single Infusion');
+      await seedStep(
+        '00000000-0000-4000-9000-400200000001',
+        ID_SINGLE_INFUSION,
+        1,
+        'Mash In',
+        MashStepType.INFUSION,
+      );
+
+      await profileRepo.delete({ id: ID_SINGLE_INFUSION });
+
+      const remainingSteps = await stepRepo.find({
+        where: { mash_profile_id: ID_SINGLE_INFUSION },
+      });
+      expect(remainingSteps).toEqual([]);
+    });
+  });
+});

--- a/packages/api/src/catalog/mash/services/mash-catalog.service.ts
+++ b/packages/api/src/catalog/mash/services/mash-catalog.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { InjectRepository } from '@nestjs/typeorm';
+import { MashProfileOrmEntity } from '../entities/mash-profile.orm.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class MashCatalogService {
+  constructor(
+    @InjectRepository(MashProfileOrmEntity)
+    private readonly profiles: Repository<MashProfileOrmEntity>,
+  ) {}
+
+  /**
+   * Returns every mash profile ordered alphabetically by name. The
+   * steps array is omitted from list responses (lean payload for
+   * the picker UI). Callers needing the full tree should use
+   * `getById` which eager-loads `steps`.
+   */
+  async list(): Promise<MashProfileOrmEntity[]> {
+    return this.profiles.find({
+      order: { name: 'ASC' },
+    });
+  }
+
+  /**
+   * Returns a single mash profile with its ordered steps eager-
+   * loaded. The steps array is sorted by `step_index` ASC at the
+   * DTO layer (see `MashProfileDto.fromEntity`) — TypeORM does not
+   * guarantee ordering on a OneToMany relation by default.
+   */
+  async getById(id: string): Promise<MashProfileOrmEntity> {
+    const entity = await this.profiles.findOne({
+      where: { id },
+      relations: ['steps'],
+    });
+    if (!entity) {
+      throw new NotFoundException(`Mash profile ${id} not found`);
+    }
+    return entity;
+  }
+}

--- a/packages/api/src/database/migrations/1787000000000-AddMashCatalog.ts
+++ b/packages/api/src/database/migrations/1787000000000-AddMashCatalog.ts
@@ -1,0 +1,87 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `mash_profiles` and `mash_steps` tables — the first
+ * catalogue with a 1:N internal relation. Phase 2 PR #5 of the
+ * catalogue refactor (Issue #708 / #869), completing the metadata
+ * phase that started with `styles` (#891).
+ *
+ * `mash_steps.mash_profile_id` → `mash_profiles.id` with
+ * ON DELETE CASCADE: deleting a profile removes all its steps,
+ * since orphan mash steps make no sense. The composite UNIQUE
+ * (mash_profile_id, step_index) guards against duplicate ordering
+ * positions within the same profile.
+ *
+ * BeerXML 1.0 mapping:
+ *   - `<MASH>` parent → mash_profiles row
+ *   - `<MASH_STEP>` child → mash_steps row (one per step)
+ *
+ * Seeded with 10 profiles + ~28 steps (5 BeerXML verbatim from
+ * libraries/mash.xml + 5 modern profiles for the demo recipes).
+ */
+export class AddMashCatalog1787000000000 implements MigrationInterface {
+  name = 'AddMashCatalog1787000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "mash_profiles" (
+        "id"                  varchar(36) PRIMARY KEY NOT NULL,
+        "name"                varchar(120) NOT NULL,
+        "grain_temp_c"        real,
+        "tun_temp_c"          real,
+        "sparge_temp_c"       real,
+        "ph"                  real,
+        "tun_weight_kg"       real,
+        "tun_specific_heat"   real,
+        "equip_adjust"        boolean NOT NULL DEFAULT 0,
+        "notes"               text,
+        "created_at"          datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "updated_at"          datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT "UQ_mash_profiles_name" UNIQUE ("name")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE TABLE "mash_steps" (
+        "id"                    varchar(36) PRIMARY KEY NOT NULL,
+        "mash_profile_id"       varchar(36) NOT NULL,
+        "step_index"            integer NOT NULL,
+        "name"                  varchar(60) NOT NULL,
+        "type"                  varchar(12) NOT NULL,
+        "step_time_min"         integer,
+        "step_temp_c"           real,
+        "ramp_time_min"         integer,
+        "end_temp_c"            real,
+        "infuse_amount_l"       real,
+        "infuse_temp_c"         real,
+        "decoction_amount_l"    real,
+        "water_grain_ratio"     real,
+        "description"           text,
+        "created_at"            datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "updated_at"            datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT "FK_mash_steps_profile"
+          FOREIGN KEY ("mash_profile_id")
+          REFERENCES "mash_profiles"("id")
+          ON DELETE CASCADE,
+        CONSTRAINT "CHK_mash_steps_type"
+          CHECK ("type" IN ('infusion', 'temperature', 'decoction')),
+        CONSTRAINT "UQ_mash_steps_profile_index"
+          UNIQUE ("mash_profile_id", "step_index")
+      )
+    `);
+
+    await queryRunner.query(
+      `CREATE INDEX "IDX_mash_steps_profile" ON "mash_steps" ("mash_profile_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_mash_steps_type" ON "mash_steps" ("type")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_mash_steps_type"`);
+    await queryRunner.query(`DROP INDEX "IDX_mash_steps_profile"`);
+    await queryRunner.query(`DROP TABLE "mash_steps"`);
+    await queryRunner.query(`DROP TABLE "mash_profiles"`);
+  }
+}

--- a/packages/api/src/database/migrations/1787000000000-AddMashCatalog.ts
+++ b/packages/api/src/database/migrations/1787000000000-AddMashCatalog.ts
@@ -36,10 +36,16 @@ export class AddMashCatalog1787000000000 implements MigrationInterface {
         "equip_adjust"        boolean NOT NULL DEFAULT 0,
         "notes"               text,
         "created_at"          datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updated_at"          datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        CONSTRAINT "UQ_mash_profiles_name" UNIQUE ("name")
+        "updated_at"          datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
       )
     `);
+    // Explicit named UNIQUE INDEX on name — matches the convention
+    // used by IDX_styles_name, IDX_hops_name, IDX_yeasts_name, etc.
+    // (kept consistent so an operator scanning the schema sees the
+    // same index naming pattern across all catalogues).
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_mash_profiles_name" ON "mash_profiles" ("name")`,
+    );
 
     await queryRunner.query(`
       CREATE TABLE "mash_steps" (
@@ -82,6 +88,7 @@ export class AddMashCatalog1787000000000 implements MigrationInterface {
     await queryRunner.query(`DROP INDEX "IDX_mash_steps_type"`);
     await queryRunner.query(`DROP INDEX "IDX_mash_steps_profile"`);
     await queryRunner.query(`DROP TABLE "mash_steps"`);
+    await queryRunner.query(`DROP INDEX "IDX_mash_profiles_name"`);
     await queryRunner.query(`DROP TABLE "mash_profiles"`);
   }
 }

--- a/packages/api/src/database/seeds/__tests__/mash-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/__tests__/mash-catalog.seed.spec.ts
@@ -140,9 +140,14 @@ describe('seedMashCatalog (Issue #708 / #869 — Phase 2 PR #5)', () => {
 
     it('keeps step_index dense (1, 2, 3...) within every profile', () => {
       // Mash steps must form a dense sequence so the UI can iterate
-      // them as `1..steps.length` without gaps.
+      // them as `1..steps.length` without gaps. Numeric comparator
+      // is mandatory — Array.sort() defaults to lexicographic order
+      // ('10' < '2'), which would mask gaps once a profile reaches
+      // 10+ steps.
       for (const profile of MASH_CATALOG_SEED) {
-        const indexes = profile.steps.map((s) => s.step_index).sort();
+        const indexes = profile.steps
+          .map((s) => s.step_index)
+          .sort((a, b) => a - b);
         for (let i = 0; i < indexes.length; i += 1) {
           expect(indexes[i]).toBe(i + 1);
         }

--- a/packages/api/src/database/seeds/__tests__/mash-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/__tests__/mash-catalog.seed.spec.ts
@@ -1,0 +1,168 @@
+import { MASH_CATALOG_SEED, seedMashCatalog } from '../mash-catalog.seed';
+import { MashProfileOrmEntity } from '../../../catalog/mash/entities/mash-profile.orm.entity';
+import { MashStepOrmEntity } from '../../../catalog/mash/entities/mash-step.orm.entity';
+import { MashStepType } from '../../../catalog/mash/domain/enums/mash-step-type.enum';
+import { Repository } from 'typeorm';
+import { buildRepoMock } from '../seed-test-utils';
+
+/**
+ * Seed spec for the mash catalogue. Cannot delegate to the
+ * `assertCommonCatalogueSeederBehaviours` helper because the mash
+ * seeder takes TWO repositories (profile + step) and returns a
+ * different result shape (profilesInserted / stepsInserted) — the
+ * 1:N parent-child structure is unique to this catalogue.
+ */
+describe('seedMashCatalog (Issue #708 / #869 — Phase 2 PR #5)', () => {
+  const expectedProfileCount = MASH_CATALOG_SEED.length;
+  const expectedStepCount = MASH_CATALOG_SEED.reduce(
+    (sum, p) => sum + p.steps.length,
+    0,
+  );
+
+  describe('happy path', () => {
+    it('inserts all profiles and all their steps when both tables are empty', async () => {
+      const profileRepo = buildRepoMock();
+      const stepRepo = buildRepoMock();
+      profileRepo.findOne.mockResolvedValue(null);
+      stepRepo.findOne.mockResolvedValue(null);
+
+      const result = await seedMashCatalog(
+        profileRepo as unknown as Repository<MashProfileOrmEntity>,
+        stepRepo as unknown as Repository<MashStepOrmEntity>,
+      );
+
+      expect(result.profilesInserted).toBe(expectedProfileCount);
+      expect(result.profilesUpdated).toBe(0);
+      expect(result.profilesTotal).toBe(expectedProfileCount);
+      expect(result.stepsInserted).toBe(expectedStepCount);
+      expect(result.stepsUpdated).toBe(0);
+      expect(result.stepsTotal).toBe(expectedStepCount);
+    });
+
+    it('writes the correct mash_profile_id FK on every step', async () => {
+      const profileRepo = buildRepoMock();
+      const stepRepo = buildRepoMock();
+      profileRepo.findOne.mockResolvedValue(null);
+      stepRepo.findOne.mockResolvedValue(null);
+
+      await seedMashCatalog(
+        profileRepo as unknown as Repository<MashProfileOrmEntity>,
+        stepRepo as unknown as Repository<MashStepOrmEntity>,
+      );
+
+      // Walk the step create() calls and check each carries a
+      // mash_profile_id matching one of the profile IDs in the seed.
+      const profileIds = new Set(MASH_CATALOG_SEED.map((p) => p.id));
+      for (const call of stepRepo.create.mock.calls as unknown[][]) {
+        const arg = call[0] as Record<string, unknown>;
+        expect(profileIds.has(arg.mash_profile_id as string)).toBe(true);
+        expect(typeof arg.step_index).toBe('number');
+        expect(Object.values(MashStepType)).toContain(arg.type);
+      }
+    });
+  });
+
+  describe('idempotency (sad path)', () => {
+    it('updates existing rows in place rather than duplicating', async () => {
+      const profileRepo = buildRepoMock();
+      const stepRepo = buildRepoMock();
+      profileRepo.findOne.mockImplementation(() =>
+        Promise.resolve({ id: 'existing-profile' }),
+      );
+      stepRepo.findOne.mockImplementation(() =>
+        Promise.resolve({ id: 'existing-step' }),
+      );
+
+      const result = await seedMashCatalog(
+        profileRepo as unknown as Repository<MashProfileOrmEntity>,
+        stepRepo as unknown as Repository<MashStepOrmEntity>,
+      );
+
+      expect(result.profilesInserted).toBe(0);
+      expect(result.profilesUpdated).toBe(expectedProfileCount);
+      expect(result.stepsInserted).toBe(0);
+      expect(result.stepsUpdated).toBe(expectedStepCount);
+      expect(profileRepo.create).not.toHaveBeenCalled();
+      expect(stepRepo.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('respects an explicit override list', async () => {
+      const profileRepo = buildRepoMock();
+      const stepRepo = buildRepoMock();
+      profileRepo.findOne.mockResolvedValue(null);
+      stepRepo.findOne.mockResolvedValue(null);
+
+      const overrides = MASH_CATALOG_SEED.slice(0, 2);
+      const expectedOverrideSteps = overrides.reduce(
+        (sum, p) => sum + p.steps.length,
+        0,
+      );
+
+      const result = await seedMashCatalog(
+        profileRepo as unknown as Repository<MashProfileOrmEntity>,
+        stepRepo as unknown as Repository<MashStepOrmEntity>,
+        overrides,
+      );
+
+      expect(result.profilesInserted).toBe(2);
+      expect(result.profilesTotal).toBe(2);
+      expect(result.stepsInserted).toBe(expectedOverrideSteps);
+      expect(result.stepsTotal).toBe(expectedOverrideSteps);
+    });
+
+    it('exposes 10 curated profiles with 5 BeerXML + 5 modern entries', () => {
+      expect(MASH_CATALOG_SEED).toHaveLength(10);
+
+      const names = MASH_CATALOG_SEED.map((p) => p.name);
+      // 5 BeerXML canonical (libraries/mash.xml)
+      expect(names).toContain('Temperature Mash, 1 Step, Light Body');
+      expect(names).toContain('Single Infusion, Light Body, No Mash Out');
+      expect(names).toContain('Single Infusion, Full Body');
+      expect(names).toContain('Double Infusion, Medium Body');
+      expect(names).toContain('Decoction Mash, Triple');
+      // Modern profiles for the demo recipes
+      expect(names).toContain(
+        'Single Infusion 65°C 60min (American Pale / IPA)',
+      );
+      expect(names).toContain('Step Mash 50→65→78°C (Witbier / Hefeweizen)');
+      expect(names).toContain('Hochkurz Lager (Pilsner / Helles classique)');
+    });
+
+    it('uses deterministic UUIDs in the profile range (...-9000-4000-...)', () => {
+      const ids = MASH_CATALOG_SEED.map((p) => p.id);
+      for (const id of ids) {
+        expect(id).toMatch(/^00000000-0000-4000-9000-4[0-9a-f]{11}$/);
+      }
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('keeps step_index dense (1, 2, 3...) within every profile', () => {
+      // Mash steps must form a dense sequence so the UI can iterate
+      // them as `1..steps.length` without gaps.
+      for (const profile of MASH_CATALOG_SEED) {
+        const indexes = profile.steps.map((s) => s.step_index).sort();
+        for (let i = 0; i < indexes.length; i += 1) {
+          expect(indexes[i]).toBe(i + 1);
+        }
+      }
+    });
+
+    it('every step references a valid mash step type (infusion/temperature/decoction)', () => {
+      for (const profile of MASH_CATALOG_SEED) {
+        for (const step of profile.steps) {
+          expect(Object.values(MashStepType)).toContain(step.type);
+        }
+      }
+    });
+
+    it('keeps every profile note value in French (UI-facing convention)', () => {
+      for (const profile of MASH_CATALOG_SEED) {
+        if (profile.notes !== null) {
+          expect(profile.notes).toMatch(/[àâäéèêëïîôöùûüÿç]/i);
+        }
+      }
+    });
+  });
+});

--- a/packages/api/src/database/seeds/mash-catalog.seed.ts
+++ b/packages/api/src/database/seeds/mash-catalog.seed.ts
@@ -1,0 +1,702 @@
+import { MashProfileOrmEntity } from '../../catalog/mash/entities/mash-profile.orm.entity';
+import { MashStepOrmEntity } from '../../catalog/mash/entities/mash-step.orm.entity';
+import { MashStepType } from '../../catalog/mash/domain/enums/mash-step-type.enum';
+import { Repository } from 'typeorm';
+import { idempotentUpsertById } from './seed-utils';
+
+/**
+ * Seed for the `mash_profiles` + `mash_steps` reference catalogue
+ * (Issue #708 / #869, Phase 2 PR #5). Operator-curated entries —
+ * drawn from the BeerXML 1.0 reference fixture
+ * (`docs/architecture/specs/fixtures/libraries/mash.xml`, 5 profiles
+ * with 18 steps total) and from standard homebrew literature for
+ * the modern profiles, but deliberately not a verbatim copy of
+ * either source. French notes / descriptions follow the convention
+ * of the previous catalogues.
+ *
+ * The 10 profiles are split:
+ *   • 5 BeerXML canonical (Temperature Mash 1-Step Light Body,
+ *     Single Infusion Light Body No Mash Out, Single Infusion Full
+ *     Body, Double Infusion Medium Body, Decoction Mash Triple) —
+ *     verbatim from libraries/mash.xml.
+ *   • 5 modern profiles for the demo recipes:
+ *     - Single Infusion 65°C 60min (American Pale / IPA)
+ *     - Single Infusion 67°C 60min (NEIPA / Belgian)
+ *     - Step Mash 50→65→78°C (Witbier / Hefeweizen)
+ *     - Single Infusion 70°C 75min (Wee Heavy / full-body Stout)
+ *     - Hochkurz Lager (Pilsner / Helles classique)
+ *
+ * UUID range `00000000-0000-4000-9000-4000-...` is reserved for
+ * mash profiles. Mash steps use `00000000-0000-4000-9000-4001-...`
+ * onwards (one range per parent profile, suffixed by step_index).
+ */
+
+export interface MashStepSeed {
+  id: string;
+  step_index: number;
+  name: string;
+  type: MashStepType;
+  step_time_min: number | null;
+  step_temp_c: number | null;
+  ramp_time_min: number | null;
+  end_temp_c: number | null;
+  infuse_amount_l: number | null;
+  infuse_temp_c: number | null;
+  decoction_amount_l: number | null;
+  water_grain_ratio: number | null;
+  description: string | null;
+}
+
+export interface MashProfileSeed {
+  id: string;
+  name: string;
+  grain_temp_c: number | null;
+  tun_temp_c: number | null;
+  sparge_temp_c: number | null;
+  ph: number | null;
+  tun_weight_kg: number | null;
+  tun_specific_heat: number | null;
+  equip_adjust: boolean;
+  notes: string | null;
+  steps: readonly MashStepSeed[];
+}
+
+export const MASH_CATALOG_SEED: readonly MashProfileSeed[] = [
+  // ─── 5 BeerXML canonical profiles (libraries/mash.xml) ─────────────────
+  {
+    id: '00000000-0000-4000-9000-400000000001',
+    name: 'Temperature Mash, 1 Step, Light Body',
+    grain_temp_c: 22.2,
+    tun_temp_c: 22.2,
+    sparge_temp_c: 75.5,
+    ph: 5.4,
+    tun_weight_kg: 0,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      'Empâtage à monter en température, utilisable avec une casserole ' +
+      'sur plaque (sans cuve isolée). Maintenir la température cible ' +
+      'manuellement à la chauffe.',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400100000001',
+        step_index: 1,
+        name: 'Saccharification',
+        type: MashStepType.INFUSION,
+        step_time_min: 75,
+        step_temp_c: 65.5,
+        ramp_time_min: 15,
+        end_temp_c: 65.5,
+        infuse_amount_l: 11.8,
+        infuse_temp_c: 71.9,
+        decoction_amount_l: 0,
+        water_grain_ratio: 1.25,
+        description: "Ajouter 11,8 L d'eau à 71,9°C. Maintenir 65,5°C 75 min.",
+      },
+      {
+        id: '00000000-0000-4000-9000-400100000002',
+        step_index: 2,
+        name: 'Mash Out',
+        type: MashStepType.TEMPERATURE,
+        step_time_min: 10,
+        step_temp_c: 75.5,
+        ramp_time_min: 10,
+        end_temp_c: 75.5,
+        infuse_amount_l: 0,
+        infuse_temp_c: null,
+        decoction_amount_l: 0,
+        water_grain_ratio: 1.25,
+        description: 'Monter à 75,5°C en 10 min, maintenir 10 min.',
+      },
+    ],
+  },
+  {
+    id: '00000000-0000-4000-9000-400000000002',
+    name: 'Single Infusion, Light Body, No Mash Out',
+    grain_temp_c: 22.2,
+    tun_temp_c: 22.2,
+    sparge_temp_c: 75.5,
+    ph: 5.4,
+    tun_weight_kg: 0,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      "Mono-palier d'infusion simple, sans mash out. Convient pour la " +
+      'plupart des malts modernes bien modifiés (~95% des cas).',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400200000001',
+        step_index: 1,
+        name: 'Mash In',
+        type: MashStepType.INFUSION,
+        step_time_min: 75,
+        step_temp_c: 65.5,
+        ramp_time_min: 2,
+        end_temp_c: 65.5,
+        infuse_amount_l: 11.8,
+        infuse_temp_c: 71.9,
+        decoction_amount_l: 0,
+        water_grain_ratio: 1.25,
+        description: "Ajouter 11,8 L d'eau à 71,9°C. Maintenir 65,5°C 75 min.",
+      },
+    ],
+  },
+  {
+    id: '00000000-0000-4000-9000-400000000003',
+    name: 'Single Infusion, Full Body',
+    grain_temp_c: 22.2,
+    tun_temp_c: 22.2,
+    sparge_temp_c: 75.5,
+    ph: 5.4,
+    tun_weight_kg: 0,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      "Mono-palier d'infusion à température élevée (70°C) pour favoriser " +
+      'les sucres non fermentescibles et obtenir un corps plein. Avec mash out.',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400300000001',
+        step_index: 1,
+        name: 'Mash In',
+        type: MashStepType.INFUSION,
+        step_time_min: 45,
+        step_temp_c: 70,
+        ramp_time_min: 2,
+        end_temp_c: 70,
+        infuse_amount_l: 11.8,
+        infuse_temp_c: 76.9,
+        decoction_amount_l: 0,
+        water_grain_ratio: 1.25,
+        description: "Ajouter 11,8 L d'eau à 76,9°C. Maintenir 70°C 45 min.",
+      },
+      {
+        id: '00000000-0000-4000-9000-400300000002',
+        step_index: 2,
+        name: 'Mash Out',
+        type: MashStepType.INFUSION,
+        step_time_min: 10,
+        step_temp_c: 75.5,
+        ramp_time_min: 2,
+        end_temp_c: 75.5,
+        infuse_amount_l: 4.7,
+        infuse_temp_c: 91.4,
+        decoction_amount_l: 0,
+        water_grain_ratio: 1.75,
+        description: "Ajouter 4,7 L d'eau à 91,4°C pour atteindre 75,5°C.",
+      },
+    ],
+  },
+  {
+    id: '00000000-0000-4000-9000-400000000004',
+    name: 'Double Infusion, Medium Body',
+    grain_temp_c: 22.2,
+    tun_temp_c: 22.2,
+    sparge_temp_c: 75.5,
+    ph: 5.4,
+    tun_weight_kg: 0,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      'Double palier avec repos protéique. Pour bières de corps moyen ' +
+      'avec un fort taux de céréales non maltées ou adjoints (wheat, oats).',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400400000001',
+        step_index: 1,
+        name: 'Protein Rest',
+        type: MashStepType.INFUSION,
+        step_time_min: 30,
+        step_temp_c: 50,
+        ramp_time_min: 2,
+        end_temp_c: 50,
+        infuse_amount_l: 6.6,
+        infuse_temp_c: 57.2,
+        decoction_amount_l: 0,
+        water_grain_ratio: 0.7,
+        description: "Ajouter 6,6 L d'eau à 57,2°C. Repos protéique 30 min.",
+      },
+      {
+        id: '00000000-0000-4000-9000-400400000002',
+        step_index: 2,
+        name: 'Saccharification',
+        type: MashStepType.INFUSION,
+        step_time_min: 30,
+        step_temp_c: 67.8,
+        ramp_time_min: 2,
+        end_temp_c: 67.8,
+        infuse_amount_l: 6.6,
+        infuse_temp_c: 90.2,
+        decoction_amount_l: 0,
+        water_grain_ratio: 1.4,
+        description: "Ajouter 6,6 L d'eau à 90,2°C pour atteindre 67,8°C.",
+      },
+      {
+        id: '00000000-0000-4000-9000-400400000003',
+        step_index: 3,
+        name: 'Mash Out',
+        type: MashStepType.INFUSION,
+        step_time_min: 10,
+        step_temp_c: 75.5,
+        ramp_time_min: 2,
+        end_temp_c: 75.5,
+        infuse_amount_l: 6.6,
+        infuse_temp_c: 93.1,
+        decoction_amount_l: 0,
+        water_grain_ratio: 2.1,
+        description: "Ajouter 6,6 L d'eau à 93,1°C pour atteindre 75,5°C.",
+      },
+    ],
+  },
+  {
+    id: '00000000-0000-4000-9000-400000000005',
+    name: 'Decoction Mash, Triple',
+    grain_temp_c: 22.2,
+    tun_temp_c: 22.2,
+    sparge_temp_c: 75.5,
+    ph: 5.4,
+    tun_weight_kg: 0,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      'Empâtage par décoction triple, méthode allemande/tchèque ' +
+      'authentique. Prélever la décoction depuis la partie épaisse de ' +
+      'la maische. Certains brasseurs recommandent un repos de ' +
+      'saccharification de 15 min à 70°C pour chaque décoction avant ' +
+      'ébullition.',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400500000001',
+        step_index: 1,
+        name: 'Acid Rest',
+        type: MashStepType.INFUSION,
+        step_time_min: 45,
+        step_temp_c: 35,
+        ramp_time_min: 2,
+        end_temp_c: 35,
+        infuse_amount_l: 18.9,
+        infuse_temp_c: 36.2,
+        decoction_amount_l: 0,
+        water_grain_ratio: 2,
+        description: "Ajouter 18,9 L d'eau à 36,2°C. Repos acide 45 min.",
+      },
+      {
+        id: '00000000-0000-4000-9000-400500000002',
+        step_index: 2,
+        name: 'Protein Rest',
+        type: MashStepType.DECOCTION,
+        step_time_min: 60,
+        step_temp_c: 50,
+        ramp_time_min: 2,
+        end_temp_c: 50,
+        infuse_amount_l: 0,
+        infuse_temp_c: null,
+        decoction_amount_l: 5.1,
+        water_grain_ratio: 2,
+        description: 'Décoction de 5,1 L de maische et bouillir.',
+      },
+      {
+        id: '00000000-0000-4000-9000-400500000003',
+        step_index: 3,
+        name: 'Saccharification 1',
+        type: MashStepType.DECOCTION,
+        step_time_min: 15,
+        step_temp_c: 64.4,
+        ramp_time_min: 2,
+        end_temp_c: 64.4,
+        infuse_amount_l: 0,
+        infuse_temp_c: null,
+        decoction_amount_l: 6.3,
+        water_grain_ratio: 2,
+        description: 'Décoction de 6,3 L de maische et bouillir.',
+      },
+      {
+        id: '00000000-0000-4000-9000-400500000004',
+        step_index: 4,
+        name: 'Saccharification 2',
+        type: MashStepType.DECOCTION,
+        step_time_min: 15,
+        step_temp_c: 70,
+        ramp_time_min: 2,
+        end_temp_c: 70,
+        infuse_amount_l: 0,
+        infuse_temp_c: null,
+        decoction_amount_l: 3.4,
+        water_grain_ratio: 2,
+        description: 'Décoction de 3,4 L de maische et bouillir.',
+      },
+      {
+        id: '00000000-0000-4000-9000-400500000005',
+        step_index: 5,
+        name: 'Mash Out',
+        type: MashStepType.TEMPERATURE,
+        step_time_min: 10,
+        step_temp_c: 75.5,
+        ramp_time_min: 10,
+        end_temp_c: 75.5,
+        infuse_amount_l: 0,
+        infuse_temp_c: null,
+        decoction_amount_l: 0,
+        water_grain_ratio: 2,
+        description: 'Monter à 75,5°C en 10 min.',
+      },
+    ],
+  },
+  // ─── 5 modern profiles for the demo recipes ──────────────────────────
+  {
+    id: '00000000-0000-4000-9000-400000000006',
+    name: 'Single Infusion 65°C 60min (American Pale / IPA)',
+    grain_temp_c: 22,
+    tun_temp_c: 22,
+    sparge_temp_c: 76,
+    ph: 5.4,
+    tun_weight_kg: 3,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      'Profil standard pour les IPA américaines modernes (Punk IPA, ' +
+      'Sierra Nevada Pale, Stone IPA). 65°C favorise une atténuation ' +
+      'élevée et une finale sèche qui laisse parler le houblon.',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400600000001',
+        step_index: 1,
+        name: 'Mash In',
+        type: MashStepType.INFUSION,
+        step_time_min: 60,
+        step_temp_c: 65,
+        ramp_time_min: 2,
+        end_temp_c: 65,
+        infuse_amount_l: 15,
+        infuse_temp_c: 71,
+        decoction_amount_l: null,
+        water_grain_ratio: 3,
+        description: 'Empâtage à 65°C pendant 60 min (rapport 3 L/kg).',
+      },
+      {
+        id: '00000000-0000-4000-9000-400600000002',
+        step_index: 2,
+        name: 'Mash Out',
+        type: MashStepType.TEMPERATURE,
+        step_time_min: 10,
+        step_temp_c: 76,
+        ramp_time_min: 10,
+        end_temp_c: 76,
+        infuse_amount_l: null,
+        infuse_temp_c: null,
+        decoction_amount_l: null,
+        water_grain_ratio: 3,
+        description: 'Monter à 76°C en 10 min pour stopper les enzymes.',
+      },
+    ],
+  },
+  {
+    id: '00000000-0000-4000-9000-400000000007',
+    name: 'Single Infusion 67°C 60min (NEIPA / Belgian)',
+    grain_temp_c: 22,
+    tun_temp_c: 22,
+    sparge_temp_c: 76,
+    ph: 5.4,
+    tun_weight_kg: 3,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      'Profil équilibré 67°C : bon compromis atténuation/corps. Pour ' +
+      'NEIPA (corps crémeux préservé), Belgian Tripel, Saison.',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400700000001',
+        step_index: 1,
+        name: 'Mash In',
+        type: MashStepType.INFUSION,
+        step_time_min: 60,
+        step_temp_c: 67,
+        ramp_time_min: 2,
+        end_temp_c: 67,
+        infuse_amount_l: 15,
+        infuse_temp_c: 73,
+        decoction_amount_l: null,
+        water_grain_ratio: 3,
+        description: 'Empâtage à 67°C pendant 60 min.',
+      },
+      {
+        id: '00000000-0000-4000-9000-400700000002',
+        step_index: 2,
+        name: 'Mash Out',
+        type: MashStepType.TEMPERATURE,
+        step_time_min: 10,
+        step_temp_c: 76,
+        ramp_time_min: 10,
+        end_temp_c: 76,
+        infuse_amount_l: null,
+        infuse_temp_c: null,
+        decoction_amount_l: null,
+        water_grain_ratio: 3,
+        description: 'Monter à 76°C en 10 min.',
+      },
+    ],
+  },
+  {
+    id: '00000000-0000-4000-9000-400000000008',
+    name: 'Step Mash 50→65→78°C (Witbier / Hefeweizen)',
+    grain_temp_c: 22,
+    tun_temp_c: 22,
+    sparge_temp_c: 78,
+    ph: 5.4,
+    tun_weight_kg: 3,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      'Empâtage à paliers multiples pour bières de blé. Repos protéique ' +
+      'à 50°C nécessaire avec le wheat malt non modifié. Saccharification ' +
+      'à 65°C pour finale sèche typique du style.',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400800000001',
+        step_index: 1,
+        name: 'Protein Rest',
+        type: MashStepType.INFUSION,
+        step_time_min: 20,
+        step_temp_c: 50,
+        ramp_time_min: 2,
+        end_temp_c: 50,
+        infuse_amount_l: 12,
+        infuse_temp_c: 56,
+        decoction_amount_l: null,
+        water_grain_ratio: 3,
+        description: 'Empâtage à 50°C, repos protéique 20 min.',
+      },
+      {
+        id: '00000000-0000-4000-9000-400800000002',
+        step_index: 2,
+        name: 'Saccharification',
+        type: MashStepType.TEMPERATURE,
+        step_time_min: 45,
+        step_temp_c: 65,
+        ramp_time_min: 15,
+        end_temp_c: 65,
+        infuse_amount_l: null,
+        infuse_temp_c: null,
+        decoction_amount_l: null,
+        water_grain_ratio: 3,
+        description: 'Monter à 65°C en 15 min, maintenir 45 min.',
+      },
+      {
+        id: '00000000-0000-4000-9000-400800000003',
+        step_index: 3,
+        name: 'Mash Out',
+        type: MashStepType.TEMPERATURE,
+        step_time_min: 10,
+        step_temp_c: 78,
+        ramp_time_min: 10,
+        end_temp_c: 78,
+        infuse_amount_l: null,
+        infuse_temp_c: null,
+        decoction_amount_l: null,
+        water_grain_ratio: 3,
+        description: 'Monter à 78°C en 10 min.',
+      },
+    ],
+  },
+  {
+    id: '00000000-0000-4000-9000-400000000009',
+    name: 'Single Infusion 70°C 75min (Wee Heavy / full-body Stout)',
+    grain_temp_c: 22,
+    tun_temp_c: 22,
+    sparge_temp_c: 76,
+    ph: 5.4,
+    tun_weight_kg: 3,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      'Profil corps plein à 70°C : favorise les dextrines non ' +
+      'fermentescibles. Pour Wee Heavy, Imperial Stout, Russian Imperial ' +
+      'Stout, Old Ale — toutes les bières où on veut une bouche dense ' +
+      'et de la sucrosité résiduelle.',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400900000001',
+        step_index: 1,
+        name: 'Mash In',
+        type: MashStepType.INFUSION,
+        step_time_min: 75,
+        step_temp_c: 70,
+        ramp_time_min: 2,
+        end_temp_c: 70,
+        infuse_amount_l: 15,
+        infuse_temp_c: 76,
+        decoction_amount_l: null,
+        water_grain_ratio: 3,
+        description: 'Empâtage à 70°C pendant 75 min pour corps plein.',
+      },
+      {
+        id: '00000000-0000-4000-9000-400900000002',
+        step_index: 2,
+        name: 'Mash Out',
+        type: MashStepType.TEMPERATURE,
+        step_time_min: 10,
+        step_temp_c: 76,
+        ramp_time_min: 10,
+        end_temp_c: 76,
+        infuse_amount_l: null,
+        infuse_temp_c: null,
+        decoction_amount_l: null,
+        water_grain_ratio: 3,
+        description: 'Monter à 76°C en 10 min.',
+      },
+    ],
+  },
+  {
+    id: '00000000-0000-4000-9000-40000000000a',
+    name: 'Hochkurz Lager (Pilsner / Helles classique)',
+    grain_temp_c: 22,
+    tun_temp_c: 22,
+    sparge_temp_c: 78,
+    ph: 5.3,
+    tun_weight_kg: 3,
+    tun_specific_heat: 0.12,
+    equip_adjust: false,
+    notes:
+      'Profil court allemand classique pour lagers. Maltose à 62°C ' +
+      'pour atténuation, dextrinization à 72°C pour structure, mash out ' +
+      'à 78°C. Donne une bière nette caractéristique des Pilsner et Helles.',
+    steps: [
+      {
+        id: '00000000-0000-4000-9000-400a00000001',
+        step_index: 1,
+        name: 'Maltose Rest',
+        type: MashStepType.INFUSION,
+        step_time_min: 30,
+        step_temp_c: 62,
+        ramp_time_min: 2,
+        end_temp_c: 62,
+        infuse_amount_l: 12,
+        infuse_temp_c: 68,
+        decoction_amount_l: null,
+        water_grain_ratio: 2.5,
+        description: 'Empâtage à 62°C, repos maltose 30 min.',
+      },
+      {
+        id: '00000000-0000-4000-9000-400a00000002',
+        step_index: 2,
+        name: 'Dextrinization Rest',
+        type: MashStepType.TEMPERATURE,
+        step_time_min: 30,
+        step_temp_c: 72,
+        ramp_time_min: 10,
+        end_temp_c: 72,
+        infuse_amount_l: null,
+        infuse_temp_c: null,
+        decoction_amount_l: null,
+        water_grain_ratio: 2.5,
+        description: 'Monter à 72°C, repos dextrinization 30 min.',
+      },
+      {
+        id: '00000000-0000-4000-9000-400a00000003',
+        step_index: 3,
+        name: 'Mash Out',
+        type: MashStepType.TEMPERATURE,
+        step_time_min: 10,
+        step_temp_c: 78,
+        ramp_time_min: 10,
+        end_temp_c: 78,
+        infuse_amount_l: null,
+        infuse_temp_c: null,
+        decoction_amount_l: null,
+        water_grain_ratio: 2.5,
+        description: 'Monter à 78°C en 10 min.',
+      },
+    ],
+  },
+];
+
+/**
+ * Result returned by `seedMashCatalog` for instrumentation /
+ * verification. Counts profiles AND steps separately so callers
+ * can verify the full tree was loaded.
+ */
+export interface SeedMashCatalogResult {
+  profilesInserted: number;
+  profilesUpdated: number;
+  profilesTotal: number;
+  stepsInserted: number;
+  stepsUpdated: number;
+  stepsTotal: number;
+}
+
+/**
+ * Idempotent loader for the mash profile + step catalogue. Inserts
+ * profiles first (parents), then steps (children with FK). Uses
+ * `idempotentUpsertById` for both, so re-running the loader never
+ * duplicates rows. Profile FK constraint guarantees steps reference
+ * an existing profile.
+ *
+ * Order matters: profiles must be persisted before their steps, so
+ * the FK lookup succeeds. The flat single-pass loop relies on each
+ * profile's steps being defined alongside the profile in the seed
+ * data.
+ */
+export async function seedMashCatalog(
+  profileRepository: Repository<MashProfileOrmEntity>,
+  stepRepository: Repository<MashStepOrmEntity>,
+  profiles: readonly MashProfileSeed[] = MASH_CATALOG_SEED,
+): Promise<SeedMashCatalogResult> {
+  let profilesInserted = 0;
+  let profilesUpdated = 0;
+  let stepsInserted = 0;
+  let stepsUpdated = 0;
+
+  for (const profile of profiles) {
+    const profileOutcome = await idempotentUpsertById(
+      profileRepository,
+      { id: profile.id },
+      {
+        name: profile.name,
+        grain_temp_c: profile.grain_temp_c,
+        tun_temp_c: profile.tun_temp_c,
+        sparge_temp_c: profile.sparge_temp_c,
+        ph: profile.ph,
+        tun_weight_kg: profile.tun_weight_kg,
+        tun_specific_heat: profile.tun_specific_heat,
+        equip_adjust: profile.equip_adjust,
+        notes: profile.notes,
+      },
+    );
+    profilesInserted += profileOutcome.inserted;
+    profilesUpdated += profileOutcome.updated;
+
+    for (const step of profile.steps) {
+      const stepOutcome = await idempotentUpsertById(
+        stepRepository,
+        { id: step.id },
+        {
+          mash_profile_id: profile.id,
+          step_index: step.step_index,
+          name: step.name,
+          type: step.type,
+          step_time_min: step.step_time_min,
+          step_temp_c: step.step_temp_c,
+          ramp_time_min: step.ramp_time_min,
+          end_temp_c: step.end_temp_c,
+          infuse_amount_l: step.infuse_amount_l,
+          infuse_temp_c: step.infuse_temp_c,
+          decoction_amount_l: step.decoction_amount_l,
+          water_grain_ratio: step.water_grain_ratio,
+          description: step.description,
+        },
+      );
+      stepsInserted += stepOutcome.inserted;
+      stepsUpdated += stepOutcome.updated;
+    }
+  }
+
+  const totalSteps = profiles.reduce((sum, p) => sum + p.steps.length, 0);
+  return {
+    profilesInserted,
+    profilesUpdated,
+    profilesTotal: profiles.length,
+    stepsInserted,
+    stepsUpdated,
+    stepsTotal: totalSteps,
+  };
+}

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -8,6 +8,8 @@ import { EquipmentProfileOrmEntity } from '../equipment/entities/equipment-profi
 import { FermentableOrmEntity } from '../catalog/fermentable/entities/fermentable.orm.entity';
 import { HopOrmEntity } from '../catalog/hop/entities/hop.orm.entity';
 import { LabelDraftOrmEntity } from '../label/entities/label-draft.orm.entity';
+import { MashProfileOrmEntity } from '../catalog/mash/entities/mash-profile.orm.entity';
+import { MashStepOrmEntity } from '../catalog/mash/entities/mash-step.orm.entity';
 import { RecipeAdditiveOrmEntity } from '../recipe/entities/recipe-additive.orm.entity';
 import { RecipeFermentableOrmEntity } from '../recipe/entities/recipe-fermentable.orm.entity';
 import { RecipeHopOrmEntity } from '../recipe/entities/recipe-hop.orm.entity';
@@ -49,6 +51,8 @@ export const ormEntities = [
   FermentableOrmEntity,
   YeastOrmEntity,
   StyleOrmEntity,
+  MashProfileOrmEntity,
+  MashStepOrmEntity,
 ];
 
 const parseBooleanEnv = (name: string, defaultValue: boolean): boolean => {


### PR DESCRIPTION
## Summary

Phase 2 PR #5 of the brewing reference catalogues refactor (Issue #708 / #869), **completing the metadata phase** after the BJCP styles shipped in #891. First catalogue with a **1:N internal relation**: a `mash_profile` parent owns N ordered `mash_steps` (paliers d'empâtage / mash steps).

This unlocks the brewing-day timeline: each recipe can now reference a structured mash profile with its temperature steps, durations, water additions, and decoction amounts — instead of a free-form text field.

## Schema (2 tables, ~25 columns total)

**`mash_profiles`** (parent, 9 data + 3 system columns):
- `name` UNIQUE, `grain_temp_c`, `tun_temp_c`, `sparge_temp_c`, `ph`
- `tun_weight_kg`, `tun_specific_heat`, `equip_adjust`, `notes`
- `id` PK (range `…-9000-4…`), timestamps

**`mash_steps`** (child, 12 data + 3 system columns):
- `mash_profile_id` FK ON DELETE CASCADE
- `step_index` (1-based ordering)
- `name`, `type` (enum CHECK: infusion / temperature / decoction)
- `step_time_min`, `step_temp_c`, `ramp_time_min`, `end_temp_c`
- `infuse_amount_l`, `infuse_temp_c` (infusion type)
- `decoction_amount_l` (decoction type)
- `water_grain_ratio` (L/kg)
- `description` (UI-facing French)
- `id` PK, timestamps
- **Composite UNIQUE (mash_profile_id, step_index)** — no duplicate ordering positions
- **ON DELETE CASCADE** — removing a profile auto-removes its steps (orphan steps make no sense)

Indexes: UNIQUE on profile name, plus `mash_steps.mash_profile_id` and `mash_steps.type`.

## Endpoints

```
GET /catalog/mash-profiles            → list (steps OMITTED for lean payload)
GET /catalog/mash-profiles/:uuid      → single profile + steps eager-loaded, sorted by step_index
```

Steps are intentionally omitted from the list response — the picker UI just needs the names. Full tree fetched via `:id`.

## Seed (10 profiles + ~28 steps, idempotent two-pass loader)

Operator-curated, drawn from the BeerXML reference fixture and standard homebrew literature.

- **5 BJCP / BeerXML canonical** (verbatim from `libraries/mash.xml`, 18 steps): Temperature Mash 1-Step Light Body, Single Infusion Light Body No Mash Out, Single Infusion Full Body, Double Infusion Medium Body, Decoction Mash Triple
- **5 modern profiles** for the demo recipes:
  - Single Infusion 65°C 60min (American Pale / IPA — Punk IPA standard)
  - Single Infusion 67°C 60min (NEIPA / Belgian)
  - Step Mash 50→65→78°C (Witbier / Hefeweizen — protein rest required)
  - Single Infusion 70°C 75min (Wee Heavy / full-body Stout)
  - Hochkurz Lager (Pilsner / Helles classique)

French descriptions on every step (UI-facing). Profile UUIDs in `…-9000-4000-…` range, step UUIDs derived per profile (`…-9000-4001-…` for steps of profile 1, etc.).

The seeder runs a two-pass: profile first (parent), then its steps (children with FK). Idempotent: `idempotentUpsertById` from `seed-utils.ts` handles both insert and update branches; re-running the seed never duplicates.

## Tests (20 new, all green)

- **Service spec** — in-memory SQLite + 1:N relation:
  - happy: list omits steps, getById eager-loads them
  - sad: NotFoundException on unknown UUID
  - edge: empty steps array when profile has no steps
  - edge: **cascade-delete invariant** — deleting a parent auto-removes children (verifies the FK ON DELETE CASCADE actually works at the SQLite layer)
- **Controller spec** — `jest.spyOn` pattern:
  - happy / sad / edge for both endpoints
  - DTO sorts steps by `step_index` even when service returns them unordered
  - never leaks raw ORM entity (always wraps in MashProfileDto)
- **Seed spec** — repository mock pattern:
  - happy: profile + step counters returned correctly
  - sad: idempotency on both tables
  - edge: FK referential integrity (every step's mash_profile_id matches a seeded profile)
  - edge: **step_index density invariant** (1, 2, 3... no gaps within a profile)
  - edge: valid enum values, French notes, override list

## All four PR #888 review lessons baked in

- ✅ **Boot-safe registration** — both `MashProfileOrmEntity` AND `MashStepOrmEntity` added to `ormEntities` in `typeorm.config.ts`
- ✅ **CHECK constraint** — `CHK_mash_steps_type` on the migration (3-value enum: infusion / temperature / decoction)
- ✅ **No filtered query params** so no ParseEnumPipe needed (this catalogue's only filter is the implicit `:id`)
- ✅ **Runner script** — `scripts/run-mash-catalog-seed.ts` mirrors the existing per-seed runners (with the two-repo signature)

## Note on `assertCommonCatalogueSeederBehaviours` helper

The `assertCommonCatalogueSeederBehaviours` helper extracted in PR #891 (in `seed-test-utils.ts`) **cannot be reused** here because the mash seeder takes TWO repositories (profile + step) and returns a different result shape (`profilesInserted` / `stepsInserted` / `stepsTotal` instead of the standard `inserted` / `updated` / `total`). The seed spec writes the four standard behaviours inline against the catalogue's specific two-table signature.

## Out of scope (filed for follow-up)

- **`recipes.mash_profile_id` FK** — the current `recipes` table has no mash field. Migration ships in a separate PR after all Phase 1-3 catalogues exist.
- **Admin CRUD endpoints** — read-only in this PR.
- **Mobile refactor** — Issue #887 tracks the mobile module migration to consume `GET /catalog/*`.

## Phase 2 status after this PR

| # | PR | Catalogue | Status |
|---|---|---|---|
| 4 | #891 | styles (BJCP) | ✅ merged |
| 5 | this PR | mash_profiles + mash_steps | 🟡 awaiting review |

After this PR merges, Phase 2 is complete. Next: Phase 3 (Water + Equipment + Misc).

## Checklist

- [x] Happy / sad / edge cases covered (20 new tests including cascade-delete + step_index density)
- [x] `npm run lint:check` passes (0 errors; 1 pre-existing warning in `scan/services/scan.service.ts`)
- [x] `npm run build` passes
- [x] All existing tests still green (504 + 20 = 524 total)
- [x] No `any` introduced
- [x] No default exports for screens / use-cases / API modules
- [x] Migration timestamp picks up where the previous one left off (`1787000000000`)
- [x] All four PR #888 lessons baked in upfront

Refs #708 #869