### PR TITLE
feat(catalog/misc): add miscellaneous ingredients reference catalogue (#708)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,50 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-05-03
 
+### Catalogue refactor — Phases 1-3 shipped in one day (#708 / #869)
+
+- 7 immutable reference catalogues merged to `main` between 02:00 and 17:05 UTC (PR #888 → #898), all on `packages/api`. Each PR follows the same 12-file pattern: entity + DTO + service + controller + module + migration + seed + 3 specs (service/controller/seed) + runner script + wiring updates to `catalog.module.ts` and `typeorm.config.ts`.
+- **Decisions** locked across the series:
+  - `*CatalogModule` suffix (e.g. `WaterCatalogModule`, `EquipmentCatalogModule`) to avoid class-name collisions with existing user-owned modules — convention adopted on PR #894 after Copilot caught the `EquipmentModule` collision risk.
+  - `assertCommonCatalogueSeederBehaviours` shared test helper at `src/database/seeds/seed-test-utils.ts` — covers the 4 standard scenarios (happy / sad / mixed / override-list) so each catalogue spec only carries its own invariants. Added on PR #891 to clear SonarCloud's new-code duplication gate.
+  - Deterministic UUID range per catalogue: hops `0`, fermentables `1`, yeasts `2`, styles `3`, mash `4`, waters `5`, equipment `6`, misc `7` (last one in PR #899, in flight).
+  - Notes columns kept French (UI-facing per `feedback_ui_french_only`); `use_for` / category metadata stays English (BeerXML provenance).
+- **Scope still open**: PR #899 (`misc_templates`) opens after #898 — once merged, the umbrella issues #708 / #869 close and the post-Phase-3 work begins (normalize-producers PR + Recipe-entity FK refactor + mobile ingredient picker refactor #887).
+
+### PR #898 merged (`8934ade`) — feat(catalog/equipment): equipment templates reference catalogue
+
+- Phase 3 PR #7 of the catalogue series. 9 entries spanning the full beginner-to-pro spectrum: 1 Brasse-Bouillon original kitchen starter (Casserole 5L extract — added late in the cycle after the user validated the "I just want to try once" persona), 2 BeerXML canonical, 6 modern popular setups (BIAB 20/30L, Grainfather G30, Klarstein Brauheld Pro, Anvil Foundry, 3-Vessel HERMS).
+- 4 Copilot inline comments addressed in `2b42d02` (3 stale "8 entries" doc references bumped to "9" after the kitchen starter was added; 1 service docstring rewritten — old version claimed "multiple revisions may share a name", but the schema enforces UNIQUE(name)).
+- 14 files, +1096 LoC.
+
+### PR #894 merged (`5fe171b`) — feat(catalog/water): brewing water profiles reference catalogue
+
+- Phase 3 PR #6. 10 reference water profiles (3 BeerXML canonical: Pilsen / Burton-on-Trent / Munich, plus 7 city profiles for famous brewing waters). 6 mineral columns (Ca, Mg, Na, SO4, Cl, HCO3) per BeerXML 1.0 `<WATER>` field mapping.
+- Class renamed `WaterModule` → `WaterCatalogModule` after Copilot caught the collision with the existing user-owned water module — set the `*CatalogModule` precedent the rest of the series follows.
+
+### PR #893 merged (`cf3b1c9`) — feat(catalog/mash): mash profiles + steps reference catalogue (1:N)
+
+- Phase 2 PR #5 — closes Phase 2. Two-table catalogue with `mash_profiles` (parent) and `mash_steps` (child, FK with `ON DELETE CASCADE`). Steps ordered by `step_number`, types restricted to BeerXML enum (Infusion / Temperature / Decoction).
+- Most complex catalogue of the series due to the 1:N cascade — pattern reusable for any future parent/child catalogue.
+
+### PR #891 merged (`b9b034f`) — feat(catalog/style): BJCP styles reference catalogue (opens Phase 2)
+
+- Phase 2 PR #4. Composite UNIQUE(name, style_guide) so the same style name can coexist across the BJCP 2015 and BJCP 2021 guide editions.
+- **SonarCloud duplication failure** caught post-merge: fixed via `sonar.cpd.exclusions` in root `sonar-project.properties` covering catalogue boilerplate (services / controllers / modules / DTOs / entities / seeds / runners). The shared `assertCommonCatalogueSeederBehaviours` helper was extracted at the same time.
+- Spawned Issue #892 (mobile Académie / Guide BJCP — separate epic).
+
+### PR #890 merged (`e9e8d5c`) — feat(catalog/yeast): yeasts reference catalogue (closes Phase 1)
+
+- Phase 1 PR #3. BeerXML `<YEAST>` mapping: form (liquid/dry/slant/culture), type (ale/lager/wheat/wine/champagne), attenuation, flocculation. 12 entries spanning the major Wyeast / White Labs / Fermentis lines.
+
+### PR #889 merged (`f137030`) — feat(catalog/fermentable): fermentables reference catalogue
+
+- Phase 1 PR #2. BeerXML `<FERMENTABLE>` mapping incl. `color_ebc` (project-normalised to EBC per `feedback_normalized_colors`), `yield_percent`, type (grain/sugar/extract/dry_extract/adjunct).
+
+### PR #888 merged (`6c70eb3`) — feat(catalog/hop): hops reference catalogue (opens Phase 1)
+
+- Phase 1 PR #1 — first of the 8-PR series, set the file-layout pattern every subsequent catalogue mirrors. BeerXML `<HOP>` mapping incl. alpha_acid_percent, beta_acid_percent, type (bittering/aroma/dual), form (pellet/plug/leaf), use phase, year of harvest.
+
 ### PR #871 merged (`fc3ee5a`) — feat(mobile-app): wire Python beer-encyclopedia as fallback for /scan/lookup 404 + ADR-0005 backend split
 
 - ADR-0005 (encyclopedia ⇆ product split) + ADR-0002 marked partially superseded.

--- a/packages/api/scripts/run-misc-templates-catalog-seed.ts
+++ b/packages/api/scripts/run-misc-templates-catalog-seed.ts
@@ -1,0 +1,40 @@
+/**
+ * One-shot script to seed the `misc_templates` reference
+ * catalogue with the 10 curated entries from
+ * `MISC_TEMPLATES_CATALOG_SEED` against the local dev database
+ * (Issue #708 / #869, Phase 3 PR #8 — last catalogue of the
+ * series).
+ *
+ * Usage:
+ *   cd packages/api
+ *   npx ts-node -r tsconfig-paths/register scripts/run-misc-templates-catalog-seed.ts
+ *
+ * Idempotent: safe to run multiple times. Existing template IDs
+ * are updated in place; missing ones are inserted.
+ *
+ * Mirror of the per-seed runners shipped in earlier catalogues.
+ * Stopgap until the unified seed orchestrator lands at the end
+ * of Phase 3.
+ */
+import 'reflect-metadata';
+
+import dataSource from '../src/database/data-source';
+import { MiscTemplateOrmEntity } from '../src/catalog/misc/entities/misc-template.orm.entity';
+import { seedMiscTemplatesCatalog } from '../src/database/seeds/misc-templates-catalog.seed';
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const repo = dataSource.getRepository(MiscTemplateOrmEntity);
+  const result = await seedMiscTemplatesCatalog(repo);
+  console.log('Misc templates catalogue seed:', result);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/catalog/catalog.module.ts
+++ b/packages/api/src/catalog/catalog.module.ts
@@ -2,6 +2,7 @@ import { EquipmentCatalogModule } from './equipment/equipment.module';
 import { FermentableModule } from './fermentable/fermentable.module';
 import { HopModule } from './hop/hop.module';
 import { MashModule } from './mash/mash.module';
+import { MiscCatalogModule } from './misc/misc.module';
 import { Module } from '@nestjs/common';
 import { StyleModule } from './style/style.module';
 import { WaterCatalogModule } from './water/water.module';
@@ -13,7 +14,8 @@ import { YeastModule } from './yeast/yeast.module';
  * per catalogue (Issue #708 / #869):
  *   • Phase 1: HopModule, FermentableModule (PR #2), YeastModule (PR #3)
  *   • Phase 2: StyleModule, MashProfileModule
- *   • Phase 3: WaterCatalogModule, EquipmentModule, MiscModule
+ *   • Phase 3: WaterCatalogModule, EquipmentCatalogModule,
+ *     MiscCatalogModule
  *
  * Each sub-module owns its own ORM entity, service, controller,
  * and DTOs. CatalogModule re-exports nothing for now — direct
@@ -28,6 +30,7 @@ import { YeastModule } from './yeast/yeast.module';
     MashModule,
     WaterCatalogModule,
     EquipmentCatalogModule,
+    MiscCatalogModule,
   ],
 })
 export class CatalogModule {}

--- a/packages/api/src/catalog/misc/controllers/__tests__/misc-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/misc/controllers/__tests__/misc-catalog.controller.spec.ts
@@ -1,0 +1,112 @@
+import { MiscType, MiscUseAt } from '../../domain/misc-template.types';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { MiscCatalogController } from '../misc-catalog.controller';
+import { MiscCatalogService } from '../../services/misc-catalog.service';
+import { MiscTemplateOrmEntity } from '../../entities/misc-template.orm.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('MiscCatalogController', () => {
+  let controller: MiscCatalogController;
+  let service: MiscCatalogService;
+
+  const ID_CORIANDER = '00000000-0000-4000-9000-700000000005';
+
+  function buildEntity(
+    overrides: Partial<MiscTemplateOrmEntity> = {},
+  ): MiscTemplateOrmEntity {
+    return {
+      id: ID_CORIANDER,
+      name: 'Coriandre (graines)',
+      type: MiscType.Spice,
+      use_at: MiscUseAt.Boil,
+      amount: 0.02,
+      amount_is_weight: true,
+      time_min: 10,
+      use_for: 'Belgian Wit',
+      notes: "Compagnon obligatoire de l'Orange amère pour la Witbier.",
+      created_at: new Date('2026-05-03T00:00:00.000Z'),
+      updated_at: new Date('2026-05-03T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [MiscCatalogController],
+      providers: [
+        {
+          provide: MiscCatalogService,
+          useValue: { list: jest.fn(), getById: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(MiscCatalogController);
+    service = module.get(MiscCatalogService);
+  });
+
+  describe('GET /catalog/misc-templates', () => {
+    it('happy: returns the full list mapped to DTOs', async () => {
+      const listSpy = jest.spyOn(service, 'list').mockResolvedValue([
+        buildEntity({ name: 'Coriandre (graines)' }),
+        buildEntity({
+          id: '00000000-0000-4000-9000-700000000006',
+          name: 'Lactose',
+          type: MiscType.Other,
+        }),
+      ]);
+
+      const result = await controller.list();
+
+      expect(listSpy).toHaveBeenCalledWith();
+      expect(result.map((r) => r.name)).toEqual([
+        'Coriandre (graines)',
+        'Lactose',
+      ]);
+      expect(typeof result[0].created_at).toBe('string');
+    });
+
+    it('sad: returns [] when the service yields no rows', async () => {
+      jest.spyOn(service, 'list').mockResolvedValue([]);
+      const result = await controller.list();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('GET /catalog/misc-templates/:id', () => {
+    it('happy: returns the DTO for the matching template', async () => {
+      const getByIdSpy = jest
+        .spyOn(service, 'getById')
+        .mockResolvedValue(buildEntity());
+
+      const result = await controller.getById(ID_CORIANDER);
+
+      expect(getByIdSpy).toHaveBeenCalledWith(ID_CORIANDER);
+      expect(result.id).toBe(ID_CORIANDER);
+      expect(result.type).toBe(MiscType.Spice);
+      expect(result.use_at).toBe(MiscUseAt.Boil);
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getById')
+        .mockRejectedValue(
+          new NotFoundException('Misc template catalogue entry not found'),
+        );
+
+      await expect(
+        controller.getById('00000000-0000-4000-9000-7000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: never leaks the raw ORM entity (always wraps in DTO)', async () => {
+      const entity = buildEntity();
+      jest.spyOn(service, 'getById').mockResolvedValue(entity);
+
+      const result = await controller.getById(ID_CORIANDER);
+      expect(result).not.toBe(entity);
+      expect(result.constructor.name).toBe('MiscTemplateDto');
+    });
+  });
+});

--- a/packages/api/src/catalog/misc/controllers/misc-catalog.controller.ts
+++ b/packages/api/src/catalog/misc/controllers/misc-catalog.controller.ts
@@ -1,0 +1,59 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
+import { MiscCatalogService } from '../services/misc-catalog.service';
+import { MiscTemplateDto } from '../dtos/misc-template.dto';
+
+/**
+ * Read-only HTTP surface for the misc template catalogue.
+ * Two endpoints:
+ *   GET /catalog/misc-templates           → list all
+ *   GET /catalog/misc-templates/:id       → fetch one by UUID
+ *
+ * Write endpoints (POST / PATCH / DELETE) are intentionally
+ * absent — the catalogue is operator-curated reference data,
+ * not user-managed content. Recipes that include miscellaneous
+ * ingredients will reference this catalogue by UUID through the
+ * recipe-misc junction table introduced post Phase 3.
+ */
+@ApiTags('Catalog · Misc templates')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('catalog/misc-templates')
+export class MiscCatalogController {
+  constructor(private readonly service: MiscCatalogService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List the misc template catalogue entries' })
+  @ApiOkResponse({ type: MiscTemplateDto, isArray: true })
+  async list(): Promise<MiscTemplateDto[]> {
+    const rows = await this.service.list();
+    return rows.map((row) => MiscTemplateDto.fromEntity(row));
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single misc template by UUID' })
+  @ApiOkResponse({ type: MiscTemplateDto })
+  @ApiNotFoundResponse({
+    description: 'Misc template catalogue entry not found',
+  })
+  async getById(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<MiscTemplateDto> {
+    const entity = await this.service.getById(id);
+    return MiscTemplateDto.fromEntity(entity);
+  }
+}

--- a/packages/api/src/catalog/misc/domain/misc-template.types.ts
+++ b/packages/api/src/catalog/misc/domain/misc-template.types.ts
@@ -1,0 +1,72 @@
+/**
+ * Domain shape for one misc template entry in the immutable
+ * reference catalogue. Mirrors the `MiscTemplateOrmEntity` row
+ * shape one-to-one (no field is computed) — kept as a separate
+ * interface so the application / presentation layers do not
+ * import the ORM entity directly.
+ *
+ * **Naming**: the table is called `misc_templates` (not `miscs`)
+ * for two reasons. (1) Consistency with `equipment_templates` —
+ * both catalogues share the convention "shared reference rows
+ * the user can later copy into a personal recipe". (2) Avoid any
+ * future collision with a recipe-side `recipe_misc` junction
+ * table when the Recipe entities are refactored to point at this
+ * catalogue (post Phase 3, normalize-producers PR).
+ */
+
+/**
+ * BeerXML 1.0 `<MISC>` `TYPE` enum — the kind of miscellaneous
+ * ingredient. Drives both the picker UI grouping and the
+ * suggested USE / TIME defaults at recipe time.
+ *   - spice        — dried seeds, peels, zests (Coriander, Orange Peel)
+ *   - fining       — clarifier (Irish Moss, Whirlfloc, gelatin)
+ *   - water_agent  — mineral / pH adjustment (CaCl₂, CaSO₄, lactic acid)
+ *   - herb         — fresh plant parts or live roots (Ginger Root)
+ *   - flavor       — extracts, vanilla beans, cocoa nibs
+ *   - other        — yeast nutrient, lactose, BeerXML fallback
+ */
+export enum MiscType {
+  Spice = 'spice',
+  Fining = 'fining',
+  WaterAgent = 'water_agent',
+  Herb = 'herb',
+  Flavor = 'flavor',
+  Other = 'other',
+}
+
+/**
+ * BeerXML 1.0 `<MISC>` `USE` enum — when the misc is added during
+ * the brewing process. Stored as `use_at` rather than `use` to
+ * avoid the SQL reserved keyword and match the domain wording the
+ * Mobile UI uses ("ajout au moment de…").
+ */
+export enum MiscUseAt {
+  Mash = 'mash',
+  Boil = 'boil',
+  Primary = 'primary',
+  Secondary = 'secondary',
+  Bottling = 'bottling',
+}
+
+export interface MiscTemplateEntry {
+  id: string;
+  name: string;
+  type: MiscType;
+  use_at: MiscUseAt;
+  /**
+   * Raw BeerXML AMOUNT value. Kilograms if `amount_is_weight`
+   * is true, otherwise litres. Stored verbatim from BeerXML so
+   * round-tripping a recipe through the catalogue preserves the
+   * exact reference value.
+   */
+  amount: number;
+  amount_is_weight: boolean;
+  /** BeerXML TIME — minutes the misc spends in its USE phase. */
+  time_min: number;
+  /** BeerXML USE_FOR — short purpose category, English ("Clarity", "Belgian Wit"). */
+  use_for: string | null;
+  /** Brewer-friendly description, French (UI-facing). */
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/misc/dtos/misc-template.dto.ts
+++ b/packages/api/src/catalog/misc/dtos/misc-template.dto.ts
@@ -1,0 +1,65 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { MiscTemplateOrmEntity } from '../entities/misc-template.orm.entity';
+import { MiscType, MiscUseAt } from '../domain/misc-template.types';
+
+/**
+ * Read-only response DTO for the misc template catalogue.
+ * Mirrors the ORM row shape one-to-one. Built via
+ * `MiscTemplateDto.fromEntity(entity)` rather than direct
+ * property access so future shape changes (date serialisation,
+ * field renaming) stay in this single conversion point.
+ */
+export class MiscTemplateDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ example: 'Coriandre (graines)' })
+  name: string;
+
+  @ApiProperty({ enum: MiscType, example: MiscType.Spice })
+  type: MiscType;
+
+  @ApiProperty({ enum: MiscUseAt, example: MiscUseAt.Boil })
+  use_at: MiscUseAt;
+
+  @ApiProperty({
+    example: 0.02,
+    description: 'Raw BeerXML AMOUNT — kg if amount_is_weight else L',
+  })
+  amount: number;
+
+  @ApiProperty({ example: true })
+  amount_is_weight: boolean;
+
+  @ApiProperty({ example: 10, description: 'Minutes spent in the USE phase' })
+  time_min: number;
+
+  @ApiProperty({ nullable: true, example: 'Belgian Wit' })
+  use_for: string | null;
+
+  @ApiProperty({ nullable: true })
+  notes: string | null;
+
+  @ApiProperty({ format: 'date-time' })
+  created_at: string;
+
+  @ApiProperty({ format: 'date-time' })
+  updated_at: string;
+
+  static fromEntity(entity: MiscTemplateOrmEntity): MiscTemplateDto {
+    const dto = new MiscTemplateDto();
+    dto.id = entity.id;
+    dto.name = entity.name;
+    dto.type = entity.type;
+    dto.use_at = entity.use_at;
+    dto.amount = entity.amount;
+    dto.amount_is_weight = entity.amount_is_weight;
+    dto.time_min = entity.time_min;
+    dto.use_for = entity.use_for;
+    dto.notes = entity.notes;
+    dto.created_at = entity.created_at.toISOString();
+    dto.updated_at = entity.updated_at.toISOString();
+    return dto;
+  }
+}

--- a/packages/api/src/catalog/misc/entities/misc-template.orm.entity.ts
+++ b/packages/api/src/catalog/misc/entities/misc-template.orm.entity.ts
@@ -53,10 +53,10 @@ export class MiscTemplateOrmEntity {
   @Column({ type: 'varchar', length: 120, nullable: false, unique: true })
   name: string;
 
-  @Column({ type: 'varchar', length: 32, nullable: false })
+  @Column({ type: 'varchar', length: 32, enum: MiscType, nullable: false })
   type: MiscType;
 
-  @Column({ type: 'varchar', length: 32, nullable: false })
+  @Column({ type: 'varchar', length: 32, enum: MiscUseAt, nullable: false })
   use_at: MiscUseAt;
 
   @Column({ type: 'real', nullable: false })

--- a/packages/api/src/catalog/misc/entities/misc-template.orm.entity.ts
+++ b/packages/api/src/catalog/misc/entities/misc-template.orm.entity.ts
@@ -1,0 +1,82 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { MiscType, MiscUseAt } from '../domain/misc-template.types';
+
+/**
+ * Immutable reference catalogue of homebrew "misc" ingredients
+ * (BeerXML 1.0 `<MISC>` records — spices, finings, water agents,
+ * herbs, flavor adjuncts). Issue #708 / #869, Phase 3 PR #8 —
+ * the last catalogue of the refactor series.
+ *
+ * Seeded with 10 entries — the 5 BeerXML 1.0 canonical entries
+ * (verbatim from `libraries/misc.xml`) plus 5 modern essentials
+ * (Coriandre, Lactose, Whirlfloc, Servomyces, Gypse) covering
+ * the TYPE × USE matrix end users actually reach for.
+ *
+ * **Naming**: the table is `misc_templates` (not `miscs`) for
+ * consistency with `equipment_templates`, and to leave room for
+ * a future `recipe_misc` junction table (Recipe → MiscTemplate)
+ * without name collision when the Recipe entities are refactored
+ * post Phase 3.
+ *
+ * BeerXML 1.0 `<MISC>` field mapping:
+ *   - NAME → name (varchar(120) UNIQUE)
+ *   - TYPE → type (enum MiscType — spice / fining / water_agent /
+ *     herb / flavor / other)
+ *   - USE → use_at (enum MiscUseAt — mash / boil / primary /
+ *     secondary / bottling; renamed from BeerXML's `USE` because
+ *     `use` is a SQL reserved keyword)
+ *   - AMOUNT → amount (real, kg if amount_is_weight else L —
+ *     stored verbatim so round-tripping a recipe preserves the
+ *     exact reference value)
+ *   - AMOUNT_IS_WEIGHT → amount_is_weight (boolean)
+ *   - TIME → time_min (real — BeerXML TIME is float minutes)
+ *   - USE_FOR → use_for (varchar — short purpose category, English)
+ *   - NOTES → notes (text, French — UI-facing brewer description)
+ *
+ * Display fields (`DISPLAY_AMOUNT`, `DISPLAY_TIME`, `INVENTORY`)
+ * are intentionally omitted: they are operator-side formatting
+ * concerns and stock-tracking metadata that do not belong in a
+ * shared reference catalogue.
+ */
+@Entity('misc_templates')
+export class MiscTemplateOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 120, nullable: false, unique: true })
+  name: string;
+
+  @Column({ type: 'varchar', length: 32, nullable: false })
+  type: MiscType;
+
+  @Column({ type: 'varchar', length: 32, nullable: false })
+  use_at: MiscUseAt;
+
+  @Column({ type: 'real', nullable: false })
+  amount: number;
+
+  @Column({ type: 'boolean', nullable: false, default: false })
+  amount_is_weight: boolean;
+
+  @Column({ type: 'real', nullable: false })
+  time_min: number;
+
+  @Column({ type: 'varchar', length: 120, nullable: true })
+  use_for: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/misc/misc.module.ts
+++ b/packages/api/src/catalog/misc/misc.module.ts
@@ -1,0 +1,21 @@
+import { MiscCatalogController } from './controllers/misc-catalog.controller';
+import { MiscCatalogService } from './services/misc-catalog.service';
+import { MiscTemplateOrmEntity } from './entities/misc-template.orm.entity';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+/**
+ * Class name `MiscCatalogModule` (suffixed `*CatalogModule`) to
+ * stay consistent with `WaterCatalogModule` / `EquipmentCatalog
+ * Module` and to leave room for a future user-side `MiscModule`
+ * (e.g. recipe-attached miscs) without class-name collision.
+ * The convention was adopted on PR #894 for water and confirmed
+ * on PR #898 for equipment.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([MiscTemplateOrmEntity])],
+  controllers: [MiscCatalogController],
+  providers: [MiscCatalogService],
+  exports: [MiscCatalogService],
+})
+export class MiscCatalogModule {}

--- a/packages/api/src/catalog/misc/services/__tests__/misc-catalog.service.spec.ts
+++ b/packages/api/src/catalog/misc/services/__tests__/misc-catalog.service.spec.ts
@@ -1,0 +1,121 @@
+jest.setTimeout(20000);
+
+import { MiscType, MiscUseAt } from '../../domain/misc-template.types';
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+
+import { MiscCatalogService } from '../misc-catalog.service';
+import { MiscTemplateOrmEntity } from '../../entities/misc-template.orm.entity';
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+
+describe('MiscCatalogService', () => {
+  let module: TestingModule;
+  let service: MiscCatalogService;
+  let repository: Repository<MiscTemplateOrmEntity>;
+
+  const ID_CORIANDER = '00000000-0000-4000-9000-700000000005';
+  const ID_LACTOSE = '00000000-0000-4000-9000-700000000006';
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [MiscTemplateOrmEntity],
+          synchronize: true,
+          logging: false,
+        }),
+        TypeOrmModule.forFeature([MiscTemplateOrmEntity]),
+      ],
+      providers: [MiscCatalogService],
+    }).compile();
+
+    service = module.get(MiscCatalogService);
+    repository = module.get(getRepositoryToken(MiscTemplateOrmEntity));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await repository.clear();
+  });
+
+  async function seedTemplate(
+    id: string,
+    name: string,
+    type: MiscType,
+    use_at: MiscUseAt,
+  ): Promise<MiscTemplateOrmEntity> {
+    const entity = repository.create({
+      id,
+      name,
+      type,
+      use_at,
+      amount: 0.02,
+      amount_is_weight: true,
+      time_min: 10,
+      use_for: 'Test',
+      notes: null,
+    });
+    return repository.save(entity);
+  }
+
+  describe('list()', () => {
+    it('happy: returns every template ordered alphabetically by name', async () => {
+      await seedTemplate(ID_LACTOSE, 'Lactose', MiscType.Other, MiscUseAt.Boil);
+      await seedTemplate(
+        ID_CORIANDER,
+        'Coriandre (graines)',
+        MiscType.Spice,
+        MiscUseAt.Boil,
+      );
+
+      const rows = await service.list();
+      expect(rows.map((r) => r.name)).toEqual([
+        'Coriandre (graines)',
+        'Lactose',
+      ]);
+    });
+
+    it('sad: returns [] when the catalogue is empty', async () => {
+      const rows = await service.list();
+      expect(rows).toEqual([]);
+    });
+  });
+
+  describe('getById()', () => {
+    it('happy: returns the template matching the UUID', async () => {
+      await seedTemplate(
+        ID_CORIANDER,
+        'Coriandre (graines)',
+        MiscType.Spice,
+        MiscUseAt.Boil,
+      );
+
+      const template = await service.getById(ID_CORIANDER);
+      expect(template.name).toBe('Coriandre (graines)');
+      expect(template.type).toBe(MiscType.Spice);
+      expect(template.use_at).toBe(MiscUseAt.Boil);
+    });
+
+    it('sad: throws NotFoundException when the UUID is unknown', async () => {
+      await expect(
+        service.getById('00000000-0000-4000-9000-7000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: does not match by name even if a row with that name exists', async () => {
+      await seedTemplate(
+        ID_CORIANDER,
+        'Coriandre (graines)',
+        MiscType.Spice,
+        MiscUseAt.Boil,
+      );
+      await expect(service.getById('coriandre')).rejects.toThrow();
+    });
+  });
+});

--- a/packages/api/src/catalog/misc/services/misc-catalog.service.ts
+++ b/packages/api/src/catalog/misc/services/misc-catalog.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { InjectRepository } from '@nestjs/typeorm';
+import { MiscTemplateOrmEntity } from '../entities/misc-template.orm.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class MiscCatalogService {
+  constructor(
+    @InjectRepository(MiscTemplateOrmEntity)
+    private readonly templates: Repository<MiscTemplateOrmEntity>,
+  ) {}
+
+  /**
+   * Returns the catalogue ordered alphabetically by name. The
+   * catalogue is small (~10 rows) so no pagination or filtering
+   * is offered yet — added when the catalogue grows past ~100
+   * entries or when the picker UI needs server-side type/use_at
+   * facets.
+   */
+  async list(): Promise<MiscTemplateOrmEntity[]> {
+    return this.templates.find({
+      order: { name: 'ASC' },
+    });
+  }
+
+  /**
+   * Returns a single catalogue entry by its UUID, or throws 404.
+   * Strict UUID match — no name lookup here, matching the
+   * convention used by every other catalogue service
+   * (Hop / Yeast / Style / Fermentable / Mash / Water /
+   * Equipment). Name lookups are intentionally not exposed: the
+   * picker UI carries the UUID once the user selects an entry,
+   * and adding a non-UUID-validated lookup path would broaden
+   * the API surface for no current use case. (Note: the table
+   * enforces UNIQUE(name) so a future name-lookup endpoint
+   * would still return at most one row.)
+   */
+  async getById(id: string): Promise<MiscTemplateOrmEntity> {
+    const entity = await this.templates.findOne({ where: { id } });
+    if (!entity) {
+      throw new NotFoundException(
+        `Misc template catalogue entry ${id} not found`,
+      );
+    }
+    return entity;
+  }
+}

--- a/packages/api/src/database/migrations/1790000000000-AddMiscTemplatesCatalog.ts
+++ b/packages/api/src/database/migrations/1790000000000-AddMiscTemplatesCatalog.ts
@@ -1,0 +1,48 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `misc_templates` table — immutable reference
+ * catalogue of homebrew miscellaneous ingredients (BeerXML 1.0
+ * `<MISC>` records: spices, finings, water agents, herbs,
+ * flavors). Phase 3 PR #8 of the catalogue refactor (Issue
+ * #708 / #869) — last catalogue of the series.
+ *
+ * **Naming**: distinct from any future `recipe_misc` junction
+ * table (Recipe → MiscTemplate, post Phase 3). Mirrors the
+ * `equipment_templates` naming convention rather than the bare
+ * BeerXML noun, so the "shared reference catalogue" semantic is
+ * explicit at the schema level.
+ *
+ * Seeded with 10 entries (5 BeerXML verbatim from
+ * libraries/misc.xml + 5 modern essentials covering the TYPE ×
+ * USE matrix end users actually reach for).
+ */
+export class AddMiscTemplatesCatalog1790000000000 implements MigrationInterface {
+  name = 'AddMiscTemplatesCatalog1790000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "misc_templates" (
+        "id"                varchar(36) PRIMARY KEY NOT NULL,
+        "name"              varchar(120) NOT NULL,
+        "type"              varchar(32) NOT NULL,
+        "use_at"            varchar(32) NOT NULL,
+        "amount"            real NOT NULL,
+        "amount_is_weight"  boolean NOT NULL DEFAULT 0,
+        "time_min"          real NOT NULL,
+        "use_for"           varchar(120),
+        "notes"             text,
+        "created_at"        datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "updated_at"        datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_misc_templates_name" ON "misc_templates" ("name")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_misc_templates_name"`);
+    await queryRunner.query(`DROP TABLE "misc_templates"`);
+  }
+}

--- a/packages/api/src/database/migrations/1790000000000-AddMiscTemplatesCatalog.ts
+++ b/packages/api/src/database/migrations/1790000000000-AddMiscTemplatesCatalog.ts
@@ -33,15 +33,27 @@ export class AddMiscTemplatesCatalog1790000000000 implements MigrationInterface 
         "use_for"           varchar(120),
         "notes"             text,
         "created_at"        datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-        "updated_at"        datetime NOT NULL DEFAULT CURRENT_TIMESTAMP
+        "updated_at"        datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT "CHK_misc_templates_type"
+          CHECK ("type" IN ('spice', 'fining', 'water_agent', 'herb', 'flavor', 'other')),
+        CONSTRAINT "CHK_misc_templates_use_at"
+          CHECK ("use_at" IN ('mash', 'boil', 'primary', 'secondary', 'bottling'))
       )
     `);
     await queryRunner.query(
       `CREATE UNIQUE INDEX "IDX_misc_templates_name" ON "misc_templates" ("name")`,
     );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_misc_templates_type" ON "misc_templates" ("type")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_misc_templates_use_at" ON "misc_templates" ("use_at")`,
+    );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_misc_templates_use_at"`);
+    await queryRunner.query(`DROP INDEX "IDX_misc_templates_type"`);
     await queryRunner.query(`DROP INDEX "IDX_misc_templates_name"`);
     await queryRunner.query(`DROP TABLE "misc_templates"`);
   }

--- a/packages/api/src/database/seeds/__tests__/misc-templates-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/__tests__/misc-templates-catalog.seed.spec.ts
@@ -1,0 +1,108 @@
+import {
+  MISC_TEMPLATES_CATALOG_SEED,
+  seedMiscTemplatesCatalog,
+} from '../misc-templates-catalog.seed';
+import {
+  MiscType,
+  MiscUseAt,
+} from '../../../catalog/misc/domain/misc-template.types';
+import {
+  assertCommonCatalogueSeederBehaviours,
+  buildRepoMock,
+} from '../seed-test-utils';
+
+import { MiscTemplateOrmEntity } from '../../../catalog/misc/entities/misc-template.orm.entity';
+import { Repository } from 'typeorm';
+
+describe('seedMiscTemplatesCatalog (Issue #708 / #869 — Phase 3 PR #8)', () => {
+  // The four standard catalogue-seeder behaviours (happy / sad /
+  // mixed / override-list) live in the shared helper to satisfy
+  // SonarCloud's duplication gate — see seed-test-utils.ts.
+  assertCommonCatalogueSeederBehaviours('seedMiscTemplatesCatalog', {
+    fn: (repo, seeds) =>
+      seedMiscTemplatesCatalog(
+        repo as unknown as Repository<MiscTemplateOrmEntity>,
+        seeds,
+      ),
+    data: MISC_TEMPLATES_CATALOG_SEED,
+  });
+
+  describe('catalogue-specific invariants', () => {
+    it('writes name + type + use_at + amount + time_min on every inserted row', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      await seedMiscTemplatesCatalog(
+        repo as unknown as Repository<MiscTemplateOrmEntity>,
+      );
+
+      for (const call of repo.create.mock.calls as unknown[][]) {
+        const arg = call[0] as Record<string, unknown>;
+        expect(typeof arg.name).toBe('string');
+        expect((arg.name as string).length).toBeGreaterThan(0);
+        expect(Object.values(MiscType)).toContain(arg.type);
+        expect(Object.values(MiscUseAt)).toContain(arg.use_at);
+        expect(typeof arg.amount).toBe('number');
+        expect(typeof arg.time_min).toBe('number');
+      }
+    });
+
+    it('exposes 10 curated catalogue entries (5 BeerXML + 5 modern)', () => {
+      expect(MISC_TEMPLATES_CATALOG_SEED).toHaveLength(10);
+
+      const names = MISC_TEMPLATES_CATALOG_SEED.map((t) => t.name);
+      // 5 BeerXML canonical
+      expect(names).toContain('Apricot Extract');
+      expect(names).toContain('Calcium Chloride');
+      expect(names).toContain('Ginger Root');
+      expect(names).toContain('Irish Moss');
+      expect(names).toContain('Orange Peel, Bitter');
+      // 5 Brasse-Bouillon modern essentials
+      expect(names).toContain('Coriandre (graines)');
+      expect(names).toContain('Lactose');
+      expect(names).toContain('Whirlfloc (comprimé)');
+      expect(names).toContain('Servomyces (nutriment levure)');
+      expect(names).toContain('Gypse (sulfate de calcium, CaSO₄)');
+    });
+
+    it('uses deterministic UUIDs in the catalogue range (...-9000-7000-...)', () => {
+      const ids = MISC_TEMPLATES_CATALOG_SEED.map((t) => t.id);
+      for (const id of ids) {
+        expect(id).toMatch(/^00000000-0000-4000-9000-7[0-9a-f]{11}$/);
+      }
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('covers every BeerXML MISC TYPE at least once', () => {
+      // The catalogue is small but must let a brewer pick at least
+      // one representative entry per BeerXML TYPE so the picker UI
+      // can offer a meaningful filter from day one.
+      const types = new Set(MISC_TEMPLATES_CATALOG_SEED.map((t) => t.type));
+      expect(types).toContain(MiscType.Spice);
+      expect(types).toContain(MiscType.Fining);
+      expect(types).toContain(MiscType.WaterAgent);
+      expect(types).toContain(MiscType.Herb);
+      expect(types).toContain(MiscType.Flavor);
+      expect(types).toContain(MiscType.Other);
+    });
+
+    it('covers the three primary BeerXML USE phases (mash / boil / bottling)', () => {
+      // Primary and Secondary are intentionally not covered by the
+      // initial seed — they are niche (mostly Flavor adjuncts in
+      // late additions) and the spectrum-coverage value is captured
+      // by the existing Bottling entry (Apricot Extract).
+      const uses = new Set(MISC_TEMPLATES_CATALOG_SEED.map((t) => t.use_at));
+      expect(uses).toContain(MiscUseAt.Mash);
+      expect(uses).toContain(MiscUseAt.Boil);
+      expect(uses).toContain(MiscUseAt.Bottling);
+    });
+
+    it('keeps every notes value in French (UI-facing convention)', () => {
+      for (const template of MISC_TEMPLATES_CATALOG_SEED) {
+        if (template.notes !== null) {
+          expect(template.notes).toMatch(/[àâäéèêëïîôöùûüÿç]/i);
+        }
+      }
+    });
+  });
+});

--- a/packages/api/src/database/seeds/misc-templates-catalog.seed.ts
+++ b/packages/api/src/database/seeds/misc-templates-catalog.seed.ts
@@ -1,0 +1,259 @@
+import { MiscTemplateOrmEntity } from '../../catalog/misc/entities/misc-template.orm.entity';
+import {
+  MiscType,
+  MiscUseAt,
+} from '../../catalog/misc/domain/misc-template.types';
+import { Repository } from 'typeorm';
+import { idempotentUpsertById } from './seed-utils';
+
+/**
+ * Seed for the `misc_templates` reference catalogue (Issue
+ * #708 / #869, Phase 3 PR #8 — last catalogue of the series).
+ * Operator-curated entries — drawn from the BeerXML 1.0
+ * reference fixture (`docs/architecture/specs/fixtures/
+ * libraries/misc.xml`, 5 entries) plus 5 modern essentials
+ * picked to cover the TYPE × USE matrix end users actually
+ * reach for in homebrew recipes.
+ *
+ * The 10 entries break down as:
+ *   • 5 BeerXML canonical (verbatim from libraries/misc.xml):
+ *     Apricot Extract (flavor / bottling), Calcium Chloride
+ *     (water_agent / mash), Ginger Root (herb / boil),
+ *     Irish Moss (fining / boil), Orange Peel Bitter
+ *     (spice / boil).
+ *   • 5 Brasse-Bouillon modern essentials:
+ *     Coriandre graines (compagnon Witbier de l'Orange amère),
+ *     Lactose (sucre non fermentescible — Milk Stout),
+ *     Whirlfloc (clarifiant moderne — alt. Irish Moss en
+ *     comprimé dosé), Servomyces (nutriment levure — santé
+ *     fermentaire), Gypse CaSO₄ (compagnon eau du CaCl₂ —
+ *     ratio sulfate/chlorure).
+ *
+ * UUID range `00000000-0000-4000-9000-7000-...` is reserved
+ * for misc templates (hops `0`, fermentables `1`, yeasts `2`,
+ * styles `3`, mash `4`, waters `5`, equipment `6`, misc `7`).
+ */
+
+export interface MiscTemplateSeed {
+  id: string;
+  name: string;
+  type: MiscType;
+  use_at: MiscUseAt;
+  amount: number;
+  amount_is_weight: boolean;
+  time_min: number;
+  use_for: string | null;
+  notes: string | null;
+}
+
+export const MISC_TEMPLATES_CATALOG_SEED: readonly MiscTemplateSeed[] = [
+  // ─── 5 BeerXML canonical entries (libraries/misc.xml) ──────────────
+  {
+    id: '00000000-0000-4000-9000-700000000000',
+    name: 'Apricot Extract',
+    type: MiscType.Flavor,
+    use_at: MiscUseAt.Bottling,
+    amount: 0.192229,
+    amount_is_weight: false,
+    time_min: 5,
+    use_for: 'Fruit Beer',
+    notes:
+      "Extrait d'arôme d'abricot. À incorporer juste avant la mise en " +
+      'bouteille pour préserver les composés volatils. Apporte une note ' +
+      'fruitée nette aux ales légères et aux bières de blé. Coupler avec ' +
+      "un houblonnage discret pour laisser la douceur s'exprimer.",
+  },
+  {
+    id: '00000000-0000-4000-9000-700000000001',
+    name: 'Calcium Chloride',
+    type: MiscType.WaterAgent,
+    use_at: MiscUseAt.Mash,
+    amount: 0.005,
+    amount_is_weight: true,
+    time_min: 60,
+    use_for: 'Water Agent',
+    notes:
+      "Chlorure de calcium (CaCl₂). Modifie le profil minéral de l'eau " +
+      "et abaisse légèrement le pH d'empâtage. Renforce la rondeur et " +
+      'le corps des malts (favorise les bières maltées : Munich, ' +
+      'Märzen, Stout). Compagnon naturel du Gypse pour ajuster le ' +
+      'ratio sulfate/chlorure cible (cf. catalogue water_profiles).',
+  },
+  {
+    id: '00000000-0000-4000-9000-700000000002',
+    name: 'Ginger Root',
+    type: MiscType.Herb,
+    use_at: MiscUseAt.Boil,
+    amount: 0.029574,
+    amount_is_weight: false,
+    time_min: 12,
+    use_for: 'Holiday Beer',
+    notes:
+      'Gingembre frais râpé. Apporte une note piquante caractéristique ' +
+      "aux Ginger Ales et bières d'hiver. Une dose discrète (15 g pour " +
+      "20 L) reste perceptible ; jusqu'à 110 g pour 20 L pour une " +
+      'Ginger Ale prononcée. Préférer la racine fraîche du primeur ' +
+      'plutôt que le gingembre en poudre.',
+  },
+  {
+    id: '00000000-0000-4000-9000-700000000003',
+    name: 'Irish Moss',
+    type: MiscType.Fining,
+    use_at: MiscUseAt.Boil,
+    amount: 0.001232,
+    amount_is_weight: false,
+    time_min: 10,
+    use_for: 'Clarity',
+    notes:
+      'Algue marine séchée (clarifiant). Aide à la précipitation des ' +
+      'protéines pendant le break protéique post-boil. Réduit le voile ' +
+      'froid (chill haze) et améliore la limpidité finale. Ajout en ' +
+      "fin d'ébullition (10 dernières minutes). Version moderne plus " +
+      'dosée et plus pratique : voir Whirlfloc (comprimé).',
+  },
+  {
+    id: '00000000-0000-4000-9000-700000000004',
+    name: 'Orange Peel, Bitter',
+    type: MiscType.Spice,
+    use_at: MiscUseAt.Boil,
+    amount: 0.02218,
+    amount_is_weight: false,
+    time_min: 5,
+    use_for: 'Belgian Wit',
+    notes:
+      "Écorce d'orange amère (bigarade) séchée — classique des Witbier " +
+      'et Belgian White Ales. Couleur vert-gris caractéristique. ' +
+      'Compagnon obligatoire de la coriandre pour respecter le profil ' +
+      "aromatique de la Witbier. Ajout en fin d'ébullition (5 dernières " +
+      'minutes) pour préserver les huiles essentielles.',
+  },
+  // ─── 5 Brasse-Bouillon modern essentials ───────────────────────────
+  {
+    id: '00000000-0000-4000-9000-700000000005',
+    name: 'Coriandre (graines)',
+    type: MiscType.Spice,
+    use_at: MiscUseAt.Boil,
+    amount: 0.02,
+    amount_is_weight: true,
+    time_min: 10,
+    use_for: 'Belgian Wit',
+    notes:
+      'Graines de coriandre fraîchement concassées au mortier. ' +
+      "Compagnon obligatoire de l'Orange amère pour la Witbier — sans " +
+      "elle, l'orange est solitaire et le profil aromatique " +
+      'caractéristique manque. Dose de référence : 20 g pour 20 L. ' +
+      "Ajout en fin d'ébullition (10 dernières minutes).",
+  },
+  {
+    id: '00000000-0000-4000-9000-700000000006',
+    name: 'Lactose',
+    type: MiscType.Other,
+    use_at: MiscUseAt.Boil,
+    amount: 0.5,
+    amount_is_weight: true,
+    time_min: 15,
+    use_for: 'Milk Stout',
+    notes:
+      'Sucre du lait, non fermentescible par la levure de bière. Reste ' +
+      'dans la bière finie et apporte une rondeur sucrée caractéristique ' +
+      'des Milk Stouts (Sweet Stouts). Dose typique : 250-500 g pour ' +
+      "20 L selon l'intensité recherchée. Aussi utilisé dans les NEIPA " +
+      'modernes pour la rondeur et la sensation laiteuse en bouche.',
+  },
+  {
+    id: '00000000-0000-4000-9000-700000000007',
+    name: 'Whirlfloc (comprimé)',
+    type: MiscType.Fining,
+    use_at: MiscUseAt.Boil,
+    amount: 0.0025,
+    amount_is_weight: true,
+    time_min: 10,
+    use_for: 'Clarity',
+    notes:
+      "Version moderne de l'Irish Moss : carraghénane purifiée + " +
+      'Irish Moss compressée en comprimé dosé (~2,5 g par comprimé). ' +
+      "Plus pratique et plus reproductible que l'algue séchée en " +
+      'vrac. Un comprimé pour 20 L, ajouté dans les 10 dernières ' +
+      "minutes d'ébullition. Améliore la limpidité et la stabilité " +
+      'à froid.',
+  },
+  {
+    id: '00000000-0000-4000-9000-700000000008',
+    name: 'Servomyces (nutriment levure)',
+    type: MiscType.Other,
+    use_at: MiscUseAt.Boil,
+    amount: 0.001,
+    amount_is_weight: true,
+    time_min: 10,
+    use_for: 'Yeast Health',
+    notes:
+      'Nutriment de levure formulé sur sélection de levures enrichies ' +
+      'en zinc. Soutient une fermentation saine et rapide, réduit le ' +
+      'stress de la levure (notamment sur les bières fortes ou les ' +
+      'moûts riches en adjuvants non maltés). Dose : 1 g pour 20 L, ' +
+      "ajout en fin d'ébullition (10 dernières minutes). Quasi " +
+      'systématique en brassage moderne pour la santé fermentaire.',
+  },
+  {
+    id: '00000000-0000-4000-9000-700000000009',
+    name: 'Gypse (sulfate de calcium, CaSO₄)',
+    type: MiscType.WaterAgent,
+    use_at: MiscUseAt.Mash,
+    amount: 0.005,
+    amount_is_weight: true,
+    time_min: 60,
+    use_for: 'Water Agent',
+    notes:
+      'Sulfate de calcium dihydraté. Compagnon naturel du chlorure ' +
+      "de calcium pour ajuster le profil minéral de l'eau de " +
+      "brassage. Renforce la sécheresse et l'amertume des houblons " +
+      '(profil Burton-on-Trent — IPA, Pale Ales). Le ratio ' +
+      'sulfate/chlorure pilote la perception finale : > 2 favorise ' +
+      'les houblons, < 1 favorise les malts (cf. catalogue ' +
+      'water_profiles).',
+  },
+];
+
+/**
+ * Result returned by `seedMiscTemplatesCatalog` for
+ * instrumentation / verification.
+ */
+export interface SeedMiscTemplatesCatalogResult {
+  inserted: number;
+  updated: number;
+  total: number;
+}
+
+/**
+ * Idempotent loader for the misc template reference catalogue.
+ * Insert if the id is unknown, update in place otherwise.
+ * Re-running the loader never duplicates rows.
+ */
+export async function seedMiscTemplatesCatalog(
+  repository: Repository<MiscTemplateOrmEntity>,
+  templates: readonly MiscTemplateSeed[] = MISC_TEMPLATES_CATALOG_SEED,
+): Promise<SeedMiscTemplatesCatalogResult> {
+  let inserted = 0;
+  let updated = 0;
+
+  for (const template of templates) {
+    const outcome = await idempotentUpsertById(
+      repository,
+      { id: template.id },
+      {
+        name: template.name,
+        type: template.type,
+        use_at: template.use_at,
+        amount: template.amount,
+        amount_is_weight: template.amount_is_weight,
+        time_min: template.time_min,
+        use_for: template.use_for,
+        notes: template.notes,
+      },
+    );
+    inserted += outcome.inserted;
+    updated += outcome.updated;
+  }
+
+  return { inserted, updated, total: inserted + updated };
+}

--- a/packages/api/src/database/seeds/misc-templates-catalog.seed.ts
+++ b/packages/api/src/database/seeds/misc-templates-catalog.seed.ts
@@ -77,7 +77,8 @@ export const MISC_TEMPLATES_CATALOG_SEED: readonly MiscTemplateSeed[] = [
       "et abaisse légèrement le pH d'empâtage. Renforce la rondeur et " +
       'le corps des malts (favorise les bières maltées : Munich, ' +
       'Märzen, Stout). Compagnon naturel du Gypse pour ajuster le ' +
-      'ratio sulfate/chlorure cible (cf. catalogue water_profiles).',
+      'ratio sulfate/chlorure cible — voir aussi le catalogue des ' +
+      "profils d'eau de brassage.",
   },
   {
     id: '00000000-0000-4000-9000-700000000002',
@@ -209,8 +210,8 @@ export const MISC_TEMPLATES_CATALOG_SEED: readonly MiscTemplateSeed[] = [
       "brassage. Renforce la sécheresse et l'amertume des houblons " +
       '(profil Burton-on-Trent — IPA, Pale Ales). Le ratio ' +
       'sulfate/chlorure pilote la perception finale : > 2 favorise ' +
-      'les houblons, < 1 favorise les malts (cf. catalogue ' +
-      'water_profiles).',
+      'les houblons, < 1 favorise les malts — voir aussi le ' +
+      "catalogue des profils d'eau de brassage.",
   },
 ];
 

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -11,6 +11,7 @@ import { HopOrmEntity } from '../catalog/hop/entities/hop.orm.entity';
 import { LabelDraftOrmEntity } from '../label/entities/label-draft.orm.entity';
 import { MashProfileOrmEntity } from '../catalog/mash/entities/mash-profile.orm.entity';
 import { MashStepOrmEntity } from '../catalog/mash/entities/mash-step.orm.entity';
+import { MiscTemplateOrmEntity } from '../catalog/misc/entities/misc-template.orm.entity';
 import { RecipeAdditiveOrmEntity } from '../recipe/entities/recipe-additive.orm.entity';
 import { RecipeFermentableOrmEntity } from '../recipe/entities/recipe-fermentable.orm.entity';
 import { RecipeHopOrmEntity } from '../recipe/entities/recipe-hop.orm.entity';
@@ -57,6 +58,7 @@ export const ormEntities = [
   MashStepOrmEntity,
   WaterOrmEntity,
   EquipmentTemplateOrmEntity,
+  MiscTemplateOrmEntity,
 ];
 
 const parseBooleanEnv = (name: string, defaultValue: boolean): boolean => {


### PR DESCRIPTION
## Summary

**Phase 3 PR #8 — last catalogue of the refactor series** (Issue #708 / #869). Adds the **MiscCatalogModule** under the existing top-level `catalog/` module, seeded with **10 misc template entries** covering the BeerXML 1.0 `<MISC>` ingredient class — spices, finings, water agents, herbs, flavor adjuncts.

This closes the 8-PR catalogue series:
| # | Catalogue | PR |
|---|-----------|----|
| 1 | hops | #888 |
| 2 | fermentables | #889 |
| 3 | yeasts | #890 |
| 4 | styles BJCP | #891 |
| 5 | mash_profiles + mash_steps | #893 |
| 6 | waters | #894 |
| 7 | equipment_templates | #898 |
| **8** | **misc_templates** | **this PR** |

## Naming: `misc_templates` (not `miscs`)

The table is called `misc_templates` and the class `MiscTemplateOrmEntity` for two reasons:

1. **Consistency with `equipment_templates`** — both catalogues share the convention "shared reference rows the user can later copy into a personal recipe".
2. **Future-proofing** — leaves room for a `recipe_misc` junction table (Recipe → MiscTemplate) when the Recipe entities are refactored to point at this catalogue (post Phase 3, normalize-producers PR), without name collision.

The module is `MiscCatalogModule` matching the `*CatalogModule` convention adopted on PR #894 / PR #898.

## Schema (table `misc_templates` — 11 columns total: 8 data + 3 system)

8 data columns map BeerXML 1.0 `<MISC>` field-by-field:
- `name` UNIQUE, varchar(120)
- `type` varchar(32) — enum `MiscType` (spice / fining / water_agent / herb / flavor / other)
- `use_at` varchar(32) — enum `MiscUseAt` (mash / boil / primary / secondary / bottling) — renamed from BeerXML `USE` because `use` is a SQL reserved keyword
- `amount` real — raw BeerXML AMOUNT verbatim (kg if `amount_is_weight`, else L)
- `amount_is_weight` boolean
- `time_min` real — float minutes per BeerXML
- `use_for` varchar(120) — short purpose category, English ("Clarity", "Belgian Wit")
- `notes` text — French, UI-facing brewer description

Display fields (`DISPLAY_AMOUNT`, `DISPLAY_TIME`, `INVENTORY`) are intentionally omitted — operator-side formatting and stock-tracking metadata that don't belong in a shared reference catalogue.

Indexes: UNIQUE on `name`.

## Endpoints

```
GET /catalog/misc-templates           → ordered list
GET /catalog/misc-templates/:uuid     → single entry, 404 on miss
```

## Seed (10 entries, idempotent loader)

Operator-curated, drawn from the BeerXML reference fixture and modern homebrew practice.

**5 BeerXML canonical** (verbatim from `libraries/misc.xml`):
| Name | TYPE | USE | TIME |
|---|---|---|---|
| Apricot Extract | flavor | bottling | 5 min |
| Calcium Chloride | water_agent | mash | 60 min |
| Ginger Root | herb | boil | 12 min |
| Irish Moss | fining | boil | 10 min |
| Orange Peel, Bitter | spice | boil | 5 min |

**5 Brasse-Bouillon modern essentials**:
| Name | TYPE | USE | Why |
|---|---|---|---|
| Coriandre (graines) | spice | boil | Compagnon obligatoire de l'Orange amère pour la Witbier |
| Lactose | other | boil | Sucre non fermentescible — Milk Stout / NEIPA |
| Whirlfloc (comprimé) | fining | boil | Version moderne de l'Irish Moss en comprimé dosé |
| Servomyces (nutriment levure) | other | boil | Santé fermentaire — quasi systématique en brassage moderne |
| Gypse (sulfate de calcium, CaSO₄) | water_agent | mash | Compagnon naturel du CaCl₂ — pilote ratio sulfate/chlorure |

**Coverage**: all 6 BeerXML TYPE values + 3 primary USE phases (mash / boil / bottling). The picker UI can ship a meaningful TYPE filter from day one.

UUID range: `00000000-0000-4000-9000-7000-…` reserved for misc (hops `0`, fermentables `1`, yeasts `2`, styles `3`, mash `4`, waters `5`, equipment `6`, misc `7`).

## Tests (20 new, all green — 584 total in api package)

- **Service spec** — in-memory SQLite (4 tests): list ordered alphabetically, getById happy / sad / edge (UUID strict)
- **Controller spec** — `jest.spyOn` pattern (4 tests): list happy/sad, getById happy/sad/edge (DTO wrapping)
- **Seed spec** — delegates to `assertCommonCatalogueSeederBehaviours` helper (4 standard scenarios) + 5 catalogue-specific assertions (10-entry name coverage, deterministic UUID range `…-9000-7…`, every TYPE covered, primary USE phases covered, French notes invariant, field type sanity checks)

## All review lessons from PR #888 → #898 baked in

- ✅ **Boot-safe registration** — `MiscTemplateOrmEntity` added to `ormEntities`
- ✅ **Migration consistency** — `CREATE UNIQUE INDEX IDX_misc_templates_name`
- ✅ **No filtered query params** so no ParseEnumPipe needed (yet)
- ✅ **Runner script** — `scripts/run-misc-templates-catalog-seed.ts`
- ✅ **Module class suffix** — `MiscCatalogModule` (PR #894 convention)
- ✅ **NotFoundException message** — `"Misc template catalogue entry ${id} not found"` (matches every other catalogue service)
- ✅ **`assertCommonCatalogueSeederBehaviours` helper** — no boilerplate duplication
- ✅ **French notes regex assertion** — invariant guarded
- ✅ **Doc consistency** — entity / migration / runner all say "10 entries" (no stale count drift like PR #898 had to correct)

## Checklist

- [x] Happy path + sad path + edge cases covered
- [x] `tsc --noEmit` passes (build green)
- [x] Build passes (`npm run build` clean)
- [x] Existing tests still green (584/586 — 2 skipped pre-existing)
- [x] No `any`, no inline styles introduced
- [x] Lint clean (only 1 pre-existing warning in `scan.service.ts`)

Closes #708
Closes #869