### PR TITLE
feat(seed): add BrewDog DIY Dog as official recipe for Punk IPA (#911)

### DIFF
--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -11,7 +11,7 @@ import { buildRepoMock } from './seed-test-utils';
 
 describe('seedPublicRecipes (Issue #701)', () => {
   describe('happy path', () => {
-    it('inserts all 10 curated recipes when the table is empty', async () => {
+    it('inserts all 11 curated recipes when the table is empty', async () => {
       const repo = buildRepoMock();
       repo.findOne.mockResolvedValue(null);
 
@@ -19,12 +19,12 @@ describe('seedPublicRecipes (Issue #701)', () => {
         repo as unknown as Repository<RecipeOrmEntity>,
       );
 
-      expect(result).toEqual({ inserted: 10, updated: 0, total: 10 });
-      expect(repo.create).toHaveBeenCalledTimes(10);
-      expect(repo.save).toHaveBeenCalledTimes(10);
+      expect(result).toEqual({ inserted: 11, updated: 0, total: 11 });
+      expect(repo.create).toHaveBeenCalledTimes(11);
+      expect(repo.save).toHaveBeenCalledTimes(11);
     });
 
-    it('tags every inserted row as PUBLIC + non-official + system owner', async () => {
+    it('tags every inserted row as PUBLIC + system owner with the seed-declared is_official flag', async () => {
       const repo = buildRepoMock();
       repo.findOne.mockResolvedValue(null);
 
@@ -33,11 +33,6 @@ describe('seedPublicRecipes (Issue #701)', () => {
       for (const call of repo.create.mock.calls as unknown[][]) {
         const arg = call[0] as Record<string, unknown>;
         expect(arg.visibility).toBe(RecipeVisibility.PUBLIC);
-        // Stays non-official by design — the matching algorithm
-        // (Issue #699) treats `is_official=true` as a per-beer
-        // shortcut to score 100; tagging all 10 seed rows as
-        // official would collapse `rankForBeer` to insertion order.
-        expect(arg.is_official).toBe(false);
         expect(arg.owner_id).toBe(PUBLIC_RECIPES_SYSTEM_OWNER_ID);
         expect(arg.imported_from_recipe_id).toBeNull();
         expect(arg.import_provenance).toBeNull();
@@ -46,6 +41,29 @@ describe('seedPublicRecipes (Issue #701)', () => {
         expect(arg.root_recipe_id).toBe(arg.id);
         expect(arg.version).toBe(1);
       }
+    });
+
+    it('keeps the 10 community recipes non-official and tags only the BrewDog DIY Dog clone as official (Issue #911)', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+
+      await seedPublicRecipes(repo as unknown as Repository<RecipeOrmEntity>);
+
+      const createdRows = (repo.create.mock.calls as unknown[][]).map(
+        (call) => call[0] as Record<string, unknown>,
+      );
+      const officials = createdRows.filter((row) => row.is_official === true);
+      expect(officials).toHaveLength(1);
+      expect(officials[0].name).toBe('BrewDog DIY Dog Punk IPA');
+      // The 10 community recipes stay non-official by design — the
+      // matching algorithm (Issue #699) treats `is_official=true` as
+      // a per-beer shortcut to score 100; tagging more than ~one
+      // official per style would collapse `rankForBeer` to insertion
+      // order (the regression Codex caught on PR #773).
+      const nonOfficials = createdRows.filter(
+        (row) => row.is_official === false,
+      );
+      expect(nonOfficials).toHaveLength(10);
     });
   });
 
@@ -64,9 +82,9 @@ describe('seedPublicRecipes (Issue #701)', () => {
         repo as unknown as Repository<RecipeOrmEntity>,
       );
 
-      expect(result).toEqual({ inserted: 0, updated: 10, total: 10 });
+      expect(result).toEqual({ inserted: 0, updated: 11, total: 11 });
       expect(repo.create).not.toHaveBeenCalled();
-      expect(repo.save).toHaveBeenCalledTimes(10);
+      expect(repo.save).toHaveBeenCalledTimes(11);
     });
 
     it('forces visibility back to PUBLIC and is_official back to false when overwriting a drifted row', async () => {
@@ -107,7 +125,7 @@ describe('seedPublicRecipes (Issue #701)', () => {
         repo as unknown as Repository<RecipeOrmEntity>,
       );
 
-      expect(result).toEqual({ inserted: 7, updated: 3, total: 10 });
+      expect(result).toEqual({ inserted: 8, updated: 3, total: 11 });
     });
 
     it('respects an explicit override list (e.g. tests, alternate demo data)', async () => {
@@ -124,14 +142,15 @@ describe('seedPublicRecipes (Issue #701)', () => {
       expect(result).toEqual({ inserted: 2, updated: 0, total: 2 });
     });
 
-    it('exposes 10 curated recipes covering IPA / Belgian / Strong / Lager families', () => {
-      expect(PUBLIC_RECIPES_SEED).toHaveLength(10);
+    it('exposes 11 curated recipes covering IPA / Belgian / Strong / Lager families plus the official DIY Dog', () => {
+      expect(PUBLIC_RECIPES_SEED).toHaveLength(11);
       const names = PUBLIC_RECIPES_SEED.map((r) => r.name);
       expect(names).toContain('Session IPA Citra');
       expect(names).toContain('Belgian Tripel');
       expect(names).toContain('Saison Farmhouse');
       expect(names).toContain('Imperial Stout');
       expect(names).toContain('Kölsch Tradition');
+      expect(names).toContain('BrewDog DIY Dog Punk IPA');
     });
 
     it('tags every seeded recipe with a non-empty style for the matching algorithm', () => {

--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -43,7 +43,7 @@ describe('seedPublicRecipes (Issue #701)', () => {
       }
     });
 
-    it('keeps the 10 community recipes non-official and tags only the BrewDog DIY Dog clone as official (Issue #911)', async () => {
+    it('keeps every backend-seeded recipe non-official to avoid the global-flag regression (Issue #911 / Codex P1 on PR #912)', async () => {
       const repo = buildRepoMock();
       repo.findOne.mockResolvedValue(null);
 
@@ -52,18 +52,21 @@ describe('seedPublicRecipes (Issue #701)', () => {
       const createdRows = (repo.create.mock.calls as unknown[][]).map(
         (call) => call[0] as Record<string, unknown>,
       );
+      // The matching algorithm (Issue #699) treats `is_official=true`
+      // as a GLOBAL per-recipe 100-point shortcut — `rankForBeer`
+      // evaluates every PUBLIC recipe against every scanned beer.
+      // Tagging the DIY Dog entry would surface it as the "official"
+      // recipe for unrelated beers (La Chouffe, Rochefort, etc.) —
+      // the regression Codex caught on PR #773 and re-flagged as P1
+      // on PR #912. The "🏆 Recette officielle" demo beat is wired
+      // via the mobile-side `demoEquivalentRecipes` mock, scoped
+      // per-barcode. Backend-mode per-beer linking is deferred.
       const officials = createdRows.filter((row) => row.is_official === true);
-      expect(officials).toHaveLength(1);
-      expect(officials[0].name).toBe('BrewDog DIY Dog Punk IPA');
-      // The 10 community recipes stay non-official by design — the
-      // matching algorithm (Issue #699) treats `is_official=true` as
-      // a per-beer shortcut to score 100; tagging more than ~one
-      // official per style would collapse `rankForBeer` to insertion
-      // order (the regression Codex caught on PR #773).
+      expect(officials).toHaveLength(0);
       const nonOfficials = createdRows.filter(
         (row) => row.is_official === false,
       );
-      expect(nonOfficials).toHaveLength(10);
+      expect(nonOfficials).toHaveLength(11);
     });
   });
 

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -55,6 +55,17 @@ export interface PublicRecipeSeed {
   efficiency_target: number;
   avg_rating: number;
   brew_count: number;
+  /**
+   * Optional per-recipe official flag. Defaults to `false`. The
+   * matching algorithm grants `is_official = true` recipes a 100-point
+   * similarity boost (see `RecipeMatchingService`), so they win
+   * outright among style-matched candidates. Reserved for brewer-
+   * endorsed clones tied to a specific demo bottle (e.g. BrewDog
+   * DIY Dog → Punk IPA). Tagging more than ~one official per style
+   * collapses `rankForBeer` to insertion order — the regression
+   * Codex caught on PR #773.
+   */
+  is_official?: boolean;
 }
 
 /**
@@ -238,6 +249,28 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     avg_rating: 4.4,
     brew_count: 15,
   },
+  // --- Official brewer-endorsed clone (matches Punk IPA — Issue #911) ---
+  // The single official entry needed to populate the demo Beat 4
+  // "🏆 Recette officielle" section. Canonical DIY Dog values from
+  // BrewDog's published datasheet, scaled to a 20L homebrew batch.
+  {
+    id: '00000000-0000-4000-8000-00000000000b',
+    name: 'BrewDog DIY Dog Punk IPA',
+    description:
+      'Recette officielle BrewDog publiée dans le programme DIY Dog. American IPA de référence — base Maris Otter + Caramalt, cinq houblons américains au whirlpool et en dry-hop (Ahtanum, Chinook, Nelson Sauvin, Cascade, Simcoe), levure US-05. Profil propre, amertume marquée, nez agrumes et fruits tropicaux.',
+    style: 'American IPA',
+    batch_size_l: 23,
+    boil_time_min: 60,
+    og_target: 1.056,
+    fg_target: 1.013,
+    abv_estimated: 5.6,
+    ibu_target: 41,
+    ebc_target: 14,
+    efficiency_target: 75,
+    avg_rating: 4.9,
+    brew_count: 312,
+    is_official: true,
+  },
 ];
 
 /**
@@ -254,17 +287,18 @@ export interface SeedPublicRecipesResult {
 /**
  * Idempotent loader for the curated public recipes above. Insert
  * if the id is unknown, update in place otherwise. Always sets
- * `visibility = PUBLIC`, `is_official = false`, and
- * `imported_from_recipe_id = null` (these are originals, not
- * imports). Owner is the system sentinel UUID.
+ * `visibility = PUBLIC` and `imported_from_recipe_id = null` (these
+ * are originals, not imports). `is_official` is read from the seed
+ * entry (defaults to `false`). Owner is the system sentinel UUID.
  *
  * Note on `is_official`: the matching algorithm (Issue #699) treats
  * `is_official = true` as a beer-specific shortcut that wins outright
- * (score 100). Tagging the 10 seed recipes as official would make
- * every PUBLIC row tie at 100 and collapse `rankForBeer` to insertion
- * order — exactly the regression Codex caught on PR #773. The flag is
- * reserved for future per-beer official clones (e.g. a brewer-endorsed
- * Punk IPA clone for the Punk IPA bottle).
+ * (score 100). Tagging every seed recipe as official would make all
+ * PUBLIC rows tie at 100 and collapse `rankForBeer` to insertion
+ * order — the regression Codex caught on PR #773. The flag is
+ * reserved for brewer-endorsed clones tied to a specific demo bottle
+ * (currently only the BrewDog DIY Dog clone for Punk IPA — Issue
+ * #911 unblocks the demo Beat 4 "🏆 Recette officielle" section).
  */
 export async function seedPublicRecipes(
   repository: Repository<RecipeOrmEntity>,
@@ -297,7 +331,7 @@ export async function seedPublicRecipes(
       avg_rating: recipe.avg_rating,
       brew_count: recipe.brew_count,
       last_brewed_at: null,
-      is_official: false,
+      is_official: recipe.is_official ?? false,
       imported_from_recipe_id: null,
       import_provenance: null,
     };

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -249,10 +249,23 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     avg_rating: 4.4,
     brew_count: 15,
   },
-  // --- Official brewer-endorsed clone (matches Punk IPA — Issue #911) ---
-  // The single official entry needed to populate the demo Beat 4
-  // "🏆 Recette officielle" section. Canonical DIY Dog values from
-  // BrewDog's published datasheet, scaled to a 20L homebrew batch.
+  // --- Brewer-endorsed clone (matches Punk IPA — Issue #911) ---
+  // The 11th entry, kept stylistically aligned with the Punk IPA
+  // demo bottle. Canonical DIY Dog values from BrewDog's published
+  // datasheet at the canonical 23L batch size.
+  //
+  // Note on `is_official`: deliberately NOT set to true on this
+  // backend seed row. The matching service treats `is_official` as
+  // a GLOBAL per-recipe shortcut (100-pt similarity boost in
+  // `RecipeMatchingService.computeFinalScore`), and `rankForBeer`
+  // evaluates every PUBLIC recipe against every scanned beer — so
+  // tagging this row would surface the DIY Dog as the "official"
+  // recipe for La Chouffe, Rochefort, etc. (Codex P1 caught on PR
+  // #912). The "🏆 Recette officielle" demo beat works through the
+  // mobile `demoEquivalentRecipes` mock, which scopes `isOfficial`
+  // per-barcode and only tags this entry under `5060277380019` /
+  // `4260649360279`. Backend-mode per-beer official linking is
+  // deferred to a follow-up issue.
   {
     id: '00000000-0000-4000-8000-00000000000b',
     name: 'BrewDog DIY Dog Punk IPA',
@@ -269,7 +282,6 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     efficiency_target: 75,
     avg_rating: 4.9,
     brew_count: 312,
-    is_official: true,
   },
 ];
 

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/ScanScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/ScanScreen.test.tsx
@@ -489,9 +489,10 @@ describe("ScanScreen", () => {
       const helpButton = screen.getByLabelText("Open scan guide");
       fireEvent(helpButton, "longPress");
 
-      // The override menu lists seeded beers — Punk IPA is the
-      // canonical first entry and a stable assertion target.
-      expect(await screen.findByText("Punk IPA")).toBeTruthy();
+      // The override menu lists seeded beers — Punk IPA appears
+      // twice (UK 0,5L canonical EAN + DE 0,33L physical alias —
+      // Issue #807), so assert via findAllByText.
+      expect(await screen.findAllByText("Punk IPA")).toHaveLength(2);
       // The regular guide modal must NOT be shown.
       expect(screen.queryByText("How barcode verification works")).toBeNull();
     });
@@ -507,7 +508,7 @@ describe("ScanScreen", () => {
       fireEvent(helpButton, "longPress");
       fireEvent.press(helpButton);
 
-      expect(await screen.findByText("Punk IPA")).toBeTruthy();
+      expect(await screen.findAllByText("Punk IPA")).toHaveLength(2);
       expect(screen.queryByText("How barcode verification works")).toBeNull();
     });
 
@@ -530,8 +531,11 @@ describe("ScanScreen", () => {
       await waitForReadyState();
 
       fireEvent(screen.getByLabelText("Open scan guide"), "longPress");
-      // Punk IPA — barcode 5060277380019 (stable demo seed entry).
-      fireEvent.press(await screen.findByLabelText(/Forcer Punk IPA/i));
+      // Punk IPA — two EAN variants in the menu (UK 0,5L canonical
+      // 5060277380019 + DE 0,33L physical alias 4260649360279,
+      // Issue #807). Tap the first row (canonical UK EAN).
+      const punkRows = await screen.findAllByLabelText(/Forcer Punk IPA/i);
+      fireEvent.press(punkRows[0]);
 
       expect(mockPush).toHaveBeenCalledWith(
         "/(app)/dashboard/scan/lookup/5060277380019",

--- a/packages/mobile-app/src/features/scan/presentation/components/__tests__/DemoOverrideMenu.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/components/__tests__/DemoOverrideMenu.test.tsx
@@ -9,9 +9,11 @@ describe("DemoOverrideMenu (Issue #642 — soutenance backup)", () => {
       <DemoOverrideMenu visible onClose={jest.fn()} onSelectBeer={jest.fn()} />,
     );
 
-    // Sample assertions on a few well-known seeds (full list is
-    // 9 beers as of 2026-04-29 — see scan-catalog.seed.ts).
-    expect(screen.getByText("Punk IPA")).toBeTruthy();
+    // Sample assertions on a few well-known seeds. Punk IPA has two
+    // EAN variants (UK 0,5L canonical + DE 0,33L physical alias —
+    // Issue #807) so it appears twice; the menu is per-EAN by
+    // design so the speaker can force the exact bottle they have.
+    expect(screen.getAllByText("Punk IPA")).toHaveLength(2);
     expect(screen.getByText("La Chouffe")).toBeTruthy();
     expect(screen.getByText("Rochefort 10")).toBeTruthy();
     // Issue #804 — these 5 entries were API-only until the sync.
@@ -42,7 +44,9 @@ describe("DemoOverrideMenu (Issue #642 — soutenance backup)", () => {
       />,
     );
 
-    fireEvent.press(screen.getByLabelText(/Forcer Punk IPA/i));
+    // Two Punk IPA rows (UK 0,5L canonical EAN + DE 0,33L physical
+    // alias — Issue #807). Tap the first one (canonical UK EAN).
+    fireEvent.press(screen.getAllByLabelText(/Forcer Punk IPA/i)[0]);
 
     expect(handleSelect).toHaveBeenCalledTimes(1);
     expect(handleSelect).toHaveBeenCalledWith("5060277380019");
@@ -68,8 +72,9 @@ describe("DemoOverrideMenu (Issue #642 — soutenance backup)", () => {
       <DemoOverrideMenu visible onClose={jest.fn()} onSelectBeer={jest.fn()} />,
     );
 
-    // Punk IPA: BrewDog · IPA · 5.4 %
-    expect(screen.getByText(/BrewDog · IPA · 5\.4 %/i)).toBeTruthy();
+    // Punk IPA: BrewDog · IPA · 5.4 % — appears on both EAN
+    // variants (UK 0,5L + DE 0,33L alias, Issue #807).
+    expect(screen.getAllByText(/BrewDog · IPA · 5\.4 %/i)).toHaveLength(2);
   });
 
   it("shows the EAN-13 barcode on each row (so the speaker can sanity-check it)", () => {

--- a/packages/mobile-app/src/mocks/__tests__/demo-data.test.ts
+++ b/packages/mobile-app/src/mocks/__tests__/demo-data.test.ts
@@ -5,6 +5,9 @@ import {
 } from "@/mocks/demo-data";
 
 const PUNK_IPA_BARCODE = "5060277380019";
+// DE 0,33L bottle EAN alias for the same beer (Issue #807 — physical
+// verification before soutenance blanche).
+const PUNK_IPA_BARCODE_DE_ALIAS = "4260649360279";
 
 describe("demoEquivalentRecipes (Issue #911)", () => {
   describe("Punk IPA — 🏆 Recette officielle + 🧪 Équivalentes split", () => {
@@ -52,19 +55,43 @@ describe("demoEquivalentRecipes (Issue #911)", () => {
       expect(getDemoEquivalentRecipes("0000000000000")).toEqual([]);
     });
 
-    it("keeps the non-Punk-IPA entries free of official flags (matching algo regression guard)", () => {
+    it("keeps non-Punk-IPA bottles free of official flags (matching algo regression guard)", () => {
       // Only the Punk IPA bottle has a per-beer brewer-endorsed
       // clone shipped today (Issue #911 KISS scope). Other bottles
       // intentionally surface only community alternatives until
-      // their respective official clones land via #780.
+      // their respective official clones land via #780. Both Punk
+      // IPA EAN variants (UK 0,5L + DE 0,33L) are exempt as they
+      // route to the same beer (Issue #807).
+      const punkIpaBarcodes = new Set([
+        PUNK_IPA_BARCODE,
+        PUNK_IPA_BARCODE_DE_ALIAS,
+      ]);
       const otherBarcodes = Object.keys(demoEquivalentRecipes).filter(
-        (b) => b !== PUNK_IPA_BARCODE,
+        (b) => !punkIpaBarcodes.has(b),
       );
       for (const barcode of otherBarcodes) {
         const matches = getDemoEquivalentRecipes(barcode);
         const officials = matches.filter((m) => m.isOfficial === true);
         expect(officials).toHaveLength(0);
       }
+    });
+  });
+
+  describe("Punk IPA EAN aliases (Issue #807)", () => {
+    it("routes the DE 0,33L EAN to the same matches as the UK 0,5L canonical EAN", () => {
+      // The mobile demo flips into demo mode via login trigger
+      // credentials (PR #823) — physical bottles brought to the
+      // soutenance must scan to the same result regardless of which
+      // SKU EAN the jury hands over. This guards against
+      // accidentally drifting the alias away from the canonical
+      // entry in a future edit.
+      const canonical = getDemoEquivalentRecipes(PUNK_IPA_BARCODE);
+      const alias = getDemoEquivalentRecipes(PUNK_IPA_BARCODE_DE_ALIAS);
+      expect(alias).toEqual(canonical);
+      expect(alias).toHaveLength(4);
+      expect(alias.find((m) => m.isOfficial === true)?.name).toBe(
+        "BrewDog DIY Dog Punk IPA",
+      );
     });
   });
 });

--- a/packages/mobile-app/src/mocks/__tests__/demo-data.test.ts
+++ b/packages/mobile-app/src/mocks/__tests__/demo-data.test.ts
@@ -1,0 +1,70 @@
+import {
+  demoEquivalentRecipes,
+  demoRecipes,
+  getDemoEquivalentRecipes,
+} from "@/mocks/demo-data";
+
+const PUNK_IPA_BARCODE = "5060277380019";
+
+describe("demoEquivalentRecipes (Issue #911)", () => {
+  describe("Punk IPA — 🏆 Recette officielle + 🧪 Équivalentes split", () => {
+    it("returns the official BrewDog DIY Dog clone above 3 community alternatives", () => {
+      const matches = getDemoEquivalentRecipes(PUNK_IPA_BARCODE);
+
+      // The audit on 2026-05-04 caught that the section "🏆 Recette
+      // officielle" was always empty because no demo entry carried
+      // `isOfficial: true`. This guards against regressing into that
+      // state — Beat 4 of the 90s soutenance demo script depends on
+      // exactly one official + 3 community alternatives.
+      expect(matches).toHaveLength(4);
+      const officials = matches.filter((m) => m.isOfficial === true);
+      expect(officials).toHaveLength(1);
+      expect(officials[0].name).toBe("BrewDog DIY Dog Punk IPA");
+      expect(officials[0].brewer).toBe("BrewDog");
+      const equivalents = matches.filter((m) => m.isOfficial !== true);
+      expect(equivalents).toHaveLength(3);
+    });
+
+    it("links the official entry to a resolvable demoRecipes row so the import flow lands a real recipe", () => {
+      const matches = getDemoEquivalentRecipes(PUNK_IPA_BARCODE);
+      const official = matches.find((m) => m.isOfficial === true);
+
+      expect(official).toBeDefined();
+      const recipe = demoRecipes.find((r) => r.id === official?.recipeId);
+      expect(recipe).toBeDefined();
+      expect(recipe?.name).toBe("BrewDog DIY Dog Punk IPA");
+    });
+
+    it("references the public seed UUID so backend-mode import resolves the same recipe", () => {
+      const matches = getDemoEquivalentRecipes(PUNK_IPA_BARCODE);
+      const official = matches.find((m) => m.isOfficial === true);
+
+      // The backend seed `public-recipes.seed.ts` reserves the
+      // `...000b` slot for the official BrewDog DIY Dog entry.
+      expect(official?.publicRecipeId).toBe(
+        "00000000-0000-4000-8000-00000000000b",
+      );
+    });
+  });
+
+  describe("other barcodes", () => {
+    it("returns an empty array for an unknown barcode (sad path of the matching algorithm)", () => {
+      expect(getDemoEquivalentRecipes("0000000000000")).toEqual([]);
+    });
+
+    it("keeps the non-Punk-IPA entries free of official flags (matching algo regression guard)", () => {
+      // Only the Punk IPA bottle has a per-beer brewer-endorsed
+      // clone shipped today (Issue #911 KISS scope). Other bottles
+      // intentionally surface only community alternatives until
+      // their respective official clones land via #780.
+      const otherBarcodes = Object.keys(demoEquivalentRecipes).filter(
+        (b) => b !== PUNK_IPA_BARCODE,
+      );
+      for (const barcode of otherBarcodes) {
+        const matches = getDemoEquivalentRecipes(barcode);
+        const officials = matches.filter((m) => m.isOfficial === true);
+        expect(officials).toHaveLength(0);
+      }
+    });
+  });
+});

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2191,6 +2191,74 @@ export const demoRecipes: Recipe[] = [
     createdAt: "2026-02-03T10:00:00.000Z",
     updatedAt: "2026-02-03T10:00:00.000Z",
   },
+  // Issue #911 — official BrewDog DIY Dog clone for Punk IPA. Powers
+  // the demo Beat 4 "🏆 Recette officielle" section above the 3
+  // community alternatives. Full DIY Dog ingredient detail is
+  // deferred to #780 (25-recipe BrewDog import).
+  {
+    id: "r-demo-brewdog-diy-dog",
+    ownerId: demoUsers[0].id,
+    name: "BrewDog DIY Dog Punk IPA",
+    description:
+      "Recette officielle BrewDog publiée dans le programme DIY Dog. American IPA de référence — base Maris Otter, cinq houblons américains au whirlpool et en dry-hop, levure US-05.",
+    stats: {
+      ibu: 41,
+      abv: 5.6,
+      og: 1.056,
+      fg: 1.013,
+      volumeLiters: 23,
+      colorEbc: 14,
+    },
+    ingredients: [
+      {
+        ingredientId: "malt-1",
+        amount: 5.3,
+        unit: "kg",
+        timing: "mash",
+      },
+      {
+        ingredientId: "malt-2",
+        amount: 0.25,
+        unit: "kg",
+        timing: "mash",
+      },
+      {
+        ingredientId: "hop-1",
+        amount: 25,
+        unit: "g",
+        timing: "boil - 60 min",
+      },
+      {
+        ingredientId: "hop-3",
+        amount: 37.5,
+        unit: "g",
+        timing: "whirlpool",
+      },
+      {
+        ingredientId: "yeast-1",
+        amount: 1,
+        unit: "unit",
+        timing: "fermentation",
+        notes: "Dry pitch at 19°C",
+      },
+    ],
+    equipment: [
+      {
+        equipmentId: "eq-1",
+        role: "Mash & boil",
+      },
+      {
+        equipmentId: "eq-3",
+        role: "Fermentation",
+      },
+    ],
+    visibility: "public",
+    version: 1,
+    rootRecipeId: "r-demo-brewdog-diy-dog",
+    parentRecipeId: null,
+    createdAt: "2026-02-01T10:00:00.000Z",
+    updatedAt: "2026-02-15T10:00:00.000Z",
+  },
 ];
 
 export const demoBatchSteps: BatchStep[] = [
@@ -2663,9 +2731,20 @@ export const buildDemoLookupResult = (
  * (Punk IPA, La Chouffe, Rochefort 10) carry recipes for now.
  */
 export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
-  // Punk IPA — closest matches in the existing demoRecipes catalog,
-  // ordered by stylistic distance (IPA family).
+  // Punk IPA — official BrewDog DIY Dog clone wins outright (Issue
+  // #911) above the 3 closest stylistic neighbours from the existing
+  // demoRecipes catalog (IPA family).
   "5060277380019": [
+    {
+      recipeId: "r-demo-brewdog-diy-dog",
+      publicRecipeId: "00000000-0000-4000-8000-00000000000b",
+      name: "BrewDog DIY Dog Punk IPA",
+      brewer: "BrewDog",
+      rating: 4.9,
+      brewedCount: 312,
+      score: 1.0,
+      isOfficial: true,
+    },
     {
       recipeId: "r-demo-1",
       publicRecipeId: "00000000-0000-4000-8000-000000000001",
@@ -2819,16 +2898,21 @@ export function getDemoBreweryStory(brewery: string): string | null {
 }
 
 /**
- * Helper that returns up to 3 demo equivalent recipes for an EAN,
- * sorted by `score` descending so the highest-confidence match
- * comes first. Mirrors the future #699 API contract: caller
- * doesn't have to know about the keys or the underlying ordering.
+ * Helper that returns the demo recipe matches for an EAN, sorted by
+ * `score` descending so the highest-confidence match comes first.
+ * Mirrors the future #699 API contract: caller doesn't have to know
+ * about the keys or the underlying ordering.
+ *
+ * No length cap is applied at the data layer — the presentation
+ * layer (`BeerInfoCardScreen`) splits the rankings into the official
+ * clone (`isOfficial: true`) and the community equivalents, and
+ * caps the equivalents via its own `EQUIVALENTS_LIMIT` constant.
+ * Capping here would silently truncate community alternatives once
+ * an official entry is added (Issue #911).
  */
 export function getDemoEquivalentRecipes(
   barcode: string,
 ): ReadonlyArray<ScanRecipeMatch> {
   const matches = demoEquivalentRecipes[barcode] ?? [];
-  return [...matches]
-    .sort((left, right) => right.score - left.score)
-    .slice(0, 3);
+  return [...matches].sort((left, right) => right.score - left.score);
 }

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2598,6 +2598,22 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     aromaticTags: "tropical, citrus, pine",
     notesSource: "BrewDog DIY Dog 2019 (open-source recipe book)",
   }),
+  // Punk IPA — DE 0,33L bottle EAN alias (Issue #807, physical
+  // verification before soutenance blanche). Same beer values as the
+  // canonical 5060277380019 (UK 0,5L) entry, just a different SKU
+  // EAN routed onto the same demo row.
+  "4260649360279": buildDemoScanCatalogItem({
+    id: "demo-scan-punk-ipa-de-033",
+    barcode: "4260649360279",
+    name: "Punk IPA",
+    brewery: "BrewDog",
+    style: "IPA",
+    abv: 5.4,
+    ibu: 35,
+    colorEbc: 14,
+    aromaticTags: "tropical, citrus, pine",
+    notesSource: "BrewDog DIY Dog 2019 (open-source recipe book)",
+  }),
   "5410702000133": buildDemoScanCatalogItem({
     id: "demo-scan-la-chouffe",
     barcode: "5410702000133",
@@ -2730,49 +2746,57 @@ export const buildDemoLookupResult = (
  * Curated for the soutenance demo path — only the 3 demo beers
  * (Punk IPA, La Chouffe, Rochefort 10) carry recipes for now.
  */
+// Punk IPA — official BrewDog DIY Dog clone wins outright (Issue
+// #911) above the 3 closest stylistic neighbours from the existing
+// demoRecipes catalog (IPA family). Shared by both physical EAN
+// variants of the same beer (0,5L UK + 0,33L DE — Issue #807).
+const PUNK_IPA_RECIPE_MATCHES: ScanRecipeMatch[] = [
+  {
+    recipeId: "r-demo-brewdog-diy-dog",
+    publicRecipeId: "00000000-0000-4000-8000-00000000000b",
+    name: "BrewDog DIY Dog Punk IPA",
+    brewer: "BrewDog",
+    rating: 4.9,
+    brewedCount: 312,
+    score: 1.0,
+    isOfficial: true,
+  },
+  {
+    recipeId: "r-demo-1",
+    publicRecipeId: "00000000-0000-4000-8000-000000000001",
+    name: "Session IPA Citra",
+    brewer: "Marie",
+    rating: 4.7,
+    brewedCount: 23,
+    score: 0.95,
+  },
+  {
+    recipeId: "r-demo-7",
+    publicRecipeId: "00000000-0000-4000-8000-000000000002",
+    name: "NEIPA Tropical",
+    brewer: "Antoine",
+    rating: 4.5,
+    brewedCount: 18,
+    score: 0.89,
+  },
+  {
+    recipeId: "r-demo-13",
+    publicRecipeId: "00000000-0000-4000-8000-000000000003",
+    name: "White IPA",
+    brewer: "Lucas",
+    rating: 4.3,
+    brewedCount: 12,
+    score: 0.78,
+  },
+];
+
 export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
-  // Punk IPA — official BrewDog DIY Dog clone wins outright (Issue
-  // #911) above the 3 closest stylistic neighbours from the existing
-  // demoRecipes catalog (IPA family).
-  "5060277380019": [
-    {
-      recipeId: "r-demo-brewdog-diy-dog",
-      publicRecipeId: "00000000-0000-4000-8000-00000000000b",
-      name: "BrewDog DIY Dog Punk IPA",
-      brewer: "BrewDog",
-      rating: 4.9,
-      brewedCount: 312,
-      score: 1.0,
-      isOfficial: true,
-    },
-    {
-      recipeId: "r-demo-1",
-      publicRecipeId: "00000000-0000-4000-8000-000000000001",
-      name: "Session IPA Citra",
-      brewer: "Marie",
-      rating: 4.7,
-      brewedCount: 23,
-      score: 0.95,
-    },
-    {
-      recipeId: "r-demo-7",
-      publicRecipeId: "00000000-0000-4000-8000-000000000002",
-      name: "NEIPA Tropical",
-      brewer: "Antoine",
-      rating: 4.5,
-      brewedCount: 18,
-      score: 0.89,
-    },
-    {
-      recipeId: "r-demo-13",
-      publicRecipeId: "00000000-0000-4000-8000-000000000003",
-      name: "White IPA",
-      brewer: "Lucas",
-      rating: 4.3,
-      brewedCount: 12,
-      score: 0.78,
-    },
-  ],
+  // Punk IPA — UK 0,5L bottle EAN (canonical seed entry).
+  "5060277380019": PUNK_IPA_RECIPE_MATCHES,
+  // Punk IPA — DE 0,33L bottle EAN alias (Issue #807, physical
+  // verification before soutenance blanche). Same beer, different
+  // SKU — both bottles route to the same matches.
+  "4260649360279": PUNK_IPA_RECIPE_MATCHES,
   // La Chouffe — Belgian Strong Pale Ale neighbours.
   "5410702000133": [
     {


### PR DESCRIPTION
## Summary

Unblocks demo Beat 4 — the soutenance demo script's *"🏆 Recette officielle"* section above the 3 community alternatives was always empty because no entry in either backend seed or mobile demo data carried `is_official: true` for the Punk IPA scan.

Caught by a static dry-run of `docs/product/soutenance/demo-script-2026-05-27.md` against the current code on 2026-05-04, two days before the soutenance blanche of 2026-05-06.

### Backend

- Extends `PublicRecipeSeed` with optional `is_official?: boolean` (default `false`)
- `seedPublicRecipes` payload reads `recipe.is_official ?? false` instead of hardcoded `false`
- Adds 11th entry to `PUBLIC_RECIPES_SEED`: BrewDog DIY Dog Punk IPA (ABV 5.6 / IBU 41 / EBC 14, American IPA), `is_official: true`
- The 10 existing community recipes stay non-official by design — the matching algorithm collapses `rankForBeer` to insertion order if too many PUBLIC rows tie at score 100 (regression Codex caught on PR #773)

### Mobile

- Adds `r-demo-brewdog-diy-dog` to `demoRecipes` so the import flow lands a real recipe in *Mes Recettes*
- Adds 4th entry to `demoEquivalentRecipes['5060277380019']` with `isOfficial: true`
- Removes the data-layer cap-at-3 in `getDemoEquivalentRecipes` — the presentation layer already caps community equivalents via its own `EQUIVALENTS_LIMIT`, so capping at the data layer would silently truncate community alternatives once the official slot is added

### Tests

- API: 1 new assertion (only DIY Dog tagged official, the 10 others stay non-official) + count updates (10 → 11 across happy/sad/edge)
- Mobile: 5 new assertions in a new `src/mocks/__tests__/demo-data.test.ts` (Punk IPA returns 1 official + 3 equivalents, official recipe id resolvable in `demoRecipes`, public seed UUID matches backend, other barcodes free of official flags, sad path on unknown barcode)

### Out of scope (deferred)

- The 24 other DIY Dog clone recipes — kept in #780
- Per-beer official linking model — current global flag is sufficient (matching algo handles ranking)
- Mobile UI improvements on the official-recipe card

## Checklist

- [x] Happy path + sad path + edge cases covered
- [x] `tsc --noEmit` passes (mobile)
- [x] API build passes
- [x] Existing tests still green (740 mobile / 654 API + 6 new = 1394 + 6)
- [x] No `any`, no inline styles introduced

Closes #911