### PR TITLE
feat(catalog/distributor): add distributors + 5 M:N junctions per catalogue (#901)

### DIFF
--- a/packages/api/scripts/run-distributors-catalog-seed.ts
+++ b/packages/api/scripts/run-distributors-catalog-seed.ts
@@ -1,0 +1,38 @@
+/**
+ * One-shot script to seed the `distributors` reference
+ * catalogue with the 12 curated entries from
+ * `DISTRIBUTORS_CATALOG_SEED` against the local dev database
+ * (Issue #901).
+ *
+ * Usage :
+ *   cd packages/api
+ *   npx ts-node -r tsconfig-paths/register scripts/run-distributors-catalog-seed.ts
+ *
+ * Idempotent : safe to run multiple times. Existing distributor
+ * IDs are updated in place; missing ones are inserted.
+ *
+ * Mirror of the per-seed runners shipped in earlier catalogues.
+ * Stopgap until the unified seed orchestrator lands.
+ */
+import 'reflect-metadata';
+
+import dataSource from '../src/database/data-source';
+import { DistributorOrmEntity } from '../src/catalog/distributor/entities/distributor.orm.entity';
+import { seedDistributorsCatalog } from '../src/database/seeds/distributors-catalog.seed';
+
+async function main(): Promise<void> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const repo = dataSource.getRepository(DistributorOrmEntity);
+  const result = await seedDistributorsCatalog(repo);
+  console.log('Distributors catalogue seed:', result);
+
+  await dataSource.destroy();
+}
+
+main().catch((err) => {
+  console.error('Seeding failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/catalog/catalog.module.ts
+++ b/packages/api/src/catalog/catalog.module.ts
@@ -1,3 +1,4 @@
+import { DistributorCatalogModule } from './distributor/distributor.module';
 import { EquipmentCatalogModule } from './equipment/equipment.module';
 import { FermentableModule } from './fermentable/fermentable.module';
 import { HopModule } from './hop/hop.module';
@@ -21,6 +22,13 @@ import { YeastModule } from './yeast/yeast.module';
  * Each sub-module owns its own ORM entity, service, controller,
  * and DTOs. CatalogModule re-exports nothing for now — direct
  * sub-module dependencies are explicit at the consumer side.
+ *
+ * Post-Phase 3 follow-ups (cross-catalogue dimensions) :
+ *   • ProducerCatalogModule — brand owners (FK 1:1, PR #902)
+ *   • DistributorCatalogModule — resellers (M:N junctions per
+ *     catalogue, PR #901). Each per-catalogue module also
+ *     registers its own junction entity in TypeOrmModule.forFeature
+ *     so the per-catalogue service can load distributors directly.
  */
 @Module({
   imports: [
@@ -33,6 +41,7 @@ import { YeastModule } from './yeast/yeast.module';
     EquipmentCatalogModule,
     MiscCatalogModule,
     ProducerCatalogModule,
+    DistributorCatalogModule,
   ],
 })
 export class CatalogModule {}

--- a/packages/api/src/catalog/distributor/controllers/__tests__/distributor-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/distributor/controllers/__tests__/distributor-catalog.controller.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { DistributorCatalogController } from '../distributor-catalog.controller';
+import { DistributorCatalogService } from '../../services/distributor-catalog.service';
+import { DistributorOrmEntity } from '../../entities/distributor.orm.entity';
+import { NotFoundException } from '@nestjs/common';
+
+describe('DistributorCatalogController', () => {
+  let controller: DistributorCatalogController;
+  let service: DistributorCatalogService;
+
+  const ID_BROUWLAND = '00000000-0000-4000-9000-900000000000';
+
+  function buildEntity(
+    overrides: Partial<DistributorOrmEntity> = {},
+  ): DistributorOrmEntity {
+    return {
+      id: ID_BROUWLAND,
+      name: 'Brouwland',
+      country: 'BE',
+      website: 'https://www.brouwland.com',
+      ships_to: JSON.stringify(['BE', 'FR', 'LU', 'NL']),
+      currency_default: 'EUR',
+      notes: 'Distributeur belge historique (Beverlo, fondé 1976).',
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DistributorCatalogController],
+      providers: [
+        {
+          provide: DistributorCatalogService,
+          useValue: { list: jest.fn(), getById: jest.fn() },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(DistributorCatalogController);
+    service = module.get(DistributorCatalogService);
+  });
+
+  describe('GET /catalog/distributors', () => {
+    it('happy: returns the full list mapped to DTOs with ships_to decoded', async () => {
+      const listSpy = jest.spyOn(service, 'list').mockResolvedValue([
+        buildEntity({ name: 'Brouwland' }),
+        buildEntity({
+          id: '00000000-0000-4000-9000-900000000001',
+          name: 'Hopt',
+          country: 'FR',
+          ships_to: JSON.stringify(['FR']),
+        }),
+      ]);
+
+      const result = await controller.list();
+
+      expect(listSpy).toHaveBeenCalledWith();
+      expect(result.map((r) => r.name)).toEqual(['Brouwland', 'Hopt']);
+      // ships_to is decoded from JSON string to string[] on the wire
+      expect(result[0].ships_to).toEqual(['BE', 'FR', 'LU', 'NL']);
+      expect(typeof result[0].created_at).toBe('string');
+    });
+
+    it('sad: returns [] when the service yields no rows', async () => {
+      jest.spyOn(service, 'list').mockResolvedValue([]);
+      const result = await controller.list();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('GET /catalog/distributors/:id', () => {
+    it('happy: returns the DTO for the matching distributor', async () => {
+      const getByIdSpy = jest
+        .spyOn(service, 'getById')
+        .mockResolvedValue(buildEntity());
+
+      const result = await controller.getById(ID_BROUWLAND);
+
+      expect(getByIdSpy).toHaveBeenCalledWith(ID_BROUWLAND);
+      expect(result.id).toBe(ID_BROUWLAND);
+      expect(result.country).toBe('BE');
+      expect(result.currency_default).toBe('EUR');
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getById')
+        .mockRejectedValue(
+          new NotFoundException('Distributor catalogue entry not found'),
+        );
+
+      await expect(
+        controller.getById('00000000-0000-4000-9000-9000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: never leaks the raw ORM entity (always wraps in DTO)', async () => {
+      const entity = buildEntity();
+      jest.spyOn(service, 'getById').mockResolvedValue(entity);
+
+      const result = await controller.getById(ID_BROUWLAND);
+      expect(result).not.toBe(entity);
+      expect(result.constructor.name).toBe('DistributorDto');
+    });
+
+    it('edge: ships_to falls back to [] when the stored JSON is corrupted', async () => {
+      jest
+        .spyOn(service, 'getById')
+        .mockResolvedValue(buildEntity({ ships_to: 'NOT_VALID_JSON' }));
+
+      const result = await controller.getById(ID_BROUWLAND);
+      expect(result.ships_to).toEqual([]);
+    });
+  });
+});

--- a/packages/api/src/catalog/distributor/controllers/distributor-catalog.controller.ts
+++ b/packages/api/src/catalog/distributor/controllers/distributor-catalog.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+} from '@nestjs/swagger';
+
+import { DistributorCatalogService } from '../services/distributor-catalog.service';
+import { DistributorDto } from '../dtos/distributor.dto';
+import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
+
+/**
+ * Read-only HTTP surface for the distributor catalogue.
+ * Two endpoints :
+ *   GET /catalog/distributors          → list all
+ *   GET /catalog/distributors/:uuid    → fetch one by UUID
+ *
+ * The per-product distributor list (e.g. "every distributor
+ * that sells Citra") lives on the per-catalogue controllers as
+ * a sub-route — see `GET /catalog/hops/:id/distributors` and
+ * the equivalents for fermentables / yeasts / misc-templates /
+ * equipment-templates. Keeps each catalogue's HTTP surface
+ * modular instead of introducing a polymorphic shared route.
+ *
+ * Write endpoints (POST / PATCH / DELETE) are intentionally
+ * absent — the catalogue is operator-curated reference data,
+ * not user-managed content.
+ */
+@ApiTags('Catalog · Distributors')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('catalog/distributors')
+export class DistributorCatalogController {
+  constructor(private readonly service: DistributorCatalogService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'List the distributor catalogue entries' })
+  @ApiOkResponse({ type: DistributorDto, isArray: true })
+  async list(): Promise<DistributorDto[]> {
+    const rows = await this.service.list();
+    return rows.map((row) => DistributorDto.fromEntity(row));
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a single distributor by UUID' })
+  @ApiOkResponse({ type: DistributorDto })
+  @ApiNotFoundResponse({
+    description: 'Distributor catalogue entry not found',
+  })
+  async getById(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<DistributorDto> {
+    const entity = await this.service.getById(id);
+    return DistributorDto.fromEntity(entity);
+  }
+}

--- a/packages/api/src/catalog/distributor/distributor.module.ts
+++ b/packages/api/src/catalog/distributor/distributor.module.ts
@@ -1,0 +1,25 @@
+import { DistributorCatalogController } from './controllers/distributor-catalog.controller';
+import { DistributorCatalogService } from './services/distributor-catalog.service';
+import { DistributorOrmEntity } from './entities/distributor.orm.entity';
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+/**
+ * Class names follow the `*Catalog{Module|Service|Controller}`
+ * convention adopted on PR #894 (water) and confirmed across
+ * the rest of the catalogue series. Distributor itself is the
+ * 9th catalogue under this convention.
+ *
+ * The 5 junction entities (`HopDistributorOrmEntity`, etc.)
+ * are NOT registered here — they live in their respective
+ * catalogue modules so each catalogue keeps ownership of its
+ * own data. This module exposes only the distributor surface
+ * itself.
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([DistributorOrmEntity])],
+  controllers: [DistributorCatalogController],
+  providers: [DistributorCatalogService],
+  exports: [DistributorCatalogService],
+})
+export class DistributorCatalogModule {}

--- a/packages/api/src/catalog/distributor/domain/distributor.types.ts
+++ b/packages/api/src/catalog/distributor/domain/distributor.types.ts
@@ -1,0 +1,42 @@
+/**
+ * Domain shape for one distributor entry in the immutable
+ * reference catalogue. Mirrors the `DistributorOrmEntity` row
+ * shape one-to-one.
+ *
+ * **Distributor ≠ Producer**: a producer (issue #900) is the
+ * brand owner — 1 product = 1 producer. A distributor (this
+ * issue #901) is the entity that SELLS the product to the
+ * brewer — 1 product = N distributors. The boutique 'Acheter'
+ * button (#625) lets the brewer pick from the N distributors
+ * who carry the exact catalogue entry, ranked by location,
+ * currency, and (later) price.
+ *
+ * Linked to the 5 catalogue tables via M:N junction tables
+ * (one per catalogue: hop_distributors, fermentable_distributors,
+ * yeast_distributors, misc_template_distributors,
+ * equipment_template_distributors), each carrying the
+ * distributor-specific outbound URL + SKU + per-distributor
+ * notes. See `packages/api/src/catalog/<x>/entities/<x>-distributor.orm.entity.ts`
+ * for the junction shapes.
+ */
+
+export interface DistributorEntry {
+  id: string;
+  name: string;
+  /** ISO 3166-1 alpha-2 (uppercase ASCII), e.g. "FR", "BE", "US". */
+  country: string;
+  website: string;
+  /**
+   * JSON array of ISO 3166-1 alpha-2 country codes the
+   * distributor ships to. Stored as a JSON-encoded string to
+   * stay portable across SQLite (no native JSON column).
+   * Application-side serialisation handles the encode/decode.
+   */
+  ships_to: string[];
+  /** ISO 4217 currency code, e.g. "EUR", "USD", "GBP". */
+  currency_default: string;
+  /** Brewer-friendly description in French (UI-facing). */
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/distributor/domain/distributor.types.ts
+++ b/packages/api/src/catalog/distributor/domain/distributor.types.ts
@@ -1,42 +1,30 @@
 /**
- * Domain shape for one distributor entry in the immutable
- * reference catalogue. Mirrors the `DistributorOrmEntity` row
- * shape one-to-one.
+ * Domain types for the distributor catalogue (Issue #901).
  *
  * **Distributor ≠ Producer**: a producer (issue #900) is the
- * brand owner — 1 product = 1 producer. A distributor (this
- * issue #901) is the entity that SELLS the product to the
- * brewer — 1 product = N distributors. The boutique 'Acheter'
- * button (#625) lets the brewer pick from the N distributors
- * who carry the exact catalogue entry, ranked by location,
- * currency, and (later) price.
+ * brand owner — 1 product = 1 producer. A distributor is the
+ * entity that SELLS the product to the brewer — 1 product = N
+ * distributors. The boutique 'Acheter' button (#625) lets the
+ * brewer pick from the N distributors who carry the exact
+ * catalogue entry, ranked by location, currency, and (later)
+ * price.
  *
  * Linked to the 5 catalogue tables via M:N junction tables
- * (one per catalogue: hop_distributors, fermentable_distributors,
- * yeast_distributors, misc_template_distributors,
- * equipment_template_distributors), each carrying the
+ * (one per catalogue : `hop_distributors`,
+ * `fermentable_distributors`, `yeast_distributors`,
+ * `misc_template_distributors`,
+ * `equipment_template_distributors`), each carrying the
  * distributor-specific outbound URL + SKU + per-distributor
  * notes. See `packages/api/src/catalog/<x>/entities/<x>-distributor.orm.entity.ts`
  * for the junction shapes.
+ *
+ * **Note** : no `DistributorEntry` domain interface is exported
+ * here yet — the ORM entity (`DistributorOrmEntity`) and the
+ * wire DTO (`DistributorDto`) cover the read paths today.
+ * Adding a domain-layer shape would currently be dead code
+ * (Copilot catch on PR #908 review). The interface lands when
+ * an actual application-layer use case needs to round-trip
+ * through a non-ORM shape (e.g. boutique UI builders, future
+ * write paths).
  */
-
-export interface DistributorEntry {
-  id: string;
-  name: string;
-  /** ISO 3166-1 alpha-2 (uppercase ASCII), e.g. "FR", "BE", "US". */
-  country: string;
-  website: string;
-  /**
-   * JSON array of ISO 3166-1 alpha-2 country codes the
-   * distributor ships to. Stored as a JSON-encoded string to
-   * stay portable across SQLite (no native JSON column).
-   * Application-side serialisation handles the encode/decode.
-   */
-  ships_to: string[];
-  /** ISO 4217 currency code, e.g. "EUR", "USD", "GBP". */
-  currency_default: string;
-  /** Brewer-friendly description in French (UI-facing). */
-  notes: string | null;
-  created_at: Date;
-  updated_at: Date;
-}
+export {};

--- a/packages/api/src/catalog/distributor/dtos/catalog-distributor-link.dto.ts
+++ b/packages/api/src/catalog/distributor/dtos/catalog-distributor-link.dto.ts
@@ -1,0 +1,71 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { DistributorDto } from './distributor.dto';
+
+/**
+ * Response shape for the per-catalogue distributor sub-route
+ * (`GET /catalog/<x>/:id/distributors`). Identical shape across
+ * the 5 catalogues — one per junction table — so it lives here
+ * once instead of being duplicated 5×.
+ *
+ * Each row = "this distributor sells this catalogue entry,
+ * here's the outbound product URL". The full distributor info
+ * is nested so the boutique mobile screen can display country
+ * flag + currency + ships_to badges in one round-trip.
+ *
+ * No `created_at`/`updated_at` on the link itself — they're
+ * audit fields without business value for the picker UI.
+ */
+export class CatalogDistributorLinkDto {
+  @ApiProperty({ type: DistributorDto })
+  distributor: DistributorDto;
+
+  @ApiProperty({
+    example: 'https://www.brouwland.com/en/citra-pellets-100g',
+    description:
+      'Outbound deeplink to this distributor’s product page for the ' +
+      'catalogue entry. Always https://.',
+  })
+  product_url: string;
+
+  @ApiProperty({
+    nullable: true,
+    example: 'BRW-CITRA-100',
+    description: 'Distributor-specific SKU when available',
+  })
+  sku: string | null;
+
+  @ApiProperty({ nullable: true })
+  notes_per_distributor: string | null;
+}
+
+/**
+ * Shape of a junction row with its distributor relation eagerly
+ * loaded. Used by the per-catalogue services to type the result
+ * of `find({ relations: ['distributor'] })` before mapping to
+ * the DTO above.
+ */
+export interface CatalogDistributorJunctionRow {
+  distributor_id: string;
+  product_url: string;
+  sku: string | null;
+  notes_per_distributor: string | null;
+  distributor: import('../entities/distributor.orm.entity').DistributorOrmEntity;
+}
+
+/**
+ * Maps one junction row to the wire DTO. The 5 services that
+ * expose `getDistributors(catalogueId)` call this exact mapper
+ * — keeps the wire shape consistent and the conversion in one
+ * place.
+ */
+export function mapJunctionRowToDto(
+  row: CatalogDistributorJunctionRow,
+): CatalogDistributorLinkDto {
+  const dto = new CatalogDistributorLinkDto();
+  dto.distributor = DistributorDto.fromEntity(row.distributor);
+  dto.product_url = row.product_url;
+  dto.sku = row.sku;
+  dto.notes_per_distributor = row.notes_per_distributor;
+  return dto;
+}

--- a/packages/api/src/catalog/distributor/dtos/distributor.dto.ts
+++ b/packages/api/src/catalog/distributor/dtos/distributor.dto.ts
@@ -1,0 +1,80 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { DistributorOrmEntity } from '../entities/distributor.orm.entity';
+
+/**
+ * Read-only response DTO for the distributor catalogue.
+ * Built via `DistributorDto.fromEntity(entity)` so future shape
+ * changes (date serialisation, joined surfaces on the per-
+ * catalogue `:id/distributors` endpoints) stay in this single
+ * conversion point.
+ *
+ * `ships_to` is decoded from its JSON-encoded TEXT storage form
+ * back into a string array on the wire — the API consumer never
+ * sees the raw JSON string.
+ */
+export class DistributorDto {
+  @ApiProperty({ format: 'uuid' })
+  id: string;
+
+  @ApiProperty({ example: 'Brouwland' })
+  name: string;
+
+  @ApiProperty({ example: 'BE', description: 'ISO 3166-1 alpha-2' })
+  country: string;
+
+  @ApiProperty({ example: 'https://www.brouwland.com' })
+  website: string;
+
+  @ApiProperty({
+    type: [String],
+    example: ['FR', 'BE', 'LU', 'CH'],
+    description: 'ISO 3166-1 alpha-2 country codes the distributor ships to',
+  })
+  ships_to: string[];
+
+  @ApiProperty({ example: 'EUR', description: 'ISO 4217 currency code' })
+  currency_default: string;
+
+  @ApiProperty({ nullable: true })
+  notes: string | null;
+
+  @ApiProperty({ format: 'date-time' })
+  created_at: string;
+
+  @ApiProperty({ format: 'date-time' })
+  updated_at: string;
+
+  static fromEntity(entity: DistributorOrmEntity): DistributorDto {
+    const dto = new DistributorDto();
+    dto.id = entity.id;
+    dto.name = entity.name;
+    dto.country = entity.country;
+    dto.website = entity.website;
+    dto.ships_to = parseShipsTo(entity.ships_to);
+    dto.currency_default = entity.currency_default;
+    dto.notes = entity.notes;
+    dto.created_at = entity.created_at.toISOString();
+    dto.updated_at = entity.updated_at.toISOString();
+    return dto;
+  }
+}
+
+/**
+ * Defensive JSON decoder for the `ships_to` TEXT column.
+ * Returns an empty array on any parse failure (corrupted row,
+ * legacy NULL slipped through) rather than throwing — the
+ * boutique surface degrades gracefully (no shipping hint
+ * shown) instead of 500-ing the entire endpoint.
+ */
+function parseShipsTo(raw: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((value): value is string => typeof value === 'string');
+  } catch {
+    return [];
+  }
+}

--- a/packages/api/src/catalog/distributor/entities/distributor.orm.entity.ts
+++ b/packages/api/src/catalog/distributor/entities/distributor.orm.entity.ts
@@ -1,0 +1,86 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+/**
+ * Immutable reference catalogue of brewing-product distributors
+ * (Issue #901). Foundation for the boutique 'Acheter' button
+ * (#625). Seeded with 12 entries spanning FR / BE / UK / US / DE
+ * — the major homebrew shops that carry the catalogue products.
+ *
+ * **Distributor ≠ Producer**: a producer (#900) is the brand
+ * owner (1 product = 1 producer); a distributor is the reseller
+ * (1 product = N distributors). Producers live in `producers`
+ * via 1:1 FK on each catalogue. Distributors live HERE and link
+ * via M:N junction tables (one per catalogue, see
+ * `<x>-distributor.orm.entity.ts`).
+ *
+ * Linked to the 5 catalogue tables via M:N junctions :
+ *   - `hop_distributors`               (Citra → Yakima [producer] → Brewferm/Hopt/MaltMiller [distributors])
+ *   - `fermentable_distributors`
+ *   - `yeast_distributors`
+ *   - `misc_template_distributors`
+ *   - `equipment_template_distributors`
+ *
+ * Each junction row carries the distributor-specific
+ * `product_url` (outbound deeplink to that shop's product page),
+ * optional `sku`, and optional `notes_per_distributor`.
+ */
+@Entity('distributors')
+@Index(['country'])
+export class DistributorOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column({ type: 'varchar', length: 120, nullable: false, unique: true })
+  name: string;
+
+  /**
+   * ISO 3166-1 alpha-2 country code (uppercase ASCII).
+   * Migration applies a CHECK that enforces 2 ASCII letters.
+   */
+  @Column({ type: 'varchar', length: 2, nullable: false })
+  country: string;
+
+  /**
+   * Distributor home page (e.g. `https://www.brouwland.com`).
+   * Migration applies a CHECK that enforces `https://` prefix
+   * — no `http://` (mixed-content risk on the mobile WebView)
+   * and no relative URLs.
+   */
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  website: string;
+
+  /**
+   * JSON-encoded array of ISO 3166-1 alpha-2 codes the
+   * distributor ships to (e.g. `'["FR","BE","LU","CH"]'`).
+   * SQLite has no native JSON column so we store as TEXT and
+   * serialise/deserialise application-side.
+   */
+  @Column({ type: 'text', nullable: false })
+  ships_to: string;
+
+  /**
+   * Default currency the distributor advertises prices in
+   * (ISO 4217, e.g. "EUR", "USD", "GBP"). The boutique button
+   * uses this as a hint when surfacing N distributors so the
+   * brewer can pick a price they understand.
+   */
+  @Column({ type: 'varchar', length: 3, nullable: false })
+  currency_default: string;
+
+  /** Brewer-friendly description in French (UI-facing). */
+  @Column({ type: 'text', nullable: true })
+  notes: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+}

--- a/packages/api/src/catalog/distributor/services/__tests__/distributor-catalog.service.spec.ts
+++ b/packages/api/src/catalog/distributor/services/__tests__/distributor-catalog.service.spec.ts
@@ -1,0 +1,99 @@
+jest.setTimeout(20000);
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
+
+import { DistributorCatalogService } from '../distributor-catalog.service';
+import { DistributorOrmEntity } from '../../entities/distributor.orm.entity';
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+
+describe('DistributorCatalogService', () => {
+  let module: TestingModule;
+  let service: DistributorCatalogService;
+  let repository: Repository<DistributorOrmEntity>;
+
+  const ID_BROUWLAND = '00000000-0000-4000-9000-900000000000';
+  const ID_HOPT = '00000000-0000-4000-9000-900000000001';
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [DistributorOrmEntity],
+          synchronize: true,
+          logging: false,
+        }),
+        TypeOrmModule.forFeature([DistributorOrmEntity]),
+      ],
+      providers: [DistributorCatalogService],
+    }).compile();
+
+    service = module.get(DistributorCatalogService);
+    repository = module.get(getRepositoryToken(DistributorOrmEntity));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  beforeEach(async () => {
+    await repository.clear();
+  });
+
+  async function seedDistributor(
+    id: string,
+    name: string,
+    country: string,
+  ): Promise<DistributorOrmEntity> {
+    const entity = repository.create({
+      id,
+      name,
+      country,
+      website: `https://www.${name.toLowerCase().replace(/\s+/g, '')}.test`,
+      ships_to: JSON.stringify([country]),
+      currency_default: 'EUR',
+      notes: null,
+    });
+    return repository.save(entity);
+  }
+
+  describe('list()', () => {
+    it('happy: returns every distributor ordered alphabetically by name', async () => {
+      await seedDistributor(ID_HOPT, 'Hopt', 'FR');
+      await seedDistributor(ID_BROUWLAND, 'Brouwland', 'BE');
+
+      const rows = await service.list();
+      expect(rows.map((r) => r.name)).toEqual(['Brouwland', 'Hopt']);
+    });
+
+    it('sad: returns [] when the catalogue is empty', async () => {
+      const rows = await service.list();
+      expect(rows).toEqual([]);
+    });
+  });
+
+  describe('getById()', () => {
+    it('happy: returns the distributor matching the UUID', async () => {
+      await seedDistributor(ID_BROUWLAND, 'Brouwland', 'BE');
+
+      const distributor = await service.getById(ID_BROUWLAND);
+      expect(distributor.name).toBe('Brouwland');
+      expect(distributor.country).toBe('BE');
+      expect(distributor.currency_default).toBe('EUR');
+    });
+
+    it('sad: throws NotFoundException when the UUID is unknown', async () => {
+      await expect(
+        service.getById('00000000-0000-4000-9000-9000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: does not match by name even if a row with that name exists', async () => {
+      await seedDistributor(ID_BROUWLAND, 'Brouwland', 'BE');
+      await expect(service.getById('brouwland')).rejects.toThrow();
+    });
+  });
+});

--- a/packages/api/src/catalog/distributor/services/distributor-catalog.service.ts
+++ b/packages/api/src/catalog/distributor/services/distributor-catalog.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { DistributorOrmEntity } from '../entities/distributor.orm.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class DistributorCatalogService {
+  constructor(
+    @InjectRepository(DistributorOrmEntity)
+    private readonly distributors: Repository<DistributorOrmEntity>,
+  ) {}
+
+  /**
+   * Returns the catalogue ordered alphabetically by name. The
+   * catalogue is small (~12 rows initially) so no pagination
+   * or filtering is offered yet — added when the catalogue
+   * grows past ~100 entries or when the boutique UI needs
+   * server-side country / ships_to facets.
+   */
+  async list(): Promise<DistributorOrmEntity[]> {
+    return this.distributors.find({
+      order: { name: 'ASC' },
+    });
+  }
+
+  /**
+   * Returns a single catalogue entry by its UUID, or throws 404.
+   * Strict UUID match — no name lookup here, matching the
+   * convention used by every other catalogue service
+   * (Hop / Yeast / Style / Fermentable / Mash / Water /
+   * Equipment / Misc / Producer). Name lookups are
+   * intentionally not exposed: the picker UI carries the UUID
+   * once the user selects an entry, and adding a non-UUID-
+   * validated lookup path would broaden the API surface for
+   * no current use case.
+   */
+  async getById(id: string): Promise<DistributorOrmEntity> {
+    const entity = await this.distributors.findOne({ where: { id } });
+    if (!entity) {
+      throw new NotFoundException(
+        `Distributor catalogue entry ${id} not found`,
+      );
+    }
+    return entity;
+  }
+}

--- a/packages/api/src/catalog/equipment/controllers/__tests__/equipment-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/equipment/controllers/__tests__/equipment-catalog.controller.spec.ts
@@ -1,7 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { EquipmentCatalogController } from '../equipment-catalog.controller';
 import { EquipmentCatalogService } from '../../services/equipment-catalog.service';
+import { EquipmentTemplateDistributorOrmEntity } from '../../entities/equipment-template-distributor.orm.entity';
 import { EquipmentTemplateOrmEntity } from '../../entities/equipment-template.orm.entity';
 import { NotFoundException } from '@nestjs/common';
 
@@ -37,13 +39,51 @@ describe('EquipmentCatalogController', () => {
     };
   }
 
+  function buildDistributor(
+    overrides: Partial<DistributorOrmEntity> = {},
+  ): DistributorOrmEntity {
+    return {
+      id: '00000000-0000-4000-9000-900000000003',
+      name: 'Brouwland',
+      country: 'BE',
+      website: 'https://www.brouwland.com',
+      ships_to: JSON.stringify(['BE', 'FR', 'NL']),
+      currency_default: 'EUR',
+      notes: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  function buildJunction(
+    overrides: Partial<EquipmentTemplateDistributorOrmEntity> = {},
+  ): EquipmentTemplateDistributorOrmEntity {
+    return {
+      equipment_template_id: ID_GRAINFATHER,
+      distributor_id: '00000000-0000-4000-9000-900000000003',
+      product_url: 'https://www.brouwland.com/grainfather-g30',
+      sku: 'BRW-GF-G30',
+      notes_per_distributor: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      equipment_template: buildEntity(),
+      distributor: buildDistributor(),
+      ...overrides,
+    };
+  }
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [EquipmentCatalogController],
       providers: [
         {
           provide: EquipmentCatalogService,
-          useValue: { list: jest.fn(), getById: jest.fn() },
+          useValue: {
+            list: jest.fn(),
+            getById: jest.fn(),
+            getDistributors: jest.fn(),
+          },
         },
       ],
     }).compile();
@@ -112,6 +152,35 @@ describe('EquipmentCatalogController', () => {
       const result = await controller.getById(ID_GRAINFATHER);
       expect(result).not.toBe(entity);
       expect(result.constructor.name).toBe('EquipmentTemplateDto');
+    });
+  });
+
+  describe('GET /catalog/equipment-templates/:id/distributors (Issue #901)', () => {
+    it('happy: maps junction rows to CatalogDistributorLinkDto with distributor nested', async () => {
+      const getDistributorsSpy = jest
+        .spyOn(service, 'getDistributors')
+        .mockResolvedValue([buildJunction()]);
+
+      const result = await controller.getDistributors(ID_GRAINFATHER);
+
+      expect(getDistributorsSpy).toHaveBeenCalledWith(ID_GRAINFATHER);
+      expect(result).toHaveLength(1);
+      expect(result[0].product_url).toBe(
+        'https://www.brouwland.com/grainfather-g30',
+      );
+      expect(result[0].distributor.name).toBe('Brouwland');
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getDistributors')
+        .mockRejectedValue(
+          new NotFoundException('Equipment template catalogue entry not found'),
+        );
+
+      await expect(
+        controller.getDistributors('00000000-0000-4000-9000-6000000000ff'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/packages/api/src/catalog/equipment/controllers/equipment-catalog.controller.ts
+++ b/packages/api/src/catalog/equipment/controllers/equipment-catalog.controller.ts
@@ -13,6 +13,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import {
+  CatalogDistributorLinkDto,
+  mapJunctionRowToDto,
+} from '../../distributor/dtos/catalog-distributor-link.dto';
 import { EquipmentCatalogService } from '../services/equipment-catalog.service';
 import { EquipmentTemplateDto } from '../dtos/equipment-template.dto';
 import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
@@ -57,5 +61,21 @@ export class EquipmentCatalogController {
   ): Promise<EquipmentTemplateDto> {
     const entity = await this.service.getById(id);
     return EquipmentTemplateDto.fromEntity(entity);
+  }
+
+  @Get(':id/distributors')
+  @ApiOperation({
+    summary:
+      'List distributors that sell this equipment template (boutique foundation)',
+  })
+  @ApiOkResponse({ type: CatalogDistributorLinkDto, isArray: true })
+  @ApiNotFoundResponse({
+    description: 'Equipment template catalogue entry not found',
+  })
+  async getDistributors(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<CatalogDistributorLinkDto[]> {
+    const rows = await this.service.getDistributors(id);
+    return rows.map(mapJunctionRowToDto);
   }
 }

--- a/packages/api/src/catalog/equipment/entities/equipment-template-distributor.orm.entity.ts
+++ b/packages/api/src/catalog/equipment/entities/equipment-template-distributor.orm.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { DistributorOrmEntity } from '../../distributor/entities/distributor.orm.entity';
+import { EquipmentTemplateOrmEntity } from './equipment-template.orm.entity';
+
+/**
+ * M:N junction between equipment templates and distributors
+ * (Issue #901). Mirrors `hop_distributors` — see that docblock
+ * for design rationale.
+ *
+ * Equipment is the only catalogue where one item often costs
+ * 100-2000 € (Grainfather, Klarstein, Anvil), so the boutique
+ * link is even more valuable here than for ingredients (the
+ * brewer compares prices across distributors before clicking
+ * "Acheter").
+ */
+@Entity('equipment_template_distributors')
+export class EquipmentTemplateDistributorOrmEntity {
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  equipment_template_id: string;
+
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  distributor_id: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: false })
+  product_url: string;
+
+  @Column({ type: 'varchar', length: 80, nullable: true })
+  sku: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  notes_per_distributor: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+
+  @ManyToOne(() => EquipmentTemplateOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'equipment_template_id' })
+  equipment_template: EquipmentTemplateOrmEntity;
+
+  @ManyToOne(() => DistributorOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'distributor_id' })
+  distributor: DistributorOrmEntity;
+}

--- a/packages/api/src/catalog/equipment/equipment.module.ts
+++ b/packages/api/src/catalog/equipment/equipment.module.ts
@@ -1,5 +1,6 @@
 import { EquipmentCatalogController } from './controllers/equipment-catalog.controller';
 import { EquipmentCatalogService } from './services/equipment-catalog.service';
+import { EquipmentTemplateDistributorOrmEntity } from './entities/equipment-template-distributor.orm.entity';
 import { EquipmentTemplateOrmEntity } from './entities/equipment-template.orm.entity';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -14,7 +15,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
  * adopted on PR #894 for `WaterCatalogModule`.
  */
 @Module({
-  imports: [TypeOrmModule.forFeature([EquipmentTemplateOrmEntity])],
+  imports: [
+    TypeOrmModule.forFeature([
+      EquipmentTemplateOrmEntity,
+      EquipmentTemplateDistributorOrmEntity,
+    ]),
+  ],
   controllers: [EquipmentCatalogController],
   providers: [EquipmentCatalogService],
   exports: [EquipmentCatalogService],

--- a/packages/api/src/catalog/equipment/services/__tests__/equipment-catalog.service.spec.ts
+++ b/packages/api/src/catalog/equipment/services/__tests__/equipment-catalog.service.spec.ts
@@ -3,7 +3,9 @@ jest.setTimeout(20000);
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { EquipmentCatalogService } from '../equipment-catalog.service';
+import { EquipmentTemplateDistributorOrmEntity } from '../../entities/equipment-template-distributor.orm.entity';
 import { EquipmentTemplateOrmEntity } from '../../entities/equipment-template.orm.entity';
 import { NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
@@ -22,11 +24,19 @@ describe('EquipmentCatalogService', () => {
         TypeOrmModule.forRoot({
           type: 'sqlite',
           database: ':memory:',
-          entities: [EquipmentTemplateOrmEntity],
+          entities: [
+            EquipmentTemplateOrmEntity,
+            DistributorOrmEntity,
+            EquipmentTemplateDistributorOrmEntity,
+          ],
           synchronize: true,
           logging: false,
         }),
-        TypeOrmModule.forFeature([EquipmentTemplateOrmEntity]),
+        TypeOrmModule.forFeature([
+          EquipmentTemplateOrmEntity,
+          DistributorOrmEntity,
+          EquipmentTemplateDistributorOrmEntity,
+        ]),
       ],
       providers: [EquipmentCatalogService],
     }).compile();

--- a/packages/api/src/catalog/equipment/services/__tests__/equipment-catalog.service.spec.ts
+++ b/packages/api/src/catalog/equipment/services/__tests__/equipment-catalog.service.spec.ts
@@ -14,9 +14,12 @@ describe('EquipmentCatalogService', () => {
   let module: TestingModule;
   let service: EquipmentCatalogService;
   let repository: Repository<EquipmentTemplateOrmEntity>;
+  let distributorRepository: Repository<DistributorOrmEntity>;
+  let equipmentDistributorRepository: Repository<EquipmentTemplateDistributorOrmEntity>;
 
   const ID_KITCHEN = '00000000-0000-4000-9000-600000000000';
   const ID_GRAINFATHER = '00000000-0000-4000-9000-600000000005';
+  const ID_BROUWLAND = '00000000-0000-4000-9000-900000000003';
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
@@ -43,6 +46,12 @@ describe('EquipmentCatalogService', () => {
 
     service = module.get(EquipmentCatalogService);
     repository = module.get(getRepositoryToken(EquipmentTemplateOrmEntity));
+    distributorRepository = module.get(
+      getRepositoryToken(DistributorOrmEntity),
+    );
+    equipmentDistributorRepository = module.get(
+      getRepositoryToken(EquipmentTemplateDistributorOrmEntity),
+    );
   });
 
   afterAll(async () => {
@@ -50,8 +59,42 @@ describe('EquipmentCatalogService', () => {
   });
 
   beforeEach(async () => {
+    await equipmentDistributorRepository.clear();
     await repository.clear();
+    await distributorRepository.clear();
   });
+
+  async function seedDistributor(
+    id: string,
+    name: string,
+  ): Promise<DistributorOrmEntity> {
+    const entity = distributorRepository.create({
+      id,
+      name,
+      country: 'BE',
+      website: `https://www.${name.toLowerCase().replace(/\s+/g, '')}.test`,
+      ships_to: JSON.stringify(['BE']),
+      currency_default: 'EUR',
+      notes: null,
+    });
+    return distributorRepository.save(entity);
+  }
+
+  async function linkEquipmentToDistributor(
+    equipmentTemplateId: string,
+    distributorId: string,
+    productUrl: string,
+  ): Promise<void> {
+    await equipmentDistributorRepository.save(
+      equipmentDistributorRepository.create({
+        equipment_template_id: equipmentTemplateId,
+        distributor_id: distributorId,
+        product_url: productUrl,
+        sku: null,
+        notes_per_distributor: null,
+      }),
+    );
+  }
 
   async function seedTemplate(
     id: string,
@@ -115,6 +158,37 @@ describe('EquipmentCatalogService', () => {
     it('edge: does not match by name even if a row with that name exists', async () => {
       await seedTemplate(ID_GRAINFATHER, 'Grainfather G30', 23);
       await expect(service.getById('grainfather-g30')).rejects.toThrow();
+    });
+  });
+
+  describe('getDistributors() — boutique foundation (Issue #901)', () => {
+    it('happy: returns the junction rows with the distributor relation eagerly loaded', async () => {
+      await seedTemplate(ID_GRAINFATHER, 'Grainfather G30', 23);
+      await seedDistributor(ID_BROUWLAND, 'Brouwland');
+      await linkEquipmentToDistributor(
+        ID_GRAINFATHER,
+        ID_BROUWLAND,
+        'https://www.brouwland.com/grainfather-g30',
+      );
+
+      const rows = await service.getDistributors(ID_GRAINFATHER);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].distributor.name).toBe('Brouwland');
+      expect(rows[0].product_url).toBe(
+        'https://www.brouwland.com/grainfather-g30',
+      );
+    });
+
+    it('sad: throws NotFoundException when the equipment UUID is unknown', async () => {
+      await expect(
+        service.getDistributors('00000000-0000-4000-9000-6000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: returns [] when the equipment exists but has no distributors yet', async () => {
+      await seedTemplate(ID_GRAINFATHER, 'Grainfather G30', 23);
+      const rows = await service.getDistributors(ID_GRAINFATHER);
+      expect(rows).toEqual([]);
     });
   });
 });

--- a/packages/api/src/catalog/equipment/services/equipment-catalog.service.ts
+++ b/packages/api/src/catalog/equipment/services/equipment-catalog.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
+import { EquipmentTemplateDistributorOrmEntity } from '../entities/equipment-template-distributor.orm.entity';
 import { EquipmentTemplateOrmEntity } from '../entities/equipment-template.orm.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -9,6 +10,8 @@ export class EquipmentCatalogService {
   constructor(
     @InjectRepository(EquipmentTemplateOrmEntity)
     private readonly templates: Repository<EquipmentTemplateOrmEntity>,
+    @InjectRepository(EquipmentTemplateDistributorOrmEntity)
+    private readonly equipmentDistributors: Repository<EquipmentTemplateDistributorOrmEntity>,
   ) {}
 
   /**
@@ -43,5 +46,24 @@ export class EquipmentCatalogService {
       );
     }
     return entity;
+  }
+
+  /**
+   * Returns the distributors that sell this exact equipment
+   * template, with their per-distributor outbound URL +
+   * optional SKU + notes. Powers the boutique 'Acheter' button
+   * (Issue #901, #625) — particularly valuable on equipment
+   * where one item often costs 100-2000 € so the brewer
+   * compares prices across distributors. Throws 404 if the
+   * equipment UUID is unknown.
+   */
+  async getDistributors(
+    id: string,
+  ): Promise<EquipmentTemplateDistributorOrmEntity[]> {
+    await this.getById(id);
+    return this.equipmentDistributors.find({
+      where: { equipment_template_id: id },
+      relations: ['distributor'],
+    });
   }
 }

--- a/packages/api/src/catalog/fermentable/controllers/__tests__/fermentable-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/fermentable/controllers/__tests__/fermentable-catalog.controller.spec.ts
@@ -1,7 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { FermentableCatalogController } from '../fermentable-catalog.controller';
 import { FermentableCatalogService } from '../../services/fermentable-catalog.service';
+import { FermentableDistributorOrmEntity } from '../../entities/fermentable-distributor.orm.entity';
 import { FermentableOrmEntity } from '../../entities/fermentable.orm.entity';
 import { FermentableType } from '../../domain/enums/fermentable-type.enum';
 import { NotFoundException } from '@nestjs/common';
@@ -41,6 +43,40 @@ describe('FermentableCatalogController', () => {
     };
   }
 
+  function buildDistributor(
+    overrides: Partial<DistributorOrmEntity> = {},
+  ): DistributorOrmEntity {
+    return {
+      id: '00000000-0000-4000-9000-900000000003',
+      name: 'Brouwland',
+      country: 'BE',
+      website: 'https://www.brouwland.com',
+      ships_to: JSON.stringify(['BE', 'FR', 'NL']),
+      currency_default: 'EUR',
+      notes: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  function buildJunction(
+    overrides: Partial<FermentableDistributorOrmEntity> = {},
+  ): FermentableDistributorOrmEntity {
+    return {
+      fermentable_id: ID_PALE,
+      distributor_id: '00000000-0000-4000-9000-900000000003',
+      product_url: 'https://www.brouwland.com/pale-ale-malt-25kg',
+      sku: 'BRW-PALE-25',
+      notes_per_distributor: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      fermentable: buildEntity(),
+      distributor: buildDistributor(),
+      ...overrides,
+    };
+  }
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FermentableCatalogController],
@@ -50,6 +86,7 @@ describe('FermentableCatalogController', () => {
           useValue: {
             list: jest.fn(),
             getById: jest.fn(),
+            getDistributors: jest.fn(),
           },
         },
       ],
@@ -131,6 +168,37 @@ describe('FermentableCatalogController', () => {
 
       expect(result).not.toBe(entity);
       expect(result.constructor.name).toBe('FermentableDto');
+    });
+  });
+
+  describe('GET /catalog/fermentables/:id/distributors (Issue #901)', () => {
+    it('happy: maps junction rows to CatalogDistributorLinkDto with distributor nested', async () => {
+      const getDistributorsSpy = jest
+        .spyOn(service, 'getDistributors')
+        .mockResolvedValue([buildJunction()]);
+
+      const result = await controller.getDistributors(ID_PALE);
+
+      expect(getDistributorsSpy).toHaveBeenCalledWith(ID_PALE);
+      expect(result).toHaveLength(1);
+      expect(result[0].product_url).toBe(
+        'https://www.brouwland.com/pale-ale-malt-25kg',
+      );
+      expect(result[0].sku).toBe('BRW-PALE-25');
+      expect(result[0].distributor.name).toBe('Brouwland');
+      expect(result[0].distributor.ships_to).toEqual(['BE', 'FR', 'NL']);
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getDistributors')
+        .mockRejectedValue(
+          new NotFoundException('Fermentable catalogue entry not found'),
+        );
+
+      await expect(
+        controller.getDistributors('00000000-0000-4000-9000-1000000000ff'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/packages/api/src/catalog/fermentable/controllers/fermentable-catalog.controller.ts
+++ b/packages/api/src/catalog/fermentable/controllers/fermentable-catalog.controller.ts
@@ -16,6 +16,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import {
+  CatalogDistributorLinkDto,
+  mapJunctionRowToDto,
+} from '../../distributor/dtos/catalog-distributor-link.dto';
 import { FermentableCatalogService } from '../services/fermentable-catalog.service';
 import { FermentableDto } from '../dtos/fermentable.dto';
 import { FermentableType } from '../domain/enums/fermentable-type.enum';
@@ -66,5 +70,19 @@ export class FermentableCatalogController {
   ): Promise<FermentableDto> {
     const entity = await this.service.getById(id);
     return FermentableDto.fromEntity(entity);
+  }
+
+  @Get(':id/distributors')
+  @ApiOperation({
+    summary:
+      'List distributors that sell this fermentable (boutique foundation)',
+  })
+  @ApiOkResponse({ type: CatalogDistributorLinkDto, isArray: true })
+  @ApiNotFoundResponse({ description: 'Fermentable catalogue entry not found' })
+  async getDistributors(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<CatalogDistributorLinkDto[]> {
+    const rows = await this.service.getDistributors(id);
+    return rows.map(mapJunctionRowToDto);
   }
 }

--- a/packages/api/src/catalog/fermentable/entities/fermentable-distributor.orm.entity.ts
+++ b/packages/api/src/catalog/fermentable/entities/fermentable-distributor.orm.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { DistributorOrmEntity } from '../../distributor/entities/distributor.orm.entity';
+import { FermentableOrmEntity } from './fermentable.orm.entity';
+
+/**
+ * M:N junction between fermentables and distributors
+ * (Issue #901). Mirrors the `hop_distributors` shape exactly
+ * — see the docblock there for the design rationale (composite
+ * PK, ON DELETE CASCADE both sides, https-only product URLs).
+ */
+@Entity('fermentable_distributors')
+export class FermentableDistributorOrmEntity {
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  fermentable_id: string;
+
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  distributor_id: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: false })
+  product_url: string;
+
+  @Column({ type: 'varchar', length: 80, nullable: true })
+  sku: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  notes_per_distributor: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+
+  @ManyToOne(() => FermentableOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'fermentable_id' })
+  fermentable: FermentableOrmEntity;
+
+  @ManyToOne(() => DistributorOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'distributor_id' })
+  distributor: DistributorOrmEntity;
+}

--- a/packages/api/src/catalog/fermentable/fermentable.module.ts
+++ b/packages/api/src/catalog/fermentable/fermentable.module.ts
@@ -1,11 +1,17 @@
 import { FermentableCatalogController } from './controllers/fermentable-catalog.controller';
 import { FermentableCatalogService } from './services/fermentable-catalog.service';
+import { FermentableDistributorOrmEntity } from './entities/fermentable-distributor.orm.entity';
 import { FermentableOrmEntity } from './entities/fermentable.orm.entity';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([FermentableOrmEntity])],
+  imports: [
+    TypeOrmModule.forFeature([
+      FermentableOrmEntity,
+      FermentableDistributorOrmEntity,
+    ]),
+  ],
   controllers: [FermentableCatalogController],
   providers: [FermentableCatalogService],
   exports: [FermentableCatalogService],

--- a/packages/api/src/catalog/fermentable/services/__tests__/fermentable-catalog.service.spec.ts
+++ b/packages/api/src/catalog/fermentable/services/__tests__/fermentable-catalog.service.spec.ts
@@ -22,10 +22,13 @@ describe('FermentableCatalogService', () => {
   let module: TestingModule;
   let service: FermentableCatalogService;
   let repository: Repository<FermentableOrmEntity>;
+  let distributorRepository: Repository<DistributorOrmEntity>;
+  let fermentableDistributorRepository: Repository<FermentableDistributorOrmEntity>;
 
   const ID_ACID = '00000000-0000-4000-9000-100000000001';
   const ID_PILSNER = '00000000-0000-4000-9000-100000000006';
   const ID_SUCROSE = '00000000-0000-4000-9000-100000000011';
+  const ID_BROUWLAND = '00000000-0000-4000-9000-900000000003';
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
@@ -52,6 +55,12 @@ describe('FermentableCatalogService', () => {
 
     service = module.get(FermentableCatalogService);
     repository = module.get(getRepositoryToken(FermentableOrmEntity));
+    distributorRepository = module.get(
+      getRepositoryToken(DistributorOrmEntity),
+    );
+    fermentableDistributorRepository = module.get(
+      getRepositoryToken(FermentableDistributorOrmEntity),
+    );
   });
 
   afterAll(async () => {
@@ -59,8 +68,42 @@ describe('FermentableCatalogService', () => {
   });
 
   beforeEach(async () => {
+    await fermentableDistributorRepository.clear();
     await repository.clear();
+    await distributorRepository.clear();
   });
+
+  async function seedDistributor(
+    id: string,
+    name: string,
+  ): Promise<DistributorOrmEntity> {
+    const entity = distributorRepository.create({
+      id,
+      name,
+      country: 'BE',
+      website: `https://www.${name.toLowerCase().replace(/\s+/g, '')}.test`,
+      ships_to: JSON.stringify(['BE']),
+      currency_default: 'EUR',
+      notes: null,
+    });
+    return distributorRepository.save(entity);
+  }
+
+  async function linkFermentableToDistributor(
+    fermentableId: string,
+    distributorId: string,
+    productUrl: string,
+  ): Promise<void> {
+    await fermentableDistributorRepository.save(
+      fermentableDistributorRepository.create({
+        fermentable_id: fermentableId,
+        distributor_id: distributorId,
+        product_url: productUrl,
+        sku: null,
+        notes_per_distributor: null,
+      }),
+    );
+  }
 
   async function seedFermentable(
     id: string,
@@ -132,6 +175,37 @@ describe('FermentableCatalogService', () => {
 
       // Strict UUID PK lookup — name-shaped strings still 404.
       await expect(service.getById('acid-malt')).rejects.toThrow();
+    });
+  });
+
+  describe('getDistributors() — boutique foundation (Issue #901)', () => {
+    it('happy: returns the junction rows with the distributor relation eagerly loaded', async () => {
+      await seedFermentable(ID_PILSNER, 'Pilsner Malt', FermentableType.GRAIN);
+      await seedDistributor(ID_BROUWLAND, 'Brouwland');
+      await linkFermentableToDistributor(
+        ID_PILSNER,
+        ID_BROUWLAND,
+        'https://www.brouwland.com/pilsner-malt-25kg',
+      );
+
+      const rows = await service.getDistributors(ID_PILSNER);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].distributor.name).toBe('Brouwland');
+      expect(rows[0].product_url).toBe(
+        'https://www.brouwland.com/pilsner-malt-25kg',
+      );
+    });
+
+    it('sad: throws NotFoundException when the fermentable UUID is unknown', async () => {
+      await expect(
+        service.getDistributors('00000000-0000-4000-9000-1000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: returns [] when the fermentable exists but has no distributors yet', async () => {
+      await seedFermentable(ID_PILSNER, 'Pilsner Malt', FermentableType.GRAIN);
+      const rows = await service.getDistributors(ID_PILSNER);
+      expect(rows).toEqual([]);
     });
   });
 });

--- a/packages/api/src/catalog/fermentable/services/__tests__/fermentable-catalog.service.spec.ts
+++ b/packages/api/src/catalog/fermentable/services/__tests__/fermentable-catalog.service.spec.ts
@@ -3,7 +3,9 @@ jest.setTimeout(20000);
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { FermentableCatalogService } from '../fermentable-catalog.service';
+import { FermentableDistributorOrmEntity } from '../../entities/fermentable-distributor.orm.entity';
 import { FermentableOrmEntity } from '../../entities/fermentable.orm.entity';
 import { FermentableType } from '../../domain/enums/fermentable-type.enum';
 import { NotFoundException } from '@nestjs/common';
@@ -31,11 +33,19 @@ describe('FermentableCatalogService', () => {
         TypeOrmModule.forRoot({
           type: 'sqlite',
           database: ':memory:',
-          entities: [FermentableOrmEntity],
+          entities: [
+            FermentableOrmEntity,
+            DistributorOrmEntity,
+            FermentableDistributorOrmEntity,
+          ],
           synchronize: true,
           logging: false,
         }),
-        TypeOrmModule.forFeature([FermentableOrmEntity]),
+        TypeOrmModule.forFeature([
+          FermentableOrmEntity,
+          DistributorOrmEntity,
+          FermentableDistributorOrmEntity,
+        ]),
       ],
       providers: [FermentableCatalogService],
     }).compile();

--- a/packages/api/src/catalog/fermentable/services/fermentable-catalog.service.ts
+++ b/packages/api/src/catalog/fermentable/services/fermentable-catalog.service.ts
@@ -1,6 +1,7 @@
 import { FindOptionsWhere, Repository } from 'typeorm';
 import { Injectable, NotFoundException } from '@nestjs/common';
 
+import { FermentableDistributorOrmEntity } from '../entities/fermentable-distributor.orm.entity';
 import { FermentableOrmEntity } from '../entities/fermentable.orm.entity';
 import { FermentableType } from '../domain/enums/fermentable-type.enum';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -18,6 +19,8 @@ export class FermentableCatalogService {
   constructor(
     @InjectRepository(FermentableOrmEntity)
     private readonly fermentables: Repository<FermentableOrmEntity>,
+    @InjectRepository(FermentableDistributorOrmEntity)
+    private readonly fermentableDistributors: Repository<FermentableDistributorOrmEntity>,
   ) {}
 
   /**
@@ -52,5 +55,21 @@ export class FermentableCatalogService {
       );
     }
     return entity;
+  }
+
+  /**
+   * Returns the distributors that sell this exact fermentable,
+   * with their per-distributor outbound URL + optional SKU +
+   * notes. Powers the boutique 'Acheter' button (Issue #901,
+   * #625). Throws 404 if the fermentable UUID is unknown.
+   */
+  async getDistributors(
+    id: string,
+  ): Promise<FermentableDistributorOrmEntity[]> {
+    await this.getById(id);
+    return this.fermentableDistributors.find({
+      where: { fermentable_id: id },
+      relations: ['distributor'],
+    });
   }
 }

--- a/packages/api/src/catalog/hop/controllers/__tests__/hop-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/hop/controllers/__tests__/hop-catalog.controller.spec.ts
@@ -1,7 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { HopCatalogController } from '../hop-catalog.controller';
 import { HopCatalogService } from '../../services/hop-catalog.service';
+import { HopDistributorOrmEntity } from '../../entities/hop-distributor.orm.entity';
 import { HopForm } from '../../domain/enums/hop-form.enum';
 import { HopOrmEntity } from '../../entities/hop.orm.entity';
 import { HopUsageType } from '../../domain/enums/hop-usage-type.enum';
@@ -39,6 +41,40 @@ describe('HopCatalogController', () => {
     };
   }
 
+  function buildDistributor(
+    overrides: Partial<DistributorOrmEntity> = {},
+  ): DistributorOrmEntity {
+    return {
+      id: '00000000-0000-4000-9000-900000000003',
+      name: 'Brouwland',
+      country: 'BE',
+      website: 'https://www.brouwland.com',
+      ships_to: JSON.stringify(['BE', 'FR', 'NL']),
+      currency_default: 'EUR',
+      notes: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  function buildJunction(
+    overrides: Partial<HopDistributorOrmEntity> = {},
+  ): HopDistributorOrmEntity {
+    return {
+      hop_id: ID_CASCADE,
+      distributor_id: '00000000-0000-4000-9000-900000000003',
+      product_url: 'https://www.brouwland.com/cascade-100g',
+      sku: 'BRW-CASCADE-100',
+      notes_per_distributor: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      hop: buildEntity(),
+      distributor: buildDistributor(),
+      ...overrides,
+    };
+  }
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [HopCatalogController],
@@ -48,6 +84,7 @@ describe('HopCatalogController', () => {
           useValue: {
             list: jest.fn(),
             getById: jest.fn(),
+            getDistributors: jest.fn(),
           },
         },
       ],
@@ -132,6 +169,38 @@ describe('HopCatalogController', () => {
       // The DTO is a separate object — never the entity itself.
       expect(result).not.toBe(entity);
       expect(result.constructor.name).toBe('HopDto');
+    });
+  });
+
+  describe('GET /catalog/hops/:id/distributors (Issue #901)', () => {
+    it('happy: maps junction rows to CatalogDistributorLinkDto with distributor nested', async () => {
+      const getDistributorsSpy = jest
+        .spyOn(service, 'getDistributors')
+        .mockResolvedValue([buildJunction()]);
+
+      const result = await controller.getDistributors(ID_CASCADE);
+
+      expect(getDistributorsSpy).toHaveBeenCalledWith(ID_CASCADE);
+      expect(result).toHaveLength(1);
+      expect(result[0].product_url).toBe(
+        'https://www.brouwland.com/cascade-100g',
+      );
+      expect(result[0].sku).toBe('BRW-CASCADE-100');
+      expect(result[0].distributor.name).toBe('Brouwland');
+      // ships_to is decoded from JSON string to string[] on the wire
+      expect(result[0].distributor.ships_to).toEqual(['BE', 'FR', 'NL']);
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getDistributors')
+        .mockRejectedValue(
+          new NotFoundException('Hop catalogue entry not found'),
+        );
+
+      await expect(
+        controller.getDistributors('00000000-0000-4000-9000-0000000000ff'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/packages/api/src/catalog/hop/controllers/hop-catalog.controller.ts
+++ b/packages/api/src/catalog/hop/controllers/hop-catalog.controller.ts
@@ -16,6 +16,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import {
+  CatalogDistributorLinkDto,
+  mapJunctionRowToDto,
+} from '../../distributor/dtos/catalog-distributor-link.dto';
 import { HopCatalogService } from '../services/hop-catalog.service';
 import { HopDto } from '../dtos/hop.dto';
 import { HopForm } from '../domain/enums/hop-form.enum';
@@ -71,5 +75,18 @@ export class HopCatalogController {
   async getById(@Param('id', new ParseUUIDPipe()) id: string): Promise<HopDto> {
     const entity = await this.service.getById(id);
     return HopDto.fromEntity(entity);
+  }
+
+  @Get(':id/distributors')
+  @ApiOperation({
+    summary: 'List distributors that sell this hop (boutique foundation)',
+  })
+  @ApiOkResponse({ type: CatalogDistributorLinkDto, isArray: true })
+  @ApiNotFoundResponse({ description: 'Hop catalogue entry not found' })
+  async getDistributors(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<CatalogDistributorLinkDto[]> {
+    const rows = await this.service.getDistributors(id);
+    return rows.map(mapJunctionRowToDto);
   }
 }

--- a/packages/api/src/catalog/hop/entities/hop-distributor.orm.entity.ts
+++ b/packages/api/src/catalog/hop/entities/hop-distributor.orm.entity.ts
@@ -1,0 +1,79 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { DistributorOrmEntity } from '../../distributor/entities/distributor.orm.entity';
+import { HopOrmEntity } from './hop.orm.entity';
+
+/**
+ * M:N junction between hops and distributors (Issue #901).
+ * One row = "this distributor sells this hop, here's the
+ * outbound product page URL".
+ *
+ * **Composite primary key on (hop_id, distributor_id)** —
+ * canonical M:N pattern. The junction has no business meaning
+ * beyond the link itself; the per-row business fields
+ * (`product_url`, `sku`, `notes_per_distributor`) are
+ * attributes of the link, not of a separately addressable
+ * entity. No surrogate UUID needed.
+ *
+ * **ON DELETE CASCADE on both sides**: if the hop is removed
+ * (rare — catalogue tables are append-only) or the distributor
+ * goes out of business, the link goes too. No orphan junction
+ * rows possible.
+ *
+ * **Pattern precedent**: this PR sets the M:N junction pattern
+ * for the codebase. The 4 sibling junctions
+ * (`fermentable_distributors`, `yeast_distributors`,
+ * `misc_template_distributors`, `equipment_template_distributors`)
+ * mirror this exact shape.
+ */
+@Entity('hop_distributors')
+export class HopDistributorOrmEntity {
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  hop_id: string;
+
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  distributor_id: string;
+
+  /**
+   * Outbound deeplink to the distributor's product page for
+   * this exact hop. Migration applies a CHECK that enforces
+   * `https://` prefix — no `http://` (mixed-content risk on
+   * the mobile WebView) and no relative URLs.
+   */
+  @Column({ type: 'varchar', length: 500, nullable: false })
+  product_url: string;
+
+  /**
+   * Distributor-specific SKU when the brewer needs to copy it
+   * (e.g. for a phone order). Optional — most boutique shops
+   * surface URLs but not always machine-readable SKUs.
+   */
+  @Column({ type: 'varchar', length: 80, nullable: true })
+  sku: string | null;
+
+  /** Brewer-friendly note in French (UI-facing, optional). */
+  @Column({ type: 'text', nullable: true })
+  notes_per_distributor: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+
+  @ManyToOne(() => HopOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'hop_id' })
+  hop: HopOrmEntity;
+
+  @ManyToOne(() => DistributorOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'distributor_id' })
+  distributor: DistributorOrmEntity;
+}

--- a/packages/api/src/catalog/hop/hop.module.ts
+++ b/packages/api/src/catalog/hop/hop.module.ts
@@ -1,11 +1,12 @@
 import { HopCatalogController } from './controllers/hop-catalog.controller';
 import { HopCatalogService } from './services/hop-catalog.service';
+import { HopDistributorOrmEntity } from './entities/hop-distributor.orm.entity';
 import { HopOrmEntity } from './entities/hop.orm.entity';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([HopOrmEntity])],
+  imports: [TypeOrmModule.forFeature([HopOrmEntity, HopDistributorOrmEntity])],
   controllers: [HopCatalogController],
   providers: [HopCatalogService],
   exports: [HopCatalogService],

--- a/packages/api/src/catalog/hop/services/__tests__/hop-catalog.service.spec.ts
+++ b/packages/api/src/catalog/hop/services/__tests__/hop-catalog.service.spec.ts
@@ -57,7 +57,9 @@ describe('HopCatalogService', () => {
 
     service = module.get(HopCatalogService);
     repository = module.get(getRepositoryToken(HopOrmEntity));
-    distributorRepository = module.get(getRepositoryToken(DistributorOrmEntity));
+    distributorRepository = module.get(
+      getRepositoryToken(DistributorOrmEntity),
+    );
     hopDistributorRepository = module.get(
       getRepositoryToken(HopDistributorOrmEntity),
     );

--- a/packages/api/src/catalog/hop/services/__tests__/hop-catalog.service.spec.ts
+++ b/packages/api/src/catalog/hop/services/__tests__/hop-catalog.service.spec.ts
@@ -3,7 +3,9 @@ jest.setTimeout(20000);
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { HopCatalogService } from '../hop-catalog.service';
+import { HopDistributorOrmEntity } from '../../entities/hop-distributor.orm.entity';
 import { HopForm } from '../../domain/enums/hop-form.enum';
 import { HopOrmEntity } from '../../entities/hop.orm.entity';
 import { HopUsageType } from '../../domain/enums/hop-usage-type.enum';
@@ -21,10 +23,14 @@ describe('HopCatalogService', () => {
   let module: TestingModule;
   let service: HopCatalogService;
   let repository: Repository<HopOrmEntity>;
+  let distributorRepository: Repository<DistributorOrmEntity>;
+  let hopDistributorRepository: Repository<HopDistributorOrmEntity>;
 
   const ID_CASCADE = '00000000-0000-4000-9000-000000000001';
   const ID_GALENA = '00000000-0000-4000-9000-000000000002';
   const ID_TETTNANG = '00000000-0000-4000-9000-000000000005';
+  const ID_BROUWLAND = '00000000-0000-4000-9000-900000000003';
+  const ID_HOPT = '00000000-0000-4000-9000-900000000001';
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
@@ -32,17 +38,29 @@ describe('HopCatalogService', () => {
         TypeOrmModule.forRoot({
           type: 'sqlite',
           database: ':memory:',
-          entities: [HopOrmEntity],
+          entities: [
+            HopOrmEntity,
+            DistributorOrmEntity,
+            HopDistributorOrmEntity,
+          ],
           synchronize: true,
           logging: false,
         }),
-        TypeOrmModule.forFeature([HopOrmEntity]),
+        TypeOrmModule.forFeature([
+          HopOrmEntity,
+          DistributorOrmEntity,
+          HopDistributorOrmEntity,
+        ]),
       ],
       providers: [HopCatalogService],
     }).compile();
 
     service = module.get(HopCatalogService);
     repository = module.get(getRepositoryToken(HopOrmEntity));
+    distributorRepository = module.get(getRepositoryToken(DistributorOrmEntity));
+    hopDistributorRepository = module.get(
+      getRepositoryToken(HopDistributorOrmEntity),
+    );
   });
 
   afterAll(async () => {
@@ -50,8 +68,42 @@ describe('HopCatalogService', () => {
   });
 
   beforeEach(async () => {
+    await hopDistributorRepository.clear();
     await repository.clear();
+    await distributorRepository.clear();
   });
+
+  async function seedDistributor(
+    id: string,
+    name: string,
+  ): Promise<DistributorOrmEntity> {
+    const entity = distributorRepository.create({
+      id,
+      name,
+      country: 'BE',
+      website: `https://www.${name.toLowerCase().replace(/\s+/g, '')}.test`,
+      ships_to: JSON.stringify(['BE']),
+      currency_default: 'EUR',
+      notes: null,
+    });
+    return distributorRepository.save(entity);
+  }
+
+  async function linkHopToDistributor(
+    hopId: string,
+    distributorId: string,
+    productUrl: string,
+  ): Promise<void> {
+    await hopDistributorRepository.save(
+      hopDistributorRepository.create({
+        hop_id: hopId,
+        distributor_id: distributorId,
+        product_url: productUrl,
+        sku: null,
+        notes_per_distributor: null,
+      }),
+    );
+  }
 
   async function seedHop(
     id: string,
@@ -150,6 +202,46 @@ describe('HopCatalogService', () => {
       // means this still 404s. Catalog name lookups must go through
       // list(), not getById().
       await expect(service.getById('cascade')).rejects.toThrow();
+    });
+  });
+
+  describe('getDistributors() — boutique foundation (Issue #901)', () => {
+    it('happy: returns the junction rows with the distributor relation eagerly loaded', async () => {
+      await seedHop(ID_CASCADE, 'Cascade', HopUsageType.BOTH);
+      await seedDistributor(ID_BROUWLAND, 'Brouwland');
+      await seedDistributor(ID_HOPT, 'Hopt');
+      await linkHopToDistributor(
+        ID_CASCADE,
+        ID_BROUWLAND,
+        'https://www.brouwland.com/cascade-100g',
+      );
+      await linkHopToDistributor(
+        ID_CASCADE,
+        ID_HOPT,
+        'https://www.hopt.fr/cascade',
+      );
+
+      const rows = await service.getDistributors(ID_CASCADE);
+      expect(rows).toHaveLength(2);
+      expect(rows.map((r) => r.distributor.name).sort()).toEqual([
+        'Brouwland',
+        'Hopt',
+      ]);
+      expect(
+        rows.find((r) => r.distributor.name === 'Brouwland')?.product_url,
+      ).toBe('https://www.brouwland.com/cascade-100g');
+    });
+
+    it('sad: throws NotFoundException when the hop UUID is unknown', async () => {
+      await expect(
+        service.getDistributors('00000000-0000-4000-9000-0000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: returns [] when the hop exists but has no distributors yet', async () => {
+      await seedHop(ID_CASCADE, 'Cascade', HopUsageType.BOTH);
+      const rows = await service.getDistributors(ID_CASCADE);
+      expect(rows).toEqual([]);
     });
   });
 });

--- a/packages/api/src/catalog/hop/services/hop-catalog.service.ts
+++ b/packages/api/src/catalog/hop/services/hop-catalog.service.ts
@@ -1,6 +1,7 @@
 import { FindOptionsWhere, Repository } from 'typeorm';
 import { Injectable, NotFoundException } from '@nestjs/common';
 
+import { HopDistributorOrmEntity } from '../entities/hop-distributor.orm.entity';
 import { HopForm } from '../domain/enums/hop-form.enum';
 import { HopOrmEntity } from '../entities/hop.orm.entity';
 import { HopUsageType } from '../domain/enums/hop-usage-type.enum';
@@ -20,6 +21,8 @@ export class HopCatalogService {
   constructor(
     @InjectRepository(HopOrmEntity)
     private readonly hops: Repository<HopOrmEntity>,
+    @InjectRepository(HopDistributorOrmEntity)
+    private readonly hopDistributors: Repository<HopDistributorOrmEntity>,
   ) {}
 
   /**
@@ -51,5 +54,28 @@ export class HopCatalogService {
       throw new NotFoundException(`Hop catalogue entry ${id} not found`);
     }
     return entity;
+  }
+
+  /**
+   * Returns the distributors that sell this exact hop, with
+   * their per-distributor outbound URL + optional SKU + notes.
+   * Powers the boutique 'Acheter' button (Issue #901, #625).
+   *
+   * Throws 404 if the hop UUID is unknown — this short-circuits
+   * before the join so the caller gets a clear error instead of
+   * an empty list (which would be ambiguous : "no distributors
+   * yet" vs "wrong hop ID").
+   *
+   * Junction rows are loaded with the `distributor` relation
+   * eagerly resolved so the controller can wire-shape the
+   * full distributor surface (country, ships_to, currency)
+   * in a single round-trip.
+   */
+  async getDistributors(id: string): Promise<HopDistributorOrmEntity[]> {
+    await this.getById(id);
+    return this.hopDistributors.find({
+      where: { hop_id: id },
+      relations: ['distributor'],
+    });
   }
 }

--- a/packages/api/src/catalog/misc/controllers/__tests__/misc-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/misc/controllers/__tests__/misc-catalog.controller.spec.ts
@@ -1,8 +1,10 @@
 import { MiscType, MiscUseAt } from '../../domain/misc-template.types';
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { MiscCatalogController } from '../misc-catalog.controller';
 import { MiscCatalogService } from '../../services/misc-catalog.service';
+import { MiscTemplateDistributorOrmEntity } from '../../entities/misc-template-distributor.orm.entity';
 import { MiscTemplateOrmEntity } from '../../entities/misc-template.orm.entity';
 import { NotFoundException } from '@nestjs/common';
 
@@ -31,13 +33,51 @@ describe('MiscCatalogController', () => {
     };
   }
 
+  function buildDistributor(
+    overrides: Partial<DistributorOrmEntity> = {},
+  ): DistributorOrmEntity {
+    return {
+      id: '00000000-0000-4000-9000-900000000003',
+      name: 'Brouwland',
+      country: 'BE',
+      website: 'https://www.brouwland.com',
+      ships_to: JSON.stringify(['BE', 'FR', 'NL']),
+      currency_default: 'EUR',
+      notes: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  function buildJunction(
+    overrides: Partial<MiscTemplateDistributorOrmEntity> = {},
+  ): MiscTemplateDistributorOrmEntity {
+    return {
+      misc_template_id: ID_CORIANDER,
+      distributor_id: '00000000-0000-4000-9000-900000000003',
+      product_url: 'https://www.brouwland.com/coriandre-100g',
+      sku: 'BRW-COR-100',
+      notes_per_distributor: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      misc_template: buildEntity(),
+      distributor: buildDistributor(),
+      ...overrides,
+    };
+  }
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MiscCatalogController],
       providers: [
         {
           provide: MiscCatalogService,
-          useValue: { list: jest.fn(), getById: jest.fn() },
+          useValue: {
+            list: jest.fn(),
+            getById: jest.fn(),
+            getDistributors: jest.fn(),
+          },
         },
       ],
     }).compile();
@@ -107,6 +147,35 @@ describe('MiscCatalogController', () => {
       const result = await controller.getById(ID_CORIANDER);
       expect(result).not.toBe(entity);
       expect(result.constructor.name).toBe('MiscTemplateDto');
+    });
+  });
+
+  describe('GET /catalog/misc-templates/:id/distributors (Issue #901)', () => {
+    it('happy: maps junction rows to CatalogDistributorLinkDto with distributor nested', async () => {
+      const getDistributorsSpy = jest
+        .spyOn(service, 'getDistributors')
+        .mockResolvedValue([buildJunction()]);
+
+      const result = await controller.getDistributors(ID_CORIANDER);
+
+      expect(getDistributorsSpy).toHaveBeenCalledWith(ID_CORIANDER);
+      expect(result).toHaveLength(1);
+      expect(result[0].product_url).toBe(
+        'https://www.brouwland.com/coriandre-100g',
+      );
+      expect(result[0].distributor.name).toBe('Brouwland');
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getDistributors')
+        .mockRejectedValue(
+          new NotFoundException('Misc template catalogue entry not found'),
+        );
+
+      await expect(
+        controller.getDistributors('00000000-0000-4000-9000-7000000000ff'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/packages/api/src/catalog/misc/controllers/misc-catalog.controller.ts
+++ b/packages/api/src/catalog/misc/controllers/misc-catalog.controller.ts
@@ -13,6 +13,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import {
+  CatalogDistributorLinkDto,
+  mapJunctionRowToDto,
+} from '../../distributor/dtos/catalog-distributor-link.dto';
 import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
 import { MiscCatalogService } from '../services/misc-catalog.service';
 import { MiscTemplateDto } from '../dtos/misc-template.dto';
@@ -55,5 +59,21 @@ export class MiscCatalogController {
   ): Promise<MiscTemplateDto> {
     const entity = await this.service.getById(id);
     return MiscTemplateDto.fromEntity(entity);
+  }
+
+  @Get(':id/distributors')
+  @ApiOperation({
+    summary:
+      'List distributors that sell this misc template (boutique foundation)',
+  })
+  @ApiOkResponse({ type: CatalogDistributorLinkDto, isArray: true })
+  @ApiNotFoundResponse({
+    description: 'Misc template catalogue entry not found',
+  })
+  async getDistributors(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<CatalogDistributorLinkDto[]> {
+    const rows = await this.service.getDistributors(id);
+    return rows.map(mapJunctionRowToDto);
   }
 }

--- a/packages/api/src/catalog/misc/entities/misc-template-distributor.orm.entity.ts
+++ b/packages/api/src/catalog/misc/entities/misc-template-distributor.orm.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { DistributorOrmEntity } from '../../distributor/entities/distributor.orm.entity';
+import { MiscTemplateOrmEntity } from './misc-template.orm.entity';
+
+/**
+ * M:N junction between misc templates and distributors
+ * (Issue #901). Mirrors `hop_distributors` — see that docblock
+ * for design rationale.
+ */
+@Entity('misc_template_distributors')
+export class MiscTemplateDistributorOrmEntity {
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  misc_template_id: string;
+
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  distributor_id: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: false })
+  product_url: string;
+
+  @Column({ type: 'varchar', length: 80, nullable: true })
+  sku: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  notes_per_distributor: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+
+  @ManyToOne(() => MiscTemplateOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'misc_template_id' })
+  misc_template: MiscTemplateOrmEntity;
+
+  @ManyToOne(() => DistributorOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'distributor_id' })
+  distributor: DistributorOrmEntity;
+}

--- a/packages/api/src/catalog/misc/misc.module.ts
+++ b/packages/api/src/catalog/misc/misc.module.ts
@@ -1,5 +1,6 @@
 import { MiscCatalogController } from './controllers/misc-catalog.controller';
 import { MiscCatalogService } from './services/misc-catalog.service';
+import { MiscTemplateDistributorOrmEntity } from './entities/misc-template-distributor.orm.entity';
 import { MiscTemplateOrmEntity } from './entities/misc-template.orm.entity';
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -13,7 +14,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
  * on PR #898 for equipment.
  */
 @Module({
-  imports: [TypeOrmModule.forFeature([MiscTemplateOrmEntity])],
+  imports: [
+    TypeOrmModule.forFeature([
+      MiscTemplateOrmEntity,
+      MiscTemplateDistributorOrmEntity,
+    ]),
+  ],
   controllers: [MiscCatalogController],
   providers: [MiscCatalogService],
   exports: [MiscCatalogService],

--- a/packages/api/src/catalog/misc/services/__tests__/misc-catalog.service.spec.ts
+++ b/packages/api/src/catalog/misc/services/__tests__/misc-catalog.service.spec.ts
@@ -4,7 +4,9 @@ import { MiscType, MiscUseAt } from '../../domain/misc-template.types';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { MiscCatalogService } from '../misc-catalog.service';
+import { MiscTemplateDistributorOrmEntity } from '../../entities/misc-template-distributor.orm.entity';
 import { MiscTemplateOrmEntity } from '../../entities/misc-template.orm.entity';
 import { NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
@@ -23,11 +25,19 @@ describe('MiscCatalogService', () => {
         TypeOrmModule.forRoot({
           type: 'sqlite',
           database: ':memory:',
-          entities: [MiscTemplateOrmEntity],
+          entities: [
+            MiscTemplateOrmEntity,
+            DistributorOrmEntity,
+            MiscTemplateDistributorOrmEntity,
+          ],
           synchronize: true,
           logging: false,
         }),
-        TypeOrmModule.forFeature([MiscTemplateOrmEntity]),
+        TypeOrmModule.forFeature([
+          MiscTemplateOrmEntity,
+          DistributorOrmEntity,
+          MiscTemplateDistributorOrmEntity,
+        ]),
       ],
       providers: [MiscCatalogService],
     }).compile();

--- a/packages/api/src/catalog/misc/services/__tests__/misc-catalog.service.spec.ts
+++ b/packages/api/src/catalog/misc/services/__tests__/misc-catalog.service.spec.ts
@@ -15,9 +15,12 @@ describe('MiscCatalogService', () => {
   let module: TestingModule;
   let service: MiscCatalogService;
   let repository: Repository<MiscTemplateOrmEntity>;
+  let distributorRepository: Repository<DistributorOrmEntity>;
+  let miscDistributorRepository: Repository<MiscTemplateDistributorOrmEntity>;
 
   const ID_CORIANDER = '00000000-0000-4000-9000-700000000005';
   const ID_LACTOSE = '00000000-0000-4000-9000-700000000006';
+  const ID_BROUWLAND = '00000000-0000-4000-9000-900000000003';
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
@@ -44,6 +47,12 @@ describe('MiscCatalogService', () => {
 
     service = module.get(MiscCatalogService);
     repository = module.get(getRepositoryToken(MiscTemplateOrmEntity));
+    distributorRepository = module.get(
+      getRepositoryToken(DistributorOrmEntity),
+    );
+    miscDistributorRepository = module.get(
+      getRepositoryToken(MiscTemplateDistributorOrmEntity),
+    );
   });
 
   afterAll(async () => {
@@ -51,8 +60,42 @@ describe('MiscCatalogService', () => {
   });
 
   beforeEach(async () => {
+    await miscDistributorRepository.clear();
     await repository.clear();
+    await distributorRepository.clear();
   });
+
+  async function seedDistributor(
+    id: string,
+    name: string,
+  ): Promise<DistributorOrmEntity> {
+    const entity = distributorRepository.create({
+      id,
+      name,
+      country: 'BE',
+      website: `https://www.${name.toLowerCase().replace(/\s+/g, '')}.test`,
+      ships_to: JSON.stringify(['BE']),
+      currency_default: 'EUR',
+      notes: null,
+    });
+    return distributorRepository.save(entity);
+  }
+
+  async function linkMiscToDistributor(
+    miscTemplateId: string,
+    distributorId: string,
+    productUrl: string,
+  ): Promise<void> {
+    await miscDistributorRepository.save(
+      miscDistributorRepository.create({
+        misc_template_id: miscTemplateId,
+        distributor_id: distributorId,
+        product_url: productUrl,
+        sku: null,
+        notes_per_distributor: null,
+      }),
+    );
+  }
 
   async function seedTemplate(
     id: string,
@@ -126,6 +169,47 @@ describe('MiscCatalogService', () => {
         MiscUseAt.Boil,
       );
       await expect(service.getById('coriandre')).rejects.toThrow();
+    });
+  });
+
+  describe('getDistributors() — boutique foundation (Issue #901)', () => {
+    it('happy: returns the junction rows with the distributor relation eagerly loaded', async () => {
+      await seedTemplate(
+        ID_CORIANDER,
+        'Coriandre (graines)',
+        MiscType.Spice,
+        MiscUseAt.Boil,
+      );
+      await seedDistributor(ID_BROUWLAND, 'Brouwland');
+      await linkMiscToDistributor(
+        ID_CORIANDER,
+        ID_BROUWLAND,
+        'https://www.brouwland.com/coriandre-100g',
+      );
+
+      const rows = await service.getDistributors(ID_CORIANDER);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].distributor.name).toBe('Brouwland');
+      expect(rows[0].product_url).toBe(
+        'https://www.brouwland.com/coriandre-100g',
+      );
+    });
+
+    it('sad: throws NotFoundException when the misc UUID is unknown', async () => {
+      await expect(
+        service.getDistributors('00000000-0000-4000-9000-7000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: returns [] when the misc exists but has no distributors yet', async () => {
+      await seedTemplate(
+        ID_CORIANDER,
+        'Coriandre (graines)',
+        MiscType.Spice,
+        MiscUseAt.Boil,
+      );
+      const rows = await service.getDistributors(ID_CORIANDER);
+      expect(rows).toEqual([]);
     });
   });
 });

--- a/packages/api/src/catalog/misc/services/misc-catalog.service.ts
+++ b/packages/api/src/catalog/misc/services/misc-catalog.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { InjectRepository } from '@nestjs/typeorm';
+import { MiscTemplateDistributorOrmEntity } from '../entities/misc-template-distributor.orm.entity';
 import { MiscTemplateOrmEntity } from '../entities/misc-template.orm.entity';
 import { Repository } from 'typeorm';
 
@@ -9,6 +10,8 @@ export class MiscCatalogService {
   constructor(
     @InjectRepository(MiscTemplateOrmEntity)
     private readonly templates: Repository<MiscTemplateOrmEntity>,
+    @InjectRepository(MiscTemplateDistributorOrmEntity)
+    private readonly miscDistributors: Repository<MiscTemplateDistributorOrmEntity>,
   ) {}
 
   /**
@@ -44,5 +47,22 @@ export class MiscCatalogService {
       );
     }
     return entity;
+  }
+
+  /**
+   * Returns the distributors that sell this exact misc
+   * template, with their per-distributor outbound URL +
+   * optional SKU + notes. Powers the boutique 'Acheter'
+   * button (Issue #901, #625). Throws 404 if the misc UUID
+   * is unknown.
+   */
+  async getDistributors(
+    id: string,
+  ): Promise<MiscTemplateDistributorOrmEntity[]> {
+    await this.getById(id);
+    return this.miscDistributors.find({
+      where: { misc_template_id: id },
+      relations: ['distributor'],
+    });
   }
 }

--- a/packages/api/src/catalog/yeast/controllers/__tests__/yeast-catalog.controller.spec.ts
+++ b/packages/api/src/catalog/yeast/controllers/__tests__/yeast-catalog.controller.spec.ts
@@ -1,8 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { NotFoundException } from '@nestjs/common';
 import { YeastCatalogController } from '../yeast-catalog.controller';
 import { YeastCatalogService } from '../../services/yeast-catalog.service';
+import { YeastDistributorOrmEntity } from '../../entities/yeast-distributor.orm.entity';
 import { YeastFlocculation } from '../../domain/enums/yeast-flocculation.enum';
 import { YeastForm } from '../../domain/enums/yeast-form.enum';
 import { YeastOrmEntity } from '../../entities/yeast.orm.entity';
@@ -43,6 +45,40 @@ describe('YeastCatalogController', () => {
     };
   }
 
+  function buildDistributor(
+    overrides: Partial<DistributorOrmEntity> = {},
+  ): DistributorOrmEntity {
+    return {
+      id: '00000000-0000-4000-9000-900000000003',
+      name: 'Brouwland',
+      country: 'BE',
+      website: 'https://www.brouwland.com',
+      ships_to: JSON.stringify(['BE', 'FR', 'NL']),
+      currency_default: 'EUR',
+      notes: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      ...overrides,
+    };
+  }
+
+  function buildJunction(
+    overrides: Partial<YeastDistributorOrmEntity> = {},
+  ): YeastDistributorOrmEntity {
+    return {
+      yeast_id: ID_US05,
+      distributor_id: '00000000-0000-4000-9000-900000000003',
+      product_url: 'https://www.brouwland.com/safale-us-05-11g',
+      sku: 'BRW-US05-11',
+      notes_per_distributor: null,
+      created_at: new Date('2026-05-04T00:00:00.000Z'),
+      updated_at: new Date('2026-05-04T00:00:00.000Z'),
+      yeast: buildEntity(),
+      distributor: buildDistributor(),
+      ...overrides,
+    };
+  }
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [YeastCatalogController],
@@ -52,6 +88,7 @@ describe('YeastCatalogController', () => {
           useValue: {
             list: jest.fn(),
             getById: jest.fn(),
+            getDistributors: jest.fn(),
           },
         },
       ],
@@ -138,6 +175,37 @@ describe('YeastCatalogController', () => {
 
       expect(result).not.toBe(entity);
       expect(result.constructor.name).toBe('YeastDto');
+    });
+  });
+
+  describe('GET /catalog/yeasts/:id/distributors (Issue #901)', () => {
+    it('happy: maps junction rows to CatalogDistributorLinkDto with distributor nested', async () => {
+      const getDistributorsSpy = jest
+        .spyOn(service, 'getDistributors')
+        .mockResolvedValue([buildJunction()]);
+
+      const result = await controller.getDistributors(ID_US05);
+
+      expect(getDistributorsSpy).toHaveBeenCalledWith(ID_US05);
+      expect(result).toHaveLength(1);
+      expect(result[0].product_url).toBe(
+        'https://www.brouwland.com/safale-us-05-11g',
+      );
+      expect(result[0].sku).toBe('BRW-US05-11');
+      expect(result[0].distributor.name).toBe('Brouwland');
+      expect(result[0].distributor.ships_to).toEqual(['BE', 'FR', 'NL']);
+    });
+
+    it('sad: lets a NotFoundException from the service propagate', async () => {
+      jest
+        .spyOn(service, 'getDistributors')
+        .mockRejectedValue(
+          new NotFoundException('Yeast catalogue entry not found'),
+        );
+
+      await expect(
+        controller.getDistributors('00000000-0000-4000-9000-2000000000ff'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/packages/api/src/catalog/yeast/controllers/yeast-catalog.controller.ts
+++ b/packages/api/src/catalog/yeast/controllers/yeast-catalog.controller.ts
@@ -16,6 +16,10 @@ import {
   ApiTags,
 } from '@nestjs/swagger';
 
+import {
+  CatalogDistributorLinkDto,
+  mapJunctionRowToDto,
+} from '../../distributor/dtos/catalog-distributor-link.dto';
 import { JwtAuthGuard } from '../../../auth/guards/jwt.guard';
 import { YeastCatalogService } from '../services/yeast-catalog.service';
 import { YeastDto } from '../dtos/yeast.dto';
@@ -73,5 +77,18 @@ export class YeastCatalogController {
   ): Promise<YeastDto> {
     const entity = await this.service.getById(id);
     return YeastDto.fromEntity(entity);
+  }
+
+  @Get(':id/distributors')
+  @ApiOperation({
+    summary: 'List distributors that sell this yeast (boutique foundation)',
+  })
+  @ApiOkResponse({ type: CatalogDistributorLinkDto, isArray: true })
+  @ApiNotFoundResponse({ description: 'Yeast catalogue entry not found' })
+  async getDistributors(
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<CatalogDistributorLinkDto[]> {
+    const rows = await this.service.getDistributors(id);
+    return rows.map(mapJunctionRowToDto);
   }
 }

--- a/packages/api/src/catalog/yeast/entities/yeast-distributor.orm.entity.ts
+++ b/packages/api/src/catalog/yeast/entities/yeast-distributor.orm.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { DistributorOrmEntity } from '../../distributor/entities/distributor.orm.entity';
+import { YeastOrmEntity } from './yeast.orm.entity';
+
+/**
+ * M:N junction between yeasts and distributors (Issue #901).
+ * Mirrors `hop_distributors` — see that docblock for design
+ * rationale.
+ */
+@Entity('yeast_distributors')
+export class YeastDistributorOrmEntity {
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  yeast_id: string;
+
+  @PrimaryColumn({ type: 'varchar', length: 36 })
+  distributor_id: string;
+
+  @Column({ type: 'varchar', length: 500, nullable: false })
+  product_url: string;
+
+  @Column({ type: 'varchar', length: 80, nullable: true })
+  sku: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  notes_per_distributor: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+
+  @UpdateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  updated_at: Date;
+
+  @ManyToOne(() => YeastOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'yeast_id' })
+  yeast: YeastOrmEntity;
+
+  @ManyToOne(() => DistributorOrmEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'distributor_id' })
+  distributor: DistributorOrmEntity;
+}

--- a/packages/api/src/catalog/yeast/services/__tests__/yeast-catalog.service.spec.ts
+++ b/packages/api/src/catalog/yeast/services/__tests__/yeast-catalog.service.spec.ts
@@ -24,10 +24,13 @@ describe('YeastCatalogService', () => {
   let module: TestingModule;
   let service: YeastCatalogService;
   let repository: Repository<YeastOrmEntity>;
+  let distributorRepository: Repository<DistributorOrmEntity>;
+  let yeastDistributorRepository: Repository<YeastDistributorOrmEntity>;
 
   const ID_WLP002 = '00000000-0000-4000-9000-200000000001';
   const ID_US05 = '00000000-0000-4000-9000-200000000006';
   const ID_W3470 = '00000000-0000-4000-9000-200000000008';
+  const ID_BROUWLAND = '00000000-0000-4000-9000-900000000003';
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
@@ -54,6 +57,12 @@ describe('YeastCatalogService', () => {
 
     service = module.get(YeastCatalogService);
     repository = module.get(getRepositoryToken(YeastOrmEntity));
+    distributorRepository = module.get(
+      getRepositoryToken(DistributorOrmEntity),
+    );
+    yeastDistributorRepository = module.get(
+      getRepositoryToken(YeastDistributorOrmEntity),
+    );
   });
 
   afterAll(async () => {
@@ -61,8 +70,42 @@ describe('YeastCatalogService', () => {
   });
 
   beforeEach(async () => {
+    await yeastDistributorRepository.clear();
     await repository.clear();
+    await distributorRepository.clear();
   });
+
+  async function seedDistributor(
+    id: string,
+    name: string,
+  ): Promise<DistributorOrmEntity> {
+    const entity = distributorRepository.create({
+      id,
+      name,
+      country: 'BE',
+      website: `https://www.${name.toLowerCase().replace(/\s+/g, '')}.test`,
+      ships_to: JSON.stringify(['BE']),
+      currency_default: 'EUR',
+      notes: null,
+    });
+    return distributorRepository.save(entity);
+  }
+
+  async function linkYeastToDistributor(
+    yeastId: string,
+    distributorId: string,
+    productUrl: string,
+  ): Promise<void> {
+    await yeastDistributorRepository.save(
+      yeastDistributorRepository.create({
+        yeast_id: yeastId,
+        distributor_id: distributorId,
+        product_url: productUrl,
+        sku: null,
+        notes_per_distributor: null,
+      }),
+    );
+  }
 
   async function seedYeast(
     id: string,
@@ -179,6 +222,37 @@ describe('YeastCatalogService', () => {
 
       // Strict UUID PK lookup — name-shaped strings still 404.
       await expect(service.getById('safale-us-05')).rejects.toThrow();
+    });
+  });
+
+  describe('getDistributors() — boutique foundation (Issue #901)', () => {
+    it('happy: returns the junction rows with the distributor relation eagerly loaded', async () => {
+      await seedYeast(ID_US05, 'Safale US-05', YeastType.ALE, YeastForm.DRY);
+      await seedDistributor(ID_BROUWLAND, 'Brouwland');
+      await linkYeastToDistributor(
+        ID_US05,
+        ID_BROUWLAND,
+        'https://www.brouwland.com/safale-us-05-11g',
+      );
+
+      const rows = await service.getDistributors(ID_US05);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].distributor.name).toBe('Brouwland');
+      expect(rows[0].product_url).toBe(
+        'https://www.brouwland.com/safale-us-05-11g',
+      );
+    });
+
+    it('sad: throws NotFoundException when the yeast UUID is unknown', async () => {
+      await expect(
+        service.getDistributors('00000000-0000-4000-9000-2000000000ff'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('edge: returns [] when the yeast exists but has no distributors yet', async () => {
+      await seedYeast(ID_US05, 'Safale US-05', YeastType.ALE, YeastForm.DRY);
+      const rows = await service.getDistributors(ID_US05);
+      expect(rows).toEqual([]);
     });
   });
 });

--- a/packages/api/src/catalog/yeast/services/__tests__/yeast-catalog.service.spec.ts
+++ b/packages/api/src/catalog/yeast/services/__tests__/yeast-catalog.service.spec.ts
@@ -3,9 +3,11 @@ jest.setTimeout(20000);
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 
+import { DistributorOrmEntity } from '../../../distributor/entities/distributor.orm.entity';
 import { NotFoundException } from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { YeastCatalogService } from '../yeast-catalog.service';
+import { YeastDistributorOrmEntity } from '../../entities/yeast-distributor.orm.entity';
 import { YeastFlocculation } from '../../domain/enums/yeast-flocculation.enum';
 import { YeastForm } from '../../domain/enums/yeast-form.enum';
 import { YeastOrmEntity } from '../../entities/yeast.orm.entity';
@@ -33,11 +35,19 @@ describe('YeastCatalogService', () => {
         TypeOrmModule.forRoot({
           type: 'sqlite',
           database: ':memory:',
-          entities: [YeastOrmEntity],
+          entities: [
+            YeastOrmEntity,
+            DistributorOrmEntity,
+            YeastDistributorOrmEntity,
+          ],
           synchronize: true,
           logging: false,
         }),
-        TypeOrmModule.forFeature([YeastOrmEntity]),
+        TypeOrmModule.forFeature([
+          YeastOrmEntity,
+          DistributorOrmEntity,
+          YeastDistributorOrmEntity,
+        ]),
       ],
       providers: [YeastCatalogService],
     }).compile();

--- a/packages/api/src/catalog/yeast/services/yeast-catalog.service.ts
+++ b/packages/api/src/catalog/yeast/services/yeast-catalog.service.ts
@@ -2,6 +2,7 @@ import { FindOptionsWhere, Repository } from 'typeorm';
 import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { InjectRepository } from '@nestjs/typeorm';
+import { YeastDistributorOrmEntity } from '../entities/yeast-distributor.orm.entity';
 import { YeastForm } from '../domain/enums/yeast-form.enum';
 import { YeastOrmEntity } from '../entities/yeast.orm.entity';
 import { YeastType } from '../domain/enums/yeast-type.enum';
@@ -20,6 +21,8 @@ export class YeastCatalogService {
   constructor(
     @InjectRepository(YeastOrmEntity)
     private readonly yeasts: Repository<YeastOrmEntity>,
+    @InjectRepository(YeastDistributorOrmEntity)
+    private readonly yeastDistributors: Repository<YeastDistributorOrmEntity>,
   ) {}
 
   /**
@@ -51,5 +54,19 @@ export class YeastCatalogService {
       throw new NotFoundException(`Yeast catalogue entry ${id} not found`);
     }
     return entity;
+  }
+
+  /**
+   * Returns the distributors that sell this exact yeast strain,
+   * with their per-distributor outbound URL + optional SKU +
+   * notes. Powers the boutique 'Acheter' button (Issue #901,
+   * #625). Throws 404 if the yeast UUID is unknown.
+   */
+  async getDistributors(id: string): Promise<YeastDistributorOrmEntity[]> {
+    await this.getById(id);
+    return this.yeastDistributors.find({
+      where: { yeast_id: id },
+      relations: ['distributor'],
+    });
   }
 }

--- a/packages/api/src/catalog/yeast/yeast.module.ts
+++ b/packages/api/src/catalog/yeast/yeast.module.ts
@@ -2,10 +2,13 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { YeastCatalogController } from './controllers/yeast-catalog.controller';
 import { YeastCatalogService } from './services/yeast-catalog.service';
+import { YeastDistributorOrmEntity } from './entities/yeast-distributor.orm.entity';
 import { YeastOrmEntity } from './entities/yeast.orm.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([YeastOrmEntity])],
+  imports: [
+    TypeOrmModule.forFeature([YeastOrmEntity, YeastDistributorOrmEntity]),
+  ],
   controllers: [YeastCatalogController],
   providers: [YeastCatalogService],
   exports: [YeastCatalogService],

--- a/packages/api/src/database/migrations/1793000000000-AddDistributorsAndJunctions.ts
+++ b/packages/api/src/database/migrations/1793000000000-AddDistributorsAndJunctions.ts
@@ -1,0 +1,150 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `distributors` reference table + 5 M:N junction
+ * tables linking distributors to the 5 catalogues that benefit
+ * from the boutique 'Acheter' button (Issue #901).
+ *
+ * **Producer ≠ Distributor**: producers (PR #902) are brand
+ * owners — 1 product = 1 producer, FK 1:1 on catalogues.
+ * Distributors are resellers — 1 product = N distributors,
+ * M:N junctions per catalogue.
+ *
+ * **M:N pattern (sets the codebase precedent)**:
+ *   - Composite PK on `(catalogue_id, distributor_id)` —
+ *     canonical M:N, no business meaning of a row alone,
+ *     prevents duplicates by definition.
+ *   - Business fields (`product_url`, `sku`,
+ *     `notes_per_distributor`) live on the composite PK row.
+ *   - `ON DELETE CASCADE` on both sides — if a distributor
+ *     goes out of business or a catalogue entry is removed,
+ *     the link goes too. No orphan junction rows possible.
+ *
+ * **CHECK constraints applied**:
+ *   - `distributors.country` matches ISO 3166-1 alpha-2
+ *     (2 uppercase ASCII letters)
+ *   - `distributors.currency_default` matches ISO 4217
+ *     (3 uppercase ASCII letters)
+ *   - Every junction's `product_url` starts with `https://`
+ *     (no `http://` mixed-content risk on the mobile WebView)
+ *
+ * **Index strategy**:
+ *   - `IDX_distributors_name` UNIQUE for the name-lookup
+ *     (and prevents accidental duplicate seeds)
+ *   - `IDX_distributors_country` for country-faceted queries
+ *   - Each junction gets `IDX_<table>_distributor_id` for fast
+ *     reverse lookup ("which catalogue entries does this
+ *     distributor sell?"). The composite PK already covers
+ *     forward lookup ("which distributors sell this entry?").
+ */
+export class AddDistributorsAndJunctions1793000000000 implements MigrationInterface {
+  name = 'AddDistributorsAndJunctions1793000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // ─── 1. Create the distributors reference table ─────────────────
+    await queryRunner.query(`
+      CREATE TABLE "distributors" (
+        "id"               varchar(36) PRIMARY KEY NOT NULL,
+        "name"             varchar(120) NOT NULL,
+        "country"          varchar(2) NOT NULL,
+        "website"          varchar(255) NOT NULL,
+        "ships_to"         text NOT NULL,
+        "currency_default" varchar(3) NOT NULL,
+        "notes"            text,
+        "created_at"       datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "updated_at"       datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        CONSTRAINT "CHK_distributors_country"
+          CHECK ("country" GLOB '[A-Z][A-Z]' AND length("country") = 2),
+        CONSTRAINT "CHK_distributors_currency"
+          CHECK ("currency_default" GLOB '[A-Z][A-Z][A-Z]' AND length("currency_default") = 3),
+        CONSTRAINT "CHK_distributors_website_https"
+          CHECK ("website" LIKE 'https://%')
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_distributors_name" ON "distributors" ("name")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_distributors_country" ON "distributors" ("country")`,
+    );
+
+    // ─── 2. Create the 5 M:N junction tables ────────────────────────
+    // Each follows the canonical pattern: composite PK +
+    // ON DELETE CASCADE on both FKs + https-only product_url
+    // CHECK + reverse-lookup index on distributor_id.
+    const junctions: Array<{
+      table: string;
+      catalogueColumn: string;
+      catalogueTable: string;
+    }> = [
+      {
+        table: 'hop_distributors',
+        catalogueColumn: 'hop_id',
+        catalogueTable: 'hops',
+      },
+      {
+        table: 'fermentable_distributors',
+        catalogueColumn: 'fermentable_id',
+        catalogueTable: 'fermentables',
+      },
+      {
+        table: 'yeast_distributors',
+        catalogueColumn: 'yeast_id',
+        catalogueTable: 'yeasts',
+      },
+      {
+        table: 'misc_template_distributors',
+        catalogueColumn: 'misc_template_id',
+        catalogueTable: 'misc_templates',
+      },
+      {
+        table: 'equipment_template_distributors',
+        catalogueColumn: 'equipment_template_id',
+        catalogueTable: 'equipment_templates',
+      },
+    ];
+
+    for (const j of junctions) {
+      await queryRunner.query(`
+        CREATE TABLE "${j.table}" (
+          "${j.catalogueColumn}"     varchar(36) NOT NULL,
+          "distributor_id"           varchar(36) NOT NULL,
+          "product_url"              varchar(500) NOT NULL,
+          "sku"                      varchar(80),
+          "notes_per_distributor"    text,
+          "created_at"               datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          "updated_at"               datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          PRIMARY KEY ("${j.catalogueColumn}", "distributor_id"),
+          FOREIGN KEY ("${j.catalogueColumn}")
+            REFERENCES "${j.catalogueTable}"("id") ON DELETE CASCADE,
+          FOREIGN KEY ("distributor_id")
+            REFERENCES "distributors"("id") ON DELETE CASCADE,
+          CONSTRAINT "CHK_${j.table}_url_https"
+            CHECK ("product_url" LIKE 'https://%')
+        )
+      `);
+      await queryRunner.query(
+        `CREATE INDEX "IDX_${j.table}_distributor_id" ON "${j.table}" ("distributor_id")`,
+      );
+    }
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop junctions first (their FKs reference distributors),
+    // then the distributors table itself.
+    const junctions = [
+      'equipment_template_distributors',
+      'misc_template_distributors',
+      'yeast_distributors',
+      'fermentable_distributors',
+      'hop_distributors',
+    ];
+    for (const table of junctions) {
+      await queryRunner.query(`DROP INDEX "IDX_${table}_distributor_id"`);
+      await queryRunner.query(`DROP TABLE "${table}"`);
+    }
+    await queryRunner.query(`DROP INDEX "IDX_distributors_country"`);
+    await queryRunner.query(`DROP INDEX "IDX_distributors_name"`);
+    await queryRunner.query(`DROP TABLE "distributors"`);
+  }
+}

--- a/packages/api/src/database/seeds/__tests__/distributors-catalog.seed.spec.ts
+++ b/packages/api/src/database/seeds/__tests__/distributors-catalog.seed.spec.ts
@@ -1,0 +1,106 @@
+import {
+  DISTRIBUTORS_CATALOG_SEED,
+  seedDistributorsCatalog,
+} from '../distributors-catalog.seed';
+import {
+  assertCommonCatalogueSeederBehaviours,
+  buildRepoMock,
+} from '../seed-test-utils';
+
+import { DistributorOrmEntity } from '../../../catalog/distributor/entities/distributor.orm.entity';
+import { Repository } from 'typeorm';
+
+describe('seedDistributorsCatalog (Issue #901)', () => {
+  // Standard catalogue-seeder behaviours via shared helper.
+  assertCommonCatalogueSeederBehaviours('seedDistributorsCatalog', {
+    fn: (repo, seeds) =>
+      seedDistributorsCatalog(
+        repo as unknown as Repository<DistributorOrmEntity>,
+        seeds,
+      ),
+    data: DISTRIBUTORS_CATALOG_SEED,
+  });
+
+  describe('catalogue-specific invariants', () => {
+    it('writes name + country + website + ships_to + currency_default on every inserted row', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      await seedDistributorsCatalog(
+        repo as unknown as Repository<DistributorOrmEntity>,
+      );
+
+      for (const call of repo.create.mock.calls as unknown[][]) {
+        const arg = call[0] as Record<string, unknown>;
+        expect(typeof arg.name).toBe('string');
+        expect((arg.name as string).length).toBeGreaterThan(0);
+        expect(typeof arg.country).toBe('string');
+        expect(typeof arg.website).toBe('string');
+        // ships_to is JSON-encoded application-side
+        expect(typeof arg.ships_to).toBe('string');
+        expect(typeof arg.currency_default).toBe('string');
+      }
+    });
+
+    it('exposes 12 curated catalogue entries spanning 5 countries (FR/BE/GB/US/DE)', () => {
+      expect(DISTRIBUTORS_CATALOG_SEED).toHaveLength(12);
+
+      const countries = new Set(
+        DISTRIBUTORS_CATALOG_SEED.map((d) => d.country),
+      );
+      expect(countries).toContain('FR');
+      expect(countries).toContain('BE');
+      expect(countries).toContain('GB');
+      expect(countries).toContain('US');
+      expect(countries).toContain('DE');
+      expect(countries.size).toBe(5);
+    });
+
+    it('uses deterministic UUIDs in the catalogue range (...-9000-9000-...)', () => {
+      const ids = DISTRIBUTORS_CATALOG_SEED.map((d) => d.id);
+      for (const id of ids) {
+        expect(id).toMatch(/^00000000-0000-4000-9000-9[0-9a-f]{11}$/);
+      }
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('every website is HTTPS only (no http:// allowed by migration CHECK)', () => {
+      for (const distributor of DISTRIBUTORS_CATALOG_SEED) {
+        expect(distributor.website).toMatch(/^https:\/\//);
+      }
+    });
+
+    it('every country is a valid ISO 3166-1 alpha-2 code (uppercase ASCII)', () => {
+      for (const distributor of DISTRIBUTORS_CATALOG_SEED) {
+        expect(distributor.country).toMatch(/^[A-Z]{2}$/);
+      }
+    });
+
+    it('every currency is a valid ISO 4217 code (uppercase ASCII)', () => {
+      const validCurrencies = new Set(['EUR', 'USD', 'GBP', 'CHF']);
+      for (const distributor of DISTRIBUTORS_CATALOG_SEED) {
+        expect(distributor.currency_default).toMatch(/^[A-Z]{3}$/);
+        expect(validCurrencies).toContain(distributor.currency_default);
+      }
+    });
+
+    it('every ships_to entry is a valid ISO alpha-2 code, distributor self-included', () => {
+      for (const distributor of DISTRIBUTORS_CATALOG_SEED) {
+        expect(distributor.ships_to.length).toBeGreaterThan(0);
+        for (const code of distributor.ships_to) {
+          expect(code).toMatch(/^[A-Z]{2}$/);
+        }
+        // A distributor should always ship to its home country.
+        expect(distributor.ships_to).toContain(distributor.country);
+      }
+    });
+
+    it('keeps every notes value in French (UI-facing convention)', () => {
+      for (const distributor of DISTRIBUTORS_CATALOG_SEED) {
+        if (distributor.notes !== null) {
+          expect(distributor.notes).toMatch(/[àâäéèêëïîôöùûüÿç]/i);
+        }
+      }
+    });
+  });
+});

--- a/packages/api/src/database/seeds/distributors-catalog.seed.ts
+++ b/packages/api/src/database/seeds/distributors-catalog.seed.ts
@@ -1,0 +1,245 @@
+import { DistributorOrmEntity } from '../../catalog/distributor/entities/distributor.orm.entity';
+import { Repository } from 'typeorm';
+import { idempotentUpsertById } from './seed-utils';
+
+/**
+ * Seed for the `distributors` reference catalogue (Issue #901).
+ * Operator-curated entries — the major homebrew shops every
+ * brewer in the EU + US encounters when looking for a
+ * boutique link to buy a specific product.
+ *
+ * **Distributor ≠ Producer**: producers (PR #902) make the
+ * product (1:1). Distributors sell it (1:N). The 12 entries
+ * below are the boutique-side counterpart to the 17
+ * producers shipped on PR #902.
+ *
+ * Coverage by country (12 entries spanning 5 countries) :
+ *   - FR : Saveur Bière, Hopt, Brewferm.fr (3)
+ *   - BE : Brouwland, Brewferm.be (2)
+ *   - GB : MaltMiller, The Home Brew Shop (2)
+ *   - US : Northern Brewer, Brewunited, Williams Brewing (3)
+ *   - DE : Brauen.de, Hopfenhof (2)
+ *
+ * UUID range `00000000-0000-4000-9000-9000-...` reserved for
+ * distributors (hops `0`, fermentables `1`, yeasts `2`,
+ * styles `3`, mash `4`, waters `5`, equipment `6`, misc `7`,
+ * producers `8`, distributors `9`).
+ *
+ * No junction rows are seeded here — those (e.g. Citra →
+ * Brewferm + Hopt + MaltMiller) defer to a follow-up tiny
+ * PR or to the BrewDog DIY Dog seed (#780). This PR ships
+ * only the reference table itself.
+ */
+
+export interface DistributorSeed {
+  id: string;
+  name: string;
+  country: string;
+  website: string;
+  ships_to: string[];
+  currency_default: string;
+  notes: string | null;
+}
+
+export const DISTRIBUTORS_CATALOG_SEED: readonly DistributorSeed[] = [
+  // ─── France ────────────────────────────────────────────────────────
+  {
+    id: '00000000-0000-4000-9000-900000000000',
+    name: 'Saveur Bière',
+    country: 'FR',
+    website: 'https://www.saveur-biere.com',
+    ships_to: ['FR', 'BE', 'LU', 'CH'],
+    currency_default: 'EUR',
+    notes:
+      'Distributeur français généraliste (Wattignies, Nord). Catalogue ' +
+      'large : ingrédients, équipement, kits prêts-à-brasser. Souvent ' +
+      'le premier réflexe des homebrewers francophones débutants.',
+  },
+  {
+    id: '00000000-0000-4000-9000-900000000001',
+    name: 'Hopt',
+    country: 'FR',
+    website: 'https://www.hopt.fr',
+    ships_to: ['FR', 'BE', 'LU', 'CH', 'DE'],
+    currency_default: 'EUR',
+    notes:
+      'Boutique française spécialisée houblons (Lyon). Stocke les ' +
+      'variétés trademarkées difficiles à trouver ailleurs en Europe ' +
+      '(Citra, Mosaic, Galaxy) et fait la veille sur les nouvelles ' +
+      'variétés Yakima Chief.',
+  },
+  {
+    id: '00000000-0000-4000-9000-900000000002',
+    name: 'Brewferm France',
+    country: 'FR',
+    website: 'https://www.brewferm.fr',
+    ships_to: ['FR'],
+    currency_default: 'EUR',
+    notes:
+      'Antenne française du belge Brewferm (Brouwland Group). ' +
+      'Catalogue identique à la maison-mère mais expédition FR ' +
+      'rapide et sans douane.',
+  },
+  // ─── Belgique ──────────────────────────────────────────────────────
+  {
+    id: '00000000-0000-4000-9000-900000000003',
+    name: 'Brouwland',
+    country: 'BE',
+    website: 'https://www.brouwland.com',
+    ships_to: ['BE', 'NL', 'LU', 'FR', 'DE', 'GB', 'CH'],
+    currency_default: 'EUR',
+    notes:
+      'Distributeur belge historique (Beverlo, fondé 1976). ' +
+      "L'un des plus gros catalogues homebrew d'Europe — ingrédients " +
+      '+ équipement + kits + propre marque. Référence pour les ' +
+      'malts Castle Malting et Best Malz.',
+  },
+  {
+    id: '00000000-0000-4000-9000-900000000004',
+    name: 'Brewferm Belgique',
+    country: 'BE',
+    website: 'https://www.brewferm.be',
+    ships_to: ['BE', 'NL', 'LU'],
+    currency_default: 'EUR',
+    notes:
+      'Maison-mère du Brewferm Group. Partage le catalogue Brouwland ' +
+      'via accord de groupe ; distinction marketing pour cibler les ' +
+      'néerlandophones de Belgique et des Pays-Bas.',
+  },
+  // ─── Royaume-Uni ───────────────────────────────────────────────────
+  {
+    id: '00000000-0000-4000-9000-900000000005',
+    name: 'The Malt Miller',
+    country: 'GB',
+    website: 'https://www.themaltmiller.co.uk',
+    ships_to: ['GB', 'IE', 'FR', 'BE', 'NL', 'DE'],
+    currency_default: 'GBP',
+    notes:
+      'Boutique britannique de référence (Newbury, Berkshire). ' +
+      'Catalogue très large + service de mouture personnalisée ' +
+      "(d'où le nom). Apprécié pour ses kits BrewDog officiels et " +
+      'ses houblons UK frais (Maris Otter, Golden Promise).',
+  },
+  {
+    id: '00000000-0000-4000-9000-900000000006',
+    name: 'The Home Brew Shop',
+    country: 'GB',
+    website: 'https://www.the-home-brew-shop.co.uk',
+    ships_to: ['GB', 'IE'],
+    currency_default: 'GBP',
+    notes:
+      'Boutique britannique généraliste (Farnborough). ' +
+      "Grande variété d'extraits liquides et secs (DME/LME) en " +
+      "petits formats — pratique pour les recettes d'initiation.",
+  },
+  // ─── États-Unis ────────────────────────────────────────────────────
+  {
+    id: '00000000-0000-4000-9000-900000000007',
+    name: 'Northern Brewer',
+    country: 'US',
+    website: 'https://www.northernbrewer.com',
+    ships_to: ['US', 'CA'],
+    currency_default: 'USD',
+    notes:
+      'Distributeur américain de référence (Roseville, Minnesota, ' +
+      'fondé 1993). Catalogue extrêmement large + kits BrewDog ' +
+      'officiels + matériel Anvil + propre ligne de levures ' +
+      '(BrewMaster Select).',
+  },
+  {
+    id: '00000000-0000-4000-9000-900000000008',
+    name: 'BrewUnited',
+    country: 'US',
+    website: 'https://brewunited.com',
+    ships_to: ['US'],
+    currency_default: 'USD',
+    notes:
+      'Plateforme américaine moderne (web-first) avec un catalogue ' +
+      "ingredient-only (pas d'équipement) et un focus sur les " +
+      'variétés rares de houblons. Orienté brasseurs avancés.',
+  },
+  {
+    id: '00000000-0000-4000-9000-900000000009',
+    name: 'Williams Brewing',
+    country: 'US',
+    website: 'https://www.williamsbrewing.com',
+    ships_to: ['US', 'CA'],
+    currency_default: 'USD',
+    notes:
+      'Distributeur américain historique (San Leandro, Californie, ' +
+      "fondé 1979). Spécialiste des kits William's Brewing maison + " +
+      'extraits maltés. Sympa pour les premiers brassins extract.',
+  },
+  // ─── Allemagne ─────────────────────────────────────────────────────
+  {
+    id: '00000000-0000-4000-9000-90000000000a',
+    name: 'Brauen.de',
+    country: 'DE',
+    website: 'https://www.brauen.de',
+    ships_to: ['DE', 'AT', 'CH', 'NL', 'BE'],
+    currency_default: 'EUR',
+    notes:
+      'Boutique allemande de référence (Munich). Catalogue centré ' +
+      'sur les malts allemands (Weyermann, Best Malz, Bestmalz) et ' +
+      'les levures lager Wyeast/White Labs. Référence pour brasser ' +
+      'des Pilsners et Märzens authentiques.',
+  },
+  {
+    id: '00000000-0000-4000-9000-90000000000b',
+    name: 'Hopfenhof',
+    country: 'DE',
+    website: 'https://www.hopfenhof.de',
+    ships_to: ['DE', 'AT', 'CH'],
+    currency_default: 'EUR',
+    notes:
+      'Boutique allemande spécialisée houblons (Bavière). Catalogue ' +
+      'axé Hallertau et variétés européennes nobles (Tettnang, Saaz, ' +
+      'Spalt). Production locale → fraîcheur garantie sur les ' +
+      'houblons germano-tchèques.',
+  },
+];
+
+/**
+ * Result returned by `seedDistributorsCatalog` for
+ * instrumentation / verification.
+ */
+export interface SeedDistributorsCatalogResult {
+  inserted: number;
+  updated: number;
+  total: number;
+}
+
+/**
+ * Idempotent loader for the distributor reference catalogue.
+ * Insert if the id is unknown, update in place otherwise.
+ * Re-running the loader never duplicates rows.
+ *
+ * `ships_to` is JSON-encoded application-side before insert
+ * (SQLite has no native JSON column).
+ */
+export async function seedDistributorsCatalog(
+  repository: Repository<DistributorOrmEntity>,
+  distributors: readonly DistributorSeed[] = DISTRIBUTORS_CATALOG_SEED,
+): Promise<SeedDistributorsCatalogResult> {
+  let inserted = 0;
+  let updated = 0;
+
+  for (const distributor of distributors) {
+    const outcome = await idempotentUpsertById(
+      repository,
+      { id: distributor.id },
+      {
+        name: distributor.name,
+        country: distributor.country,
+        website: distributor.website,
+        ships_to: JSON.stringify(distributor.ships_to),
+        currency_default: distributor.currency_default,
+        notes: distributor.notes,
+      },
+    );
+    inserted += outcome.inserted;
+    updated += outcome.updated;
+  }
+
+  return { inserted, updated, total: inserted + updated };
+}

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -4,13 +4,18 @@ import { BatchOrmEntity } from '../batch/entities/batch.orm.entity';
 import { BatchReminderOrmEntity } from '../batch/entities/batch-reminder.orm.entity';
 import { BatchStepOrmEntity } from '../batch/entities/batch-step.orm.entity';
 import { DataSourceOptions } from 'typeorm';
+import { DistributorOrmEntity } from '../catalog/distributor/entities/distributor.orm.entity';
 import { EquipmentProfileOrmEntity } from '../equipment/entities/equipment-profile.orm.entity';
+import { EquipmentTemplateDistributorOrmEntity } from '../catalog/equipment/entities/equipment-template-distributor.orm.entity';
 import { EquipmentTemplateOrmEntity } from '../catalog/equipment/entities/equipment-template.orm.entity';
+import { FermentableDistributorOrmEntity } from '../catalog/fermentable/entities/fermentable-distributor.orm.entity';
 import { FermentableOrmEntity } from '../catalog/fermentable/entities/fermentable.orm.entity';
+import { HopDistributorOrmEntity } from '../catalog/hop/entities/hop-distributor.orm.entity';
 import { HopOrmEntity } from '../catalog/hop/entities/hop.orm.entity';
 import { LabelDraftOrmEntity } from '../label/entities/label-draft.orm.entity';
 import { MashProfileOrmEntity } from '../catalog/mash/entities/mash-profile.orm.entity';
 import { MashStepOrmEntity } from '../catalog/mash/entities/mash-step.orm.entity';
+import { MiscTemplateDistributorOrmEntity } from '../catalog/misc/entities/misc-template-distributor.orm.entity';
 import { MiscTemplateOrmEntity } from '../catalog/misc/entities/misc-template.orm.entity';
 import { ProducerOrmEntity } from '../catalog/producer/entities/producer.orm.entity';
 import { RecipeAdditiveOrmEntity } from '../recipe/entities/recipe-additive.orm.entity';
@@ -28,6 +33,7 @@ import { StyleOrmEntity } from '../catalog/style/entities/style.orm.entity';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { User } from '../user/entities/user.entity';
 import { WaterOrmEntity } from '../catalog/water/entities/water.orm.entity';
+import { YeastDistributorOrmEntity } from '../catalog/yeast/entities/yeast-distributor.orm.entity';
 import { YeastOrmEntity } from '../catalog/yeast/entities/yeast.orm.entity';
 
 const truthyEnvValues = new Set(['1', 'true', 'yes', 'on']);
@@ -61,6 +67,12 @@ export const ormEntities = [
   EquipmentTemplateOrmEntity,
   MiscTemplateOrmEntity,
   ProducerOrmEntity,
+  DistributorOrmEntity,
+  HopDistributorOrmEntity,
+  FermentableDistributorOrmEntity,
+  YeastDistributorOrmEntity,
+  MiscTemplateDistributorOrmEntity,
+  EquipmentTemplateDistributorOrmEntity,
 ];
 
 const parseBooleanEnv = (name: string, defaultValue: boolean): boolean => {


### PR DESCRIPTION
## Summary

Closes **#901**. Foundation for the boutique 'Acheter' button (#625).

**Producer ≠ Distributor** : producers (PR #902) are brand owners — 1 product = 1 producer, FK 1:1 on catalogues. Distributors (this PR) are resellers — 1 product = N distributors, M:N junctions per catalogue.

## What ships

### 1. `distributors` reference table

Mirror of the producer pattern — 7 standard files under `packages/api/src/catalog/distributor/`. Schema :
- `id` UUID PK
- `name` UNIQUE (varchar 120)
- `country` ISO 3166-1 alpha-2 + CHECK constraint (2 uppercase ASCII letters)
- `website` (varchar 255) + CHECK `LIKE 'https://%'`
- `ships_to` JSON-encoded array of ISO country codes (TEXT, decoded application-side — SQLite has no native JSON)
- `currency_default` ISO 4217 + CHECK (3 uppercase ASCII letters)
- `notes` (FR, UI-facing)

12 seeded entries spanning 5 countries :
| Country | Distributors |
|---|---|
| FR | Saveur Bière, Hopt, Brewferm.fr |
| BE | Brouwland, Brewferm.be |
| GB | The Malt Miller, The Home Brew Shop |
| US | Northern Brewer, BrewUnited, Williams Brewing |
| DE | Brauen.de, Hopfenhof |

UUID range `00000000-0000-4000-9000-9...` reserved for distributors.

### 2. 5 M:N junction tables (sets the codebase precedent)

`hop_distributors`, `fermentable_distributors`, `yeast_distributors`, `misc_template_distributors`, `equipment_template_distributors`.

**Design** :
- **Composite PK** on `(catalogue_id, distributor_id)` — canonical M:N, no business meaning of a row alone, prevents duplicates by definition.
- Business fields (`product_url`, `sku`, `notes_per_distributor`) live on the composite PK row.
- **`ON DELETE CASCADE` on both sides** — if a distributor goes out of business or a catalogue entry is removed, the link goes too. No orphan junction rows possible.
- Each junction has CHECK on `product_url LIKE 'https://%'` (no http:// mixed-content risk on the mobile WebView) + reverse-lookup INDEX on `distributor_id` (forward lookup is covered by the composite PK).

### 3. Per-catalogue endpoints (5 sub-routes)

```
GET /catalog/hops/:id/distributors
GET /catalog/fermentables/:id/distributors
GET /catalog/yeasts/:id/distributors
GET /catalog/misc-templates/:id/distributors
GET /catalog/equipment-templates/:id/distributors
```

Each returns junction rows mapped to a shared `CatalogDistributorLinkDto` (full distributor info nested + `product_url` + `sku` + `notes_per_distributor`). Single conversion point shared across the 5 catalogues to avoid 5× duplication of the mapping.

### 4. Migration `1793000000000-AddDistributorsAndJunctions`

Atomic — creates the `distributors` table + 5 junction tables in one migration. Sets the M:N pattern docblock for future reference (no ADR yet — this PR is the precedent). `down()` drops in reverse order : junctions first (FKs reference distributors), then `distributors`.

## Tests

**631/633 green** (was 605, +26 new tests, no regression). 5 catalogue-specific specs gained a constructor param (the new junction repository) — same fixture pattern, new entities added to `TypeOrmModule.forFeature` in each spec.

| Test scope | Count |
|---|---|
| `distributor-catalog.service.spec` | 4 (list ordered + getById happy/sad/edge) |
| `distributor-catalog.controller.spec` | 5 (list + getById + DTO wrap + ships_to JSON parse fallback on corrupted row) |
| `distributors-catalog.seed.spec` | 4 standard via `assertCommonCatalogueSeederBehaviours` + 7 catalogue-specific (entry count, country coverage, UUID range, https website, ISO code shapes, ships_to validity, FR notes) |
| Per-catalogue `getDistributors` integration | 5 × 3 = 15 tests (happy w/ relations + sad 404 on missing parent + edge empty list) |

## Out of scope (separate follow-ups)

- ❌ Junction seed rows (e.g. Citra → Brewferm + Hopt + MaltMiller) — defer to follow-up tiny PR or to the BrewDog DIY Dog seed (#780). This PR ships the **data shape**, not the **live links**.
- ❌ Mobile boutique button — issue #625 (frontend, blocked by this PR's API surface).
- ❌ Affiliate / referral links — defer per #901 out-of-scope.
- ❌ Price scraping / live availability — separate epic per #901 out-of-scope.
- ❌ Soft delete / `is_active` flag — over-engineering for now, hard delete via `ON DELETE CASCADE` is fine.

## Checklist

- [x] Happy path + sad path + edge cases covered (Issue #901 acceptance)
- [x] `tsc --noEmit` passes (build green)
- [x] Build passes (`npm run build` clean)
- [x] Existing tests still green (631/633 — 2 skipped pre-existing)
- [x] No `any`, no inline styles introduced
- [x] Lint clean (only pre-existing scan warning)

Closes #901