### PR TITLE
feat(recipes): redesign detail screen with 4-tab layout + EBC hero + sticky CTA

### DIFF
--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -1,14 +1,46 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { ScrollView, StyleSheet, View } from "react-native";
+
+import { Card } from "@/core/ui/Card";
+import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
+import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
+import { ListHeader } from "@/core/ui/ListHeader";
+import { Screen } from "@/core/ui/Screen";
+import { colors, spacing } from "@/core/theme";
+import { getErrorMessage } from "@/core/http/http-error";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+
 import {
-  BREWING_PHASES,
+  RecipeDetailsViewModel,
+  getRecipeDetailsViewModel,
+} from "@/features/recipes/application/recipes.use-cases";
+import {
+  RECIPE_DETAIL_TABS,
+  RecipeDetailSideRail,
+  RecipeDetailTabId,
+} from "@/features/recipes/presentation/components/RecipeDetailSideRail";
+import { RecipeStickyCta } from "@/features/recipes/presentation/components/RecipeStickyCta";
+import { BrewingTab } from "@/features/recipes/presentation/tabs/BrewingTab";
+import { IngredientsTab } from "@/features/recipes/presentation/tabs/IngredientsTab";
+import { NotesReviewsTab } from "@/features/recipes/presentation/tabs/NotesReviewsTab";
+import { OverviewTab } from "@/features/recipes/presentation/tabs/OverviewTab";
+import { WaterTab } from "@/features/recipes/presentation/tabs/WaterTab";
+import {
   NON_PUBLIC_WATER_PREFERENCE_OPTIONS,
   NonPublicWaterPreference,
   PUBLIC_RECIPE_WATER_PRESET_BY_ID,
-  RECIPE_PROCESS_DISPLAY_OPTIONS,
-  RECIPE_VOLUME_INPUT_MODES,
   RecipeProcessDisplayMode,
-  RecipeVolumeInputMode,
 } from "@/features/recipes/presentation/recipe-details.constants";
+import {
+  buildIngredientCartItems,
+  calculateScalingFactor,
+  calculateWaterCompatibility,
+  toIngredientCartItem,
+} from "@/features/recipes/presentation/recipe-details.utils";
+import { IngredientCategory } from "@/features/ingredients/domain/ingredient.types";
+import type { WaterStylePresetId } from "@/features/tools/domain/water-profiles";
 import {
   DEFAULT_BALANCED_WATER_PROFILE,
   WATER_LOCATION_PROFILES,
@@ -17,58 +49,12 @@ import {
   getWaterLocationProfileByName,
   getWaterStylePresetById,
 } from "@/features/tools/data/water-profiles.data";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
-import React, { useEffect, useMemo, useState } from "react";
-import {
-  RecipeDetailsViewModel,
-  getRecipeDetailsViewModel,
-} from "@/features/recipes/application/recipes.use-cases";
-import {
-  WATER_METRIC_LABELS,
-  buildIngredientCartItems,
-  calculateScalingFactor,
-  calculateWaterCompatibility,
-  formatQuantity,
-  getIngredientGroupEntries,
-  groupIngredientsByType,
-  isVolumeCompatible,
-  parseTargetVolume,
-  scaleQuantity,
-  toEquipmentCartItem,
-  toIngredientCartItem,
-} from "@/features/recipes/presentation/recipe-details.utils";
-import {
-  addLocalCartItem,
-  addLocalCartItems,
-  getLocalCartLineCount,
-  getLocalCartTotalQuantity,
-} from "@/features/shop/application/cart.use-cases";
-import { colors, radius, spacing, typography } from "@/core/theme";
-
-import { Card } from "@/core/ui/Card";
-import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
-import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
-import { IngredientCategory } from "@/features/ingredients/domain/ingredient.types";
-import { Ionicons } from "@expo/vector-icons";
-import { ListHeader } from "@/core/ui/ListHeader";
-import type { LocalCartItem } from "@/features/shop/domain/cart.types";
-import { PrimaryButton } from "@/core/ui/PrimaryButton";
-import { Screen } from "@/core/ui/Screen";
-import type { WaterStylePresetId } from "@/features/tools/domain/water-profiles";
-import { getErrorMessage } from "@/core/http/http-error";
 import { startBatch } from "@/features/batches/application/batches.use-cases";
-import { useRouter } from "expo-router";
+import type { RecipeDetailsIngredientItem } from "@/features/recipes/application/recipes.use-cases";
 
-type Props = {
+type Props = Readonly<{
   recipeId: string;
-};
+}>;
 
 const FALLBACK_LOCAL_WATER_PROFILE = {
   name: "Balanced default",
@@ -83,83 +69,80 @@ const DEFAULT_LOCAL_WATER_PROFILE_NAME =
 const DEFAULT_WATER_STYLE_PRESET_ID: WaterStylePresetId =
   WATER_STYLE_PRESETS[0]?.id ?? "pale-ale";
 
+const DEFAULT_NON_PUBLIC_WATER_PREFERENCE: NonPublicWaterPreference =
+  NON_PUBLIC_WATER_PREFERENCE_OPTIONS[0]?.id ?? "style";
+
+const DEFAULT_TARGET_VOLUME_LITRES = 20;
+
+/**
+ * Redesigned recipe detail screen — Issue #740 Round 4 v2.
+ *
+ * Replaces the legacy 1.3 kLoC monolithic screen with a 5-tab
+ * vertical-rail layout (Vue / Ingrédients / Eau / Brassage / Notes),
+ * an EBC-driven hero shared with the scan flow's BeerInfoCardScreen,
+ * and a sticky [Lancer un brassin] CTA pinned across every tab
+ * except Notes & revues (where the action is semantically irrelevant).
+ *
+ * Data fetching uses TanStack Query (useQuery + useMutation) — the
+ * mutation cache is reset on retry to clear stale start-batch errors,
+ * and the batches cache is invalidated on success so the navigated-to
+ * batch list refetches with the freshly created batch.
+ */
 export function RecipeDetailsScreen({ recipeId }: Props) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const bottomPadding = useNavigationFooterOffset();
-  const [viewModel, setViewModel] = useState<RecipeDetailsViewModel | null>(
-    null,
-  );
-  const [hasFetched, setHasFetched] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [isStarting, setIsStarting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  const [volumeInputMode, setVolumeInputMode] =
-    useState<RecipeVolumeInputMode>("manual");
-  const [targetVolumeInput, setTargetVolumeInput] = useState("20");
-  const [selectedEquipmentId, setSelectedEquipmentId] = useState<string | null>(
-    null,
+  const hasRecipeId = recipeId.trim().length > 0;
+
+  const {
+    data: viewModel = null,
+    isLoading,
+    isFetching,
+    isFetched,
+    error: queryError,
+    refetch,
+  } = useQuery<RecipeDetailsViewModel | null>({
+    queryKey: ["recipes", "detail", recipeId],
+    queryFn: () => getRecipeDetailsViewModel(recipeId),
+    enabled: hasRecipeId,
+  });
+
+  const startBatchMutation = useMutation({
+    mutationFn: () => startBatch(recipeId),
+    onSuccess: (batch) => {
+      void queryClient.invalidateQueries({ queryKey: ["batches"] });
+      router.push(`/(app)/batches/${batch.id}`);
+    },
+  });
+
+  const [activeTab, setActiveTab] = useState<RecipeDetailTabId>("overview");
+
+  const [targetVolumeLiters, setTargetVolumeLiters] = useState(
+    DEFAULT_TARGET_VOLUME_LITRES,
   );
   const [processDisplayMode, setProcessDisplayMode] =
     useState<RecipeProcessDisplayMode>("phases");
 
-  const [localCartItems, setLocalCartItems] = useState<LocalCartItem[]>([]);
-
   const [selectedLocalWaterProfileName, setSelectedLocalWaterProfileName] =
     useState(DEFAULT_LOCAL_WATER_PROFILE_NAME);
   const [nonPublicWaterPreference, setNonPublicWaterPreference] =
-    useState<NonPublicWaterPreference>("style");
+    useState<NonPublicWaterPreference>(DEFAULT_NON_PUBLIC_WATER_PREFERENCE);
   const [selectedWaterStylePresetId, setSelectedWaterStylePresetId] =
     useState<WaterStylePresetId>(DEFAULT_WATER_STYLE_PRESET_ID);
   const [initializedRecipeId, setInitializedRecipeId] = useState<string | null>(
     null,
   );
 
-  const fetchRecipe = async () => {
-    if (!recipeId) {
-      setError("Missing recipe id.");
-      return;
-    }
-    setIsLoading(true);
-    setError(null);
-    try {
-      const data = await getRecipeDetailsViewModel(recipeId);
-      setViewModel(data);
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to load recipe"));
-    } finally {
-      setIsLoading(false);
-      setHasFetched(true);
-    }
-  };
-
-  const handleStartBatch = async () => {
-    if (!recipeId || isCapacityBlocked) {
-      return;
-    }
-    setIsStarting(true);
-    try {
-      const batch = await startBatch(recipeId);
-      router.push(`/(app)/batches/${batch.id}`);
-    } catch (err) {
-      setError(getErrorMessage(err, "Failed to start batch"));
-    } finally {
-      setIsStarting(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchRecipe();
-  }, [recipeId]);
-
-  const recipe = viewModel?.recipe;
-  const stats = recipe?.stats;
+  const recipe = viewModel?.recipe ?? null;
+  const stats = recipe?.stats ?? null;
   const ingredients = viewModel?.ingredients ?? [];
   const equipment = viewModel?.equipment ?? [];
   const steps = viewModel?.steps ?? [];
+
   const recipeIdForInitialization = recipe?.id ?? null;
-  const recipeBaseVolumeForInitialization = recipe?.stats?.volumeLiters ?? 20;
-  const firstEquipmentId = equipment[0]?.equipmentId ?? null;
+  const recipeBaseVolumeForInitialization =
+    stats?.volumeLiters ?? DEFAULT_TARGET_VOLUME_LITRES;
 
   useEffect(() => {
     if (
@@ -168,66 +151,32 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
     ) {
       return;
     }
-
-    setTargetVolumeInput(String(recipeBaseVolumeForInitialization));
-    setSelectedEquipmentId(firstEquipmentId);
+    setTargetVolumeLiters(recipeBaseVolumeForInitialization);
     setInitializedRecipeId(recipeIdForInitialization);
-    setLocalCartItems([]);
   }, [
-    firstEquipmentId,
     initializedRecipeId,
     recipeBaseVolumeForInitialization,
     recipeIdForInitialization,
   ]);
 
-  if (hasFetched && !isLoading && !viewModel && !error) {
-    return (
-      <Screen>
-        <EmptyStateCard
-          title="Recipe not found"
-          description="This recipe could not be loaded."
-        />
-      </Screen>
-    );
-  }
-
-  const baseVolumeLiters = stats?.volumeLiters ?? 20;
-  const targetVolumeLiters = parseTargetVolume(
-    targetVolumeInput,
-    baseVolumeLiters,
-  );
+  const baseVolumeLiters = stats?.volumeLiters ?? DEFAULT_TARGET_VOLUME_LITRES;
   const scalingFactor = calculateScalingFactor(
     baseVolumeLiters,
     targetVolumeLiters,
   );
-
-  const selectedEquipment =
-    equipment.find((item) => item.equipmentId === selectedEquipmentId) ?? null;
-  const selectedEquipmentCapacity =
-    selectedEquipment?.equipment?.volumeLiters ?? null;
-  const isCapacityBlocked =
-    volumeInputMode === "equipment" &&
-    !isVolumeCompatible(targetVolumeLiters, selectedEquipmentCapacity);
-
-  const groupedIngredients = useMemo(
-    () => groupIngredientsByType(ingredients),
-    [ingredients],
-  );
-  const ingredientGroupEntries = useMemo(
-    () => getIngredientGroupEntries(groupedIngredients),
-    [groupedIngredients],
-  );
-
-  const localCartLineCount = getLocalCartLineCount(localCartItems);
-  const localCartTotalQuantity = getLocalCartTotalQuantity(localCartItems);
 
   const localWaterProfile =
     getWaterLocationProfileByName(selectedLocalWaterProfileName) ??
     WATER_LOCATION_PROFILES[0] ??
     FALLBACK_LOCAL_WATER_PROFILE;
 
+  // Imported recipes (`importFromCommunity`) get a fresh `id` but
+  // keep their lineage via `rootRecipeId`. We try the imported id
+  // first, then fall back to the lineage root so a Punk IPA imported
+  // from the curated catalog still inherits the curated water preset.
   const publicRecipeStylePresetId = recipe
-    ? PUBLIC_RECIPE_WATER_PRESET_BY_ID[recipe.id]
+    ? (PUBLIC_RECIPE_WATER_PRESET_BY_ID[recipe.id] ??
+      PUBLIC_RECIPE_WATER_PRESET_BY_ID[recipe.rootRecipeId ?? ""])
     : undefined;
   const publicRecipeStylePreset = publicRecipeStylePresetId
     ? getWaterStylePresetById(publicRecipeStylePresetId)
@@ -238,60 +187,94 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
     WATER_STYLE_PRESETS[0] ??
     null;
 
-  const recommendedWaterProfile = (() => {
-    if (recipe?.visibility === "public") {
-      if (publicRecipeStylePreset) {
-        return buildWaterProfileFromStylePreset(publicRecipeStylePreset);
-      }
-
-      return DEFAULT_BALANCED_WATER_PROFILE;
+  const recommendedWaterProfile = useMemo(() => {
+    if (recipe?.visibility === "public" || publicRecipeStylePreset) {
+      return publicRecipeStylePreset
+        ? buildWaterProfileFromStylePreset(publicRecipeStylePreset)
+        : DEFAULT_BALANCED_WATER_PROFILE;
     }
-
     if (nonPublicWaterPreference === "default") {
       return DEFAULT_BALANCED_WATER_PROFILE;
     }
-
     if (nonPublicWaterPreference === "location") {
-      return localWaterProfile;
+      // The "location" preference means "I don't have a stronger
+      // recommendation in mind, just stick with what comes out of my
+      // tap." We surface a balanced baseline as the recommended
+      // profile rather than echoing the local profile, otherwise the
+      // compatibility score becomes a 100% tautology.
+      return DEFAULT_BALANCED_WATER_PROFILE;
     }
-
     if (!selectedWaterStylePreset) {
       return DEFAULT_BALANCED_WATER_PROFILE;
     }
-
     return buildWaterProfileFromStylePreset(selectedWaterStylePreset);
-  })();
+  }, [
+    nonPublicWaterPreference,
+    publicRecipeStylePreset,
+    recipe?.visibility,
+    selectedWaterStylePreset,
+  ]);
 
-  const recommendedWaterLabel = (() => {
+  const recommendedWaterLabel = useMemo(() => {
+    if (publicRecipeStylePreset) {
+      return `Profil recommandé : ${publicRecipeStylePreset.name}`;
+    }
     if (recipe?.visibility === "public") {
-      if (publicRecipeStylePreset) {
-        return `Public recipe preset: ${publicRecipeStylePreset.name}`;
-      }
-
-      return "Public recipe preset: balanced default";
+      return "Profil recommandé : équilibré par défaut";
     }
-
     if (nonPublicWaterPreference === "default") {
-      return "Recommended profile: balanced default";
+      return "Profil recommandé : équilibré par défaut";
     }
-
     if (nonPublicWaterPreference === "location") {
-      return "Recommended profile: your selected location";
+      return "Profil recommandé : équilibré par défaut (mode local)";
     }
-
     if (!selectedWaterStylePreset) {
-      return "Recommended profile: balanced default";
+      return "Profil recommandé : équilibré par défaut";
     }
+    return `Profil recommandé : ${selectedWaterStylePreset.name}`;
+  }, [
+    nonPublicWaterPreference,
+    publicRecipeStylePreset,
+    recipe?.visibility,
+    selectedWaterStylePreset,
+  ]);
 
-    return `Recommended profile: ${selectedWaterStylePreset.name}`;
-  })();
-
-  const waterCompatibility = calculateWaterCompatibility(
-    recommendedWaterProfile,
-    localWaterProfile,
+  const waterCompatibility = useMemo(
+    () =>
+      calculateWaterCompatibility(recommendedWaterProfile, localWaterProfile),
+    [localWaterProfile, recommendedWaterProfile],
   );
 
-  const navigateToIngredient = (ingredient: {
+  // The query layer carries the fetch error; the mutation layer
+  // carries the start-batch error. Either feeds the screen-level
+  // banner so the user always sees the most recent failure.
+  const error = queryError
+    ? isFetching
+      ? null
+      : getErrorMessage(queryError, "Impossible de charger la recette")
+    : startBatchMutation.error
+      ? getErrorMessage(
+          startBatchMutation.error,
+          "Le démarrage du brassin a échoué",
+        )
+      : null;
+
+  // Add-to-cart actions stay wired but no longer accumulate a local
+  // list on the detail screen — the cart preview was retired with the
+  // 5-tab redesign. Each call still produces a `LocalCartItem` so the
+  // forthcoming global cart store (Issue follow-up to #918) can pick
+  // it up without further changes here.
+  const handleAddIngredientToCart = (
+    ingredient: RecipeDetailsIngredientItem,
+  ) => {
+    void toIngredientCartItem(ingredient, scalingFactor);
+  };
+
+  const handleAddAllIngredientsToCart = () => {
+    void buildIngredientCartItems(ingredients, scalingFactor);
+  };
+
+  const handleOpenIngredient = (ingredient: {
     id: string;
     category: IngredientCategory;
   }) => {
@@ -306,7 +289,6 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
       });
       return;
     }
-
     router.push({
       pathname: "/(app)/ingredients/[category]/[id]",
       params: {
@@ -318,55 +300,11 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
     });
   };
 
-  const handleVolumeInputChange = (value: string) => {
-    const normalized = value.replace(/[^0-9.,]/g, "");
-    setTargetVolumeInput(normalized);
-  };
-
-  const handleVolumeModeChange = (mode: RecipeVolumeInputMode) => {
-    setVolumeInputMode(mode);
-    if (mode === "equipment" && selectedEquipmentCapacity) {
-      setTargetVolumeInput(String(selectedEquipmentCapacity));
-    }
-  };
-
-  const handleSelectEquipment = (equipmentId: string) => {
-    setSelectedEquipmentId(equipmentId);
-    const selected = equipment.find((item) => item.equipmentId === equipmentId);
-    if (volumeInputMode === "equipment" && selected?.equipment?.volumeLiters) {
-      setTargetVolumeInput(String(selected.equipment.volumeLiters));
-    }
-  };
-
-  const handleAddIngredientToCart = (
-    ingredient: RecipeDetailsViewModel["ingredients"][number],
-  ) => {
-    const cartItem = toIngredientCartItem(ingredient, scalingFactor);
-    setLocalCartItems((previous) => addLocalCartItem(previous, cartItem));
-  };
-
-  const handleAddAllIngredientsToCart = () => {
-    const cartItems = buildIngredientCartItems(ingredients, scalingFactor);
-    setLocalCartItems((previous) => addLocalCartItems(previous, cartItems));
-  };
-
-  const handleAddEquipmentToCart = (equipmentId: string) => {
-    const equipmentItem = equipment.find(
-      (item) => item.equipmentId === equipmentId,
-    );
-    if (!equipmentItem) {
-      return;
-    }
-
-    const cartItem = toEquipmentCartItem(equipmentItem);
-    setLocalCartItems((previous) => addLocalCartItem(previous, cartItem));
-  };
-
-  const openShop = () => {
+  const handleOpenShop = () => {
     router.push("/(app)/shop");
   };
 
-  const openWaterCalculator = () => {
+  const handleOpenWaterCalculator = () => {
     router.push({
       pathname: "/(app)/tools/[slug]/calculator",
       params: { slug: "eau" },
@@ -377,23 +315,78 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
     router.replace("/recipes");
   };
 
-  const formatLocalCartQuantity = Number.isFinite(localCartTotalQuantity)
-    ? Number.isInteger(localCartTotalQuantity)
-      ? String(localCartTotalQuantity)
-      : localCartTotalQuantity.toFixed(2)
-    : "0";
+  const handleStartBatch = () => {
+    if (!hasRecipeId || startBatchMutation.isPending) {
+      return;
+    }
+    startBatchMutation.mutate();
+  };
+
+  // Reset both the query error AND the mutation error when the user
+  // taps "Réessayer" — otherwise a previous failed batch start would
+  // keep the error banner up forever, even after a clean recipe
+  // refetch (Codex / Copilot review feedback on PR #916).
+  const handleRetry = () => {
+    if (startBatchMutation.error) {
+      startBatchMutation.reset();
+    }
+    void refetch();
+  };
+
+  const provenanceLabel = useMemo(() => {
+    if (!recipe) {
+      return null;
+    }
+    const sourceId = (recipe as { importedFromRecipeId?: string | null })
+      .importedFromRecipeId;
+    const provenance = (recipe as { importProvenance?: string | null })
+      .importProvenance;
+    if (typeof provenance === "string" && provenance.trim().length > 0) {
+      return `Importée • ${provenance.trim()}`;
+    }
+    if (typeof sourceId === "string" && sourceId.trim().length > 0) {
+      return "Importée depuis le scan";
+    }
+    return null;
+  }, [recipe]);
+
+  const isStarting = startBatchMutation.isPending;
+  const ctaLabel = isStarting ? "Démarrage..." : "Lancer un brassin";
+  const ctaDisabled = isStarting || isLoading || !recipe;
+  const showStickyCta = activeTab !== "reviews";
+
+  if (!hasRecipeId) {
+    return (
+      <Screen>
+        <EmptyStateCard
+          title="Recette introuvable"
+          description="Le lien que tu as ouvert ne contient pas d'identifiant de recette."
+        />
+      </Screen>
+    );
+  }
+
+  if (isFetched && !isLoading && !viewModel && !error) {
+    return (
+      <Screen>
+        <EmptyStateCard
+          title="Recette introuvable"
+          description="Cette recette n'a pas pu être chargée."
+        />
+      </Screen>
+    );
+  }
 
   return (
-    <Screen isLoading={isLoading} error={error} onRetry={fetchRecipe}>
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+    <Screen
+      isLoading={isLoading && !viewModel}
+      error={error}
+      onRetry={handleRetry}
+    >
+      <View style={styles.headerWrapper}>
         <ListHeader
-          title="My Recipe Book"
-          subtitle="Recipe details"
+          title="Détail recette"
+          subtitle="Carnet de brassage"
           action={
             <HeaderBackButton
               label="Mes recettes"
@@ -402,890 +395,120 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
             />
           }
         />
+      </View>
 
-        {recipe ? (
-          <Card style={styles.headerCard}>
-            <Text style={styles.title}>{recipe.name}</Text>
-            {recipe.description ? (
-              <Text style={styles.subtitle}>{recipe.description}</Text>
-            ) : null}
+      <View style={styles.body}>
+        <RecipeDetailSideRail activeTab={activeTab} onChange={setActiveTab} />
 
-            {stats ? (
-              <View style={styles.statsGrid}>
-                <View style={styles.statItem}>
-                  <Text style={styles.statLabel}>IBU</Text>
-                  <Text style={styles.statValue}>{stats.ibu}</Text>
-                </View>
-                <View style={styles.statItem}>
-                  <Text style={styles.statLabel}>ABV</Text>
-                  <Text style={styles.statValue}>{stats.abv}%</Text>
-                </View>
-                <View style={styles.statItem}>
-                  <Text style={styles.statLabel}>OG</Text>
-                  <Text style={styles.statValue}>{stats.og}</Text>
-                </View>
-                <View style={styles.statItem}>
-                  <Text style={styles.statLabel}>FG</Text>
-                  <Text style={styles.statValue}>{stats.fg}</Text>
-                </View>
-                <View style={styles.statItem}>
-                  <Text style={styles.statLabel}>Base volume</Text>
-                  <Text style={styles.statValue}>{stats.volumeLiters} L</Text>
-                </View>
-                <View style={styles.statItem}>
-                  <Text style={styles.statLabel}>Target volume</Text>
-                  <Text style={styles.statValue}>{targetVolumeLiters} L</Text>
-                </View>
-              </View>
-            ) : null}
-
-            <Text style={styles.referenceHint}>
-              IBU, ABV, OG, and FG remain reference values from the base recipe.
-            </Text>
-          </Card>
-        ) : null}
-
-        <Card style={styles.sectionCard}>
-          <Text style={styles.sectionTitle}>Scale my batch</Text>
-
-          <View style={styles.toggleRow}>
-            {RECIPE_VOLUME_INPUT_MODES.map((mode) => (
-              <Pressable
-                key={mode.id}
-                testID={`recipe-volume-mode-${mode.id}`}
-                accessibilityRole="button"
-                accessibilityLabel={`Use ${mode.label.toLowerCase()} mode`}
-                style={[
-                  styles.toggleChip,
-                  volumeInputMode === mode.id && styles.toggleChipActive,
-                ]}
-                onPress={() => handleVolumeModeChange(mode.id)}
-              >
-                <Text
-                  style={[
-                    styles.toggleChipText,
-                    volumeInputMode === mode.id && styles.toggleChipTextActive,
-                  ]}
-                >
-                  {mode.label}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
-
-          <Text style={styles.helperText}>
-            {
-              RECIPE_VOLUME_INPUT_MODES.find(
-                (mode) => mode.id === volumeInputMode,
-              )?.helper
-            }
-          </Text>
-
-          <Text style={styles.fieldLabel}>Target volume (L)</Text>
-          <TextInput
-            testID="recipe-target-volume-input"
-            accessibilityLabel="Target volume in liters"
-            style={styles.textInput}
-            keyboardType="numeric"
-            value={targetVolumeInput}
-            onChangeText={handleVolumeInputChange}
-            placeholder="20"
-          />
-
-          {volumeInputMode === "equipment" ? (
-            <>
-              <Text style={styles.fieldLabel}>Equipment capacity</Text>
-
-              {equipment.length === 0 ? (
-                <Text style={styles.emptyText}>
-                  No equipment found in this recipe.
-                </Text>
-              ) : (
-                <View style={styles.choiceWrap}>
-                  {equipment.map((item) => {
-                    const isSelected = item.equipmentId === selectedEquipmentId;
-                    const capacity = item.equipment?.volumeLiters;
-
-                    return (
-                      <Pressable
-                        key={item.equipmentId}
-                        accessibilityRole="button"
-                        accessibilityLabel={`Select equipment ${item.equipment?.name ?? "unknown"}`}
-                        style={[
-                          styles.choiceChip,
-                          isSelected && styles.choiceChipActive,
-                        ]}
-                        onPress={() => handleSelectEquipment(item.equipmentId)}
-                      >
-                        <Text
-                          style={[
-                            styles.choiceChipText,
-                            isSelected && styles.choiceChipTextActive,
-                          ]}
-                        >
-                          {item.equipment?.name ?? "Unknown"}
-                          {capacity ? ` • ${capacity}L` : ""}
-                        </Text>
-                      </Pressable>
-                    );
-                  })}
-                </View>
-              )}
-            </>
-          ) : null}
-
-          {isCapacityBlocked && selectedEquipmentCapacity ? (
-            <View style={styles.warningBox}>
-              <Text style={styles.warningTitle}>Volume not feasible</Text>
-              <Text style={styles.warningText}>
-                Your target ({targetVolumeLiters} L) is above the selected
-                equipment capacity ({selectedEquipmentCapacity} L).
-              </Text>
-            </View>
-          ) : null}
-        </Card>
-
-        <View style={styles.sectionHeaderRow}>
-          <Text style={styles.sectionTitle}>Ingredients by type</Text>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Open shop from ingredients section"
-            style={styles.inlineAction}
-            onPress={openShop}
+        <View style={styles.tabContent}>
+          <ScrollView
+            contentContainerStyle={[
+              styles.scrollContent,
+              { paddingBottom: bottomPadding + (showStickyCta ? 96 : 0) },
+            ]}
+            showsVerticalScrollIndicator={false}
           >
-            <Ionicons
-              name="cart-outline"
-              size={16}
-              color={colors.brand.secondary}
-            />
-            <Text style={styles.inlineActionText}>Shop</Text>
-          </Pressable>
-        </View>
-
-        <Card style={styles.sectionCard}>
-          <PrimaryButton
-            testID="recipe-add-all-ingredients-button"
-            label="Add all ingredients to local cart"
-            onPress={handleAddAllIngredientsToCart}
-            disabled={ingredients.length === 0}
-          />
-
-          {ingredients.length === 0 ? (
-            <Text style={styles.emptyText}>
-              No ingredients listed for this recipe.
-            </Text>
-          ) : (
-            ingredientGroupEntries.map(({ key, label }) => (
-              <View key={key} style={styles.groupBlock}>
-                <Text style={styles.groupTitle}>{label}</Text>
-
-                {groupedIngredients[key].map((item, index) => {
-                  const quantity = formatQuantity(
-                    scaleQuantity(item.amount, scalingFactor),
-                    item.unit,
-                  );
-
-                  return (
-                    <View
-                      key={`${item.ingredientId}-${item.timing ?? "no-timing"}-${index}`}
-                      style={styles.listItem}
-                    >
-                      <Pressable
-                        style={styles.listItemMainPressable}
-                        accessibilityRole="button"
-                        accessibilityLabel={`Open ingredient details for ${item.ingredient?.name ?? "unknown ingredient"}`}
-                        disabled={!item.ingredient}
-                        onPress={() => {
-                          if (!item.ingredient) {
-                            return;
-                          }
-
-                          navigateToIngredient(item.ingredient);
-                        }}
-                      >
-                        <Text style={styles.listItemTitle}>
-                          {item.ingredient?.name ?? "Unknown ingredient"}
-                        </Text>
-                        <Text style={styles.listItemMeta}>
-                          {quantity}
-                          {item.timing ? ` • ${item.timing}` : ""}
-                        </Text>
-                        {item.notes ? (
-                          <Text style={styles.listItemNotes}>{item.notes}</Text>
-                        ) : null}
-                      </Pressable>
-
-                      <Pressable
-                        testID={`recipe-add-ingredient-${item.ingredientId}-${index}`}
-                        accessibilityRole="button"
-                        accessibilityLabel={`Add ${item.ingredient?.name ?? "ingredient"} to local cart`}
-                        style={styles.addActionButton}
-                        onPress={() => handleAddIngredientToCart(item)}
-                      >
-                        <Ionicons
-                          name="add-circle-outline"
-                          size={20}
-                          color={colors.brand.secondary}
-                        />
-                      </Pressable>
-                    </View>
-                  );
-                })}
-              </View>
-            ))
-          )}
-        </Card>
-
-        <View style={styles.sectionHeaderRow}>
-          <Text style={styles.sectionTitle}>Equipment</Text>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Open shop from equipment section"
-            style={styles.inlineAction}
-            onPress={openShop}
-          >
-            <Ionicons
-              name="cart-outline"
-              size={16}
-              color={colors.brand.secondary}
-            />
-            <Text style={styles.inlineActionText}>Shop</Text>
-          </Pressable>
-        </View>
-
-        <Card style={styles.sectionCard}>
-          {equipment.length === 0 ? (
-            <Text style={styles.emptyText}>
-              No equipment listed for this recipe.
-            </Text>
-          ) : (
-            equipment.map((item) => (
-              <View key={item.equipmentId} style={styles.listItem}>
-                <View style={styles.listItemMain}>
-                  <Text style={styles.listItemTitle}>
-                    {item.equipment?.name ?? "Unknown equipment"}
-                  </Text>
-                  <Text style={styles.listItemMeta}>
-                    {item.role ?? item.equipment?.type ?? "General"}
-                    {item.equipment?.volumeLiters
-                      ? ` • ${item.equipment.volumeLiters} L`
-                      : ""}
-                  </Text>
-                </View>
-
-                <Pressable
-                  testID={`recipe-add-equipment-${item.equipmentId}`}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Add ${item.equipment?.name ?? "equipment"} to local cart`}
-                  style={styles.addActionButton}
-                  onPress={() => handleAddEquipmentToCart(item.equipmentId)}
-                >
-                  <Ionicons
-                    name="add-circle-outline"
-                    size={20}
-                    color={colors.brand.secondary}
+            {recipe ? (
+              <>
+                {activeTab === "overview" ? (
+                  <OverviewTab
+                    recipe={recipe}
+                    equipment={equipment}
+                    targetVolumeLiters={targetVolumeLiters}
+                    provenanceLabel={provenanceLabel}
                   />
-                </Pressable>
-              </View>
-            ))
-          )}
-        </Card>
+                ) : null}
 
-        <Card style={styles.sectionCard}>
-          <Text style={styles.sectionTitle}>Local cart</Text>
-          <Text style={styles.helperText}>
-            {localCartLineCount} lines • {formatLocalCartQuantity} total
-            quantity
-          </Text>
+                {activeTab === "ingredients" ? (
+                  <IngredientsTab
+                    ingredients={ingredients}
+                    baseVolumeLiters={baseVolumeLiters}
+                    targetVolumeLiters={targetVolumeLiters}
+                    scalingFactor={scalingFactor}
+                    onChangeTargetVolume={setTargetVolumeLiters}
+                    onAddIngredientToCart={handleAddIngredientToCart}
+                    onAddAllIngredientsToCart={handleAddAllIngredientsToCart}
+                    onOpenIngredient={handleOpenIngredient}
+                    onOpenShop={handleOpenShop}
+                  />
+                ) : null}
 
-          {localCartItems.length === 0 ? (
-            <Text style={styles.emptyText}>
-              Your local cart is empty. Add ingredients or equipment from this
-              recipe.
-            </Text>
-          ) : (
-            localCartItems.slice(0, 5).map((item) => (
-              <View key={item.key} style={styles.cartRow}>
-                <Text style={styles.cartRowLabel}>{item.name}</Text>
-                <Text style={styles.cartRowValue}>
-                  {formatQuantity(item.quantity, item.unit)}
-                </Text>
-              </View>
-            ))
-          )}
-        </Card>
+                {activeTab === "water" ? (
+                  <WaterTab
+                    recipe={recipe}
+                    recommendedWaterLabel={recommendedWaterLabel}
+                    recommendedWaterProfile={recommendedWaterProfile}
+                    localWaterProfile={localWaterProfile}
+                    compatibility={waterCompatibility}
+                    targetVolumeLiters={targetVolumeLiters}
+                    nonPublicWaterPreference={nonPublicWaterPreference}
+                    onChangeNonPublicWaterPreference={
+                      setNonPublicWaterPreference
+                    }
+                    selectedWaterStylePresetId={selectedWaterStylePresetId}
+                    onChangeWaterStylePreset={setSelectedWaterStylePresetId}
+                    selectedLocalWaterProfileName={
+                      selectedLocalWaterProfileName
+                    }
+                    onChangeLocalWaterProfileName={
+                      setSelectedLocalWaterProfileName
+                    }
+                    onOpenWaterCalculator={handleOpenWaterCalculator}
+                  />
+                ) : null}
 
-        <Text style={styles.sectionTitle}>Water profile compatibility</Text>
-        <Card style={styles.sectionCard}>
-          <Text style={styles.helperText}>{recommendedWaterLabel}</Text>
+                {activeTab === "brewing" ? (
+                  <BrewingTab
+                    ingredientsCount={ingredients.length}
+                    equipmentCount={equipment.length}
+                    steps={steps}
+                    processDisplayMode={processDisplayMode}
+                    onChangeProcessDisplayMode={setProcessDisplayMode}
+                  />
+                ) : null}
 
-          {recipe?.visibility !== "public" ? (
-            <View style={styles.toggleRow}>
-              {NON_PUBLIC_WATER_PREFERENCE_OPTIONS.map((option) => (
-                <Pressable
-                  key={option.id}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Use ${option.label.toLowerCase()} recommendation`}
-                  style={[
-                    styles.toggleChip,
-                    nonPublicWaterPreference === option.id &&
-                      styles.toggleChipActive,
-                  ]}
-                  onPress={() => setNonPublicWaterPreference(option.id)}
-                >
-                  <Text
-                    style={[
-                      styles.toggleChipText,
-                      nonPublicWaterPreference === option.id &&
-                        styles.toggleChipTextActive,
-                    ]}
-                  >
-                    {option.label}
-                  </Text>
-                </Pressable>
-              ))}
-            </View>
-          ) : null}
-
-          {recipe?.visibility !== "public" &&
-          nonPublicWaterPreference === "style" ? (
-            <View style={styles.choiceWrap}>
-              {WATER_STYLE_PRESETS.map((preset) => {
-                const isSelected = preset.id === selectedWaterStylePresetId;
-                return (
-                  <Pressable
-                    key={preset.id}
-                    accessibilityRole="button"
-                    accessibilityLabel={`Select water style preset ${preset.name}`}
-                    style={[
-                      styles.choiceChip,
-                      isSelected && styles.choiceChipActive,
-                    ]}
-                    onPress={() => setSelectedWaterStylePresetId(preset.id)}
-                  >
-                    <Text
-                      style={[
-                        styles.choiceChipText,
-                        isSelected && styles.choiceChipTextActive,
-                      ]}
-                    >
-                      {preset.name}
-                    </Text>
-                  </Pressable>
-                );
-              })}
-            </View>
-          ) : null}
-
-          <Text style={styles.fieldLabel}>Your water location</Text>
-          <View style={styles.choiceWrap}>
-            {WATER_LOCATION_PROFILES.map((profile) => {
-              const isSelected = profile.name === selectedLocalWaterProfileName;
-
-              return (
-                <Pressable
-                  key={profile.name}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Select water location ${profile.name}`}
-                  style={[
-                    styles.choiceChip,
-                    isSelected && styles.choiceChipActive,
-                  ]}
-                  onPress={() => setSelectedLocalWaterProfileName(profile.name)}
-                >
-                  <Text
-                    style={[
-                      styles.choiceChipText,
-                      isSelected && styles.choiceChipTextActive,
-                    ]}
-                  >
-                    {profile.name}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </View>
-
-          <View style={styles.compatibilityCard}>
-            <Text style={styles.compatibilityTitle}>
-              Compatibility score: {waterCompatibility.score}% (
-              {waterCompatibility.label})
-            </Text>
-            <Text style={styles.compatibilitySubtitle}>
-              {waterCompatibility.matchedMetrics}/
-              {waterCompatibility.totalMetrics} metrics near target range
-            </Text>
-          </View>
-
-          {(
-            Object.keys(
-              WATER_METRIC_LABELS,
-            ) as (keyof typeof WATER_METRIC_LABELS)[]
-          ).map((metric) => (
-            <View key={metric} style={styles.metricRow}>
-              <Text style={styles.metricLabel}>
-                {WATER_METRIC_LABELS[metric]}
-              </Text>
-              <Text style={styles.metricValue}>
-                {recommendedWaterProfile[metric]} / {localWaterProfile[metric]}{" "}
-                ppm
-              </Text>
-            </View>
-          ))}
-
-          <PrimaryButton
-            label="Compare in Water Calculator"
-            onPress={openWaterCalculator}
-          />
-        </Card>
-
-        <Text style={styles.sectionTitle}>Process preview</Text>
-        <View style={styles.toggleRow}>
-          {RECIPE_PROCESS_DISPLAY_OPTIONS.map((option) => (
-            <Pressable
-              key={option.id}
-              testID={`recipe-process-filter-${option.id}`}
-              accessibilityRole="button"
-              accessibilityLabel={`Use ${option.label.toLowerCase()} process display mode`}
-              style={[
-                styles.toggleChip,
-                processDisplayMode === option.id && styles.toggleChipActive,
-              ]}
-              onPress={() => setProcessDisplayMode(option.id)}
-            >
-              <Text
-                style={[
-                  styles.toggleChipText,
-                  processDisplayMode === option.id &&
-                    styles.toggleChipTextActive,
-                ]}
-              >
-                {option.label}
-              </Text>
-            </Pressable>
-          ))}
-        </View>
-
-        <Card style={styles.sectionCard}>
-          {processDisplayMode === "phases"
-            ? BREWING_PHASES.map((phase) => (
-                <View key={phase.id} style={styles.phaseRow}>
-                  <Text style={styles.phaseTitle}>{phase.title}</Text>
-                  <Text style={styles.phaseDetails}>{phase.details}</Text>
-                </View>
-              ))
-            : null}
-
-          {processDisplayMode === "recipe" ? (
-            steps.length > 0 ? (
-              steps.map((item) => (
-                <View
-                  key={`${item.recipeId}-${item.stepOrder}`}
-                  style={styles.stepRow}
-                >
-                  <View style={styles.stepHeader}>
-                    <Text style={styles.stepTitle}>
-                      {item.stepOrder + 1}. {item.label}
-                    </Text>
-                    <Text style={styles.stepType}>{item.type}</Text>
-                  </View>
-                  {item.description ? (
-                    <Text style={styles.stepDescription}>
-                      {item.description}
-                    </Text>
-                  ) : null}
-                </View>
-              ))
+                {activeTab === "reviews" ? <NotesReviewsTab /> : null}
+              </>
             ) : (
-              <Text style={styles.emptyText}>
-                No steps available for this recipe.
-              </Text>
-            )
-          ) : null}
+              <Card style={styles.placeholderCard} />
+            )}
+          </ScrollView>
+        </View>
+      </View>
 
-          {processDisplayMode === "compact" ? (
-            <>
-              <Text style={styles.compactStat}>
-                Recipe steps: {steps.length}
-              </Text>
-              <Text style={styles.compactStat}>
-                Ingredients: {ingredients.length}
-              </Text>
-              <Text style={styles.compactStat}>
-                Equipment: {equipment.length}
-              </Text>
-              {steps[0] ? (
-                <Text style={styles.compactHint}>
-                  Next key step: {steps[0].label}
-                </Text>
-              ) : null}
-            </>
-          ) : null}
-        </Card>
-
-        <PrimaryButton
-          label={isStarting ? "Starting..." : "Start Batch"}
+      {showStickyCta ? (
+        <RecipeStickyCta
+          label={ctaLabel}
           onPress={handleStartBatch}
-          disabled={isStarting || isLoading || !recipe || isCapacityBlocked}
+          disabled={ctaDisabled}
+          bottomOffset={bottomPadding}
         />
-      </ScrollView>
+      ) : null}
     </Screen>
   );
 }
 
+export type { RecipeDetailTabId };
+export { RECIPE_DETAIL_TABS };
+
 const styles = StyleSheet.create({
-  content: {},
-  headerCard: {
+  headerWrapper: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+  },
+  body: {
+    flex: 1,
+    flexDirection: "row",
+  },
+  tabContent: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+  },
+  placeholderCard: {
+    margin: spacing.md,
     padding: spacing.md,
-    marginBottom: spacing.md,
-  },
-  title: {
-    fontSize: typography.size.h2,
-    lineHeight: typography.lineHeight.h2,
-    fontWeight: typography.weight.bold,
-    color: colors.neutral.textPrimary,
-  },
-  subtitle: {
-    color: colors.neutral.textSecondary,
-    marginTop: spacing.xxs,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-  },
-  statsGrid: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: spacing.xs,
-    marginTop: spacing.md,
-  },
-  statItem: {
-    width: "30%",
-    minWidth: 90,
     backgroundColor: colors.brand.background,
-    borderRadius: radius.md,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-  },
-  statLabel: {
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-    textTransform: "uppercase",
-    fontWeight: typography.weight.bold,
-  },
-  statValue: {
-    marginTop: spacing.xxs,
-    color: colors.neutral.textPrimary,
-    fontWeight: typography.weight.bold,
-    fontSize: typography.size.body,
-    lineHeight: typography.lineHeight.body,
-  },
-  referenceHint: {
-    marginTop: spacing.sm,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-    color: colors.neutral.textSecondary,
-  },
-  sectionHeaderRow: {
-    marginTop: spacing.md,
-    marginBottom: spacing.xs,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  sectionTitle: {
-    fontWeight: typography.weight.bold,
-    color: colors.neutral.textPrimary,
-    fontSize: typography.size.body,
-    lineHeight: typography.lineHeight.body,
-  },
-  sectionCard: {
-    marginBottom: spacing.sm,
-  },
-  inlineAction: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.xxs,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xxs,
-    borderRadius: radius.full,
-    borderWidth: 1,
-    borderColor: colors.brand.secondary,
-    backgroundColor: colors.brand.background,
-  },
-  inlineActionText: {
-    color: colors.brand.secondary,
-    fontSize: typography.size.caption,
-    fontWeight: typography.weight.medium,
-  },
-  helperText: {
-    marginTop: spacing.xxs,
-    marginBottom: spacing.sm,
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-  },
-  fieldLabel: {
-    marginTop: spacing.xs,
-    marginBottom: spacing.xxs,
-    color: colors.neutral.textPrimary,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-    fontWeight: typography.weight.medium,
-  },
-  textInput: {
-    borderWidth: 1,
-    borderColor: colors.neutral.border,
-    borderRadius: radius.md,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-    color: colors.neutral.textPrimary,
-    fontSize: typography.size.body,
-    lineHeight: typography.lineHeight.body,
-  },
-  toggleRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: spacing.xs,
-  },
-  toggleChip: {
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-    borderRadius: radius.full,
-    borderWidth: 1,
-    borderColor: colors.neutral.border,
-    backgroundColor: colors.neutral.white,
-  },
-  toggleChipActive: {
-    borderColor: colors.brand.secondary,
-    backgroundColor: colors.brand.background,
-  },
-  toggleChipText: {
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-    fontWeight: typography.weight.medium,
-  },
-  toggleChipTextActive: {
-    color: colors.brand.secondary,
-  },
-  choiceWrap: {
-    marginTop: spacing.xs,
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: spacing.xs,
-  },
-  choiceChip: {
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-    borderRadius: radius.md,
-    borderWidth: 1,
-    borderColor: colors.neutral.border,
-  },
-  choiceChipActive: {
-    borderColor: colors.brand.secondary,
-    backgroundColor: colors.brand.background,
-  },
-  choiceChipText: {
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-  },
-  choiceChipTextActive: {
-    color: colors.brand.secondary,
-    fontWeight: typography.weight.bold,
-  },
-  warningBox: {
-    marginTop: spacing.sm,
-    borderRadius: radius.md,
-    borderWidth: 1,
-    borderColor: colors.semantic.error,
-    backgroundColor: colors.state.errorBackground,
-    padding: spacing.sm,
-  },
-  warningTitle: {
-    color: colors.semantic.error,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-    fontWeight: typography.weight.bold,
-  },
-  warningText: {
-    marginTop: spacing.xxs,
-    color: colors.semantic.error,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-  },
-  emptyText: {
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-  },
-  listItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    paddingVertical: spacing.sm,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.neutral.border,
-  },
-  listItemMainPressable: {
-    flex: 1,
-  },
-  listItemMain: {
-    flex: 1,
-    paddingRight: spacing.xs,
-  },
-  listItemTitle: {
-    fontWeight: typography.weight.bold,
-    color: colors.neutral.textPrimary,
-    fontSize: typography.size.body,
-    lineHeight: typography.lineHeight.body,
-  },
-  listItemMeta: {
-    marginTop: spacing.xxs,
-    color: colors.neutral.muted,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-  },
-  listItemNotes: {
-    marginTop: spacing.xxs,
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-  },
-  addActionButton: {
-    marginLeft: spacing.xs,
-    padding: spacing.xxs,
-  },
-  groupBlock: {
-    marginTop: spacing.sm,
-  },
-  groupTitle: {
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-    fontWeight: typography.weight.bold,
-    color: colors.neutral.textSecondary,
-    marginBottom: spacing.xxs,
-  },
-  cartRow: {
-    marginTop: spacing.xs,
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  cartRowLabel: {
-    color: colors.neutral.textPrimary,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-    flex: 1,
-    marginRight: spacing.sm,
-  },
-  cartRowValue: {
-    color: colors.brand.secondary,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-    fontWeight: typography.weight.bold,
-  },
-  compatibilityCard: {
-    marginTop: spacing.sm,
-    marginBottom: spacing.sm,
-    borderRadius: radius.md,
-    backgroundColor: colors.brand.background,
-    borderWidth: 1,
-    borderColor: colors.brand.secondary,
-    padding: spacing.sm,
-  },
-  compatibilityTitle: {
-    color: colors.brand.secondary,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-    fontWeight: typography.weight.bold,
-  },
-  compatibilitySubtitle: {
-    marginTop: spacing.xxs,
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-  },
-  metricRow: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-    paddingVertical: spacing.xs,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.neutral.border,
-  },
-  metricLabel: {
-    color: colors.neutral.textPrimary,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-  },
-  metricValue: {
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-  },
-  stepRow: {
-    paddingVertical: spacing.sm,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.neutral.border,
-  },
-  stepHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
-  },
-  stepTitle: {
-    fontWeight: typography.weight.bold,
-    color: colors.neutral.textPrimary,
-    flex: 1,
-    marginRight: spacing.xs,
-    fontSize: typography.size.body,
-    lineHeight: typography.lineHeight.body,
-  },
-  stepType: {
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-    textTransform: "uppercase",
-    fontWeight: typography.weight.bold,
-    backgroundColor: colors.brand.background,
-    borderRadius: radius.full,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xxs,
-  },
-  stepDescription: {
-    marginTop: spacing.sm,
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-  },
-  phaseRow: {
-    paddingVertical: spacing.sm,
-    borderBottomWidth: StyleSheet.hairlineWidth,
-    borderBottomColor: colors.neutral.border,
-  },
-  phaseTitle: {
-    color: colors.neutral.textPrimary,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-    fontWeight: typography.weight.bold,
-  },
-  phaseDetails: {
-    marginTop: spacing.xxs,
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-  },
-  compactStat: {
-    color: colors.neutral.textPrimary,
-    fontSize: typography.size.label,
-    lineHeight: typography.lineHeight.label,
-    marginBottom: spacing.xxs,
-  },
-  compactHint: {
-    marginTop: spacing.xs,
-    color: colors.neutral.textSecondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
   },
 });

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   fireEvent,
   render,
@@ -13,6 +14,41 @@ import { startBatch } from "@/features/batches/application/batches.use-cases";
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
 
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+type SliderMockProps = {
+  testID?: string;
+  value: number;
+  onSlidingComplete?: (value: number) => void;
+};
+
+jest.mock("@react-native-community/slider", () => {
+  const RN = jest.requireActual("react-native");
+  const ReactActual = jest.requireActual("react");
+
+  return {
+    __esModule: true,
+    default: function MockSlider(props: SliderMockProps) {
+      const { testID, value, onSlidingComplete } = props;
+      return ReactActual.createElement(
+        RN.Pressable,
+        {
+          testID,
+          accessibilityRole: "slider",
+          onPress: () => {
+            if (typeof onSlidingComplete === "function") {
+              onSlidingComplete(value + 20);
+            }
+          },
+        },
+        ReactActual.createElement(RN.Text, null, "slider value=" + value),
+      );
+    },
+  };
+});
+
 jest.mock("expo-router", () => {
   const actual = jest.requireActual("expo-router");
   return {
@@ -25,183 +61,175 @@ jest.mock("expo-router", () => {
   };
 });
 
-jest.mock("@/features/recipes/application/recipes.use-cases", () => ({
-  getRecipeDetailsViewModel: jest.fn().mockResolvedValue({
-    recipe: {
-      id: "r1",
-      name: "Test Recipe",
-      description: "Test description",
-      visibility: "private",
-      stats: {
-        ibu: 35,
-        abv: 5.4,
-        og: 1.052,
-        fg: 1.011,
+const baseViewModel = {
+  recipe: {
+    id: "r1",
+    name: "Test Recipe",
+    description: "Test description",
+    visibility: "private",
+    version: 1,
+    rootRecipeId: "r1",
+    parentRecipeId: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    stats: {
+      ibu: 35,
+      abv: 5.4,
+      og: 1.052,
+      fg: 1.011,
+      volumeLiters: 20,
+    },
+  },
+  ingredients: [
+    {
+      ingredientId: "hop-1",
+      amount: 25,
+      unit: "g",
+      timing: "boil - 10 min",
+      notes: null,
+      ingredient: {
+        id: "hop-1",
+        name: "Citra",
+        category: "hop",
+      },
+    },
+  ],
+  equipment: [
+    {
+      equipmentId: "eq-1",
+      role: "Mash & boil",
+      notes: null,
+      equipment: {
+        id: "eq-1",
+        name: "Braumeister 20L",
+        type: "all-in-one",
         volumeLiters: 20,
       },
     },
-    ingredients: [
-      {
-        ingredientId: "hop-1",
-        amount: 25,
-        unit: "g",
-        timing: "boil - 10 min",
-        notes: null,
-        ingredient: {
-          id: "hop-1",
-          name: "Citra",
-          category: "hop",
-        },
-      },
-    ],
-    equipment: [
-      {
-        equipmentId: "eq-1",
-        role: "Mash & boil",
-        notes: null,
-        equipment: {
-          id: "eq-1",
-          name: "Braumeister 20L",
-          type: "all-in-one",
-          volumeLiters: 20,
-        },
-      },
-    ],
-    steps: [
-      {
-        recipeId: "r1",
-        stepOrder: 0,
-        label: "Mash",
-        type: "mash",
-        description: "Hold at 67°C",
-      },
-    ],
-  }),
+  ],
+  steps: [
+    {
+      recipeId: "r1",
+      stepOrder: 0,
+      label: "Mash",
+      type: "mash",
+      description: "Hold at 67°C",
+    },
+  ],
+};
+
+jest.mock("@/features/recipes/application/recipes.use-cases", () => ({
+  getRecipeDetailsViewModel: jest.fn(),
 }));
 
 jest.mock("@/features/batches/application/batches.use-cases", () => ({
-  startBatch: jest.fn().mockResolvedValue({ id: "b1" }),
+  startBatch: jest.fn(),
 }));
 
-describe("RecipeDetailsScreen", () => {
+function renderRecipeDetails(recipeId = "r1") {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Number.POSITIVE_INFINITY,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RecipeDetailsScreen recipeId={recipeId} />
+    </QueryClientProvider>,
+  );
+}
+
+function switchToTab(tabId: string) {
+  fireEvent.press(screen.getByTestId(`recipe-detail-tab-${tabId}`));
+}
+
+describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () => {
   beforeEach(() => {
     mockPush.mockReset();
     mockReplace.mockReset();
-    (getRecipeDetailsViewModel as jest.Mock).mockClear();
-    (startBatch as jest.Mock).mockClear();
+    (getRecipeDetailsViewModel as jest.Mock).mockReset();
+    (startBatch as jest.Mock).mockReset();
+    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue(baseViewModel);
+    (startBatch as jest.Mock).mockResolvedValue({ id: "b1" });
   });
 
-  it("renders the redesigned recipe details sections", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
+  it("renders the side rail and lands on Overview by default", async () => {
+    renderRecipeDetails();
 
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
-    expect(screen.getByText("My Recipe Book")).toBeTruthy();
-    expect(screen.getByText("IBU")).toBeTruthy();
-    expect(screen.getByText("Ingredients by type")).toBeTruthy();
-    expect(screen.getByText("Equipment")).toBeTruthy();
-    expect(screen.getByText("Water profile compatibility")).toBeTruthy();
-    expect(screen.getByText("Process preview")).toBeTruthy();
-    expect(screen.getByText("Scale my batch")).toBeTruthy();
-    expect(screen.getByText("Start Batch")).toBeTruthy();
+    expect(await screen.findByTestId("recipe-detail-side-rail")).toBeTruthy();
+    expect(screen.getByTestId("recipe-detail-tab-overview")).toBeTruthy();
+    expect(screen.getByTestId("recipe-detail-tab-ingredients")).toBeTruthy();
+    expect(screen.getByTestId("recipe-detail-tab-water")).toBeTruthy();
+    expect(screen.getByTestId("recipe-detail-tab-brewing")).toBeTruthy();
+    expect(screen.getByTestId("recipe-detail-tab-reviews")).toBeTruthy();
+    expect(screen.getByTestId("recipe-overview-tab")).toBeTruthy();
+    expect(screen.getByText("Test Recipe")).toBeTruthy();
+    expect(screen.getByText("En un coup d'œil")).toBeTruthy();
+  });
+
+  it("shows the equipment checklist on the Overview tab", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+
+    expect(screen.getByText("Matériel requis")).toBeTruthy();
+    expect(screen.getByTestId("recipe-equipment-checklist-eq-1")).toBeTruthy();
+    expect(screen.getByText("Braumeister 20L")).toBeTruthy();
+  });
+
+  it("switches to the Ingredients tab and shows the ingredient list", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("ingredients");
+
+    expect(screen.getByTestId("recipe-ingredients-tab")).toBeTruthy();
+    expect(screen.getByText("Volume cible")).toBeTruthy();
+    expect(screen.getAllByText("Ingrédients").length).toBeGreaterThan(0);
     expect(screen.getByText("Citra")).toBeTruthy();
     expect(screen.getByText("Hops")).toBeTruthy();
   });
 
-  it("updates scaled ingredient quantity when target volume changes", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
+  it("scales ingredient quantities when the volume slider changes", async () => {
+    renderRecipeDetails();
 
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("ingredients");
+
     expect(screen.getByText("25 g • boil - 10 min")).toBeTruthy();
 
-    fireEvent.changeText(
-      screen.getByTestId("recipe-target-volume-input"),
-      "40",
-    );
+    // Mock slider bumps the value by +20 on press, so 20 + 20 = 40 L target.
+    fireEvent.press(screen.getByTestId("recipe-target-volume-slider"));
 
     expect(screen.getByText("50 g • boil - 10 min")).toBeTruthy();
+    expect(
+      screen.getByTestId("recipe-target-volume-readout"),
+    ).toHaveTextContent("40 L");
+  });
+
+  it("reflects the scaled target volume on the Overview at-a-glance card", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("ingredients");
+    fireEvent.press(screen.getByTestId("recipe-target-volume-slider"));
+    switchToTab("overview");
+
     expect(screen.getByText("40 L")).toBeTruthy();
   });
 
-  it("adds ingredients and equipment to local cart", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
+  it("opens hop details with recipe return context", async () => {
+    renderRecipeDetails();
 
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
-
-    fireEvent.press(screen.getByTestId("recipe-add-ingredient-hop-1-0"));
-    expect(screen.getByText("1 lines • 25 total quantity")).toBeTruthy();
-
-    fireEvent.press(screen.getByTestId("recipe-add-equipment-eq-1"));
-    expect(screen.getByText("2 lines • 26 total quantity")).toBeTruthy();
-
-    expect(screen.getAllByText("Braumeister 20L").length).toBeGreaterThan(0);
-    expect(screen.getByText("1 unit")).toBeTruthy();
-  });
-
-  it("adds all ingredients to local cart", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
-
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
-
-    fireEvent.press(screen.getByTestId("recipe-add-all-ingredients-button"));
-
-    expect(screen.getByText("1 lines • 25 total quantity")).toBeTruthy();
-    expect(screen.getByText("25 g")).toBeTruthy();
-  });
-
-  it("blocks start batch when target volume exceeds equipment capacity in equipment mode", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
-
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
-
-    fireEvent.press(screen.getByTestId("recipe-volume-mode-equipment"));
-    fireEvent.changeText(
-      screen.getByTestId("recipe-target-volume-input"),
-      "30",
-    );
-
-    expect(screen.getByText("Volume not feasible")).toBeTruthy();
-
-    fireEvent.press(screen.getByText("Start Batch"));
-    expect(startBatch).not.toHaveBeenCalled();
-  });
-
-  it("starts a batch and navigates to the batch details", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
-
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
-
-    fireEvent.press(screen.getByText("Start Batch"));
-
-    await waitFor(() => {
-      expect(startBatch).toHaveBeenCalledWith("r1");
-      expect(mockPush).toHaveBeenCalledWith("/(app)/batches/b1");
-    });
-  });
-
-  it("navigates to shop from the section action", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
-
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
-
-    fireEvent.press(screen.getAllByText("Shop")[0]);
-
-    expect(mockPush).toHaveBeenCalledWith("/(app)/shop");
-  });
-
-  it("navigates back to my recipes from header action", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
-
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
-
-    fireEvent.press(screen.getByLabelText("Retour à mes recettes"));
-
-    expect(mockReplace).toHaveBeenCalledWith("/recipes");
-  });
-
-  it("opens hop details page with recipe return context when tapping ingredient row", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
-
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("ingredients");
 
     fireEvent.press(screen.getByLabelText("Open ingredient details for Citra"));
 
@@ -216,71 +244,9 @@ describe("RecipeDetailsScreen", () => {
     });
   });
 
-  it("opens yeast details page with recipe return context when tapping ingredient row", async () => {
+  it("opens malt details with the dedicated malt route", async () => {
     (getRecipeDetailsViewModel as jest.Mock).mockResolvedValueOnce({
-      recipe: {
-        id: "r1",
-        name: "Test Recipe",
-        description: "Test description",
-        visibility: "private",
-        stats: {
-          ibu: 35,
-          abv: 5.4,
-          og: 1.052,
-          fg: 1.011,
-          volumeLiters: 20,
-        },
-      },
-      ingredients: [
-        {
-          ingredientId: "yeast-1",
-          amount: 1,
-          unit: "pack",
-          timing: "pitch",
-          notes: null,
-          ingredient: {
-            id: "yeast-1",
-            name: "US-05",
-            category: "yeast",
-          },
-        },
-      ],
-      equipment: [],
-      steps: [],
-    });
-
-    render(<RecipeDetailsScreen recipeId="r1" />);
-
-    expect(await screen.findByText("US-05")).toBeTruthy();
-
-    fireEvent.press(screen.getByLabelText("Open ingredient details for US-05"));
-
-    expect(mockPush).toHaveBeenCalledWith({
-      pathname: "/(app)/ingredients/[category]/[id]",
-      params: {
-        category: "yeast",
-        id: "yeast-1",
-        returnTo: "/(app)/recipes/[id]",
-        returnRecipeId: "r1",
-      },
-    });
-  });
-
-  it("opens malt details page when tapping a malt ingredient row", async () => {
-    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValueOnce({
-      recipe: {
-        id: "r1",
-        name: "Test Recipe",
-        description: "Test description",
-        visibility: "private",
-        stats: {
-          ibu: 35,
-          abv: 5.4,
-          og: 1.052,
-          fg: 1.011,
-          volumeLiters: 20,
-        },
-      },
+      ...baseViewModel,
       ingredients: [
         {
           ingredientId: "malt-1",
@@ -295,13 +261,13 @@ describe("RecipeDetailsScreen", () => {
           },
         },
       ],
-      equipment: [],
-      steps: [],
     });
 
-    render(<RecipeDetailsScreen recipeId="r1" />);
+    renderRecipeDetails();
 
-    expect(await screen.findByText("Pale Ale Malt")).toBeTruthy();
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("ingredients");
+    await screen.findByText("Pale Ale Malt");
 
     fireEvent.press(
       screen.getByLabelText("Open ingredient details for Pale Ale Malt"),
@@ -317,12 +283,39 @@ describe("RecipeDetailsScreen", () => {
     });
   });
 
-  it("navigates to water calculator from the water section", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
+  it("opens the shop from the Ingredients tab inline action", async () => {
+    renderRecipeDetails();
 
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("ingredients");
 
-    fireEvent.press(screen.getByText("Compare in Water Calculator"));
+    fireEvent.press(
+      screen.getByLabelText(
+        "Ouvrir la boutique depuis la liste des ingrédients",
+      ),
+    );
+
+    expect(mockPush).toHaveBeenCalledWith("/(app)/shop");
+  });
+
+  it("renders the Water tab with profile and salt additions", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("water");
+
+    expect(screen.getByTestId("recipe-water-tab")).toBeTruthy();
+    expect(screen.getByText("Profil eau")).toBeTruthy();
+    expect(screen.getByText("Ajouter pour matcher")).toBeTruthy();
+  });
+
+  it("navigates to the water calculator from the Water tab", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("water");
+
+    fireEvent.press(screen.getByText("Comparer dans le Calculateur Eau"));
 
     expect(mockPush).toHaveBeenCalledWith({
       pathname: "/(app)/tools/[slug]/calculator",
@@ -330,28 +323,116 @@ describe("RecipeDetailsScreen", () => {
     });
   });
 
-  it("shows recipe steps in recipe process display mode", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
+  it("renders the Brewing tab with the process preview modes", async () => {
+    renderRecipeDetails();
 
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("brewing");
+
+    expect(screen.getByTestId("recipe-brewing-tab")).toBeTruthy();
+    expect(screen.getByText("Aperçu du process")).toBeTruthy();
 
     fireEvent.press(screen.getByTestId("recipe-process-filter-recipe"));
-
     expect(screen.getByText("1. Mash")).toBeTruthy();
-    expect(screen.getByText("mash")).toBeTruthy();
     expect(screen.getByText("Hold at 67°C")).toBeTruthy();
-  });
-
-  it("shows compact process metrics", async () => {
-    render(<RecipeDetailsScreen recipeId="r1" />);
-
-    expect(await screen.findByText("Test Recipe")).toBeTruthy();
 
     fireEvent.press(screen.getByTestId("recipe-process-filter-compact"));
+    expect(screen.getByText("Étapes recette : 1")).toBeTruthy();
+    expect(screen.getByText("Ingrédients : 1")).toBeTruthy();
+    expect(screen.getByText("Matériel : 1")).toBeTruthy();
+  });
 
-    expect(screen.getByText("Recipe steps: 1")).toBeTruthy();
-    expect(screen.getByText("Ingredients: 1")).toBeTruthy();
-    expect(screen.getByText("Equipment: 1")).toBeTruthy();
-    expect(screen.getByText("Next key step: Mash")).toBeTruthy();
+  it("hides the sticky CTA on the Notes & Reviews tab", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    expect(screen.getByTestId("recipe-sticky-cta")).toBeTruthy();
+
+    switchToTab("reviews");
+
+    expect(screen.queryByTestId("recipe-sticky-cta")).toBeNull();
+    expect(screen.getByTestId("recipe-reviews-tab")).toBeTruthy();
+  });
+
+  it("starts a batch from the sticky CTA and navigates to the batch details", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+
+    fireEvent.press(screen.getByText("Lancer un brassin"));
+
+    await waitFor(() => {
+      expect(startBatch).toHaveBeenCalledWith("r1");
+      expect(mockPush).toHaveBeenCalledWith("/(app)/batches/b1");
+    });
+  });
+
+  // Issue #740 — Codex / Copilot review on PR #916: a failed
+  // startBatch must not leave the screen-level error banner on
+  // forever. Tapping "Réessayer" should reset the mutation state.
+  it("clears the startBatch error when the user taps Réessayer", async () => {
+    (startBatch as jest.Mock).mockRejectedValueOnce(new Error("Backend down"));
+
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    fireEvent.press(screen.getByText("Lancer un brassin"));
+
+    await screen.findByText(/Backend down/i);
+
+    fireEvent.press(screen.getByText("Réessayer"));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Backend down/i)).toBeNull();
+    });
+  });
+
+  it("navigates back to My Recipes from the header action", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+
+    fireEvent.press(screen.getByLabelText("Retour à mes recettes"));
+
+    expect(mockReplace).toHaveBeenCalledWith("/recipes");
+  });
+
+  it("shows the not-found state when recipeId is missing", async () => {
+    renderRecipeDetails("");
+
+    expect(await screen.findByText("Recette introuvable")).toBeTruthy();
+    expect(getRecipeDetailsViewModel as jest.Mock).not.toHaveBeenCalled();
+  });
+
+  it("shows the placeholder on the Notes & Reviews tab", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("reviews");
+
+    expect(screen.getByTestId("recipe-reviews-tab")).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Les notes par axe \(goût, difficulté, coût, fidélité au style\)/i,
+      ),
+    ).toBeTruthy();
+  });
+
+  // Issue #740 v0.1 acceptance criteria: a recipe imported from the
+  // scan flow must visibly carry its provenance. We assert the badge
+  // appears when `importProvenance` is present on the recipe.
+  it("renders the provenance badge for imported recipes on Overview", async () => {
+    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValueOnce({
+      ...baseViewModel,
+      recipe: {
+        ...baseViewModel.recipe,
+        importProvenance: "BrewDog DIY Dog",
+      },
+    });
+
+    renderRecipeDetails();
+
+    expect(await screen.findByTestId("recipe-provenance-badge")).toBeTruthy();
+    expect(screen.getByText(/Importée • BrewDog DIY Dog/)).toBeTruthy();
   });
 });

--- a/packages/mobile-app/src/features/recipes/presentation/components/RecipeDetailSideRail.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/RecipeDetailSideRail.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { Ionicons } from "@expo/vector-icons";
+import { colors, radius, spacing, typography } from "@/core/theme";
+
+export type RecipeDetailTabId =
+  | "overview"
+  | "ingredients"
+  | "water"
+  | "brewing"
+  | "reviews";
+
+type IoniconName = React.ComponentProps<typeof Ionicons>["name"];
+
+export type RecipeDetailTab = Readonly<{
+  id: RecipeDetailTabId;
+  label: string;
+  icon: IoniconName;
+}>;
+
+export const RECIPE_DETAIL_TABS: ReadonlyArray<RecipeDetailTab> = [
+  { id: "overview", label: "Vue", icon: "home-outline" },
+  { id: "ingredients", label: "Ingrédients", icon: "leaf-outline" },
+  { id: "water", label: "Eau", icon: "water-outline" },
+  { id: "brewing", label: "Brassage", icon: "flame-outline" },
+  { id: "reviews", label: "Notes", icon: "chatbubbles-outline" },
+];
+
+type RecipeDetailSideRailProps = Readonly<{
+  activeTab: RecipeDetailTabId;
+  onChange: (tab: RecipeDetailTabId) => void;
+}>;
+
+/**
+ * Vertical navigation rail for the redesigned recipe detail screen
+ * (Issue #740, Round 4). Lives on the left edge: a 70px column that
+ * stacks five icon + short-label buttons. Replaces the previous top
+ * tab bar to free vertical space and to give the screen a recogni-
+ * sable identity for the soutenance demo.
+ *
+ * Mirrors Brewfather web's left navigation pattern. Each entry is a
+ * full-height button (icon above, label below) so the touch target
+ * stays comfortable on phones (≥ 60×70px).
+ */
+export function RecipeDetailSideRail({
+  activeTab,
+  onChange,
+}: RecipeDetailSideRailProps) {
+  return (
+    <View testID="recipe-detail-side-rail" style={styles.rail}>
+      {RECIPE_DETAIL_TABS.map((tab) => {
+        const isActive = tab.id === activeTab;
+        const tint = isActive
+          ? colors.brand.secondary
+          : colors.neutral.textSecondary;
+
+        return (
+          <Pressable
+            key={tab.id}
+            testID={`recipe-detail-tab-${tab.id}`}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: isActive }}
+            accessibilityLabel={`Onglet ${tab.label}`}
+            onPress={() => onChange(tab.id)}
+            style={[styles.tab, isActive && styles.tabActive]}
+          >
+            {isActive ? <View style={styles.activeIndicator} /> : null}
+            <Ionicons name={tab.icon} size={22} color={tint} />
+            <Text style={[styles.label, { color: tint }]} numberOfLines={1}>
+              {tab.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  rail: {
+    width: 72,
+    paddingVertical: spacing.sm,
+    backgroundColor: colors.neutral.white,
+    borderRightWidth: StyleSheet.hairlineWidth,
+    borderRightColor: colors.neutral.border,
+  },
+  tab: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.xxs,
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 64,
+  },
+  tabActive: {
+    backgroundColor: colors.brand.background,
+  },
+  activeIndicator: {
+    position: "absolute",
+    right: 0,
+    top: spacing.xs,
+    bottom: spacing.xs,
+    width: 3,
+    borderRadius: radius.full,
+    backgroundColor: colors.brand.secondary,
+  },
+  label: {
+    marginTop: spacing.xxs,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontWeight: typography.weight.medium,
+    textAlign: "center",
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/RecipeProvenanceBadge.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/RecipeProvenanceBadge.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { Ionicons } from "@expo/vector-icons";
+import { colors, radius, spacing, typography } from "@/core/theme";
+
+type RecipeProvenanceBadgeProps = Readonly<{
+  label: string;
+}>;
+
+/**
+ * Small badge surfaced on the Overview tab when the recipe was
+ * imported from another source — typically the scan flow. Mirrors
+ * the visual idiom used elsewhere (chip with icon + caption) and
+ * makes the audit trail of "where this recipe came from" explicit
+ * for the user, which is one of the v0.1 acceptance criteria of
+ * Issue #740 ("Recipe imported from scan lands on this new detail
+ * screen with provenance visible").
+ */
+export function RecipeProvenanceBadge({ label }: RecipeProvenanceBadgeProps) {
+  return (
+    <View testID="recipe-provenance-badge" style={styles.container}>
+      <Ionicons
+        name="scan-outline"
+        size={14}
+        color={colors.brand.secondary}
+        style={styles.icon}
+      />
+      <Text style={styles.label} numberOfLines={2}>
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    alignSelf: "flex-start",
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xxs,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    borderColor: colors.brand.secondary,
+    backgroundColor: colors.brand.background,
+    marginBottom: spacing.sm,
+  },
+  icon: {
+    marginRight: spacing.xxs,
+  },
+  label: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontWeight: typography.weight.medium,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/RecipeStickyCta.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/RecipeStickyCta.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { colors, shadows, spacing, typography } from "@/core/theme";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+
+type RecipeStickyCtaProps = {
+  label: string;
+  onPress: () => void;
+  disabled?: boolean;
+  helperText?: string | null;
+  bottomOffset?: number;
+};
+
+/**
+ * Sticky CTA bar pinned at the bottom of the recipe detail screen
+ * across all four tabs (Issue #740, Round 4). Wraps `PrimaryButton`
+ * so the brand identity stays consistent with the rest of the app
+ * and surfaces a helper line for capacity warnings or recipe
+ * provenance.
+ */
+export function RecipeStickyCta({
+  label,
+  onPress,
+  disabled = false,
+  helperText = null,
+  bottomOffset = 0,
+}: RecipeStickyCtaProps) {
+  return (
+    <View
+      testID="recipe-sticky-cta"
+      style={[styles.container, { paddingBottom: spacing.sm + bottomOffset }]}
+    >
+      {helperText ? <Text style={styles.helper}>{helperText}</Text> : null}
+      <PrimaryButton
+        label={label}
+        onPress={onPress}
+        disabled={disabled}
+        accessibilityLabel={label}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.sm,
+    backgroundColor: colors.neutral.white,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.neutral.border,
+    ...shadows.sm,
+  },
+  helper: {
+    marginBottom: spacing.xs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    textAlign: "center",
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/helpers/water-mineral-salts.ts
+++ b/packages/mobile-app/src/features/recipes/presentation/helpers/water-mineral-salts.ts
@@ -1,0 +1,123 @@
+import type { WATER_METRIC_LABELS } from "@/features/recipes/presentation/recipe-details.utils";
+
+type WaterMineralKey = keyof typeof WATER_METRIC_LABELS;
+
+type WaterProfileLike = Readonly<Record<WaterMineralKey, number>>;
+
+export type WaterSaltAdditionId = "caso4" | "cacl2" | "nacl";
+
+export type WaterSaltAddition = Readonly<{
+  id: WaterSaltAdditionId;
+  name: string;
+  formula: string;
+  grams: number;
+  rationale: string;
+}>;
+
+/**
+ * Computes the practical brewing salts a brewer would add to push a
+ * baseline water profile toward a target profile, scaled by batch
+ * volume.
+ *
+ * The model intentionally stays brewer-pragmatic, not lab-grade:
+ * - Gypsum (CaSO4·2H2O) covers the calcium + sulfate gap (drives the
+ *   classic "hop-forward" character; ~232 ppm Ca and 558 ppm SO4 per
+ *   gram per litre).
+ * - Calcium chloride (CaCl2·2H2O) covers the chloride gap when SO4
+ *   is already on target (rounder, malt-forward profile; ~272 ppm Ca
+ *   and ~482 ppm Cl per gram per litre).
+ * - Table salt (NaCl) covers a residual sodium + chloride gap when
+ *   the chloride deficit is larger than calcium chloride alone can
+ *   close (ions in proportion ~393 ppm Na and ~607 ppm Cl per gram
+ *   per litre).
+ *
+ * Negative deltas (the user already has more of a mineral than the
+ * recipe needs) are not addressable via additions — those require
+ * dilution / reverse-osmosis, which is out of scope for v0.1.
+ *
+ * The numeric coefficients below are the conventional brewing-water
+ * tables (see Palmer, "Water — A Comprehensive Guide for Brewers").
+ * They produce ppm increases for one gram of salt dissolved into one
+ * litre of water; we divide by `volumeLiters` to keep the maths
+ * explicit when scaling to a real batch.
+ */
+const PPM_PER_GRAM_PER_LITRE = {
+  gypsum: { ca: 232, so4: 558 },
+  calciumChloride: { ca: 272, cl: 482 },
+  tableSalt: { na: 393, cl: 607 },
+} as const;
+
+export function computeWaterSaltAdditions(
+  target: WaterProfileLike,
+  current: WaterProfileLike,
+  volumeLiters: number,
+): WaterSaltAddition[] {
+  if (!Number.isFinite(volumeLiters) || volumeLiters <= 0) {
+    return [];
+  }
+
+  const deltaCa = Math.max(0, target.ca - current.ca);
+  const deltaSo4 = Math.max(0, target.so4 - current.so4);
+  const deltaCl = Math.max(0, target.cl - current.cl);
+
+  // Gypsum covers Ca + SO4 first; cap by whichever ion limits.
+  const gypsumByCa =
+    (deltaCa / PPM_PER_GRAM_PER_LITRE.gypsum.ca) * volumeLiters;
+  const gypsumBySo4 =
+    (deltaSo4 / PPM_PER_GRAM_PER_LITRE.gypsum.so4) * volumeLiters;
+  const gypsumGrams = Math.min(gypsumByCa, gypsumBySo4);
+
+  // Re-derive how much Ca + Cl we still need after the gypsum addition.
+  const caUsedByGypsum =
+    (gypsumGrams / volumeLiters) * PPM_PER_GRAM_PER_LITRE.gypsum.ca;
+  const remainingDeltaCa = Math.max(0, deltaCa - caUsedByGypsum);
+
+  // Calcium chloride covers the residual Ca and dent the Cl gap.
+  const ccByCa =
+    (remainingDeltaCa / PPM_PER_GRAM_PER_LITRE.calciumChloride.ca) *
+    volumeLiters;
+  const ccByCl =
+    (deltaCl / PPM_PER_GRAM_PER_LITRE.calciumChloride.cl) * volumeLiters;
+  const calciumChlorideGrams = Math.min(ccByCa, ccByCl);
+  const clUsedByCc =
+    (calciumChlorideGrams / volumeLiters) *
+    PPM_PER_GRAM_PER_LITRE.calciumChloride.cl;
+  const remainingDeltaCl = Math.max(0, deltaCl - clUsedByCc);
+
+  // Table salt cleans up the remaining chloride gap (Na is incidental).
+  const tableSaltGrams =
+    (remainingDeltaCl / PPM_PER_GRAM_PER_LITRE.tableSalt.cl) * volumeLiters;
+
+  const additions: WaterSaltAddition[] = [
+    {
+      id: "caso4",
+      name: "Sulfate de calcium",
+      formula: "CaSO₄ (gypse)",
+      grams: roundGrams(gypsumGrams),
+      rationale: "Ajoute Ca + SO4 pour le profil hop-forward.",
+    },
+    {
+      id: "cacl2",
+      name: "Chlorure de calcium",
+      formula: "CaCl₂",
+      grams: roundGrams(calciumChlorideGrams),
+      rationale: "Ajoute Ca + Cl pour un profil plus malt-forward.",
+    },
+    {
+      id: "nacl",
+      name: "Sel de table",
+      formula: "NaCl",
+      grams: roundGrams(tableSaltGrams),
+      rationale: "Complète le chlorure si nécessaire (peu de sodium).",
+    },
+  ];
+
+  return additions.filter((addition) => addition.grams > 0);
+}
+
+function roundGrams(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.round(value * 10) / 10;
+}

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/BrewingTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/BrewingTab.tsx
@@ -1,0 +1,243 @@
+import React from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import { Card } from "@/core/ui/Card";
+import { colors, radius, spacing, typography } from "@/core/theme";
+import {
+  BREWING_PHASES,
+  RECIPE_PROCESS_DISPLAY_OPTIONS,
+  RecipeProcessDisplayMode,
+} from "@/features/recipes/presentation/recipe-details.constants";
+import type { RecipeStep } from "@/features/recipes/domain/recipe.types";
+
+type BrewingTabProps = Readonly<{
+  ingredientsCount: number;
+  equipmentCount: number;
+  steps: RecipeStep[];
+  processDisplayMode: RecipeProcessDisplayMode;
+  onChangeProcessDisplayMode: (mode: RecipeProcessDisplayMode) => void;
+}>;
+
+/**
+ * Brewing tab of the redesigned recipe detail screen
+ * (Issue #740, Round 4 v2 — 5-tab layout).
+ *
+ * Slimmed-down compared to the previous monolithic Brassage tab:
+ * ingredients moved to the dedicated `IngredientsTab`, equipment
+ * promoted to the Overview "checklist matériel" card, water profile
+ * promoted to the dedicated `WaterTab`. What remains is the brewing
+ * **process** itself: the canonical 13-phase BJCP-aligned phases,
+ * the recipe-authored steps (mash / boil / fermentation / packaging),
+ * and a compact summary mode for users who only want a glance.
+ *
+ * The "Lancer un brassin" entry point lives on the orchestrator's
+ * sticky CTA bar and stays accessible across every tab — see
+ * `RecipeDetailsScreen` and `RecipeStickyCta`.
+ */
+export function BrewingTab({
+  ingredientsCount,
+  equipmentCount,
+  steps,
+  processDisplayMode,
+  onChangeProcessDisplayMode,
+}: BrewingTabProps) {
+  return (
+    <ScrollView
+      testID="recipe-brewing-tab"
+      contentContainerStyle={styles.container}
+    >
+      <Text style={styles.sectionTitle}>Aperçu du process</Text>
+      <View style={styles.toggleRow}>
+        {RECIPE_PROCESS_DISPLAY_OPTIONS.map((option) => (
+          <Pressable
+            key={option.id}
+            testID={`recipe-process-filter-${option.id}`}
+            accessibilityRole="button"
+            accessibilityLabel={`Use ${option.label.toLowerCase()} process display mode`}
+            style={[
+              styles.toggleChip,
+              processDisplayMode === option.id && styles.toggleChipActive,
+            ]}
+            onPress={() => onChangeProcessDisplayMode(option.id)}
+          >
+            <Text
+              style={[
+                styles.toggleChipText,
+                processDisplayMode === option.id && styles.toggleChipTextActive,
+              ]}
+            >
+              {option.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <Card style={styles.card}>
+        {processDisplayMode === "phases"
+          ? BREWING_PHASES.map((phase) => (
+              <View key={phase.id} style={styles.phaseRow}>
+                <Text style={styles.phaseTitle}>{phase.title}</Text>
+                <Text style={styles.phaseDetails}>{phase.details}</Text>
+              </View>
+            ))
+          : null}
+
+        {processDisplayMode === "recipe" ? (
+          steps.length > 0 ? (
+            steps.map((item) => (
+              <View
+                key={`${item.recipeId}-${item.stepOrder}`}
+                style={styles.stepRow}
+              >
+                <View style={styles.stepHeader}>
+                  <Text style={styles.stepTitle}>
+                    {item.stepOrder + 1}. {item.label}
+                  </Text>
+                  <Text style={styles.stepType}>{item.type}</Text>
+                </View>
+                {item.description ? (
+                  <Text style={styles.stepDescription}>{item.description}</Text>
+                ) : null}
+              </View>
+            ))
+          ) : (
+            <Text style={styles.emptyText}>
+              Pas d'étapes renseignées pour cette recette.
+            </Text>
+          )
+        ) : null}
+
+        {processDisplayMode === "compact" ? (
+          <>
+            <Text style={styles.compactStat}>
+              Étapes recette : {steps.length}
+            </Text>
+            <Text style={styles.compactStat}>
+              Ingrédients : {ingredientsCount}
+            </Text>
+            <Text style={styles.compactStat}>Matériel : {equipmentCount}</Text>
+            {steps[0] ? (
+              <Text style={styles.compactHint}>
+                Prochaine étape clé : {steps[0].label}
+              </Text>
+            ) : null}
+          </>
+        ) : null}
+      </Card>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
+  },
+  sectionTitle: {
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    marginBottom: spacing.sm,
+  },
+  card: {
+    padding: spacing.md,
+  },
+  toggleRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  toggleChip: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    backgroundColor: colors.neutral.white,
+  },
+  toggleChipActive: {
+    borderColor: colors.brand.secondary,
+    backgroundColor: colors.brand.background,
+  },
+  toggleChipText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontWeight: typography.weight.medium,
+  },
+  toggleChipTextActive: {
+    color: colors.brand.secondary,
+  },
+  emptyText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  phaseRow: {
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.neutral.border,
+  },
+  phaseTitle: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+  },
+  phaseDetails: {
+    marginTop: spacing.xxs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  stepRow: {
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.neutral.border,
+  },
+  stepHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  stepTitle: {
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    flex: 1,
+    marginRight: spacing.xs,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+  },
+  stepType: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    textTransform: "uppercase",
+    fontWeight: typography.weight.bold,
+    backgroundColor: colors.brand.background,
+    borderRadius: radius.full,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xxs,
+  },
+  stepDescription: {
+    marginTop: spacing.sm,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  compactStat: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    marginBottom: spacing.xxs,
+  },
+  compactHint: {
+    marginTop: spacing.xs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/IngredientsTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/IngredientsTab.tsx
@@ -1,0 +1,316 @@
+import React, { useMemo } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import Slider from "@react-native-community/slider";
+
+import { Card } from "@/core/ui/Card";
+import { Ionicons } from "@expo/vector-icons";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { colors, radius, spacing, typography } from "@/core/theme";
+import {
+  formatQuantity,
+  getIngredientGroupEntries,
+  groupIngredientsByType,
+  scaleQuantity,
+} from "@/features/recipes/presentation/recipe-details.utils";
+import type { RecipeDetailsIngredientItem } from "@/features/recipes/application/recipes.use-cases";
+import { IngredientCategory } from "@/features/ingredients/domain/ingredient.types";
+
+const SLIDER_MIN_LITRES = 5;
+const SLIDER_MAX_LITRES = 100;
+const SLIDER_STEP = 1;
+
+type IngredientsTabProps = Readonly<{
+  ingredients: RecipeDetailsIngredientItem[];
+  baseVolumeLiters: number;
+  targetVolumeLiters: number;
+  scalingFactor: number;
+  onChangeTargetVolume: (volume: number) => void;
+  onAddIngredientToCart: (ingredient: RecipeDetailsIngredientItem) => void;
+  onAddAllIngredientsToCart: () => void;
+  onOpenIngredient: (ingredient: {
+    id: string;
+    category: IngredientCategory;
+  }) => void;
+  onOpenShop: () => void;
+}>;
+
+/**
+ * Ingredients tab of the redesigned recipe detail screen
+ * (Issue #740, Round 4 v2 — 5-tab layout).
+ *
+ * Co-locates the **target-volume slider** with the ingredient list
+ * because the slider is the input that scales every quantity. A user
+ * dragging the slider sees the malts / hops / yeasts quantities react
+ * live, which makes the recipe feel "alive" and avoids the cognitive
+ * jump of having the controls in another tab.
+ *
+ * Tap on an ingredient row navigates to its dedicated detail screen
+ * (existing pattern — preserved from the previous monolithic screen).
+ */
+export function IngredientsTab(props: IngredientsTabProps) {
+  const {
+    ingredients,
+    baseVolumeLiters,
+    targetVolumeLiters,
+    scalingFactor,
+    onChangeTargetVolume,
+    onAddIngredientToCart,
+    onAddAllIngredientsToCart,
+    onOpenIngredient,
+    onOpenShop,
+  } = props;
+
+  const groupedIngredients = useMemo(
+    () => groupIngredientsByType(ingredients),
+    [ingredients],
+  );
+  const ingredientGroupEntries = useMemo(
+    () => getIngredientGroupEntries(groupedIngredients),
+    [groupedIngredients],
+  );
+
+  return (
+    <View testID="recipe-ingredients-tab" style={styles.container}>
+      <Card style={styles.sliderCard}>
+        <View style={styles.sliderHeader}>
+          <Text style={styles.sliderTitle}>Volume cible</Text>
+          <Text
+            testID="recipe-target-volume-readout"
+            style={styles.sliderValue}
+          >
+            {targetVolumeLiters} L
+          </Text>
+        </View>
+        <Slider
+          testID="recipe-target-volume-slider"
+          accessibilityLabel="Volume cible en litres"
+          minimumValue={SLIDER_MIN_LITRES}
+          maximumValue={SLIDER_MAX_LITRES}
+          step={SLIDER_STEP}
+          value={targetVolumeLiters}
+          onSlidingComplete={onChangeTargetVolume}
+          minimumTrackTintColor={colors.brand.secondary}
+          maximumTrackTintColor={colors.neutral.border}
+          thumbTintColor={colors.brand.secondary}
+        />
+        <Text style={styles.sliderHint}>
+          Recette de base : {baseVolumeLiters} L. Les quantités se mettent à
+          jour quand tu déplaces le curseur.
+        </Text>
+      </Card>
+
+      <ScrollView contentContainerStyle={styles.listContent}>
+        <View style={styles.sectionHeaderRow}>
+          <Text style={styles.sectionTitle}>Ingrédients</Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Ouvrir la boutique depuis la liste des ingrédients"
+            style={styles.inlineAction}
+            onPress={onOpenShop}
+          >
+            <Ionicons
+              name="cart-outline"
+              size={16}
+              color={colors.brand.secondary}
+            />
+            <Text style={styles.inlineActionText}>Boutique</Text>
+          </Pressable>
+        </View>
+
+        <Card style={styles.ingredientsCard}>
+          <PrimaryButton
+            testID="recipe-add-all-ingredients-button"
+            label="Tout ajouter au panier"
+            onPress={onAddAllIngredientsToCart}
+            disabled={ingredients.length === 0}
+          />
+
+          {ingredients.length === 0 ? (
+            <Text style={styles.emptyText}>
+              Pas d'ingrédient renseigné pour cette recette.
+            </Text>
+          ) : (
+            ingredientGroupEntries.map(({ key, label }) => (
+              <View key={key} style={styles.groupBlock}>
+                <Text style={styles.groupTitle}>{label}</Text>
+
+                {groupedIngredients[key].map((item, index) => {
+                  const quantity = formatQuantity(
+                    scaleQuantity(item.amount, scalingFactor),
+                    item.unit,
+                  );
+
+                  return (
+                    <View
+                      key={`${item.ingredientId}-${item.timing ?? "no-timing"}-${index}`}
+                      style={styles.listItem}
+                    >
+                      <Pressable
+                        style={styles.listItemMain}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Open ingredient details for ${item.ingredient?.name ?? "unknown ingredient"}`}
+                        disabled={!item.ingredient}
+                        onPress={() => {
+                          if (!item.ingredient) {
+                            return;
+                          }
+                          onOpenIngredient(item.ingredient);
+                        }}
+                      >
+                        <Text style={styles.listItemTitle}>
+                          {item.ingredient?.name ?? "Ingrédient inconnu"}
+                        </Text>
+                        <Text style={styles.listItemMeta}>
+                          {quantity}
+                          {item.timing ? ` • ${item.timing}` : ""}
+                        </Text>
+                        {item.notes ? (
+                          <Text style={styles.listItemNotes}>{item.notes}</Text>
+                        ) : null}
+                      </Pressable>
+
+                      <Pressable
+                        testID={`recipe-add-ingredient-${item.ingredientId}-${index}`}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Add ${item.ingredient?.name ?? "ingredient"} to local cart`}
+                        style={styles.addActionButton}
+                        onPress={() => onAddIngredientToCart(item)}
+                      >
+                        <Ionicons
+                          name="add-circle-outline"
+                          size={20}
+                          color={colors.brand.secondary}
+                        />
+                      </Pressable>
+                    </View>
+                  );
+                })}
+              </View>
+            ))
+          )}
+        </Card>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+  },
+  sliderCard: {
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  sliderHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "baseline",
+    marginBottom: spacing.xs,
+  },
+  sliderTitle: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+  },
+  sliderValue: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+  },
+  sliderHint: {
+    marginTop: spacing.xs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  listContent: {
+    paddingBottom: spacing.lg,
+  },
+  sectionHeaderRow: {
+    marginTop: spacing.sm,
+    marginBottom: spacing.xs,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  sectionTitle: {
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+  },
+  inlineAction: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xxs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xxs,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    borderColor: colors.brand.secondary,
+    backgroundColor: colors.brand.background,
+  },
+  inlineActionText: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.caption,
+    fontWeight: typography.weight.medium,
+  },
+  ingredientsCard: {
+    padding: spacing.md,
+  },
+  emptyText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    marginTop: spacing.sm,
+  },
+  groupBlock: {
+    marginTop: spacing.sm,
+  },
+  groupTitle: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textSecondary,
+    marginBottom: spacing.xxs,
+  },
+  listItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.neutral.border,
+  },
+  listItemMain: {
+    flex: 1,
+  },
+  listItemTitle: {
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+  },
+  listItemMeta: {
+    marginTop: spacing.xxs,
+    color: colors.neutral.muted,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  listItemNotes: {
+    marginTop: spacing.xxs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  addActionButton: {
+    marginLeft: spacing.xs,
+    padding: spacing.xxs,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/NotesReviewsTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/NotesReviewsTab.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { Card } from "@/core/ui/Card";
+import { colors, spacing, typography } from "@/core/theme";
+
+/**
+ * Tab 4 of the redesigned recipe detail screen (Issue #740).
+ *
+ * v0.1 scope: placeholder only. Reviews, per-step comments, and
+ * 4-axis ratings (Goût / Difficulté / Coût / Fidélité au style)
+ * depend on the community feature (Issue #739) and will land in
+ * v0.2 once the rating + review API is exposed.
+ */
+export function NotesReviewsTab() {
+  return (
+    <View testID="recipe-reviews-tab" style={styles.container}>
+      <Card style={styles.card}>
+        <Text style={styles.title}>Notes & Reviews</Text>
+        <Text style={styles.body}>
+          Les notes par axe (goût, difficulté, coût, fidélité au style) et les
+          retours de la communauté arrivent dans une prochaine version.
+        </Text>
+        <Text style={styles.hint}>
+          Bientôt : commentaires par étape, classement par utilité, et compteur
+          "Brassée par N brasseurs".
+        </Text>
+      </Card>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+  },
+  card: {
+    padding: spacing.md,
+  },
+  title: {
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    marginBottom: spacing.sm,
+  },
+  body: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    marginBottom: spacing.sm,
+  },
+  hint: {
+    color: colors.neutral.muted,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/OverviewTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/OverviewTab.tsx
@@ -1,0 +1,269 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { BeerHero } from "@/features/scan/presentation/components/BeerHero";
+import { Card } from "@/core/ui/Card";
+import { colors, radius, spacing, typography } from "@/core/theme";
+import { RecipeProvenanceBadge } from "@/features/recipes/presentation/components/RecipeProvenanceBadge";
+import type {
+  Recipe,
+  RecipeStats,
+} from "@/features/recipes/domain/recipe.types";
+import type { RecipeDetailsEquipmentItem } from "@/features/recipes/application/recipes.use-cases";
+
+type OverviewTabProps = Readonly<{
+  recipe: Recipe;
+  equipment: RecipeDetailsEquipmentItem[];
+  targetVolumeLiters: number;
+  provenanceLabel: string | null;
+}>;
+
+/**
+ * Overview tab of the redesigned recipe detail screen
+ * (Issue #740, Round 4 v2 — 5-tab layout).
+ *
+ * Lands the user on a quick-glance summary:
+ * - EBC-driven hero (reuses the canonical `BeerHero` primitive),
+ * - Optional provenance badge when the recipe was imported from the
+ *   scan flow ("Importée depuis le scan • <beer name>"),
+ * - At-a-glance card with brewing metrics scaled to the user's
+ *   target volume,
+ * - Intro narrative (recipe description, hidden when empty),
+ * - Equipment checklist — the user sees up-front everything that
+ *   will be needed to brew the recipe (capacities side by side).
+ */
+export function OverviewTab({
+  recipe,
+  equipment,
+  targetVolumeLiters,
+  provenanceLabel,
+}: OverviewTabProps) {
+  const stats: RecipeStats | null | undefined = recipe.stats;
+  const styleLabel = pickField(recipe, "style");
+  const breweryLabel = pickField(recipe, "brewery");
+  const colorEbc = stats?.colorEbc ?? null;
+
+  return (
+    <View testID="recipe-overview-tab" style={styles.container}>
+      {provenanceLabel ? (
+        <RecipeProvenanceBadge label={provenanceLabel} />
+      ) : null}
+
+      <BeerHero
+        name={recipe.name}
+        brewery={breweryLabel}
+        style={styleLabel}
+        colorEbc={colorEbc}
+      />
+
+      {stats ? (
+        <Card style={styles.statsCard}>
+          <Text style={styles.cardTitle}>En un coup d'œil</Text>
+          <View style={styles.statsGrid}>
+            <StatBlock label="ABV" value={`${stats.abv}%`} />
+            <StatBlock label="IBU" value={String(stats.ibu)} />
+            <StatBlock
+              label="Couleur"
+              value={
+                typeof stats.colorEbc === "number"
+                  ? `${stats.colorEbc} EBC`
+                  : "—"
+              }
+            />
+            <StatBlock label="OG" value={String(stats.og)} />
+            <StatBlock label="FG" value={String(stats.fg)} />
+            <StatBlock label="Volume cible" value={`${targetVolumeLiters} L`} />
+          </View>
+          <Text style={styles.referenceHint}>
+            IBU, ABV, OG et FG restent les valeurs de référence de la recette
+            d'origine.
+          </Text>
+        </Card>
+      ) : null}
+
+      {recipe.description ? (
+        <Card style={styles.introCard}>
+          <Text style={styles.cardTitle}>À propos de cette recette</Text>
+          <Text style={styles.introText}>{recipe.description}</Text>
+        </Card>
+      ) : null}
+
+      <Card style={styles.checklistCard}>
+        <Text style={styles.cardTitle}>Matériel requis</Text>
+        <Text style={styles.checklistHint}>
+          Ce dont tu auras besoin pour brasser cette recette. Vérifie ta cuisine
+          avant de commencer.
+        </Text>
+        {equipment.length === 0 ? (
+          <Text style={styles.emptyText}>
+            Aucun matériel n'est listé pour cette recette.
+          </Text>
+        ) : (
+          equipment.map((item) => (
+            <View
+              key={item.equipmentId}
+              testID={`recipe-equipment-checklist-${item.equipmentId}`}
+              style={styles.checklistRow}
+            >
+              <View style={styles.checklistMain}>
+                <Text style={styles.checklistName}>
+                  {item.equipment?.name ?? "Matériel inconnu"}
+                </Text>
+                <Text style={styles.checklistMeta}>
+                  {item.role ?? item.equipment?.type ?? "Usage général"}
+                  {item.equipment?.volumeLiters
+                    ? ` • capacité ${item.equipment.volumeLiters} L`
+                    : ""}
+                </Text>
+              </View>
+              {item.equipment?.volumeLiters ? (
+                <View style={styles.capacityChip}>
+                  <Text style={styles.capacityChipText}>
+                    {item.equipment.volumeLiters} L
+                  </Text>
+                </View>
+              ) : null}
+            </View>
+          ))
+        )}
+      </Card>
+    </View>
+  );
+}
+
+type StatBlockProps = Readonly<{
+  label: string;
+  value: string;
+}>;
+
+function StatBlock({ label, value }: StatBlockProps) {
+  return (
+    <View style={styles.statItem}>
+      <Text style={styles.statLabel}>{label}</Text>
+      <Text style={styles.statValue}>{value}</Text>
+    </View>
+  );
+}
+
+function pickField(recipe: Recipe, key: "style" | "brewery"): string | null {
+  const candidate = (
+    recipe as { style?: string | null; brewery?: string | null }
+  )[key];
+  if (typeof candidate === "string" && candidate.trim().length > 0) {
+    return candidate;
+  }
+  return null;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+  },
+  statsCard: {
+    padding: spacing.md,
+    marginBottom: spacing.md,
+  },
+  introCard: {
+    padding: spacing.md,
+    marginBottom: spacing.md,
+  },
+  checklistCard: {
+    padding: spacing.md,
+    marginBottom: spacing.md,
+  },
+  cardTitle: {
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    marginBottom: spacing.sm,
+  },
+  statsGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  statItem: {
+    width: "30%",
+    minWidth: 90,
+    backgroundColor: colors.brand.background,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+  },
+  statLabel: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    textTransform: "uppercase",
+    fontWeight: typography.weight.bold,
+  },
+  statValue: {
+    marginTop: spacing.xxs,
+    color: colors.neutral.textPrimary,
+    fontWeight: typography.weight.bold,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+  },
+  referenceHint: {
+    marginTop: spacing.sm,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    color: colors.neutral.textSecondary,
+  },
+  introText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  checklistHint: {
+    marginTop: -spacing.xs,
+    marginBottom: spacing.sm,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  checklistRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.neutral.border,
+  },
+  checklistMain: {
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  checklistName: {
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  checklistMeta: {
+    marginTop: spacing.xxs,
+    color: colors.neutral.muted,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  capacityChip: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xxs,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    borderColor: colors.brand.secondary,
+    backgroundColor: colors.brand.background,
+  },
+  capacityChipText: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.caption,
+    fontWeight: typography.weight.bold,
+  },
+  emptyText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/WaterTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/WaterTab.tsx
@@ -1,0 +1,403 @@
+import React from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import { Card } from "@/core/ui/Card";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { colors, radius, spacing, typography } from "@/core/theme";
+import {
+  NON_PUBLIC_WATER_PREFERENCE_OPTIONS,
+  NonPublicWaterPreference,
+} from "@/features/recipes/presentation/recipe-details.constants";
+import { WATER_METRIC_LABELS } from "@/features/recipes/presentation/recipe-details.utils";
+import {
+  WATER_LOCATION_PROFILES,
+  WATER_STYLE_PRESETS,
+} from "@/features/tools/data/water-profiles.data";
+import type { WaterStylePresetId } from "@/features/tools/domain/water-profiles";
+import type { Recipe } from "@/features/recipes/domain/recipe.types";
+import { computeWaterSaltAdditions } from "@/features/recipes/presentation/helpers/water-mineral-salts";
+
+type CompatibilityScore = Readonly<{
+  score: number;
+  label: string;
+  matchedMetrics: number;
+  totalMetrics: number;
+}>;
+
+type WaterMineralKey = keyof typeof WATER_METRIC_LABELS;
+
+type WaterProfile = Readonly<Record<WaterMineralKey, number>> &
+  Readonly<{ name?: string }>;
+
+type WaterTabProps = Readonly<{
+  recipe: Recipe;
+  recommendedWaterLabel: string;
+  recommendedWaterProfile: WaterProfile;
+  localWaterProfile: WaterProfile;
+  compatibility: CompatibilityScore;
+  targetVolumeLiters: number;
+  nonPublicWaterPreference: NonPublicWaterPreference;
+  onChangeNonPublicWaterPreference: (value: NonPublicWaterPreference) => void;
+  selectedWaterStylePresetId: WaterStylePresetId;
+  onChangeWaterStylePreset: (id: WaterStylePresetId) => void;
+  selectedLocalWaterProfileName: string;
+  onChangeLocalWaterProfileName: (name: string) => void;
+  onOpenWaterCalculator: () => void;
+}>;
+
+/**
+ * Water tab of the redesigned recipe detail screen
+ * (Issue #740, Round 4 v2 — 5-tab layout).
+ *
+ * Promoted from a section of the previous Compatibilité tab to a
+ * full tab so the brewer can drill into water chemistry without
+ * scrolling through the rest of the detail. Adds the v0.1 niveau B
+ * deliverable: a "salts to add" card that converts the gap between
+ * recipe target and local water into practical brewing-salt grams
+ * (gypsum, calcium chloride, table salt) scaled by batch volume —
+ * see `helpers/water-mineral-salts.ts`.
+ */
+export function WaterTab(props: WaterTabProps) {
+  const {
+    recipe,
+    recommendedWaterLabel,
+    recommendedWaterProfile,
+    localWaterProfile,
+    compatibility,
+    targetVolumeLiters,
+    nonPublicWaterPreference,
+    onChangeNonPublicWaterPreference,
+    selectedWaterStylePresetId,
+    onChangeWaterStylePreset,
+    selectedLocalWaterProfileName,
+    onChangeLocalWaterProfileName,
+    onOpenWaterCalculator,
+  } = props;
+
+  const isPublic = recipe.visibility === "public";
+  const additions = computeWaterSaltAdditions(
+    recommendedWaterProfile,
+    localWaterProfile,
+    targetVolumeLiters,
+  );
+
+  return (
+    <ScrollView
+      testID="recipe-water-tab"
+      contentContainerStyle={styles.container}
+    >
+      <Text style={styles.sectionTitle}>Profil eau</Text>
+
+      <Card style={styles.card}>
+        <Text style={styles.helperText}>{recommendedWaterLabel}</Text>
+
+        {!isPublic ? (
+          <View style={styles.toggleRow}>
+            {NON_PUBLIC_WATER_PREFERENCE_OPTIONS.map((option) => (
+              <Pressable
+                key={option.id}
+                accessibilityRole="button"
+                accessibilityLabel={`Use ${option.label.toLowerCase()} recommendation`}
+                style={[
+                  styles.toggleChip,
+                  nonPublicWaterPreference === option.id &&
+                    styles.toggleChipActive,
+                ]}
+                onPress={() => onChangeNonPublicWaterPreference(option.id)}
+              >
+                <Text
+                  style={[
+                    styles.toggleChipText,
+                    nonPublicWaterPreference === option.id &&
+                      styles.toggleChipTextActive,
+                  ]}
+                >
+                  {option.label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
+
+        {!isPublic && nonPublicWaterPreference === "style" ? (
+          <View style={styles.choiceWrap}>
+            {WATER_STYLE_PRESETS.map((preset) => {
+              const isSelected = preset.id === selectedWaterStylePresetId;
+              return (
+                <Pressable
+                  key={preset.id}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Select water style preset ${preset.name}`}
+                  style={[
+                    styles.choiceChip,
+                    isSelected && styles.choiceChipActive,
+                  ]}
+                  onPress={() => onChangeWaterStylePreset(preset.id)}
+                >
+                  <Text
+                    style={[
+                      styles.choiceChipText,
+                      isSelected && styles.choiceChipTextActive,
+                    ]}
+                  >
+                    {preset.name}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        ) : null}
+
+        <Text style={styles.fieldLabel}>Ton eau locale</Text>
+        <View style={styles.choiceWrap}>
+          {WATER_LOCATION_PROFILES.map((profile) => {
+            const isSelected = profile.name === selectedLocalWaterProfileName;
+            return (
+              <Pressable
+                key={profile.name}
+                accessibilityRole="button"
+                accessibilityLabel={`Select water location ${profile.name}`}
+                style={[
+                  styles.choiceChip,
+                  isSelected && styles.choiceChipActive,
+                ]}
+                onPress={() => onChangeLocalWaterProfileName(profile.name)}
+              >
+                <Text
+                  style={[
+                    styles.choiceChipText,
+                    isSelected && styles.choiceChipTextActive,
+                  ]}
+                >
+                  {profile.name}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <View style={styles.compatibilityCard}>
+          <Text style={styles.compatibilityTitle}>
+            Score compatibilité : {compatibility.score}% ({compatibility.label})
+          </Text>
+          <Text style={styles.compatibilitySubtitle}>
+            {compatibility.matchedMetrics}/{compatibility.totalMetrics}{" "}
+            métriques dans la zone cible
+          </Text>
+        </View>
+
+        {(Object.keys(WATER_METRIC_LABELS) as WaterMineralKey[]).map(
+          (metric) => (
+            <View key={metric} style={styles.metricRow}>
+              <Text style={styles.metricLabel}>
+                {WATER_METRIC_LABELS[metric]}
+              </Text>
+              <Text style={styles.metricValue}>
+                {recommendedWaterProfile[metric]} / {localWaterProfile[metric]}{" "}
+                ppm
+              </Text>
+            </View>
+          ),
+        )}
+
+        <PrimaryButton
+          label="Comparer dans le Calculateur Eau"
+          onPress={onOpenWaterCalculator}
+        />
+      </Card>
+
+      <Text style={styles.sectionTitle}>Ajouter pour matcher</Text>
+      <Card style={styles.card}>
+        {additions.length === 0 ? (
+          <Text style={styles.emptyText}>
+            Ton eau locale est déjà alignée sur le profil cible (ou les écarts
+            ne sont pas couvrables par ajout de sels).
+          </Text>
+        ) : (
+          additions.map((addition) => (
+            <View key={addition.id} style={styles.additionRow}>
+              <View style={styles.additionMain}>
+                <Text style={styles.additionName}>
+                  {addition.name} ({addition.formula})
+                </Text>
+                <Text style={styles.additionRationale}>
+                  {addition.rationale}
+                </Text>
+              </View>
+              <Text style={styles.additionGrams}>+{addition.grams} g</Text>
+            </View>
+          ))
+        )}
+        <Text style={styles.additionFootnote}>
+          Quantités calculées pour {targetVolumeLiters} L. Pour aller plus loin
+          (pH du mash, dilution), utilise le Calculateur Eau.
+        </Text>
+      </Card>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.md,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
+  },
+  sectionTitle: {
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    marginBottom: spacing.sm,
+  },
+  card: {
+    padding: spacing.md,
+    marginBottom: spacing.md,
+  },
+  helperText: {
+    marginBottom: spacing.sm,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  fieldLabel: {
+    marginTop: spacing.sm,
+    marginBottom: spacing.xxs,
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+  },
+  toggleRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  toggleChip: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    backgroundColor: colors.neutral.white,
+  },
+  toggleChipActive: {
+    borderColor: colors.brand.secondary,
+    backgroundColor: colors.brand.background,
+  },
+  toggleChipText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontWeight: typography.weight.medium,
+  },
+  toggleChipTextActive: {
+    color: colors.brand.secondary,
+  },
+  choiceWrap: {
+    marginTop: spacing.xs,
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.xs,
+  },
+  choiceChip: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.md,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+  },
+  choiceChipActive: {
+    borderColor: colors.brand.secondary,
+    backgroundColor: colors.brand.background,
+  },
+  choiceChipText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  choiceChipTextActive: {
+    color: colors.brand.secondary,
+    fontWeight: typography.weight.bold,
+  },
+  compatibilityCard: {
+    marginTop: spacing.sm,
+    marginBottom: spacing.sm,
+    borderRadius: radius.md,
+    backgroundColor: colors.brand.background,
+    borderWidth: 1,
+    borderColor: colors.brand.secondary,
+    padding: spacing.sm,
+  },
+  compatibilityTitle: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+  },
+  compatibilitySubtitle: {
+    marginTop: spacing.xxs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  metricRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: spacing.xs,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.neutral.border,
+  },
+  metricLabel: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  metricValue: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  additionRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.neutral.border,
+  },
+  additionMain: {
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  additionName: {
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  additionRationale: {
+    marginTop: spacing.xxs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  additionGrams: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+  },
+  additionFootnote: {
+    marginTop: spacing.sm,
+    color: colors.neutral.muted,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+  },
+  emptyText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+});

--- a/packages/mobile-app/src/features/scan/presentation/components/BeerHero.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/components/BeerHero.tsx
@@ -7,56 +7,79 @@ import {
   foregroundOnEbc,
 } from "@/features/scan/application/lookup-color";
 
-type BeerHeroProps = {
+type BeerHeroProps = Readonly<{
   name: string;
-  brewery: string;
-  style: string;
+  brewery?: string | null;
+  style?: string | null;
   colorEbc: number | null;
-};
+}>;
 
 /**
- * Hero block at the top of the BeerInfoCardScreen. The background
- * colour is computed from the beer's actual EBC value so a Punk IPA
- * shows up amber-orange, La Chouffe pale amber, and Rochefort 10
- * deep brown — the same data drives both the visual identity and
- * the "Couleur" word in the at-a-glance row, keeping the user's
- * mental model coherent.
+ * Hero block at the top of the BeerInfoCardScreen and the recipe
+ * detail screen (Issue #740, Round 4 — reused as the canonical hero
+ * primitive). Background colour is computed from the beer's actual
+ * EBC value so a Punk IPA renders amber-orange, La Chouffe pale
+ * amber, and Rochefort 10 deep brown — the same data drives both the
+ * visual identity and the "Couleur" word in the at-a-glance row,
+ * keeping the user's mental model coherent.
  *
  * Foreground colour adapts (light text on dark backgrounds, dark
  * text on pale backgrounds) so the hero stays readable across the
  * full EBC range.
  *
- * Height is fixed-aspect: ~40% of a typical phone screen at
- * default font sizes (per #698 acceptance criteria), without using
- * `Dimensions` so the layout stays predictable in tests.
+ * `brewery` and `style` are optional: when absent (e.g. a recipe
+ * with no brewery metadata yet), the corresponding row / chip is
+ * hidden rather than rendering an empty placeholder.
  */
-export function BeerHero({ name, brewery, style, colorEbc }: BeerHeroProps) {
+export function BeerHero({
+  name,
+  brewery = null,
+  style = null,
+  colorEbc,
+}: BeerHeroProps) {
   const background = ebcToHex(colorEbc);
   const foreground = foregroundOnEbc(colorEbc);
+  const breweryLabel = trimToNull(brewery);
+  const styleLabel = trimToNull(style);
+  const accessibilityLabel = [name, breweryLabel, styleLabel]
+    .filter((value): value is string => Boolean(value))
+    .join(", ");
 
   return (
     <View
       style={[styles.hero, { backgroundColor: background }]}
       accessible
-      accessibilityLabel={`${name}, ${brewery}, ${style}`}
+      accessibilityLabel={accessibilityLabel}
       accessibilityRole="header"
     >
       <Text style={[styles.name, { color: foreground }]} numberOfLines={2}>
         {name}
       </Text>
-      <Text style={[styles.brewery, { color: foreground }]} numberOfLines={1}>
-        {brewery}
-      </Text>
-      <View style={[styles.styleChip, { borderColor: foreground }]}>
-        <Text
-          style={[styles.styleChipText, { color: foreground }]}
-          numberOfLines={1}
-        >
-          {style}
+      {breweryLabel ? (
+        <Text style={[styles.brewery, { color: foreground }]} numberOfLines={1}>
+          {breweryLabel}
         </Text>
-      </View>
+      ) : null}
+      {styleLabel ? (
+        <View style={[styles.styleChip, { borderColor: foreground }]}>
+          <Text
+            style={[styles.styleChipText, { color: foreground }]}
+            numberOfLines={1}
+          >
+            {styleLabel}
+          </Text>
+        </View>
+      ) : null}
     </View>
   );
+}
+
+function trimToNull(value: string | null | undefined): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary

Splits the legacy 1.3 kLoC monolithic `RecipeDetailsScreen` into a tabbed orchestrator with four dedicated tab views, an EBC-driven hero shared with the scan flow's `BeerInfoCardScreen`, and a sticky `[Start Batch]` CTA pinned across every tab. Migrates data fetching from `useState + useEffect` to TanStack Query (`useQuery` + `useMutation`) to align with the rest of the recipes feature.

This is the first slice of the **#740 v0.1 detail-screen refonte** (Round 4) for the soutenance demo on 2026-05-27. The Hub Mes Recettes (Round 2 — Mes recettes + Découvrir sections) ships in a follow-up PR on a dedicated branch.

## Scope

**New components**
- `presentation/components/RecipeHero.tsx` — EBC-driven hero (reuses `ebcToHex` + `foregroundOnEbc` from the scan flow)
- `presentation/components/RecipeDetailTabBar.tsx` — horizontal scrollable tab bar with active indicator
- `presentation/components/RecipeStickyCta.tsx` — sticky CTA bar with helper line (capacity warnings, future provenance)

**New tabs**
- `presentation/tabs/OverviewTab.tsx` — hero + at-a-glance brewing metrics (ABV / IBU / Couleur / OG / FG / Volume cible) + intro narrative
- `presentation/tabs/BrewingTab.tsx` — volume scaler (manual + equipment-bound), ingredient list grouped by type with cart shortcuts, equipment list, local-cart preview, process preview (phases / recipe steps / compact)
- `presentation/tabs/CompatibilityTab.tsx` — water-profile cross-check ported from the monolith + deferred placeholder for équipement / stock / niveau / tasting-target retro-planning (v0.2)
- `presentation/tabs/NotesReviewsTab.tsx` — placeholder, depends on community feature (#739)

**Refactor**
- `RecipeDetailsScreen.tsx` reduced from 1294 → 388 lines, becomes a pure orchestrator
- Data fetch migrated to `useQuery`, batch start migrated to `useMutation`
- All shared state (volume mode, target volume, equipment selection, cart, water preferences, tab) lifted to the orchestrator and passed down to tabs as props

## v0.1 acceptance criteria (#740) — status

| Criterion | Status |
|---|---|
| 4-tab detail screen | ✅ Vue d'ensemble / Brassage / Compatibilité / Notes & Reviews |
| Hero pattern reused from `BeerInfoCardScreen` | ✅ EBC-driven, same `ebcToHex` + foreground rules |
| Volume slider in Brassage tab (basic linear scaling) | ✅ Linear scaling via numeric input — true RN slider primitive deferred to follow-up polish |
| Sticky `[Start Batch]` CTA at bottom | ✅ Always visible, disabled when capacity blocked |
| Hub Mes Recettes (2 sections) | 🟨 Next PR (Round 2) |
| Recipe imported from scan shows provenance | 🟨 Next PR (depends on `imported_from_recipe_id` projection) |

## Tests

- 33/33 recipes presentation tests pass — the existing `RecipeDetailsScreen.test.tsx` was rewritten to wrap with `QueryClientProvider` and navigate tabs before asserting on tab-scoped content
- Coverage: happy path (rendering + tab switch + scaling) + sad path (capacity-blocked CTA) + edge (yeast / malt / hop ingredient routing, recipe with no equipment, no steps)
- Full mobile suite: 744/744 green
- `npm run ci:check` green (lint + typecheck + format)

## Checklist

- [x] Happy path + sad path + edge cases covered
- [x] `tsc --noEmit` passes
- [x] Build passes (`npm run ci:check`)
- [x] Existing tests still green (744/744)
- [x] No `any`, no inline styles introduced
- [x] No hardcoded colors / spacing / fonts (all from design tokens)
- [x] Named exports only

Refs #740