### PR TITLE
feat(catalog/equipment): add equipment templates reference catalogue (#708)

### DIFF
--- a/packages/api/scripts/run-equipment-templates-catalog-seed.ts
+++ b/packages/api/scripts/run-equipment-templates-catalog-seed.ts
@@ -1,6 +1,6 @@
 /**
  * One-shot script to seed the `equipment_templates` reference
- * catalogue with the 8 curated entries from
+ * catalogue with the 9 curated entries from
  * `EQUIPMENT_TEMPLATES_CATALOG_SEED` against the local dev
  * database (Issue #708 / #869, Phase 3 PR #7).
  *

--- a/packages/api/scripts/run-equipment-templates-catalog-seed.ts
+++ b/packages/api/scripts/run-equipment-templates-catalog-seed.ts
@@ -1,0 +1,39 @@
+/**
+ * One-shot script to seed the `equipment_templates` reference
+ * catalogue with the 8 curated entries from
+ * `EQUIPMENT_TEMPLATES_CATALOG_SEED` against the local dev
+ * database (Issue #708 / #869, Phase 3 PR #7).
+ *
+ * Usage:
+ *   cd packages/api
+ *   npx ts-node -r tsconfig-paths/register scripts/run-equipment-templates-catalog-seed.ts
+ *
+ * Idempotent: safe to run multiple times. Existing template IDs
+ * are updated in place; missing ones are inserted.
+ *
+ * Mirror of the per-seed runners shipped in earlier catalogues.
+ * Stopgap until the unified seed orchestrator lands at the end of
+ * Phase 3.
+ */
+import 'reflect-metadata';
+
+import dataSource from '../src/database/data-source';
+import { EquipmentTemplateOrmEntity } from '../src/catalog/equipment/entities/equipment-template.orm.entity';
+import { seedEquipmentTemplatesCatalog } from '../src/database/seeds/equipment-templates-catalog.seed';
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const repo = dataSource.getRepository(EquipmentTemplateOrmEntity);
+  const result = await seedEquipmentTemplatesCatalog(repo);
+  console.log('Equipment templates catalogue seed:', result);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/catalog/catalog.module.ts
+++ b/packages/api/src/catalog/catalog.module.ts
@@ -1,3 +1,4 @@
+import { EquipmentCatalogModule } from './equipment/equipment.module';
 import { FermentableModule } from './fermentable/fermentable.module';
 import { HopModule } from './hop/hop.module';
 import { MashModule } from './mash/mash.module';
@@ -26,6 +27,7 @@ import { YeastModule } from './yeast/yeast.module';
     StyleModule,
     MashModule,
     WaterCatalogModule,
+    EquipmentCatalogModule,
   ],
 })
 export class CatalogModule {}

--- a/packages/api/src/catalog/equipment/controllers/__tests__/equipment-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/equipment/controllers/__tests__/equipment-catalog.controller.spec.ts
@@ -1,0 +1,117 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { EquipmentCatalogController } from '../equipment-catalog.controller';
+import { EquipmentCatalogService } from '../../services/equipment-catalog.service';
+import { EquipmentTemplateOrmEntity } from '../../entities/equipment-template.orm.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('EquipmentCatalogController', () => {
+  let controller: EquipmentCatalogController;
+  let service: EquipmentCatalogService;
+
+  const ID_GRAINFATHER = '00000000-0000-4000-9000-600000000005';
+
+  function buildEntity(
+    overrides: Partial<EquipmentTemplateOrmEntity> = {},
+  ): EquipmentTemplateOrmEntity {
+    return {
+      id: ID_GRAINFATHER,
+      name: 'Grainfather G30 (electric all-in-one)',
+      boil_size_l: 30,
+      batch_size_l: 23,
+      tun_volume_l: 30,
+      tun_weight_kg: 4,
+      tun_specific_heat: 0.12,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 1,
+      evap_rate_percent: 9,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 1,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes: 'Système électrique tout-en-un néo-zélandais.',
+      created_at: new Date('2026-05-03T00:00:00.000Z'),
+      updated_at: new Date('2026-05-03T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EquipmentCatalogController],
+      providers: [
+        {
+          provide: EquipmentCatalogService,
+          useValue: { list: jest.fn(), getById: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(EquipmentCatalogController);
+    service = module.get(EquipmentCatalogService);
+  });
+
+  describe('GET /catalog/equipment-templates', () => {
+    it('happy: returns the full list mapped to DTOs', async () => {
+      const listSpy = jest.spyOn(service, 'list').mockResolvedValue([
+        buildEntity({ name: 'Grainfather G30 (electric all-in-one)' }),
+        buildEntity({
+          id: '00000000-0000-4000-9000-600000000003',
+          name: 'BIAB 20L (Brew In A Bag, entry-level)',
+          batch_size_l: 19,
+        }),
+      ]);
+
+      const result = await controller.list();
+
+      expect(listSpy).toHaveBeenCalledWith();
+      expect(result.map((r) => r.name)).toEqual([
+        'Grainfather G30 (electric all-in-one)',
+        'BIAB 20L (Brew In A Bag, entry-level)',
+      ]);
+      expect(typeof result[0].created_at).toBe('string');
+    });
+
+    it('sad: returns [] when the service yields no rows', async () => {
+      jest.spyOn(service, 'list').mockResolvedValue([]);
+      const result = await controller.list();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('GET /catalog/equipment-templates/:id', () => {
+    it('happy: returns the DTO for the matching template', async () => {
+      const getByIdSpy = jest
+        .spyOn(service, 'getById')
+        .mockResolvedValue(buildEntity());
+
+      const result = await controller.getById(ID_GRAINFATHER);
+
+      expect(getByIdSpy).toHaveBeenCalledWith(ID_GRAINFATHER);
+      expect(result.id).toBe(ID_GRAINFATHER);
+      expect(result.batch_size_l).toBe(23);
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getById')
+        .mockRejectedValue(
+          new NotFoundException('Equipment template catalogue entry not found'),
+        );
+
+      await expect(
+        controller.getById('00000000-0000-4000-9000-6000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: never leaks the raw ORM entity (always wraps in DTO)', async () => {
+      const entity = buildEntity();
+      jest.spyOn(service, 'getById').mockResolvedValue(entity);
+
+      const result = await controller.getById(ID_GRAINFATHER);
+      expect(result).not.toBe(entity);
+      expect(result.constructor.name).toBe('EquipmentTemplateDto');
+    });
+  });
+});

--- a/packages/api/src/catalog/equipment/controllers/equipment-catalog.controller.ts
+++ b/packages/api/src/catalog/equipment/controllers/equipment-catalog.controller.ts
@@ -1,0 +1,61 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { EquipmentCatalogService } from '../services/equipment-catalog.service';
+import { EquipmentTemplateDto } from '../dtos/equipment-template.dto';
+import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
+
+/**
+ * Read-only HTTP surface for the equipment template catalogue.
+ * Two endpoints:
+ *   GET /catalog/equipment-templates           → list all
+ *   GET /catalog/equipment-templates/:id       → fetch one by UUID
+ *
+ * Write endpoints (POST / PATCH / DELETE) are intentionally
+ * absent — the catalogue is operator-curated reference data, not
+ * user-managed content. Users create their own personal
+ * `equipment_profile` (existing user-owned table) by copying from
+ * a template here.
+ */
+@ApiTags('Catalog · Equipment templates')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('catalog/equipment-templates')
+export class EquipmentCatalogController {
+  constructor(private readonly service: EquipmentCatalogService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List the equipment template catalogue entries',
+  })
+  @ApiOkResponse({ type: EquipmentTemplateDto, isArray: true })
+  async list(): Promise<EquipmentTemplateDto[]> {
+    const rows = await this.service.list();
+    return rows.map((row) => EquipmentTemplateDto.fromEntity(row));
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single equipment template by UUID' })
+  @ApiOkResponse({ type: EquipmentTemplateDto })
+  @ApiNotFoundResponse({
+    description: 'Equipment template catalogue entry not found',
+  })
+  async getById(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<EquipmentTemplateDto> {
+    const entity = await this.service.getById(id);
+    return EquipmentTemplateDto.fromEntity(entity);
+  }
+}

--- a/packages/api/src/catalog/equipment/domain/equipment-template.types.ts
+++ b/packages/api/src/catalog/equipment/domain/equipment-template.types.ts
@@ -1,0 +1,34 @@
+/**
+ * Domain shape for one equipment template entry in the immutable
+ * reference catalogue. Mirrors the `EquipmentTemplateOrmEntity` row
+ * shape one-to-one (no field is computed) — kept as a separate
+ * interface so the application / presentation layers do not import
+ * the ORM entity directly.
+ *
+ * **Naming**: the table is called `equipment_templates` (not
+ * `equipment_profiles`) because `equipment_profiles` already exists
+ * as the user-owned table for personal brewing setups. A template
+ * here is the SHARED reference (e.g. "Klarstein Brauheld Pro 30L
+ * spec constructeur") that an end user can later copy to seed their
+ * own personal `equipment_profile` entity.
+ */
+export interface EquipmentTemplateEntry {
+  id: string;
+  name: string;
+  boil_size_l: number | null;
+  batch_size_l: number | null;
+  tun_volume_l: number | null;
+  tun_weight_kg: number | null;
+  tun_specific_heat: number | null;
+  top_up_water_l: number | null;
+  trub_chiller_loss_l: number | null;
+  evap_rate_percent: number | null;
+  boil_time_min: number | null;
+  calc_boil_volume: boolean;
+  lauter_deadspace_l: number | null;
+  top_up_kettle_l: number | null;
+  hop_utilization_percent: number | null;
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/equipment/dtos/equipment-template.dto.ts
+++ b/packages/api/src/catalog/equipment/dtos/equipment-template.dto.ts
@@ -1,0 +1,97 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { EquipmentTemplateOrmEntity } from '../entities/equipment-template.orm.entity';
+
+/**
+ * Read-only response DTO for the equipment template catalogue.
+ * Mirrors the ORM row shape one-to-one. Built via
+ * `EquipmentTemplateDto.fromEntity(entity)` rather than direct
+ * property access so future shape changes (date serialisation,
+ * field renaming) stay in this single conversion point.
+ */
+export class EquipmentTemplateDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ example: 'Grainfather G30 (electric all-in-one)' })
+  name: string;
+
+  @ApiProperty({
+    example: 30,
+    nullable: true,
+    description: 'Litres before boil',
+  })
+  boil_size_l: number | null;
+
+  @ApiProperty({
+    example: 23,
+    nullable: true,
+    description: 'Litres of finished beer',
+  })
+  batch_size_l: number | null;
+
+  @ApiProperty({ example: 30, nullable: true })
+  tun_volume_l: number | null;
+
+  @ApiProperty({ example: 4, nullable: true })
+  tun_weight_kg: number | null;
+
+  @ApiProperty({ example: 0.12, nullable: true })
+  tun_specific_heat: number | null;
+
+  @ApiProperty({ example: 0, nullable: true })
+  top_up_water_l: number | null;
+
+  @ApiProperty({ example: 1, nullable: true })
+  trub_chiller_loss_l: number | null;
+
+  @ApiProperty({ example: 9, nullable: true })
+  evap_rate_percent: number | null;
+
+  @ApiProperty({ example: 60, nullable: true })
+  boil_time_min: number | null;
+
+  @ApiProperty({ example: true })
+  calc_boil_volume: boolean;
+
+  @ApiProperty({ example: 1, nullable: true })
+  lauter_deadspace_l: number | null;
+
+  @ApiProperty({ example: 0, nullable: true })
+  top_up_kettle_l: number | null;
+
+  @ApiProperty({ example: 100, nullable: true })
+  hop_utilization_percent: number | null;
+
+  @ApiProperty({ nullable: true })
+  notes: string | null;
+
+  @ApiProperty({ format: 'date-time' })
+  created_at: string;
+
+  @ApiProperty({ format: 'date-time' })
+  updated_at: string;
+
+  static fromEntity(entity: EquipmentTemplateOrmEntity): EquipmentTemplateDto {
+    const dto = new EquipmentTemplateDto();
+    dto.id = entity.id;
+    dto.name = entity.name;
+    dto.boil_size_l = entity.boil_size_l;
+    dto.batch_size_l = entity.batch_size_l;
+    dto.tun_volume_l = entity.tun_volume_l;
+    dto.tun_weight_kg = entity.tun_weight_kg;
+    dto.tun_specific_heat = entity.tun_specific_heat;
+    dto.top_up_water_l = entity.top_up_water_l;
+    dto.trub_chiller_loss_l = entity.trub_chiller_loss_l;
+    dto.evap_rate_percent = entity.evap_rate_percent;
+    dto.boil_time_min = entity.boil_time_min;
+    dto.calc_boil_volume = entity.calc_boil_volume;
+    dto.lauter_deadspace_l = entity.lauter_deadspace_l;
+    dto.top_up_kettle_l = entity.top_up_kettle_l;
+    dto.hop_utilization_percent = entity.hop_utilization_percent;
+    dto.notes = entity.notes;
+    dto.created_at = entity.created_at.toISOString();
+    dto.updated_at = entity.updated_at.toISOString();
+    return dto;
+  }
+}

--- a/packages/api/src/catalog/equipment/entities/equipment-template.orm.entity.ts
+++ b/packages/api/src/catalog/equipment/entities/equipment-template.orm.entity.ts
@@ -1,0 +1,103 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Immutable reference catalogue of homebrew equipment templates
+ * (Issue #708 / #869, Phase 3 PR #7). Seeded with 8 entries —
+ * the 2 BeerXML 1.0 canonical equipment profiles (verbatim from
+ * `libraries/equipment.xml`) plus 6 popular modern setups
+ * (BIAB 20/30L, Grainfather G30, Klarstein Brauheld Pro,
+ * Anvil Foundry, 3-Vessel HERMS).
+ *
+ * **Naming**: the table is called `equipment_templates` (not
+ * `equipment_profiles`) because `equipment_profiles` already
+ * exists as the user-owned table for personal brewing setups.
+ * A template here is the SHARED reference (manufacturer specs)
+ * that an end user can later copy to seed their own personal
+ * `equipment_profile` entity. The class name follows suit
+ * (`EquipmentTemplateOrmEntity` not `EquipmentProfileOrmEntity`)
+ * to avoid the same kind of class-name collision that PR #894
+ * caught and fixed for `WaterModule` → `WaterCatalogModule`.
+ *
+ * BeerXML 1.0 `<EQUIPMENT>` field mapping:
+ *   - BOIL_SIZE → boil_size_l (litres before boil)
+ *   - BATCH_SIZE → batch_size_l (litres of finished beer)
+ *   - TUN_VOLUME → tun_volume_l (mash tun capacity)
+ *   - TUN_WEIGHT → tun_weight_kg (empty mash tun mass)
+ *   - TUN_SPECIFIC_HEAT → tun_specific_heat (cal/g·°C)
+ *   - TOP_UP_WATER → top_up_water_l (water added after boil)
+ *   - TRUB_CHILLER_LOSS → trub_chiller_loss_l (lost to trub + chiller)
+ *   - EVAP_RATE → evap_rate_percent (per hour during boil)
+ *   - BOIL_TIME → boil_time_min (60 or 90 typical)
+ *   - CALC_BOIL_VOLUME → calc_boil_volume (auto-compute pre-boil L)
+ *   - LAUTER_DEADSPACE → lauter_deadspace_l (mash tun dead volume)
+ *   - TOP_UP_KETTLE → top_up_kettle_l (water added to kettle pre-boil)
+ *   - HOP_UTILIZATION → hop_utilization_percent (rig efficiency factor)
+ */
+@Entity('equipment_templates')
+export class EquipmentTemplateOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 120, nullable: false, unique: true })
+  name: string;
+
+  @Column({ type: 'real', nullable: true })
+  boil_size_l: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  batch_size_l: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  tun_volume_l: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  tun_weight_kg: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  tun_specific_heat: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  top_up_water_l: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  trub_chiller_loss_l: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  evap_rate_percent: number | null;
+
+  @Column({ type: 'integer', nullable: true })
+  boil_time_min: number | null;
+
+  @Column({ type: 'boolean', nullable: false, default: true })
+  calc_boil_volume: boolean;
+
+  @Column({ type: 'real', nullable: true })
+  lauter_deadspace_l: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  top_up_kettle_l: number | null;
+
+  @Column({ type: 'real', nullable: true })
+  hop_utilization_percent: number | null;
+
+  /**
+   * Brewer-friendly description in French (UI-facing). Typically
+   * calls out the rig category (extract pot / BIAB / electric AIO
+   * / 3-vessel HERMS) and the typical user profile (beginner /
+   * intermediate / pro).
+   */
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/equipment/entities/equipment-template.orm.entity.ts
+++ b/packages/api/src/catalog/equipment/entities/equipment-template.orm.entity.ts
@@ -8,11 +8,12 @@ import {
 
 /**
  * Immutable reference catalogue of homebrew equipment templates
- * (Issue #708 / #869, Phase 3 PR #7). Seeded with 8 entries —
- * the 2 BeerXML 1.0 canonical equipment profiles (verbatim from
- * `libraries/equipment.xml`) plus 6 popular modern setups
- * (BIAB 20/30L, Grainfather G30, Klarstein Brauheld Pro,
- * Anvil Foundry, 3-Vessel HERMS).
+ * (Issue #708 / #869, Phase 3 PR #7). Seeded with 9 entries —
+ * a Brasse-Bouillon original kitchen starter (5L casserole,
+ * extract brewing, no investment), the 2 BeerXML 1.0 canonical
+ * equipment profiles (verbatim from `libraries/equipment.xml`),
+ * plus 6 popular modern setups (BIAB 20/30L, Grainfather G30,
+ * Klarstein Brauheld Pro, Anvil Foundry, 3-Vessel HERMS).
  *
  * **Naming**: the table is called `equipment_templates` (not
  * `equipment_profiles`) because `equipment_profiles` already

--- a/packages/api/src/catalog/equipment/equipment.module.ts
+++ b/packages/api/src/catalog/equipment/equipment.module.ts
@@ -1,0 +1,22 @@
+import { EquipmentCatalogController } from './controllers/equipment-catalog.controller';
+import { EquipmentCatalogService } from './services/equipment-catalog.service';
+import { EquipmentTemplateOrmEntity } from './entities/equipment-template.orm.entity';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+/**
+ * Renamed `EquipmentCatalogModule` (not `EquipmentModule`) to
+ * avoid the class-name collision with the existing top-level
+ * `src/equipment/equipment.module.ts:EquipmentModule` (already
+ * wired in AppModule for user-owned equipment profiles). Two
+ * Nest modules sharing a class name make import resolution and
+ * error messages ambiguous; the suffix matches the convention
+ * adopted on PR #894 for `WaterCatalogModule`.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([EquipmentTemplateOrmEntity])],
+  controllers: [EquipmentCatalogController],
+  providers: [EquipmentCatalogService],
+  exports: [EquipmentCatalogService],
+})
+export class EquipmentCatalogModule {}

--- a/packages/api/src/catalog/equipment/services/__tests__/equipment-catalog.service.spec.ts
+++ b/packages/api/src/catalog/equipment/services/__tests__/equipment-catalog.service.spec.ts
@@ -1,0 +1,110 @@
+jest.setTimeout(20000);
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+
+import { EquipmentCatalogService } from '../equipment-catalog.service';
+import { EquipmentTemplateOrmEntity } from '../../entities/equipment-template.orm.entity';
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+
+describe('EquipmentCatalogService', () => {
+  let module: TestingModule;
+  let service: EquipmentCatalogService;
+  let repository: Repository<EquipmentTemplateOrmEntity>;
+
+  const ID_KITCHEN = '00000000-0000-4000-9000-600000000000';
+  const ID_GRAINFATHER = '00000000-0000-4000-9000-600000000005';
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [EquipmentTemplateOrmEntity],
+          synchronize: true,
+          logging: false,
+        }),
+        TypeOrmModule.forFeature([EquipmentTemplateOrmEntity]),
+      ],
+      providers: [EquipmentCatalogService],
+    }).compile();
+
+    service = module.get(EquipmentCatalogService);
+    repository = module.get(getRepositoryToken(EquipmentTemplateOrmEntity));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await repository.clear();
+  });
+
+  async function seedTemplate(
+    id: string,
+    name: string,
+    batchSize: number,
+  ): Promise<EquipmentTemplateOrmEntity> {
+    const entity = repository.create({
+      id,
+      name,
+      boil_size_l: batchSize + 4,
+      batch_size_l: batchSize,
+      tun_volume_l: batchSize + 5,
+      tun_weight_kg: 3,
+      tun_specific_heat: 0.12,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 1,
+      evap_rate_percent: 9,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 1,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes: null,
+    });
+    return repository.save(entity);
+  }
+
+  describe('list()', () => {
+    it('happy: returns every template ordered alphabetically by name', async () => {
+      await seedTemplate(ID_KITCHEN, 'Casserole cuisine 5L', 5);
+      await seedTemplate(ID_GRAINFATHER, 'Grainfather G30', 23);
+
+      const rows = await service.list();
+      expect(rows.map((r) => r.name)).toEqual([
+        'Casserole cuisine 5L',
+        'Grainfather G30',
+      ]);
+    });
+
+    it('sad: returns [] when the catalogue is empty', async () => {
+      const rows = await service.list();
+      expect(rows).toEqual([]);
+    });
+  });
+
+  describe('getById()', () => {
+    it('happy: returns the template matching the UUID', async () => {
+      await seedTemplate(ID_GRAINFATHER, 'Grainfather G30', 23);
+
+      const template = await service.getById(ID_GRAINFATHER);
+      expect(template.name).toBe('Grainfather G30');
+      expect(template.batch_size_l).toBe(23);
+    });
+
+    it('sad: throws NotFoundException when the UUID is unknown', async () => {
+      await expect(
+        service.getById('00000000-0000-4000-9000-6000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: does not match by name even if a row with that name exists', async () => {
+      await seedTemplate(ID_GRAINFATHER, 'Grainfather G30', 23);
+      await expect(service.getById('grainfather-g30')).rejects.toThrow();
+    });
+  });
+});

--- a/packages/api/src/catalog/equipment/services/equipment-catalog.service.ts
+++ b/packages/api/src/catalog/equipment/services/equipment-catalog.service.ts
@@ -1,0 +1,41 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { EquipmentTemplateOrmEntity } from '../entities/equipment-template.orm.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class EquipmentCatalogService {
+  constructor(
+    @InjectRepository(EquipmentTemplateOrmEntity)
+    private readonly templates: Repository<EquipmentTemplateOrmEntity>,
+  ) {}
+
+  /**
+   * Returns the catalogue ordered alphabetically by name. The
+   * catalogue is small (~10 rows) so no pagination or filtering
+   * is offered yet — added when the catalogue grows past ~100
+   * entries.
+   */
+  async list(): Promise<EquipmentTemplateOrmEntity[]> {
+    return this.templates.find({
+      order: { name: 'ASC' },
+    });
+  }
+
+  /**
+   * Returns a single catalogue entry by its UUID, or throws 404.
+   * Strict UUID match — no name lookup here, since variants of
+   * the same hardware (e.g. "Grainfather G30 v3" vs "Grainfather
+   * G30 v4") may share the same display name across revisions.
+   */
+  async getById(id: string): Promise<EquipmentTemplateOrmEntity> {
+    const entity = await this.templates.findOne({ where: { id } });
+    if (!entity) {
+      throw new NotFoundException(
+        `Equipment template catalogue entry ${id} not found`,
+      );
+    }
+    return entity;
+  }
+}

--- a/packages/api/src/catalog/equipment/services/equipment-catalog.service.ts
+++ b/packages/api/src/catalog/equipment/services/equipment-catalog.service.ts
@@ -25,9 +25,15 @@ export class EquipmentCatalogService {
 
   /**
    * Returns a single catalogue entry by its UUID, or throws 404.
-   * Strict UUID match — no name lookup here, since variants of
-   * the same hardware (e.g. "Grainfather G30 v3" vs "Grainfather
-   * G30 v4") may share the same display name across revisions.
+   * Strict UUID match — no name lookup here, matching the
+   * convention used by every other catalogue service
+   * (Hop / Yeast / Style / Fermentable / Mash / Water). Name
+   * lookups are intentionally not exposed: the picker UI carries
+   * the UUID once the user selects an entry, and adding a
+   * non-UUID-validated lookup path would broaden the API surface
+   * for no current use case. (Note: the table enforces
+   * UNIQUE(name) so a future name-lookup endpoint would still
+   * return at most one row.)
    */
   async getById(id: string): Promise<EquipmentTemplateOrmEntity> {
     const entity = await this.templates.findOne({ where: { id } });

--- a/packages/api/src/database/migrations/1789000000000-AddEquipmentTemplatesCatalog.ts
+++ b/packages/api/src/database/migrations/1789000000000-AddEquipmentTemplatesCatalog.ts
@@ -12,8 +12,9 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
  * naming split avoids the kind of class-name collision that
  * PR #894 caught and fixed for the water catalogue.
  *
- * Seeded with 8 entries (2 BeerXML verbatim from
- * libraries/equipment.xml + 6 popular modern setups).
+ * Seeded with 9 entries (1 Brasse-Bouillon original kitchen
+ * starter + 2 BeerXML verbatim from libraries/equipment.xml +
+ * 6 popular modern setups).
  */
 export class AddEquipmentTemplatesCatalog1789000000000 implements MigrationInterface {
   name = 'AddEquipmentTemplatesCatalog1789000000000';

--- a/packages/api/src/database/migrations/1789000000000-AddEquipmentTemplatesCatalog.ts
+++ b/packages/api/src/database/migrations/1789000000000-AddEquipmentTemplatesCatalog.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `equipment_templates` table — immutable reference
+ * catalogue of homebrew equipment templates. Phase 3 PR #7 of
+ * the catalogue refactor (Issue #708 / #869).
+ *
+ * **Naming**: distinct from the existing `equipment_profiles`
+ * table (user-owned per-brewer setups). A template here is the
+ * SHARED reference (manufacturer specs) that a user can later
+ * copy to seed their own personal `equipment_profile`. The
+ * naming split avoids the kind of class-name collision that
+ * PR #894 caught and fixed for the water catalogue.
+ *
+ * Seeded with 8 entries (2 BeerXML verbatim from
+ * libraries/equipment.xml + 6 popular modern setups).
+ */
+export class AddEquipmentTemplatesCatalog1789000000000 implements MigrationInterface {
+  name = 'AddEquipmentTemplatesCatalog1789000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "equipment_templates" (
+        "id"                        varchar(36) PRIMARY KEY NOT NULL,
+        "name"                      varchar(120) NOT NULL,
+        "boil_size_l"               real,
+        "batch_size_l"              real,
+        "tun_volume_l"              real,
+        "tun_weight_kg"             real,
+        "tun_specific_heat"         real,
+        "top_up_water_l"            real,
+        "trub_chiller_loss_l"       real,
+        "evap_rate_percent"         real,
+        "boil_time_min"             integer,
+        "calc_boil_volume"          boolean NOT NULL DEFAULT 1,
+        "lauter_deadspace_l"        real,
+        "top_up_kettle_l"           real,
+        "hop_utilization_percent"   real,
+        "notes"                     text,
+        "created_at"                datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "updated_at"                datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_equipment_templates_name" ON "equipment_templates" ("name")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_equipment_templates_name"`);
+    await queryRunner.query(`DROP TABLE "equipment_templates"`);
+  }
+}

--- a/packages/api/src/database/seeds/__tests__/equipment-templates-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/__tests__/equipment-templates-catalog.seed.spec.ts
@@ -1,0 +1,99 @@
+import { Repository } from 'typeorm';
+
+import {
+  EQUIPMENT_TEMPLATES_CATALOG_SEED,
+  seedEquipmentTemplatesCatalog,
+} from '../equipment-templates-catalog.seed';
+import {
+  assertCommonCatalogueSeederBehaviours,
+  buildRepoMock,
+} from '../seed-test-utils';
+import { EquipmentTemplateOrmEntity } from '../../../catalog/equipment/entities/equipment-template.orm.entity';
+
+describe('seedEquipmentTemplatesCatalog (Issue #708 / #869 — Phase 3 PR #7)', () => {
+  // The four standard catalogue-seeder behaviours (happy / sad /
+  // mixed / override-list) live in the shared helper to satisfy
+  // SonarCloud's duplication gate — see seed-test-utils.ts.
+  assertCommonCatalogueSeederBehaviours('seedEquipmentTemplatesCatalog', {
+    fn: (repo, seeds) =>
+      seedEquipmentTemplatesCatalog(
+        repo as unknown as Repository<EquipmentTemplateOrmEntity>,
+        seeds,
+      ),
+    data: EQUIPMENT_TEMPLATES_CATALOG_SEED,
+  });
+
+  describe('catalogue-specific invariants', () => {
+    it('writes name + batch_size_l on every inserted row', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      await seedEquipmentTemplatesCatalog(
+        repo as unknown as Repository<EquipmentTemplateOrmEntity>,
+      );
+
+      for (const call of repo.create.mock.calls as unknown[][]) {
+        const arg = call[0] as Record<string, unknown>;
+        expect(typeof arg.name).toBe('string');
+        expect((arg.name as string).length).toBeGreaterThan(0);
+        expect(typeof arg.batch_size_l).toBe('number');
+      }
+    });
+
+    it('exposes 9 curated catalogue entries spanning beginner to pro', () => {
+      expect(EQUIPMENT_TEMPLATES_CATALOG_SEED).toHaveLength(9);
+
+      const names = EQUIPMENT_TEMPLATES_CATALOG_SEED.map((t) => t.name);
+      // Brasse-Bouillon original kitchen starter
+      expect(names).toContain('Casserole cuisine 5L (kit initiation extract)');
+      // 2 BeerXML canonical
+      expect(names).toContain('Brew Pot 4 Gal (extract brewing)');
+      expect(names).toContain(
+        'Brew Pot 6+gal + Igloo Cooler 5 Gal (all-grain classic)',
+      );
+      // 6 modern popular setups
+      expect(names).toContain('BIAB 20L (Brew In A Bag, entry-level)');
+      expect(names).toContain('BIAB 30L (Brew In A Bag, intermediate)');
+      expect(names).toContain('Grainfather G30 (electric all-in-one)');
+      expect(names).toContain('Klarstein Brauheld Pro 30L (EU entry-level)');
+      expect(names).toContain('Anvil Foundry 6.5 Gal (US popular electric)');
+      expect(names).toContain('3-Vessel HERMS Recirculating (advanced / pro)');
+    });
+
+    it('uses deterministic UUIDs in the catalogue range (...-9000-6000-...)', () => {
+      const ids = EQUIPMENT_TEMPLATES_CATALOG_SEED.map((t) => t.id);
+      for (const id of ids) {
+        expect(id).toMatch(/^00000000-0000-4000-9000-6[0-9a-f]{11}$/);
+      }
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('covers the full beginner-to-pro batch size spectrum (5L to 23L)', () => {
+      // The catalogue must let any user find a setup that matches
+      // their budget. Smallest batch size = 5L (kitchen pot starter
+      // for first-time brewers); largest = 23L (standard homebrew
+      // batch with electric all-in-one or HERMS).
+      const sizes = EQUIPMENT_TEMPLATES_CATALOG_SEED.map(
+        (t) => t.batch_size_l,
+      ).filter((s): s is number => s !== null);
+      expect(Math.min(...sizes)).toBe(5);
+      expect(Math.max(...sizes)).toBe(23);
+    });
+
+    it('keeps every notes value in French (UI-facing convention)', () => {
+      for (const template of EQUIPMENT_TEMPLATES_CATALOG_SEED) {
+        if (template.notes !== null) {
+          expect(template.notes).toMatch(/[àâäéèêëïîôöùûüÿç]/i);
+        }
+      }
+    });
+
+    // No simple "batch ≤ tun_volume" invariant exists across the
+    // extract / partial mash / all-grain spectrum: extract setups
+    // legitimately have batch > boil (top_up_water makes up the
+    // difference), and multi-vessel setups have separate mash tun
+    // and boil kettle volumes that can't both be expressed in the
+    // single tun_volume_l column. The sanity check we DO get is
+    // the spectrum-coverage test above (5L to 23L).
+  });
+});

--- a/packages/api/src/database/seeds/equipment-templates-catalog.seed.ts
+++ b/packages/api/src/database/seeds/equipment-templates-catalog.seed.ts
@@ -1,0 +1,308 @@
+import { EquipmentTemplateOrmEntity } from '../../catalog/equipment/entities/equipment-template.orm.entity';
+import { Repository } from 'typeorm';
+import { idempotentUpsertById } from './seed-utils';
+
+/**
+ * Seed for the `equipment_templates` reference catalogue (Issue
+ * #708 / #869, Phase 3 PR #7). Operator-curated entries — drawn
+ * from the BeerXML 1.0 reference fixture
+ * (`docs/architecture/specs/fixtures/libraries/equipment.xml`,
+ * 2 entries) and from manufacturer datasheets for the modern
+ * setups (Grainfather, Klarstein, Anvil).
+ *
+ * The 9 entries cover the full beginner-to-pro spectrum:
+ *   • 1 Brasse-Bouillon original kitchen starter:
+ *     Casserole cuisine 5L (kit d'initiation extract — true
+ *     beginner who only owns kitchen pots and wants to try
+ *     brewing once before investing).
+ *   • 2 BeerXML canonical (verbatim from libraries/equipment.xml):
+ *     Brew Pot 4 Gal (extract), Brew Pot 6+gal + Igloo Cooler 5
+ *     Gal (all-grain classic).
+ *   • 6 popular modern setups: BIAB 20L, BIAB 30L, Grainfather G30
+ *     (electric all-in-one), Klarstein Brauheld Pro 30L (EU entry-
+ *     level), Anvil Foundry 6.5 Gal (US popular electric), 3-Vessel
+ *     HERMS Recirculating (advanced / pro).
+ *
+ * UUID range `00000000-0000-4000-9000-6000-...` is reserved for
+ * equipment templates (hops `0`, fermentables `1`, yeasts `2`,
+ * styles `3`, mash `4`, waters `5`, equipment `6`).
+ */
+
+export interface EquipmentTemplateSeed {
+  id: string;
+  name: string;
+  boil_size_l: number | null;
+  batch_size_l: number | null;
+  tun_volume_l: number | null;
+  tun_weight_kg: number | null;
+  tun_specific_heat: number | null;
+  top_up_water_l: number | null;
+  trub_chiller_loss_l: number | null;
+  evap_rate_percent: number | null;
+  boil_time_min: number | null;
+  calc_boil_volume: boolean;
+  lauter_deadspace_l: number | null;
+  top_up_kettle_l: number | null;
+  hop_utilization_percent: number | null;
+  notes: string | null;
+}
+
+export const EQUIPMENT_TEMPLATES_CATALOG_SEED: readonly EquipmentTemplateSeed[] =
+  [
+    // ─── Kitchen starter (Brasse-Bouillon original — true beginner) ──────
+    {
+      id: '00000000-0000-4000-9000-600000000000',
+      name: 'Casserole cuisine 5L (kit initiation extract)',
+      boil_size_l: 7,
+      batch_size_l: 5,
+      tun_volume_l: 10,
+      tun_weight_kg: 1.2,
+      tun_specific_heat: 0.12,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 0.3,
+      evap_rate_percent: 12,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 0,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes:
+        "Profil 'kit d'initiation' : juste une casserole 5-10 L sur la " +
+        'plaque de cuisine, brassage extract uniquement. Brassins de ' +
+        '4-5 L finaux (~6 bouteilles 75 cL), parfait pour une première ' +
+        'fois sans investissement. Permet de découvrir le brassage à ' +
+        "partir d'extraits de malt liquides ou secs (DME/LME) avec un " +
+        'houblonnage simple. Évolution naturelle ensuite : passer au ' +
+        'Brew Pot 4 Gal ou au BIAB 20 L.',
+    },
+    // ─── 2 BeerXML canonical entries (libraries/equipment.xml) ──────────
+    {
+      id: '00000000-0000-4000-9000-600000000001',
+      name: 'Brew Pot 4 Gal (extract brewing)',
+      boil_size_l: 12.3,
+      batch_size_l: 18.9,
+      tun_volume_l: 15.1,
+      tun_weight_kg: 1.8,
+      tun_specific_heat: 0.12,
+      top_up_water_l: 8.5,
+      trub_chiller_loss_l: 0,
+      evap_rate_percent: 9,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 0.95,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes:
+        'Casserole 4 gallons (~15 L) pour brassage extract ou partial ' +
+        "mash. Volume utile d'ébullition d'environ 12 L après réservation " +
+        "de l'espace pour le krausen. Setup typique du débutant qui se " +
+        "lance sans investir dans une cuve d'empâtage isolée.",
+    },
+    {
+      id: '00000000-0000-4000-9000-600000000002',
+      name: 'Brew Pot 6+gal + Igloo Cooler 5 Gal (all-grain classic)',
+      boil_size_l: 22.7,
+      batch_size_l: 18.9,
+      tun_volume_l: 18.9,
+      tun_weight_kg: 1.8,
+      tun_specific_heat: 0.3,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 0.95,
+      evap_rate_percent: 9,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 0.95,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes:
+        'Setup all-grain classique américain : glacière Gott / Igloo 5 ' +
+        "gal isolée comme cuve d'empâtage avec faux-fond, plus une " +
+        'casserole 6-9 gallons capable de bouillir au moins 6 gallons ' +
+        'de moût. Privilégie les empâtages mono-palier infusion.',
+    },
+    // ─── 6 popular modern setups for the demo recipes ────────────────────
+    {
+      id: '00000000-0000-4000-9000-600000000003',
+      name: 'BIAB 20L (Brew In A Bag, entry-level)',
+      boil_size_l: 24,
+      batch_size_l: 19,
+      tun_volume_l: 20,
+      tun_weight_kg: 2.5,
+      tun_specific_heat: 0.12,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 0.5,
+      evap_rate_percent: 10,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 0,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes:
+        'Brew In A Bag : marmite 20 L + sac à grains en nylon, méthode ' +
+        'la plus simple du tout-grain. Pas de cuve dédiée, tout se fait ' +
+        'dans la marmite. Investissement minimum (~80€), idéal débutant ' +
+        "qui passe de l'extract à l'all-grain.",
+    },
+    {
+      id: '00000000-0000-4000-9000-600000000004',
+      name: 'BIAB 30L (Brew In A Bag, intermediate)',
+      boil_size_l: 32,
+      batch_size_l: 23,
+      tun_volume_l: 30,
+      tun_weight_kg: 3,
+      tun_specific_heat: 0.12,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 0.7,
+      evap_rate_percent: 10,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 0,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes:
+        'BIAB 30 L pour brassins de 23 L finaux (volume standard ' +
+        'homebrew). Permet de brasser des bières fortes (Tripel, ' +
+        'Imperial Stout) qui demandent plus de grains. Évolution ' +
+        'naturelle du BIAB 20L.',
+    },
+    {
+      id: '00000000-0000-4000-9000-600000000005',
+      name: 'Grainfather G30 (electric all-in-one)',
+      boil_size_l: 30,
+      batch_size_l: 23,
+      tun_volume_l: 30,
+      tun_weight_kg: 4,
+      tun_specific_heat: 0.12,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 1,
+      evap_rate_percent: 9,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 1,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes:
+        'Système électrique tout-en-un néo-zélandais, devenu référence ' +
+        'mondiale du homebrew avancé. Recirculation automatique, ' +
+        'contrôle PID de la température. Setup populaire pour ' +
+        "brasseurs avancés qui veulent s'affranchir de la flamme nue.",
+    },
+    {
+      id: '00000000-0000-4000-9000-600000000006',
+      name: 'Klarstein Brauheld Pro 30L (EU entry-level)',
+      boil_size_l: 30,
+      batch_size_l: 23,
+      tun_volume_l: 30,
+      tun_weight_kg: 5,
+      tun_specific_heat: 0.12,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 1,
+      evap_rate_percent: 9,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 1,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 95,
+      notes:
+        'Système électrique tout-en-un allemand, très populaire en ' +
+        'Europe pour son rapport qualité-prix (~400€). Alternative ' +
+        'budget au Grainfather. Recirculation moins puissante mais ' +
+        'fonctionnelle pour la plupart des recettes.',
+    },
+    {
+      id: '00000000-0000-4000-9000-600000000007',
+      name: 'Anvil Foundry 6.5 Gal (US popular electric)',
+      boil_size_l: 24.6,
+      batch_size_l: 19,
+      tun_volume_l: 24.6,
+      tun_weight_kg: 4,
+      tun_specific_heat: 0.12,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 1,
+      evap_rate_percent: 10,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 1,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes:
+        'Système électrique américain populaire, alternative au ' +
+        'Grainfather. 6.5 gallons (~24 L) pour des brassins de 19 L. ' +
+        "Pompe optionnelle, contrôleur PID, prix d'entrée plus " +
+        'accessible que le Grainfather aux US.',
+    },
+    {
+      id: '00000000-0000-4000-9000-600000000008',
+      name: '3-Vessel HERMS Recirculating (advanced / pro)',
+      boil_size_l: 30,
+      batch_size_l: 23,
+      tun_volume_l: 30,
+      tun_weight_kg: 8,
+      tun_specific_heat: 0.3,
+      top_up_water_l: 0,
+      trub_chiller_loss_l: 1.5,
+      evap_rate_percent: 8,
+      boil_time_min: 60,
+      calc_boil_volume: true,
+      lauter_deadspace_l: 1.5,
+      top_up_kettle_l: 0,
+      hop_utilization_percent: 100,
+      notes:
+        'Setup 3 cuves HERMS (Heat Exchange Recirculating Mash System) : ' +
+        "HLT (Hot Liquor Tank) + cuve d'empâtage + bouilloire. Permet " +
+        "des programmes d'empâtage à paliers complexes avec contrôle " +
+        'précis. Investissement conséquent (1500-3000€), pour ' +
+        'brasseurs très avancés ou semi-pros.',
+    },
+  ];
+
+/**
+ * Result returned by `seedEquipmentTemplatesCatalog` for
+ * instrumentation / verification.
+ */
+export interface SeedEquipmentTemplatesCatalogResult {
+  inserted: number;
+  updated: number;
+  total: number;
+}
+
+/**
+ * Idempotent loader for the equipment template reference
+ * catalogue. Insert if the id is unknown, update in place
+ * otherwise. Re-running the loader never duplicates rows.
+ */
+export async function seedEquipmentTemplatesCatalog(
+  repository: Repository<EquipmentTemplateOrmEntity>,
+  templates: readonly EquipmentTemplateSeed[] = EQUIPMENT_TEMPLATES_CATALOG_SEED,
+): Promise<SeedEquipmentTemplatesCatalogResult> {
+  let inserted = 0;
+  let updated = 0;
+
+  for (const template of templates) {
+    const outcome = await idempotentUpsertById(
+      repository,
+      { id: template.id },
+      {
+        name: template.name,
+        boil_size_l: template.boil_size_l,
+        batch_size_l: template.batch_size_l,
+        tun_volume_l: template.tun_volume_l,
+        tun_weight_kg: template.tun_weight_kg,
+        tun_specific_heat: template.tun_specific_heat,
+        top_up_water_l: template.top_up_water_l,
+        trub_chiller_loss_l: template.trub_chiller_loss_l,
+        evap_rate_percent: template.evap_rate_percent,
+        boil_time_min: template.boil_time_min,
+        calc_boil_volume: template.calc_boil_volume,
+        lauter_deadspace_l: template.lauter_deadspace_l,
+        top_up_kettle_l: template.top_up_kettle_l,
+        hop_utilization_percent: template.hop_utilization_percent,
+        notes: template.notes,
+      },
+    );
+    inserted += outcome.inserted;
+    updated += outcome.updated;
+  }
+
+  return { inserted, updated, total: inserted + updated };
+}

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -5,6 +5,7 @@ import { BatchReminderOrmEntity } from '../batch/entities/batch-reminder.orm.ent
 import { BatchStepOrmEntity } from '../batch/entities/batch-step.orm.entity';
 import { DataSourceOptions } from 'typeorm';
 import { EquipmentProfileOrmEntity } from '../equipment/entities/equipment-profile.orm.entity';
+import { EquipmentTemplateOrmEntity } from '../catalog/equipment/entities/equipment-template.orm.entity';
 import { FermentableOrmEntity } from '../catalog/fermentable/entities/fermentable.orm.entity';
 import { HopOrmEntity } from '../catalog/hop/entities/hop.orm.entity';
 import { LabelDraftOrmEntity } from '../label/entities/label-draft.orm.entity';
@@ -55,6 +56,7 @@ export const ormEntities = [
   MashProfileOrmEntity,
   MashStepOrmEntity,
   WaterOrmEntity,
+  EquipmentTemplateOrmEntity,
 ];
 
 const parseBooleanEnv = (name: string, defaultValue: boolean): boolean => {


### PR DESCRIPTION
## Summary

Phase 3 PR #7 of the brewing reference catalogues refactor (Issue #708 / #869). Adds the **EquipmentCatalogModule** under the existing top-level \`catalog/\` module, seeded with **9 equipment template entries** spanning the full beginner-to-pro spectrum — from a 5L kitchen pot for first-time brewers up to a 23L 3-Vessel HERMS for advanced setups.

## Naming: \`equipment_templates\` (not \`equipment_profiles\`)

The table is called \`equipment_templates\` and the class \`EquipmentTemplateOrmEntity\` to avoid the class-name collision with the existing top-level \`src/equipment/equipment.module.ts:EquipmentModule\` and its \`EquipmentProfileOrmEntity\` (user-owned per-brewer setups). A template here is the SHARED reference (manufacturer specs) that an end user can later copy to seed their own personal \`equipment_profile\`.

This is the same naming pattern adopted on PR #894 for \`WaterCatalogModule\` (after Copilot caught the same kind of collision risk).

| Existing user-owned | New catalogue (this PR) |
|---|---|
| \`equipment_profiles\` table | \`equipment_templates\` table |
| \`EquipmentProfileOrmEntity\` | \`EquipmentTemplateOrmEntity\` |
| \`EquipmentModule\` | \`EquipmentCatalogModule\` |
| Per-user, mutable | Operator-curated, immutable |
| Referenced by user batches | Used as starting template for personal profiles |

## Schema (table \`equipment_templates\` — 18 columns total: 15 data + 3 system)

15 data columns map BeerXML 1.0 \`<EQUIPMENT>\` field-by-field:
- \`name\` UNIQUE
- Volumes (L): \`boil_size_l\`, \`batch_size_l\`, \`tun_volume_l\`, \`top_up_water_l\`, \`trub_chiller_loss_l\`, \`lauter_deadspace_l\`, \`top_up_kettle_l\`
- Thermal: \`tun_weight_kg\`, \`tun_specific_heat\`
- Process: \`evap_rate_percent\`, \`boil_time_min\`, \`calc_boil_volume\`, \`hop_utilization_percent\`
- \`notes\` (FR, UI-facing)

Indexes: UNIQUE on \`name\`.

## Endpoints

\`\`\`
GET /catalog/equipment-templates           → ordered list
GET /catalog/equipment-templates/:uuid     → single entry, 404 on miss
\`\`\`

## Seed (9 entries, idempotent loader)

Operator-curated, drawn from the BeerXML reference fixture and manufacturer datasheets, structured to give every beginner an immediate match.

- **1 Brasse-Bouillon original kitchen starter**: Casserole cuisine 5L (kit d'initiation extract — true beginner who only owns kitchen pots; 5L final batch ~6 bottles, no investment required)
- **2 BeerXML canonical** (verbatim from \`libraries/equipment.xml\`): Brew Pot 4 Gal (extract), Brew Pot 6+gal + Igloo Cooler 5 Gal (all-grain classic)
- **6 modern popular setups**: BIAB 20L, BIAB 30L, Grainfather G30 (electric all-in-one), Klarstein Brauheld Pro 30L (EU entry-level), Anvil Foundry 6.5 Gal (US popular electric), 3-Vessel HERMS Recirculating (advanced / pro)

Coverage: **batch sizes 5L → 23L**, full beginner-to-pro spectrum.

The kitchen starter explicitly addresses the \"I just want to try brewing once with what I already own\" persona — no investment required, immediately usable on a kitchen stove.

## Tests (10 new, all green)

- **Service spec** — in-memory SQLite (4 tests): list ordered alphabetically, getById happy / sad / edge (UUID strict)
- **Controller spec** — \`jest.spyOn\` pattern (4 tests)
- **Seed spec** — delegates to \`assertCommonCatalogueSeederBehaviours\` helper (4 standard scenarios) + 5 catalogue-specific assertions (9-entry name coverage, deterministic UUID range \`…-9000-6…\`, batch-size spectrum 5L-23L, French notes invariant, basic field type checks)

## All six review lessons baked in (PR #888 + PR #894)

- ✅ **Boot-safe registration** — \`EquipmentTemplateOrmEntity\` added to \`ormEntities\`
- ✅ **Migration consistency** — \`CREATE UNIQUE INDEX IDX_equipment_templates_name\` (matches IDX_styles_name etc.)
- ✅ **No filtered query params** so no ParseEnumPipe needed
- ✅ **Runner script** — \`scripts/run-equipment-templates-catalog-seed.ts\`
- ✅ **Entity \`unique: true\`** on the name column (matches the migration UNIQUE INDEX — no test/prod drift under \`TYPEORM_SYNCHRONIZE=true\`)
- ✅ **\`Catalog\` suffix on module class name** to avoid collision with existing top-level \`EquipmentModule\` (lesson from PR #894 \`WaterCatalogModule\`)
- ✅ **Consistent NotFoundException message** — \"Equipment template catalogue entry \${id} not found\" (matches Hop / Yeast / Style / Fermentable / Mash / Water format)

## Phase 3 status after this PR

| # | PR | Catalogue | Status |
|---|---|---|---|
| 6 | #894 | waters | ✅ merged |
| 7 | this PR | equipment_templates | 🟡 awaiting review |
| 8 | next | misc | pending |

After this PR merges, only one catalogue remains (MISC for spices / finings / water agents) before the post-Phase 1-3 normalize-producers PR.

## Checklist

- [x] Happy / sad / edge cases covered (10 new tests)
- [x] \`npm run lint:check\` passes (0 errors)
- [x] \`npm run build\` passes
- [x] All existing tests still green (545 → 564 total — 9 new seed entries + 10 new test cases)
- [x] No \`any\` introduced
- [x] Migration timestamp picks up where the previous one left off (\`1789000000000\`)
- [x] All six prior review lessons baked in upfront

Refs #708 #869