### PR TITLE
feat(catalog/water): add brewing water profiles reference catalogue (#708)

### DIFF
--- a/packages/api/scripts/run-waters-catalog-seed.ts
+++ b/packages/api/scripts/run-waters-catalog-seed.ts
@@ -1,0 +1,38 @@
+/**
+ * One-shot script to seed the `waters` reference catalogue with
+ * the 10 curated entries from `WATERS_CATALOG_SEED` against the
+ * local dev database (Issue #708 / #869, Phase 3 PR #6).
+ *
+ * Usage:
+ *   cd packages/api
+ *   npx ts-node -r tsconfig-paths/register scripts/run-waters-catalog-seed.ts
+ *
+ * Idempotent: safe to run multiple times. Existing water IDs are
+ * updated in place; missing ones are inserted.
+ *
+ * Mirror of the per-seed runners shipped in earlier catalogues.
+ * Stopgap until the unified seed orchestrator lands at the end of
+ * Phase 3.
+ */
+import 'reflect-metadata';
+
+import dataSource from '../src/database/data-source';
+import { WaterOrmEntity } from '../src/catalog/water/entities/water.orm.entity';
+import { seedWatersCatalog } from '../src/database/seeds/waters-catalog.seed';
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const repo = dataSource.getRepository(WaterOrmEntity);
+  const result = await seedWatersCatalog(repo);
+  console.log('Waters catalogue seed:', result);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/catalog/catalog.module.ts
+++ b/packages/api/src/catalog/catalog.module.ts
@@ -3,7 +3,7 @@ import { HopModule } from './hop/hop.module';
 import { MashModule } from './mash/mash.module';
 import { Module } from '@nestjs/common';
 import { StyleModule } from './style/style.module';
-import { WaterModule } from './water/water.module';
+import { WaterCatalogModule } from './water/water.module';
 import { YeastModule } from './yeast/yeast.module';
 
 /**
@@ -12,7 +12,7 @@ import { YeastModule } from './yeast/yeast.module';
  * per catalogue (Issue #708 / #869):
  *   • Phase 1: HopModule, FermentableModule (PR #2), YeastModule (PR #3)
  *   • Phase 2: StyleModule, MashProfileModule
- *   • Phase 3: WaterModule, EquipmentModule, MiscModule
+ *   • Phase 3: WaterCatalogModule, EquipmentModule, MiscModule
  *
  * Each sub-module owns its own ORM entity, service, controller,
  * and DTOs. CatalogModule re-exports nothing for now — direct
@@ -25,7 +25,7 @@ import { YeastModule } from './yeast/yeast.module';
     YeastModule,
     StyleModule,
     MashModule,
-    WaterModule,
+    WaterCatalogModule,
   ],
 })
 export class CatalogModule {}

--- a/packages/api/src/catalog/catalog.module.ts
+++ b/packages/api/src/catalog/catalog.module.ts
@@ -3,6 +3,7 @@ import { HopModule } from './hop/hop.module';
 import { MashModule } from './mash/mash.module';
 import { Module } from '@nestjs/common';
 import { StyleModule } from './style/style.module';
+import { WaterModule } from './water/water.module';
 import { YeastModule } from './yeast/yeast.module';
 
 /**
@@ -18,6 +19,13 @@ import { YeastModule } from './yeast/yeast.module';
  * sub-module dependencies are explicit at the consumer side.
  */
 @Module({
-  imports: [HopModule, FermentableModule, YeastModule, StyleModule, MashModule],
+  imports: [
+    HopModule,
+    FermentableModule,
+    YeastModule,
+    StyleModule,
+    MashModule,
+    WaterModule,
+  ],
 })
 export class CatalogModule {}

--- a/packages/api/src/catalog/water/controllers/__tests__/water-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/water/controllers/__tests__/water-catalog.controller.spec.ts
@@ -1,0 +1,120 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { NotFoundException } from '@nestjs/common';
+import { WaterCatalogController } from '../water-catalog.controller';
+import { WaterCatalogService } from '../../services/water-catalog.service';
+import { WaterOrmEntity } from '../../entities/water.orm.entity';
+
+/**
+ * Controller spec for the brewing water catalogue. Mocks the
+ * service layer so the test isolates the HTTP-shape mapping
+ * (URL → service call → DTO transform) from the database concerns
+ * covered in `water-catalog.service.spec.ts`.
+ */
+describe('WaterCatalogController', () => {
+  let controller: WaterCatalogController;
+  let service: WaterCatalogService;
+
+  const ID_BURTON = '00000000-0000-4000-9000-500000000001';
+
+  function buildEntity(
+    overrides: Partial<WaterOrmEntity> = {},
+  ): WaterOrmEntity {
+    return {
+      id: ID_BURTON,
+      name: 'Burton on Trent, UK',
+      origin: 'United Kingdom',
+      calcium_ppm: 295,
+      bicarbonate_ppm: 300,
+      sulfate_ppm: 725,
+      chloride_ppm: 25,
+      sodium_ppm: 55,
+      magnesium_ppm: 45,
+      ph: 8,
+      notes: "Eau historique de Burton-on-Trent, berceau de l'IPA.",
+      created_at: new Date('2026-05-03T00:00:00.000Z'),
+      updated_at: new Date('2026-05-03T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WaterCatalogController],
+      providers: [
+        {
+          provide: WaterCatalogService,
+          useValue: {
+            list: jest.fn(),
+            getById: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(WaterCatalogController);
+    service = module.get(WaterCatalogService);
+  });
+
+  describe('GET /catalog/waters', () => {
+    it('happy: returns the full list mapped to DTOs', async () => {
+      const listSpy = jest.spyOn(service, 'list').mockResolvedValue([
+        buildEntity({ id: ID_BURTON, name: 'Burton on Trent, UK' }),
+        buildEntity({
+          id: '00000000-0000-4000-9000-500000000005',
+          name: 'Pilsen, Czech Republic',
+          sulfate_ppm: 5,
+        }),
+      ]);
+
+      const result = await controller.list();
+
+      expect(listSpy).toHaveBeenCalledWith();
+      expect(result.map((r) => r.name)).toEqual([
+        'Burton on Trent, UK',
+        'Pilsen, Czech Republic',
+      ]);
+      // DTO must serialise dates to ISO strings — never raw Date.
+      expect(typeof result[0].created_at).toBe('string');
+    });
+
+    it('sad: returns [] when the service yields no rows', async () => {
+      jest.spyOn(service, 'list').mockResolvedValue([]);
+      const result = await controller.list();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('GET /catalog/waters/:id', () => {
+    it('happy: returns the DTO for the matching water', async () => {
+      const getByIdSpy = jest
+        .spyOn(service, 'getById')
+        .mockResolvedValue(buildEntity());
+
+      const result = await controller.getById(ID_BURTON);
+
+      expect(getByIdSpy).toHaveBeenCalledWith(ID_BURTON);
+      expect(result.id).toBe(ID_BURTON);
+      expect(result.sulfate_ppm).toBe(725);
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getById')
+        .mockRejectedValue(new NotFoundException('Water profile not found'));
+
+      await expect(
+        controller.getById('00000000-0000-4000-9000-5000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: never leaks the raw ORM entity (always wraps in DTO)', async () => {
+      const entity = buildEntity();
+      jest.spyOn(service, 'getById').mockResolvedValue(entity);
+
+      const result = await controller.getById(ID_BURTON);
+      expect(result).not.toBe(entity);
+      expect(result.constructor.name).toBe('WaterDto');
+    });
+  });
+});

--- a/packages/api/src/catalog/water/controllers/water-catalog.controller.ts
+++ b/packages/api/src/catalog/water/controllers/water-catalog.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
+import { WaterCatalogService } from '../services/water-catalog.service';
+import { WaterDto } from '../dtos/water.dto';
+
+/**
+ * Read-only HTTP surface for the brewing water catalogue. Two endpoints:
+ *   GET /catalog/waters         → list all
+ *   GET /catalog/waters/:id     → fetch one by UUID
+ *
+ * No filters in this PR — the catalogue is small (~10 rows) and
+ * the picker UX scrolls the full list. Add pagination / search
+ * once the catalogue grows past ~100 entries.
+ *
+ * Write endpoints (POST / PATCH / DELETE) are intentionally absent
+ * — the catalogue is operator-curated reference data.
+ */
+@ApiTags('Catalog · Waters')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('catalog/waters')
+export class WaterCatalogController {
+  constructor(private readonly service: WaterCatalogService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List the water profile catalogue entries' })
+  @ApiOkResponse({ type: WaterDto, isArray: true })
+  async list(): Promise<WaterDto[]> {
+    const rows = await this.service.list();
+    return rows.map((row) => WaterDto.fromEntity(row));
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single water profile by UUID' })
+  @ApiOkResponse({ type: WaterDto })
+  @ApiNotFoundResponse({ description: 'Water profile not found' })
+  async getById(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<WaterDto> {
+    const entity = await this.service.getById(id);
+    return WaterDto.fromEntity(entity);
+  }
+}

--- a/packages/api/src/catalog/water/domain/water.types.ts
+++ b/packages/api/src/catalog/water/domain/water.types.ts
@@ -1,0 +1,34 @@
+/**
+ * Domain shape for one water profile entry in the immutable
+ * reference catalogue. Mirrors the `WaterOrmEntity` row shape
+ * one-to-one (no field is computed) — kept as a separate interface
+ * so the application / presentation layers do not import the ORM
+ * entity directly.
+ *
+ * Mineral concentrations are expressed in ppm (parts per million),
+ * equivalent to mg/L for dilute aqueous solutions. The six ions
+ * tracked are the brewing-relevant ones; trace minerals (iron,
+ * fluoride, etc.) are out of scope.
+ *
+ * The sulfate-to-chloride ratio is the most consequential
+ * brewing-water characteristic:
+ *   - sulfate-dominant (e.g. Burton 725:25) → hop-forward IPAs,
+ *     dry assertive bitterness
+ *   - chloride-dominant (e.g. Munich, London) → malt-forward
+ *     lagers and stouts, rounded mouthfeel
+ */
+export interface WaterCatalogEntry {
+  id: string;
+  name: string;
+  origin: string | null;
+  calcium_ppm: number | null;
+  bicarbonate_ppm: number | null;
+  sulfate_ppm: number | null;
+  chloride_ppm: number | null;
+  sodium_ppm: number | null;
+  magnesium_ppm: number | null;
+  ph: number | null;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/water/dtos/water.dto.ts
+++ b/packages/api/src/catalog/water/dtos/water.dto.ts
@@ -1,0 +1,69 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { WaterOrmEntity } from '../entities/water.orm.entity';
+
+/**
+ * Read-only response DTO for the brewing water catalogue. Mirrors
+ * the ORM row shape one-to-one (no field is computed). Built via
+ * `WaterDto.fromEntity(entity)` rather than direct property access
+ * so future shape changes (date serialisation, field renaming)
+ * stay in this single conversion point.
+ */
+export class WaterDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ example: 'Burton on Trent, UK' })
+  name: string;
+
+  @ApiProperty({ example: 'United Kingdom', nullable: true })
+  origin: string | null;
+
+  @ApiProperty({ example: 295, nullable: true, description: 'Ca²⁺ (ppm)' })
+  calcium_ppm: number | null;
+
+  @ApiProperty({ example: 300, nullable: true, description: 'HCO₃⁻ (ppm)' })
+  bicarbonate_ppm: number | null;
+
+  @ApiProperty({ example: 725, nullable: true, description: 'SO₄²⁻ (ppm)' })
+  sulfate_ppm: number | null;
+
+  @ApiProperty({ example: 25, nullable: true, description: 'Cl⁻ (ppm)' })
+  chloride_ppm: number | null;
+
+  @ApiProperty({ example: 55, nullable: true, description: 'Na⁺ (ppm)' })
+  sodium_ppm: number | null;
+
+  @ApiProperty({ example: 45, nullable: true, description: 'Mg²⁺ (ppm)' })
+  magnesium_ppm: number | null;
+
+  @ApiProperty({ example: 8.0, nullable: true })
+  ph: number | null;
+
+  @ApiProperty({ nullable: true })
+  notes: string | null;
+
+  @ApiProperty({ format: 'date-time' })
+  created_at: string;
+
+  @ApiProperty({ format: 'date-time' })
+  updated_at: string;
+
+  static fromEntity(entity: WaterOrmEntity): WaterDto {
+    const dto = new WaterDto();
+    dto.id = entity.id;
+    dto.name = entity.name;
+    dto.origin = entity.origin;
+    dto.calcium_ppm = entity.calcium_ppm;
+    dto.bicarbonate_ppm = entity.bicarbonate_ppm;
+    dto.sulfate_ppm = entity.sulfate_ppm;
+    dto.chloride_ppm = entity.chloride_ppm;
+    dto.sodium_ppm = entity.sodium_ppm;
+    dto.magnesium_ppm = entity.magnesium_ppm;
+    dto.ph = entity.ph;
+    dto.notes = entity.notes;
+    dto.created_at = entity.created_at.toISOString();
+    dto.updated_at = entity.updated_at.toISOString();
+    return dto;
+  }
+}

--- a/packages/api/src/catalog/water/entities/water.orm.entity.ts
+++ b/packages/api/src/catalog/water/entities/water.orm.entity.ts
@@ -40,7 +40,7 @@ export class WaterOrmEntity {
   @PrimaryColumn('uuid')
   id: string;
 
-  @Column({ type: 'varchar', length: 120, nullable: false })
+  @Column({ type: 'varchar', length: 120, nullable: false, unique: true })
   name: string;
 
   /**

--- a/packages/api/src/catalog/water/entities/water.orm.entity.ts
+++ b/packages/api/src/catalog/water/entities/water.orm.entity.ts
@@ -1,0 +1,128 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Immutable reference catalogue of historical brewing water
+ * profiles (Issue #708 / #869, Phase 3 PR #6). Seeded with 10
+ * entries — the 5 BeerXML 1.0 canonical profiles (verbatim from
+ * `libraries/water.xml`) plus 5 historically-significant water
+ * profiles needed by the demo recipes (Munich, London, Dortmund,
+ * Vienna, Dublin).
+ *
+ * Mineral concentrations are stored in ppm (parts per million),
+ * equivalent to mg/L for dilute aqueous solutions. The six ions
+ * tracked are the brewing-relevant ones — calcium, bicarbonate,
+ * sulfate, chloride, sodium, magnesium — plus the baseline pH.
+ * Trace minerals (iron, fluoride, manganese, etc.) are out of
+ * scope: they have no impact on standard brewing styles and
+ * complicate the data model without practical benefit.
+ *
+ * Brewing water history: each historical brewing city built its
+ * style around its native water profile. Burton-on-Trent's high
+ * sulfate (725 ppm) made it the cradle of the IPA; Pilsen's
+ * exceptionally soft water (5 ppm sulfate) gave birth to the
+ * Pilsner; Munich's moderate alkalinity favoured the dark Bock
+ * styles. Modern brewers replicate these profiles by treating
+ * their local tap water with brewing salts (gypsum, calcium
+ * chloride, baking soda).
+ *
+ * `recipes` is not yet migrated to point at this catalogue via a
+ * `water_profile_id` FK — that migration ships in a separate PR
+ * after all Phase 1-3 catalogues exist.
+ */
+@Entity('waters')
+export class WaterOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 120, nullable: false })
+  name: string;
+
+  /**
+   * Geographic origin (city, region) of the water profile. Free-
+   * text varchar — labels in the wild include "Burton on Trent",
+   * "Pilsen, Czech Republic", "Pacific Northwest", etc.
+   */
+  @Column({ type: 'varchar', length: 80, nullable: true })
+  origin: string | null;
+
+  /**
+   * Calcium (Ca²⁺) in ppm. Critical mineral for brewing — drives
+   * mash enzyme activity, lowers mash pH, improves yeast
+   * flocculation and beer clarity. Target range 50-150 ppm for
+   * most styles.
+   */
+  @Column({ type: 'real', nullable: true })
+  calcium_ppm: number | null;
+
+  /**
+   * Bicarbonate (HCO₃⁻) in ppm. Drives water alkalinity. Low
+   * (<50 ppm) for pale beers, high (>200 ppm) tolerated for
+   * roasted dark beers (Stout, Porter) where the acidic dark
+   * malts neutralise it.
+   */
+  @Column({ type: 'real', nullable: true })
+  bicarbonate_ppm: number | null;
+
+  /**
+   * Sulfate (SO₄²⁻) in ppm. Accentuates hop bitterness perception
+   * — high sulfate (>250 ppm) gives the dry assertive finish of
+   * British IPAs. Burton-on-Trent water sits at 725 ppm.
+   */
+  @Column({ type: 'real', nullable: true })
+  sulfate_ppm: number | null;
+
+  /**
+   * Chloride (Cl⁻) in ppm. Accentuates malt sweetness and rounded
+   * mouthfeel. High chloride favours malt-forward styles (lagers,
+   * stouts, brown ales). Should NOT be confused with chlorine
+   * (Cl₂), which must be removed before brewing.
+   */
+  @Column({ type: 'real', nullable: true })
+  chloride_ppm: number | null;
+
+  /**
+   * Sodium (Na⁺) in ppm. Accentuates malt character at low levels
+   * (<150 ppm); above 250 ppm gives a noticeable salty/metallic
+   * off-flavour. Most brewing waters sit at 5-50 ppm.
+   */
+  @Column({ type: 'real', nullable: true })
+  sodium_ppm: number | null;
+
+  /**
+   * Magnesium (Mg²⁺) in ppm. Yeast nutrient at trace levels;
+   * above 30 ppm contributes a sour-bitter note. Not actively
+   * targeted in brewing water adjustment.
+   */
+  @Column({ type: 'real', nullable: true })
+  magnesium_ppm: number | null;
+
+  /**
+   * Baseline pH of the source water. Note this is the *water* pH
+   * before mashing — the *mash* pH (post-grain) is the value
+   * brewers actually target (typically 5.2-5.6) and is influenced
+   * by both the water profile and the grain bill acidity.
+   */
+  @Column({ type: 'real', nullable: true })
+  ph: number | null;
+
+  /**
+   * Brewer-friendly description in French (UI-facing). Mirrors
+   * the convention used by HOPS / FERMENTABLES / YEASTS /
+   * STYLES / MASH catalog seeds. Typically calls out the
+   * historical style this water is famous for.
+   */
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/water/services/__tests__/water-catalog.service.spec.ts
+++ b/packages/api/src/catalog/water/services/__tests__/water-catalog.service.spec.ts
@@ -1,0 +1,109 @@
+jest.setTimeout(20000);
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { WaterCatalogService } from '../water-catalog.service';
+import { WaterOrmEntity } from '../../entities/water.orm.entity';
+
+/**
+ * Service spec for the brewing water catalogue (Issue #708 / #869,
+ * Phase 3 PR #6). Wires the real ORM entity against an in-memory
+ * SQLite so every where-clause and order-clause is exercised
+ * end-to-end.
+ */
+describe('WaterCatalogService', () => {
+  let module: TestingModule;
+  let service: WaterCatalogService;
+  let repository: Repository<WaterOrmEntity>;
+
+  const ID_BURTON = '00000000-0000-4000-9000-500000000001';
+  const ID_PILSEN = '00000000-0000-4000-9000-500000000005';
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [WaterOrmEntity],
+          synchronize: true,
+          logging: false,
+        }),
+        TypeOrmModule.forFeature([WaterOrmEntity]),
+      ],
+      providers: [WaterCatalogService],
+    }).compile();
+
+    service = module.get(WaterCatalogService);
+    repository = module.get(getRepositoryToken(WaterOrmEntity));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await repository.clear();
+  });
+
+  async function seedWater(
+    id: string,
+    name: string,
+    sulfate: number,
+  ): Promise<WaterOrmEntity> {
+    const entity = repository.create({
+      id,
+      name,
+      origin: 'Test',
+      calcium_ppm: 100,
+      bicarbonate_ppm: 100,
+      sulfate_ppm: sulfate,
+      chloride_ppm: 50,
+      sodium_ppm: 10,
+      magnesium_ppm: 10,
+      ph: 7.5,
+      notes: null,
+    });
+    return repository.save(entity);
+  }
+
+  describe('list()', () => {
+    it('happy: returns every water profile ordered alphabetically by name', async () => {
+      await seedWater(ID_BURTON, 'Burton on Trent', 725);
+      await seedWater(ID_PILSEN, 'Pilsen', 5);
+
+      const rows = await service.list();
+      expect(rows.map((r) => r.name)).toEqual(['Burton on Trent', 'Pilsen']);
+    });
+
+    it('sad: returns [] when the catalogue is empty', async () => {
+      const rows = await service.list();
+      expect(rows).toEqual([]);
+    });
+  });
+
+  describe('getById()', () => {
+    it('happy: returns the water profile matching the UUID', async () => {
+      await seedWater(ID_BURTON, 'Burton on Trent', 725);
+
+      const water = await service.getById(ID_BURTON);
+      expect(water.name).toBe('Burton on Trent');
+      expect(water.sulfate_ppm).toBe(725);
+    });
+
+    it('sad: throws NotFoundException when the UUID is unknown', async () => {
+      await expect(
+        service.getById('00000000-0000-4000-9000-5000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: does not match by name even if a row with that name exists', async () => {
+      await seedWater(ID_BURTON, 'Burton on Trent', 725);
+      // Strict UUID PK lookup — name-shaped strings still 404.
+      await expect(service.getById('burton-on-trent')).rejects.toThrow();
+    });
+  });
+});

--- a/packages/api/src/catalog/water/services/water-catalog.service.ts
+++ b/packages/api/src/catalog/water/services/water-catalog.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WaterOrmEntity } from '../entities/water.orm.entity';
+
+@Injectable()
+export class WaterCatalogService {
+  constructor(
+    @InjectRepository(WaterOrmEntity)
+    private readonly waters: Repository<WaterOrmEntity>,
+  ) {}
+
+  /**
+   * Returns the catalogue ordered alphabetically by name. The
+   * catalogue is small (~10 rows on day one) so no pagination
+   * or filtering is offered yet — added when the catalogue grows
+   * past ~100 entries.
+   */
+  async list(): Promise<WaterOrmEntity[]> {
+    return this.waters.find({
+      order: { name: 'ASC' },
+    });
+  }
+
+  /**
+   * Returns a single catalogue entry by its UUID, or throws 404.
+   * Strict UUID match — no name lookup here, since the same
+   * historical city name can refer to entries from different
+   * source datasets ("Burton on Trent, UK" verbatim from BeerXML
+   * vs a hypothetical "Burton on Trent, modern reading").
+   */
+  async getById(id: string): Promise<WaterOrmEntity> {
+    const entity = await this.waters.findOne({ where: { id } });
+    if (!entity) {
+      throw new NotFoundException(`Water profile ${id} not found`);
+    }
+    return entity;
+  }
+}

--- a/packages/api/src/catalog/water/services/water-catalog.service.ts
+++ b/packages/api/src/catalog/water/services/water-catalog.service.ts
@@ -33,7 +33,7 @@ export class WaterCatalogService {
   async getById(id: string): Promise<WaterOrmEntity> {
     const entity = await this.waters.findOne({ where: { id } });
     if (!entity) {
-      throw new NotFoundException(`Water profile ${id} not found`);
+      throw new NotFoundException(`Water catalogue entry ${id} not found`);
     }
     return entity;
   }

--- a/packages/api/src/catalog/water/water.module.ts
+++ b/packages/api/src/catalog/water/water.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { WaterCatalogController } from './controllers/water-catalog.controller';
+import { WaterCatalogService } from './services/water-catalog.service';
+import { WaterOrmEntity } from './entities/water.orm.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([WaterOrmEntity])],
+  controllers: [WaterCatalogController],
+  providers: [WaterCatalogService],
+  exports: [WaterCatalogService],
+})
+export class WaterModule {}

--- a/packages/api/src/catalog/water/water.module.ts
+++ b/packages/api/src/catalog/water/water.module.ts
@@ -4,10 +4,18 @@ import { WaterCatalogController } from './controllers/water-catalog.controller';
 import { WaterCatalogService } from './services/water-catalog.service';
 import { WaterOrmEntity } from './entities/water.orm.entity';
 
+/**
+ * Renamed `WaterCatalogModule` (not `WaterModule`) to avoid the
+ * class-name collision with the existing top-level
+ * `src/water/water.module.ts:WaterModule` (already wired in
+ * AppModule). Two Nest modules sharing a class name make import
+ * resolution and error messages ambiguous; the suffix makes the
+ * intent unambiguous at a glance.
+ */
 @Module({
   imports: [TypeOrmModule.forFeature([WaterOrmEntity])],
   controllers: [WaterCatalogController],
   providers: [WaterCatalogService],
   exports: [WaterCatalogService],
 })
-export class WaterModule {}
+export class WaterCatalogModule {}

--- a/packages/api/src/database/migrations/1788000000000-AddWatersCatalog.ts
+++ b/packages/api/src/database/migrations/1788000000000-AddWatersCatalog.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `waters` table — immutable reference catalogue of
+ * historical brewing water profiles. Phase 3 PR #6 of the catalogue
+ * refactor (Issue #708 / #869), opening the equipment & water phase
+ * after the metadata phase (#891 + #893) shipped.
+ *
+ * Mineral concentrations stored in ppm (parts per million,
+ * equivalent to mg/L for dilute aqueous solutions). The six ions
+ * tracked are calcium, bicarbonate, sulfate, chloride, sodium,
+ * magnesium — the brewing-relevant ones — plus the baseline pH.
+ *
+ * Seeded with 10 profiles (5 BeerXML verbatim from
+ * libraries/water.xml + 5 historically-significant brewing cities
+ * needed by the demo recipes: Munich, London, Dortmund, Vienna,
+ * Dublin).
+ */
+export class AddWatersCatalog1788000000000 implements MigrationInterface {
+  name = 'AddWatersCatalog1788000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "waters" (
+        "id"                varchar(36) PRIMARY KEY NOT NULL,
+        "name"              varchar(120) NOT NULL,
+        "origin"            varchar(80),
+        "calcium_ppm"       real,
+        "bicarbonate_ppm"   real,
+        "sulfate_ppm"       real,
+        "chloride_ppm"      real,
+        "sodium_ppm"        real,
+        "magnesium_ppm"     real,
+        "ph"                real,
+        "notes"             text,
+        "created_at"        datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "updated_at"        datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_waters_name" ON "waters" ("name")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_waters_name"`);
+    await queryRunner.query(`DROP TABLE "waters"`);
+  }
+}

--- a/packages/api/src/database/seeds/__tests__/waters-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/__tests__/waters-catalog.seed.spec.ts
@@ -1,0 +1,107 @@
+import { Repository } from 'typeorm';
+
+import { WATERS_CATALOG_SEED, seedWatersCatalog } from '../waters-catalog.seed';
+import {
+  assertCommonCatalogueSeederBehaviours,
+  buildRepoMock,
+} from '../seed-test-utils';
+import { WaterOrmEntity } from '../../../catalog/water/entities/water.orm.entity';
+
+describe('seedWatersCatalog (Issue #708 / #869 — Phase 3 PR #6)', () => {
+  // The four standard catalogue-seeder behaviours (happy / sad /
+  // mixed / override-list) live in the shared helper to satisfy
+  // SonarCloud's duplication gate — see seed-test-utils.ts.
+  assertCommonCatalogueSeederBehaviours('seedWatersCatalog', {
+    fn: (repo, seeds) =>
+      seedWatersCatalog(repo as unknown as Repository<WaterOrmEntity>, seeds),
+    data: WATERS_CATALOG_SEED,
+  });
+
+  describe('catalogue-specific invariants', () => {
+    it('writes name + 6 mineral columns + ph on every inserted row', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      await seedWatersCatalog(repo as unknown as Repository<WaterOrmEntity>);
+
+      for (const call of repo.create.mock.calls as unknown[][]) {
+        const arg = call[0] as Record<string, unknown>;
+        expect(typeof arg.name).toBe('string');
+        expect((arg.name as string).length).toBeGreaterThan(0);
+        // Six mineral columns + ph should all be set (real numbers
+        // or 0 for distilled water).
+        expect(typeof arg.calcium_ppm).toBe('number');
+        expect(typeof arg.bicarbonate_ppm).toBe('number');
+        expect(typeof arg.sulfate_ppm).toBe('number');
+        expect(typeof arg.chloride_ppm).toBe('number');
+        expect(typeof arg.sodium_ppm).toBe('number');
+        expect(typeof arg.magnesium_ppm).toBe('number');
+        expect(typeof arg.ph).toBe('number');
+      }
+    });
+
+    it('exposes 10 curated catalogue entries (5 BeerXML + 5 historical)', () => {
+      expect(WATERS_CATALOG_SEED).toHaveLength(10);
+
+      const names = WATERS_CATALOG_SEED.map((w) => w.name);
+      // 5 BeerXML canonical
+      expect(names).toContain('Burton on Trent, UK');
+      expect(names).toContain('Distilled Water');
+      expect(names).toContain('Edinburgh, Scotland');
+      expect(names).toContain('Milwaukee, WI');
+      expect(names).toContain('Pilsen, Czech Republic');
+      // Historical brewing cities for the demo recipes
+      expect(names).toContain('Munich, Germany');
+      expect(names).toContain('London, UK');
+      expect(names).toContain('Dortmund, Germany');
+      expect(names).toContain('Vienna, Austria');
+      expect(names).toContain('Dublin, Ireland');
+    });
+
+    it('uses deterministic UUIDs in the catalogue range (...-9000-5000-...)', () => {
+      const ids = WATERS_CATALOG_SEED.map((w) => w.id);
+      for (const id of ids) {
+        expect(id).toMatch(/^00000000-0000-4000-9000-5[0-9a-f]{11}$/);
+      }
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it("captures Burton-on-Trent's signature high sulfate (>500 ppm)", () => {
+      // Burton's water defines the IPA style — sulfate must be high
+      // for the catalogue to teach the right brewing-water lesson.
+      const burton = WATERS_CATALOG_SEED.find(
+        (w) => w.name === 'Burton on Trent, UK',
+      );
+      expect(burton?.sulfate_ppm).toBeGreaterThan(500);
+    });
+
+    it('captures Pilsen-Czech extremely soft mineral profile (<20 ppm sulfate)', () => {
+      // Pilsen's softness defines the Pilsner style — sulfate must
+      // be very low for the catalogue to teach the right lesson.
+      const pilsen = WATERS_CATALOG_SEED.find(
+        (w) => w.name === 'Pilsen, Czech Republic',
+      );
+      expect(pilsen?.sulfate_ppm).toBeLessThan(20);
+      expect(pilsen?.calcium_ppm).toBeLessThan(20);
+    });
+
+    it('captures Dublin water high alkalinity (>250 ppm bicarbonate) for Irish Stout', () => {
+      // Dublin's high bicarbonate is what made Roasted Barley
+      // mandatory for Irish Stout — the dark malts neutralise the
+      // alkalinity. The catalogue must reflect this so the mash pH
+      // calculations remain pedagogically correct.
+      const dublin = WATERS_CATALOG_SEED.find(
+        (w) => w.name === 'Dublin, Ireland',
+      );
+      expect(dublin?.bicarbonate_ppm).toBeGreaterThan(250);
+    });
+
+    it('keeps every notes value in French (UI-facing convention)', () => {
+      for (const water of WATERS_CATALOG_SEED) {
+        if (water.notes !== null) {
+          expect(water.notes).toMatch(/[àâäéèêëïîôöùûüÿç]/i);
+        }
+      }
+    });
+  });
+});

--- a/packages/api/src/database/seeds/waters-catalog.seed.ts
+++ b/packages/api/src/database/seeds/waters-catalog.seed.ts
@@ -1,0 +1,268 @@
+import { Repository } from 'typeorm';
+
+import { WaterOrmEntity } from '../../catalog/water/entities/water.orm.entity';
+import { idempotentUpsertById } from './seed-utils';
+
+/**
+ * Seed for the `waters` reference catalogue (Issue #708 / #869,
+ * Phase 3 PR #6). Operator-curated entries — drawn from the
+ * BeerXML 1.0 reference fixture (`docs/architecture/specs/fixtures/
+ * libraries/water.xml`, 5 entries) and from standard brewing
+ * literature for the modern profiles (Palmer, "How to Brew",
+ * appendix B), but deliberately not a verbatim copy. French notes
+ * follow the convention of the previous catalogues.
+ *
+ * The 10 profiles are split:
+ *   • 5 BeerXML canonical (Burton on Trent UK, Distilled Water,
+ *     Edinburgh Scotland, Milwaukee WI, Pilsen Czech) — verbatim
+ *     from libraries/water.xml.
+ *   • 5 historically-significant brewing cities for the demo
+ *     recipes: Munich, London, Dortmund, Vienna, Dublin.
+ *
+ * Each historical brewing city built its style around its native
+ * water profile. Burton-on-Trent's high sulfate cradled the IPA;
+ * Pilsen's softness gave birth to the Pilsner; Dublin's high
+ * bicarbonate enabled the dark roasted Irish Stout (Guinness).
+ *
+ * UUID range `00000000-0000-4000-9000-5000-...` is reserved for
+ * waters (hops `0`, fermentables `1`, yeasts `2`, styles `3`,
+ * mash `4`, waters `5`).
+ */
+
+export interface WaterCatalogSeed {
+  id: string;
+  name: string;
+  origin: string | null;
+  calcium_ppm: number | null;
+  bicarbonate_ppm: number | null;
+  sulfate_ppm: number | null;
+  chloride_ppm: number | null;
+  sodium_ppm: number | null;
+  magnesium_ppm: number | null;
+  ph: number | null;
+  notes: string | null;
+}
+
+export const WATERS_CATALOG_SEED: readonly WaterCatalogSeed[] = [
+  // ─── 5 BeerXML canonical entries (libraries/water.xml) ─────────────────
+  {
+    id: '00000000-0000-4000-9000-500000000001',
+    name: 'Burton on Trent, UK',
+    origin: 'United Kingdom',
+    calcium_ppm: 295,
+    bicarbonate_ppm: 300,
+    sulfate_ppm: 725,
+    chloride_ppm: 25,
+    sodium_ppm: 55,
+    magnesium_ppm: 45,
+    ph: 8,
+    notes:
+      "Eau historique de Burton-on-Trent, berceau de l'IPA anglaise. " +
+      "Sulfate extrême (725 ppm) qui accentue brutalement l'amertume " +
+      'des houblons et donne la finale sèche et tranchante des Bass ' +
+      'Ale et autres pale ales anglaises. Référence absolue pour les ' +
+      'IPA modernes.',
+  },
+  {
+    id: '00000000-0000-4000-9000-500000000002',
+    name: 'Distilled Water',
+    origin: null,
+    calcium_ppm: 0,
+    bicarbonate_ppm: 0,
+    sulfate_ppm: 0,
+    chloride_ppm: 0,
+    sodium_ppm: 0,
+    magnesium_ppm: 0,
+    ph: 7,
+    notes:
+      'Eau distillée, vierge de tout minéral. Utilisée comme base pour ' +
+      'construire un profil minéral cible avec des sels brassicoles ' +
+      '(gypse, chlorure de calcium, bicarbonate de soude). Approche ' +
+      'préférée des brasseurs avancés qui ne font pas confiance à ' +
+      'leur eau du robinet.',
+  },
+  {
+    id: '00000000-0000-4000-9000-500000000003',
+    name: 'Edinburgh, Scotland',
+    origin: 'United Kingdom',
+    calcium_ppm: 120,
+    bicarbonate_ppm: 225,
+    sulfate_ppm: 140,
+    chloride_ppm: 20,
+    sodium_ppm: 55,
+    magnesium_ppm: 25,
+    ph: 8,
+    notes:
+      'Eau écossaise modérément alcaline. Profil équilibré qui favorise ' +
+      'les Brown Ales maltées et les Scottish Ales légèrement caramel. ' +
+      'Faible amertume du houblon, mise en valeur du malt.',
+  },
+  {
+    id: '00000000-0000-4000-9000-500000000004',
+    name: 'Milwaukee, WI',
+    origin: 'United States',
+    calcium_ppm: 96,
+    bicarbonate_ppm: 107,
+    sulfate_ppm: 26,
+    chloride_ppm: 16,
+    sodium_ppm: 7,
+    magnesium_ppm: 47,
+    ph: 7.5,
+    notes:
+      'Eau historique de Milwaukee, berceau de la brasserie américaine ' +
+      'XIXᵉ (Schlitz, Pabst, Miller). Faible sulfate, calcium modéré : ' +
+      'profil parfait pour les Pilsners et lagers américaines pré-' +
+      'prohibition.',
+  },
+  {
+    id: '00000000-0000-4000-9000-500000000005',
+    name: 'Pilsen, Czech Republic',
+    origin: 'Czech Republic',
+    calcium_ppm: 7,
+    bicarbonate_ppm: 15,
+    sulfate_ppm: 5,
+    chloride_ppm: 5,
+    sodium_ppm: 2,
+    magnesium_ppm: 2,
+    ph: 8,
+    notes:
+      'Eau extraordinairement douce de Plzeň, République tchèque. ' +
+      'Quasiment minéral-vide (calcium 7 ppm, sulfate 5 ppm). ' +
+      'Cette douceur a permis la naissance de la Pilsner Urquell en ' +
+      '1842 — couleur pâle dorée et amertume Saaz nette sans astringence.',
+  },
+  // ─── 5 historical profiles for the demo recipes ────────────────────────
+  {
+    id: '00000000-0000-4000-9000-500000000006',
+    name: 'Munich, Germany',
+    origin: 'Germany',
+    calcium_ppm: 75,
+    bicarbonate_ppm: 152,
+    sulfate_ppm: 10,
+    chloride_ppm: 2,
+    sodium_ppm: 2,
+    magnesium_ppm: 18,
+    ph: 7.5,
+    notes:
+      'Eau modérément alcaline de Munich. Le bicarbonate élevé est ' +
+      'compensé naturellement par les malts Munich et Vienne ' +
+      'légèrement acides. Référence pour Helles, Märzen, Dunkel et ' +
+      'Bock — toutes les lagers maltées allemandes.',
+  },
+  {
+    id: '00000000-0000-4000-9000-500000000007',
+    name: 'London, UK',
+    origin: 'United Kingdom',
+    calcium_ppm: 100,
+    bicarbonate_ppm: 156,
+    sulfate_ppm: 80,
+    chloride_ppm: 60,
+    sodium_ppm: 12,
+    magnesium_ppm: 11,
+    ph: 7.5,
+    notes:
+      'Eau de Londres, équilibre sulfate/chlorure typique des Porters ' +
+      'et Brown Ales anglaises historiques. Le bicarbonate élevé est ' +
+      'absorbé par les malts torréfiés. Pour ESB, Best Bitter, ' +
+      'London Porter, Sweet Stout.',
+  },
+  {
+    id: '00000000-0000-4000-9000-500000000008',
+    name: 'Dortmund, Germany',
+    origin: 'Germany',
+    calcium_ppm: 250,
+    bicarbonate_ppm: 180,
+    sulfate_ppm: 280,
+    chloride_ppm: 100,
+    sodium_ppm: 60,
+    magnesium_ppm: 23,
+    ph: 7.5,
+    notes:
+      'Eau dure de Dortmund, équilibre ions très élevés. Profil ' +
+      'unique au monde qui a engendré le Dortmunder Export — lager ' +
+      'pâle plus corsée que la Pilsner, plus sèche que la Helles. ' +
+      'Sulfate (280) et chlorure (100) tous deux élevés.',
+  },
+  {
+    id: '00000000-0000-4000-9000-500000000009',
+    name: 'Vienna, Austria',
+    origin: 'Austria',
+    calcium_ppm: 75,
+    bicarbonate_ppm: 165,
+    sulfate_ppm: 60,
+    chloride_ppm: 6,
+    sodium_ppm: 8,
+    magnesium_ppm: 26,
+    ph: 7.4,
+    notes:
+      'Eau viennoise modérément alcaline. Profil similaire à Munich ' +
+      'avec un peu plus de sulfate, qui a engendré la Vienna Lager ' +
+      '(Anton Dreher 1841) et le style Märzen. Couleur ambrée, malt ' +
+      'légèrement toasté.',
+  },
+  {
+    id: '00000000-0000-4000-9000-50000000000a',
+    name: 'Dublin, Ireland',
+    origin: 'Ireland',
+    calcium_ppm: 118,
+    bicarbonate_ppm: 319,
+    sulfate_ppm: 54,
+    chloride_ppm: 19,
+    sodium_ppm: 12,
+    magnesium_ppm: 4,
+    ph: 7.8,
+    notes:
+      'Eau dublinoise extrêmement alcaline (bicarbonate 319 ppm). ' +
+      "Cette alcalinité explique l'origine de l'Irish Dry Stout : seule " +
+      "l'utilisation massive de Roasted Barley et de malt black/" +
+      'chocolat acidifie suffisamment le moût pour atteindre un pH de ' +
+      'mash correct. Référence Guinness.',
+  },
+];
+
+/**
+ * Result returned by `seedWatersCatalog` for instrumentation /
+ * verification. Lets callers (tests, CLI, npm scripts) report what
+ * happened without re-querying the DB.
+ */
+export interface SeedWatersCatalogResult {
+  inserted: number;
+  updated: number;
+  total: number;
+}
+
+/**
+ * Idempotent loader for the brewing water reference catalogue.
+ * Insert if the id is unknown, update in place otherwise.
+ * Re-running the loader never duplicates rows.
+ */
+export async function seedWatersCatalog(
+  repository: Repository<WaterOrmEntity>,
+  waters: readonly WaterCatalogSeed[] = WATERS_CATALOG_SEED,
+): Promise<SeedWatersCatalogResult> {
+  let inserted = 0;
+  let updated = 0;
+
+  for (const water of waters) {
+    const outcome = await idempotentUpsertById(
+      repository,
+      { id: water.id },
+      {
+        name: water.name,
+        origin: water.origin,
+        calcium_ppm: water.calcium_ppm,
+        bicarbonate_ppm: water.bicarbonate_ppm,
+        sulfate_ppm: water.sulfate_ppm,
+        chloride_ppm: water.chloride_ppm,
+        sodium_ppm: water.sodium_ppm,
+        magnesium_ppm: water.magnesium_ppm,
+        ph: water.ph,
+        notes: water.notes,
+      },
+    );
+    inserted += outcome.inserted;
+    updated += outcome.updated;
+  }
+
+  return { inserted, updated, total: inserted + updated };
+}

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -24,6 +24,7 @@ import { ScanReviewQueueOrmEntity } from '../scan/entities/scan-review-queue.orm
 import { StyleOrmEntity } from '../catalog/style/entities/style.orm.entity';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { User } from '../user/entities/user.entity';
+import { WaterOrmEntity } from '../catalog/water/entities/water.orm.entity';
 import { YeastOrmEntity } from '../catalog/yeast/entities/yeast.orm.entity';
 
 const truthyEnvValues = new Set(['1', 'true', 'yes', 'on']);
@@ -53,6 +54,7 @@ export const ormEntities = [
   StyleOrmEntity,
   MashProfileOrmEntity,
   MashStepOrmEntity,
+  WaterOrmEntity,
 ];
 
 const parseBooleanEnv = (name: string, defaultValue: boolean): boolean => {


### PR DESCRIPTION
## Summary

Phase 3 PR #6 of the brewing reference catalogues refactor (Issue #708 / #869), opening the equipment & water phase. Adds the **WaterModule** under the existing top-level `catalog/` module, seeded with **10 historical brewing water profiles** that taught the brewing world how to match water chemistry to beer style.

## Schema (table `waters` — 13 columns total: 10 data + 3 system)

| Group | Columns |
|---|---|
| Identity | `name` UNIQUE, `origin` |
| Minerals (ppm) | `calcium_ppm`, `bicarbonate_ppm`, `sulfate_ppm`, `chloride_ppm`, `sodium_ppm`, `magnesium_ppm` |
| pH | `ph` (baseline source water) |
| Description | `notes` (FR, UI-facing) |
| System | `id` PK (range `…-9000-5…`), timestamps |

Indexes: UNIQUE on `name`.

## Endpoints

```
GET /catalog/waters         → ordered list
GET /catalog/waters/:uuid   → single entry, 404 on miss
```

No filters in this PR — catalogue is small (~10 rows) and the picker UX scrolls the full list.

## Seed (10 entries, idempotent loader)

- **5 BeerXML canonical** (verbatim from `libraries/water.xml`): Burton on Trent UK, Distilled Water, Edinburgh Scotland, Milwaukee WI, Pilsen Czech Republic
- **5 historical brewing cities** for the demo recipes: Munich (Helles / Märzen), London (Porter / Stout / ESB), Dortmund (Dortmunder Export), Vienna (Vienna Lager), **Dublin (Irish Dry Stout — Guinness)**

French notes explain how each water profile shaped its signature beer style — useful pedagogical content for the future Académie Brassicole module.

## Pedagogical signature: water → style

The catalogue carries inline tests asserting the historical brewing-water lessons stay correct:

- **Burton-on-Trent**: sulfate >500 ppm — the IPA cradle, accentuates hop bitterness
- **Pilsen**: sulfate <20 ppm AND calcium <20 ppm — the world's softest brewing water, gave birth to the Pilsner
- **Dublin**: bicarbonate >250 ppm — extreme alkalinity that made Roasted Barley mandatory for Irish Dry Stout (the dark malts neutralise it)

If a future PR accidentally drifts these mineral values, the tests catch it.

## Tests (10 new, all green)

- **Service spec** — in-memory SQLite (4 tests)
- **Controller spec** — `jest.spyOn` pattern, DTO transform isolation (4 tests)
- **Seed spec** — delegates to `assertCommonCatalogueSeederBehaviours` helper (extracted in PR #891) for the 4 standard scenarios + catalogue-specific assertions (Burton sulfate, Pilsen softness, Dublin alkalinity, French notes invariant)

## All four PR #888 review lessons baked in

- ✅ **Boot-safe registration** — `WaterOrmEntity` added to `ormEntities` in `typeorm.config.ts`
- ✅ **Migration consistency** — `CREATE UNIQUE INDEX IDX_waters_name` (same pattern as `IDX_styles_name`, `IDX_hops_name`, etc.)
- ✅ **No filtered query params** so no ParseEnumPipe needed
- ✅ **Runner script** — `scripts/run-waters-catalog-seed.ts`

## Phase 3 status after this PR

| # | PR | Catalogue | Status |
|---|---|---|---|
| 6 | this PR | waters | 🟡 awaiting review |
| 7 | next | equipment | pending |
| 8 | next | misc | pending |

## Checklist

- [x] Happy / sad / edge cases covered (10 new tests)
- [x] `npm run lint:check` passes (0 errors)
- [x] `npm run build` passes
- [x] All existing tests still green (524 + 10 + recipe-water specs touched = 545 total)
- [x] No `any` introduced
- [x] Migration timestamp picks up where the previous one left off (`1788000000000`)
- [x] All four PR #888 lessons baked in upfront

Refs #708 #869