### PR TITLE
feat(recipes): refactor Mes Recettes into 2-section hub (Mes recettes + Découvrir)

### DIFF
--- a/packages/mobile-app/src/features/recipes/presentation/CatalogScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/CatalogScreen.tsx
@@ -82,7 +82,7 @@ export function CatalogScreen() {
         renderItem={({ item }) => (
           <RecipeCard
             recipe={item}
-            badgeLabel="Public"
+            badgeLabel="Publique"
             onPress={() => router.push(`/(app)/recipes/${item.id}`)}
           />
         )}

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
@@ -10,10 +10,13 @@ import { getSrmColor } from "@/features/tools/data/catalogs/srm";
 
 const ebcToSrm = (ebc: number): number => ebc * 0.508;
 
+// Mobile UI is French (cf. project convention "UI stays French"). The
+// catalogue path overrides this with `badgeLabel` to force "Public" as
+// a deliberate marker on its discovery surface.
 const VISIBILITY_LABELS: Record<Recipe["visibility"], string> = {
-  public: "Public",
-  private: "Private",
-  unlisted: "Unlisted",
+  public: "Publique",
+  private: "Privée",
+  unlisted: "Non listée",
 };
 
 const VISIBILITY_VARIANTS: Record<Recipe["visibility"], "success" | "info"> = {

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
@@ -11,8 +11,9 @@ import { getSrmColor } from "@/features/tools/data/catalogs/srm";
 const ebcToSrm = (ebc: number): number => ebc * 0.508;
 
 // Mobile UI is French (cf. project convention "UI stays French"). The
-// catalogue path overrides this with `badgeLabel` to force "Public" as
-// a deliberate marker on its discovery surface.
+// catalogue path overrides this with `badgeLabel="Publique"` as a
+// deliberate marker on its discovery surface — the override is now
+// just a defensive guarantee in case the API leaks a non-public row.
 const VISIBILITY_LABELS: Record<Recipe["visibility"], string> = {
   public: "Publique",
   private: "Privée",
@@ -25,19 +26,19 @@ const VISIBILITY_VARIANTS: Record<Recipe["visibility"], "success" | "info"> = {
   unlisted: "info",
 };
 
-type Props = {
+type Props = Readonly<{
   recipe: Recipe;
   /**
    * Optional override of the visibility badge's label. Defaults to
    * the canonical `VISIBILITY_LABELS[visibility]`. Passed by callers
    * that want to force a specific label (e.g. CatalogScreen always
-   * shows "Public" because it pre-filters on visibility — so a
+   * shows "Publique" because it pre-filters on visibility — so a
    * future bug that lets a non-public recipe through still renders
    * the correct badge text rather than a contradiction).
    */
   badgeLabel?: string;
   onPress: () => void;
-};
+}>;
 
 /**
  * Shared card used by both `RecipesScreen` (Mon Carnet) and

--- a/packages/mobile-app/src/features/recipes/presentation/RecipesScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipesScreen.tsx
@@ -67,14 +67,15 @@ export function RecipesScreen() {
     discoverQuery.isLoading &&
     discoverRecipes.length === 0;
 
-  const queryError = myRecipesQuery.error ?? discoverQuery.error;
-  const isFetching = myRecipesQuery.isFetching || discoverQuery.isFetching;
+  // Per-query error suppression: each query only suppresses its own
+  // error while it's actively refetching. A failed `listRecipes` is
+  // surfaced even if `listPublicRecipes` is still in flight, and vice
+  // versa (Copilot review on PR #917 — the previous combined
+  // `isFetching` check could mask one query's failure behind the
+  // other's loading state).
+  const error = pickQueryError([myRecipesQuery, discoverQuery]);
 
-  const error = queryError
-    ? isFetching
-      ? null
-      : getErrorMessage(queryError, "Impossible de charger les recettes")
-    : null;
+  const isFetching = myRecipesQuery.isFetching || discoverQuery.isFetching;
 
   const handleRefetch = () => {
     void myRecipesQuery.refetch();
@@ -114,6 +115,7 @@ export function RecipesScreen() {
         ListHeaderComponent={
           <MyRecipesSectionHeader
             isEmpty={myRecipes.length === 0}
+            isLoading={myRecipesQuery.isLoading}
             onPressScanCta={handleOpenScan}
           />
         }
@@ -123,6 +125,7 @@ export function RecipesScreen() {
         ListFooterComponent={
           <DiscoverSection
             recipes={discoverRecipes}
+            isLoading={discoverQuery.isLoading}
             onPressRecipe={handleOpenRecipe}
             onPressSeeAll={handleOpenCatalog}
           />
@@ -130,6 +133,27 @@ export function RecipesScreen() {
       />
     </Screen>
   );
+}
+
+type QueryWithError = Readonly<{
+  error: Error | null;
+  isFetching: boolean;
+}>;
+
+/**
+ * Returns the human-readable message of the first query in the list
+ * that has a settled error (i.e. not currently re-fetching). Returns
+ * `null` if no query has a surfaced error. Encodes the per-query
+ * error-suppression rule called out in the Copilot review on
+ * PR #917.
+ */
+function pickQueryError(queries: ReadonlyArray<QueryWithError>): string | null {
+  for (const query of queries) {
+    if (query.error && !query.isFetching) {
+      return getErrorMessage(query.error, "Impossible de charger les recettes");
+    }
+  }
+  return null;
 }
 
 const styles = StyleSheet.create({

--- a/packages/mobile-app/src/features/recipes/presentation/RecipesScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipesScreen.tsx
@@ -1,8 +1,7 @@
 import React from "react";
-import { RefreshControl, ScrollView, StyleSheet } from "react-native";
+import { FlatList, RefreshControl, StyleSheet } from "react-native";
 
 import { ListHeader } from "@/core/ui/ListHeader";
-import { Recipe } from "@/features/recipes/domain/recipe.types";
 import { Screen } from "@/core/ui/Screen";
 import { spacing } from "@/core/theme";
 import {
@@ -14,8 +13,10 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 
 import { DiscoverSection } from "@/features/recipes/presentation/sections/DiscoverSection";
-import { MyRecipesSection } from "@/features/recipes/presentation/sections/MyRecipesSection";
+import { MyRecipesSectionHeader } from "@/features/recipes/presentation/sections/MyRecipesSection";
+import { RecipeCard } from "@/features/recipes/presentation/RecipeCard";
 import { getErrorMessage } from "@/core/http/http-error";
+import type { Recipe } from "@/features/recipes/domain/recipe.types";
 
 /**
  * Mes Recettes Hub — Issue #740 Round 2 (v0.1 demo scope).
@@ -30,6 +31,13 @@ import { getErrorMessage } from "@/core/http/http-error";
  *
  * Stats / Brouillons / Favoris / Tutoriels sections are explicitly
  * deferred to v0.2 per the issue's section tier table.
+ *
+ * Implementation note: the hub uses a single FlatList rather than a
+ * ScrollView so the virtualization the previous flat list relied on
+ * is preserved (Codex P2 review on PR #917). Mes recettes data drives
+ * the FlatList rows, the section header sits in `ListHeaderComponent`,
+ * and Découvrir (capped at 5 preview cards) sits in
+ * `ListFooterComponent`.
  */
 export function RecipesScreen() {
   const bottomPadding = useNavigationFooterOffset();
@@ -48,9 +56,16 @@ export function RecipesScreen() {
   const myRecipes = myRecipesQuery.data ?? [];
   const discoverRecipes = discoverQuery.data ?? [];
 
+  // Only show the full-screen spinner when *both* queries are still in
+  // their first load and have nothing cached. As soon as either side
+  // returns, render the hub so the user sees something immediately
+  // instead of staying behind a single shared loader (Copilot review on
+  // PR #917).
   const isFirstLoading =
-    (myRecipesQuery.isLoading && myRecipes.length === 0) ||
-    (discoverQuery.isLoading && discoverRecipes.length === 0);
+    myRecipesQuery.isLoading &&
+    myRecipes.length === 0 &&
+    discoverQuery.isLoading &&
+    discoverRecipes.length === 0;
 
   const queryError = myRecipesQuery.error ?? discoverQuery.error;
   const isFetching = myRecipesQuery.isFetching || discoverQuery.isFetching;
@@ -85,33 +100,41 @@ export function RecipesScreen() {
         subtitle="Ton hub de recettes de brassage"
       />
 
-      <ScrollView
+      <FlatList
+        testID="recipes-hub-list"
+        data={myRecipes}
+        keyExtractor={(item) => item.id}
         contentContainerStyle={[
-          styles.scrollContent,
+          styles.listContent,
           { paddingBottom: bottomPadding },
         ]}
         refreshControl={
           <RefreshControl refreshing={isFetching} onRefresh={handleRefetch} />
         }
-      >
-        <MyRecipesSection
-          recipes={myRecipes}
-          onPressRecipe={handleOpenRecipe}
-          onPressScanCta={handleOpenScan}
-        />
-
-        <DiscoverSection
-          recipes={discoverRecipes}
-          onPressRecipe={handleOpenRecipe}
-          onPressSeeAll={handleOpenCatalog}
-        />
-      </ScrollView>
+        ListHeaderComponent={
+          <MyRecipesSectionHeader
+            isEmpty={myRecipes.length === 0}
+            onPressScanCta={handleOpenScan}
+          />
+        }
+        renderItem={({ item }) => (
+          <RecipeCard recipe={item} onPress={() => handleOpenRecipe(item.id)} />
+        )}
+        ListFooterComponent={
+          <DiscoverSection
+            recipes={discoverRecipes}
+            onPressRecipe={handleOpenRecipe}
+            onPressSeeAll={handleOpenCatalog}
+          />
+        }
+      />
     </Screen>
   );
 }
 
 const styles = StyleSheet.create({
-  scrollContent: {
+  listContent: {
     paddingTop: spacing.xs,
+    paddingHorizontal: spacing.sm,
   },
 });

--- a/packages/mobile-app/src/features/recipes/presentation/RecipesScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipesScreen.tsx
@@ -1,130 +1,117 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
-import {
-  FlatList,
-  Pressable,
-  RefreshControl,
-  StyleSheet,
-  Text,
-} from "react-native";
-import { colors, radius, spacing, typography } from "@/core/theme";
-
-import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
-import { Ionicons } from "@expo/vector-icons";
-import { ListHeader } from "@/core/ui/ListHeader";
-import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import React from "react";
+import { RefreshControl, ScrollView, StyleSheet } from "react-native";
+
+import { ListHeader } from "@/core/ui/ListHeader";
 import { Recipe } from "@/features/recipes/domain/recipe.types";
-import { RecipeCard } from "@/features/recipes/presentation/RecipeCard";
 import { Screen } from "@/core/ui/Screen";
-import { getErrorMessage } from "@/core/http/http-error";
-import { listRecipes } from "@/features/recipes/application/recipes.use-cases";
+import { spacing } from "@/core/theme";
+import {
+  listPublicRecipes,
+  listRecipes,
+} from "@/features/recipes/application/recipes.use-cases";
+import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 
+import { DiscoverSection } from "@/features/recipes/presentation/sections/DiscoverSection";
+import { MyRecipesSection } from "@/features/recipes/presentation/sections/MyRecipesSection";
+import { getErrorMessage } from "@/core/http/http-error";
+
+/**
+ * Mes Recettes Hub — Issue #740 Round 2 (v0.1 demo scope).
+ *
+ * Replaces the previous flat "My Recipes" list with a 2-section hub:
+ *
+ * - Mes recettes (the user's carnet — perso + scan-imported); when
+ *   empty, surfaces the "Scanner ta 1ère bière" CTA wired to the
+ *   scan flow (Pattern A landing per the issue).
+ * - Découvrir (top 5 of `listPublicRecipes`); a "Voir tout" pill
+ *   links to the full CatalogScreen.
+ *
+ * Stats / Brouillons / Favoris / Tutoriels sections are explicitly
+ * deferred to v0.2 per the issue's section tier table.
+ */
 export function RecipesScreen() {
   const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
-  const {
-    data: recipes = [],
-    isLoading,
-    isFetching,
-    isFetched,
-    error: queryError,
-    refetch,
-  } = useQuery<Recipe[]>({
+
+  const myRecipesQuery = useQuery<Recipe[]>({
     queryKey: ["recipes", "list"],
     queryFn: listRecipes,
   });
 
+  const discoverQuery = useQuery<Recipe[]>({
+    queryKey: ["recipes", "catalog"],
+    queryFn: listPublicRecipes,
+  });
+
+  const myRecipes = myRecipesQuery.data ?? [];
+  const discoverRecipes = discoverQuery.data ?? [];
+
+  const isFirstLoading =
+    (myRecipesQuery.isLoading && myRecipes.length === 0) ||
+    (discoverQuery.isLoading && discoverRecipes.length === 0);
+
+  const queryError = myRecipesQuery.error ?? discoverQuery.error;
+  const isFetching = myRecipesQuery.isFetching || discoverQuery.isFetching;
+
   const error = queryError
     ? isFetching
       ? null
-      : getErrorMessage(queryError, "Failed to load recipes")
+      : getErrorMessage(queryError, "Impossible de charger les recettes")
     : null;
-  const showEmptyState = isFetched && !isLoading && recipes.length === 0;
-  const isRetryingWithError = isFetching && Boolean(queryError);
 
   const handleRefetch = () => {
-    void refetch();
+    void myRecipesQuery.refetch();
+    void discoverQuery.refetch();
+  };
+
+  const handleOpenRecipe = (recipeId: string) => {
+    router.push(`/(app)/recipes/${recipeId}`);
+  };
+
+  const handleOpenScan = () => {
+    router.push("/(app)/dashboard/scan");
+  };
+
+  const handleOpenCatalog = () => {
+    router.push("/(app)/recipes/catalog");
   };
 
   return (
-    <Screen
-      isLoading={(isLoading && recipes.length === 0) || isRetryingWithError}
-      error={error}
-      onRetry={handleRefetch}
-    >
+    <Screen isLoading={isFirstLoading} error={error} onRetry={handleRefetch}>
       <ListHeader
-        title="My Recipes"
-        subtitle="Tes recettes de brassage"
-        action={
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Ouvrir le catalogue de recettes"
-            style={styles.catalogLink}
-            onPress={() => router.push("/(app)/recipes/catalog")}
-          >
-            <Ionicons
-              name="library-outline"
-              size={16}
-              color={colors.brand.secondary}
-            />
-            <Text style={styles.catalogLinkText}>Catalogue</Text>
-          </Pressable>
-        }
+        title="Mes Recettes"
+        subtitle="Ton hub de recettes de brassage"
       />
 
-      {showEmptyState ? (
-        <EmptyStateCard
-          title="Aucune recette"
-          description="Découvre les recettes partagées par la communauté pour démarrer ton carnet."
-          action={
-            <PrimaryButton
-              accessibilityLabel="Découvrir le catalogue de recettes"
-              label="Découvrir le catalogue"
-              onPress={() => router.push("/(app)/recipes/catalog")}
-            />
-          }
-        />
-      ) : null}
-
-      <FlatList
-        data={recipes}
-        keyExtractor={(item) => item.id}
-        contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
+      <ScrollView
+        contentContainerStyle={[
+          styles.scrollContent,
+          { paddingBottom: bottomPadding },
+        ]}
         refreshControl={
           <RefreshControl refreshing={isFetching} onRefresh={handleRefetch} />
         }
-        renderItem={({ item }) => (
-          <RecipeCard
-            recipe={item}
-            onPress={() => router.push(`/(app)/recipes/${item.id}`)}
-          />
-        )}
-      />
+      >
+        <MyRecipesSection
+          recipes={myRecipes}
+          onPressRecipe={handleOpenRecipe}
+          onPressScanCta={handleOpenScan}
+        />
+
+        <DiscoverSection
+          recipes={discoverRecipes}
+          onPressRecipe={handleOpenRecipe}
+          onPressSeeAll={handleOpenCatalog}
+        />
+      </ScrollView>
     </Screen>
   );
 }
 
 const styles = StyleSheet.create({
-  catalogLink: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.xxs,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-    borderRadius: radius.md,
-    borderWidth: 1,
-    borderColor: colors.brand.secondary,
-    backgroundColor: colors.brand.background,
-  },
-  catalogLinkText: {
-    color: colors.brand.secondary,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
-    fontWeight: typography.weight.medium,
-  },
-  list: {
-    paddingHorizontal: spacing.sm,
+  scrollContent: {
+    paddingTop: spacing.xs,
   },
 });

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/CatalogScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/CatalogScreen.test.tsx
@@ -105,10 +105,10 @@ describe("CatalogScreen (Issue #779 — KISS Recipe Catalog mini)", () => {
     ).toBeTruthy();
   });
 
-  // edge: the screen never accidentally renders the "Public" badge
+  // edge: the screen never accidentally renders the "Publique" badge
   // text from a non-public recipe (defensive guard against the
   // use-case leaking private/unlisted entries).
-  it("edge: every rendered card carries the Public badge", async () => {
+  it("edge: every rendered card carries the Publique badge", async () => {
     mockedListPublicRecipes.mockResolvedValue([
       buildPublicRecipe({ id: "r-public-1", name: "Punk IPA" }),
       buildPublicRecipe({ id: "r-public-2", name: "Hazy Jane" }),
@@ -118,7 +118,7 @@ describe("CatalogScreen (Issue #779 — KISS Recipe Catalog mini)", () => {
 
     await screen.findByText("Punk IPA");
     // Badge uppercases its label internally — assert on the rendered text.
-    const publicBadges = screen.getAllByText("PUBLIC");
+    const publicBadges = screen.getAllByText("PUBLIQUE");
     expect(publicBadges.length).toBe(2);
   });
 });

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipesScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipesScreen.test.tsx
@@ -123,6 +123,11 @@ describe("RecipesScreen — Mes Recettes Hub (Issue #740 Round 2)", () => {
     expect(mockPush).toHaveBeenCalledWith("/(app)/dashboard/scan");
   });
 
+  // Pressing the recipe name `Text` is brittle because the press
+  // handler lives on the surrounding `Pressable` in `RecipeCard`. We
+  // press the accessibility label instead so the test pins the
+  // contract used by assistive tech and survives card-layout tweaks
+  // (Copilot review on PR #917).
   it("navigates to a recipe detail when tapping a card in Mes recettes", async () => {
     (listRecipes as jest.Mock).mockResolvedValue([FAKE_MY_RECIPE]);
     (listPublicRecipes as jest.Mock).mockResolvedValue([]);
@@ -131,7 +136,7 @@ describe("RecipesScreen — Mes Recettes Hub (Issue #740 Round 2)", () => {
 
     await screen.findByText("My Saison");
 
-    fireEvent.press(screen.getByText("My Saison"));
+    fireEvent.press(screen.getByLabelText("Ouvrir la recette My Saison"));
 
     expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/r-mine-1");
   });
@@ -149,6 +154,8 @@ describe("RecipesScreen — Mes Recettes Hub (Issue #740 Round 2)", () => {
     expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/catalog");
   });
 
+  // Same accessibility-label pattern as the Mes recettes test above
+  // (Copilot review on PR #917).
   it("navigates to a public recipe detail when tapping a Découvrir card", async () => {
     (listRecipes as jest.Mock).mockResolvedValue([FAKE_MY_RECIPE]);
     (listPublicRecipes as jest.Mock).mockResolvedValue([FAKE_PUBLIC_RECIPE]);
@@ -157,7 +164,7 @@ describe("RecipesScreen — Mes Recettes Hub (Issue #740 Round 2)", () => {
 
     await screen.findByText("Punk IPA Clone");
 
-    fireEvent.press(screen.getByText("Punk IPA Clone"));
+    fireEvent.press(screen.getByLabelText("Ouvrir la recette Punk IPA Clone"));
 
     expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/r-public-1");
   });

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipesScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipesScreen.test.tsx
@@ -3,6 +3,11 @@ import { fireEvent, render, screen } from "@testing-library/react-native";
 
 import React from "react";
 import { RecipesScreen } from "@/features/recipes/presentation/RecipesScreen";
+import {
+  listPublicRecipes,
+  listRecipes,
+} from "@/features/recipes/application/recipes.use-cases";
+import type { Recipe } from "@/features/recipes/domain/recipe.types";
 
 const mockPush = jest.fn();
 
@@ -23,19 +28,39 @@ jest.mock("expo-router", () => {
 });
 
 jest.mock("@/features/recipes/application/recipes.use-cases", () => ({
-  listRecipes: jest.fn().mockResolvedValue([]),
+  listRecipes: jest.fn(),
+  listPublicRecipes: jest.fn(),
 }));
 
-function renderRecipesScreen() {
+const FAKE_MY_RECIPE: Recipe = {
+  id: "r-mine-1",
+  name: "My Saison",
+  description: "Personal recipe",
+  visibility: "private",
+  version: 1,
+  rootRecipeId: "r-mine-1",
+  parentRecipeId: null,
+  createdAt: "2026-04-01T00:00:00Z",
+  updatedAt: "2026-04-01T00:00:00Z",
+};
+
+const FAKE_PUBLIC_RECIPE: Recipe = {
+  id: "r-public-1",
+  name: "Punk IPA Clone",
+  description: "BrewDog DIY Dog",
+  visibility: "public",
+  version: 1,
+  rootRecipeId: "r-public-1",
+  parentRecipeId: null,
+  createdAt: "2026-04-01T00:00:00Z",
+  updatedAt: "2026-04-01T00:00:00Z",
+};
+
+function renderHub() {
   const queryClient = new QueryClient({
     defaultOptions: {
-      queries: {
-        retry: false,
-        gcTime: Number.POSITIVE_INFINITY,
-      },
-      mutations: {
-        retry: false,
-      },
+      queries: { retry: false, gcTime: Number.POSITIVE_INFINITY },
+      mutations: { retry: false },
     },
   });
 
@@ -46,44 +71,125 @@ function renderRecipesScreen() {
   );
 }
 
-describe("RecipesScreen", () => {
+describe("RecipesScreen — Mes Recettes Hub (Issue #740 Round 2)", () => {
   beforeEach(() => {
     mockPush.mockReset();
+    (listRecipes as jest.Mock).mockReset();
+    (listPublicRecipes as jest.Mock).mockReset();
   });
 
-  it("renders header and empty state", async () => {
-    renderRecipesScreen();
+  it("renders the Mes Recettes header and the two hub sections", async () => {
+    (listRecipes as jest.Mock).mockResolvedValue([FAKE_MY_RECIPE]);
+    (listPublicRecipes as jest.Mock).mockResolvedValue([FAKE_PUBLIC_RECIPE]);
 
-    expect(await screen.findByText("My Recipes")).toBeTruthy();
-    expect(await screen.findByText("Aucune recette")).toBeTruthy();
+    renderHub();
+
+    expect(await screen.findByText("Mes Recettes")).toBeTruthy();
+    expect(screen.getByText("Ton hub de recettes de brassage")).toBeTruthy();
+    expect(screen.getByTestId("hub-my-recipes-section")).toBeTruthy();
+    expect(screen.getByTestId("hub-discover-section")).toBeTruthy();
+    expect(screen.getByText("Mes recettes")).toBeTruthy();
+    expect(screen.getByText("Découvrir")).toBeTruthy();
+    expect(screen.getByText("My Saison")).toBeTruthy();
+    expect(screen.getByText("Punk IPA Clone")).toBeTruthy();
   });
 
-  // Issue #779 — the new "Catalogue" pill in the header is the
-  // always-visible entry point into the Recipe Catalog discovery
-  // surface. A regression where it stops navigating would silently
-  // strip the only header-level path to the new feature.
-  it("navigates to /(app)/recipes/catalog when tapping the Catalogue header pill", async () => {
-    renderRecipesScreen();
+  // Issue #740 Round 2 — Pattern A landing.
+  // When the user has no recipes, the empty state is the only forward
+  // path and must surface the scan CTA. Pinning this assertion guards
+  // the bootstrap flow for new users (Léa, Nicolas).
+  it("shows the scan CTA in the empty state when the carnet is empty", async () => {
+    (listRecipes as jest.Mock).mockResolvedValue([]);
+    (listPublicRecipes as jest.Mock).mockResolvedValue([FAKE_PUBLIC_RECIPE]);
 
-    await screen.findByText("My Recipes");
+    renderHub();
 
-    fireEvent.press(screen.getByLabelText("Ouvrir le catalogue de recettes"));
+    expect(
+      await screen.findByText("Aucune recette pour l'instant"),
+    ).toBeTruthy();
+    expect(screen.getByLabelText("Scanner ta 1ère bière")).toBeTruthy();
+  });
+
+  it("navigates to the scan flow when tapping the empty-state CTA", async () => {
+    (listRecipes as jest.Mock).mockResolvedValue([]);
+    (listPublicRecipes as jest.Mock).mockResolvedValue([]);
+
+    renderHub();
+
+    await screen.findByText("Aucune recette pour l'instant");
+
+    fireEvent.press(screen.getByLabelText("Scanner ta 1ère bière"));
+
+    expect(mockPush).toHaveBeenCalledWith("/(app)/dashboard/scan");
+  });
+
+  it("navigates to a recipe detail when tapping a card in Mes recettes", async () => {
+    (listRecipes as jest.Mock).mockResolvedValue([FAKE_MY_RECIPE]);
+    (listPublicRecipes as jest.Mock).mockResolvedValue([]);
+
+    renderHub();
+
+    await screen.findByText("My Saison");
+
+    fireEvent.press(screen.getByText("My Saison"));
+
+    expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/r-mine-1");
+  });
+
+  it("navigates to the catalog from the Découvrir Voir tout pill", async () => {
+    (listRecipes as jest.Mock).mockResolvedValue([FAKE_MY_RECIPE]);
+    (listPublicRecipes as jest.Mock).mockResolvedValue([FAKE_PUBLIC_RECIPE]);
+
+    renderHub();
+
+    await screen.findByText("Découvrir");
+
+    fireEvent.press(screen.getByTestId("hub-discover-see-all"));
 
     expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/catalog");
   });
 
-  // Issue #779 — the empty-state CTA is the second entry point
-  // into the Catalog. Together with the header pill the two
-  // assertions pin both surfaces of the discovery flow.
-  it("navigates to /(app)/recipes/catalog when tapping the empty-state Discover button", async () => {
-    renderRecipesScreen();
+  it("navigates to a public recipe detail when tapping a Découvrir card", async () => {
+    (listRecipes as jest.Mock).mockResolvedValue([FAKE_MY_RECIPE]);
+    (listPublicRecipes as jest.Mock).mockResolvedValue([FAKE_PUBLIC_RECIPE]);
 
-    await screen.findByText("Aucune recette");
+    renderHub();
 
-    fireEvent.press(
-      screen.getByLabelText("Découvrir le catalogue de recettes"),
-    );
+    await screen.findByText("Punk IPA Clone");
 
-    expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/catalog");
+    fireEvent.press(screen.getByText("Punk IPA Clone"));
+
+    expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/r-public-1");
+  });
+
+  // Issue #740 Round 2 — the Découvrir section caps at 5 previews; the
+  // "Voir tout" pill is the only path to the full catalog.
+  it("caps the Découvrir preview at 5 recipes", async () => {
+    const manyPublic = Array.from({ length: 8 }, (_, index) => ({
+      ...FAKE_PUBLIC_RECIPE,
+      id: `r-public-${index + 1}`,
+      name: `Public Recipe ${index + 1}`,
+    }));
+    (listRecipes as jest.Mock).mockResolvedValue([]);
+    (listPublicRecipes as jest.Mock).mockResolvedValue(manyPublic);
+
+    renderHub();
+
+    await screen.findByText("Public Recipe 1");
+
+    expect(screen.getByText("Public Recipe 5")).toBeTruthy();
+    expect(screen.queryByText("Public Recipe 6")).toBeNull();
+    expect(screen.queryByText("Public Recipe 8")).toBeNull();
+  });
+
+  it("shows the Découvrir empty placeholder when no public recipes are available", async () => {
+    (listRecipes as jest.Mock).mockResolvedValue([FAKE_MY_RECIPE]);
+    (listPublicRecipes as jest.Mock).mockResolvedValue([]);
+
+    renderHub();
+
+    await screen.findByText("Découvrir");
+
+    expect(screen.getByText("Le catalogue arrive bientôt.")).toBeTruthy();
   });
 });

--- a/packages/mobile-app/src/features/recipes/presentation/sections/DiscoverSection.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/sections/DiscoverSection.tsx
@@ -38,7 +38,7 @@ export function DiscoverSection({
         <View style={styles.headerText}>
           <Text style={styles.sectionTitle}>Découvrir</Text>
           <Text style={styles.sectionSubtitle}>
-            Recettes publiques curées par Brasse-Bouillon.
+            Recettes publiques sélectionnées par Brasse-Bouillon.
           </Text>
         </View>
 
@@ -65,7 +65,7 @@ export function DiscoverSection({
           <RecipeCard
             key={recipe.id}
             recipe={recipe}
-            badgeLabel="Public"
+            badgeLabel="Publique"
             onPress={() => onPressRecipe(recipe.id)}
           />
         ))

--- a/packages/mobile-app/src/features/recipes/presentation/sections/DiscoverSection.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/sections/DiscoverSection.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { Ionicons } from "@expo/vector-icons";
+import { RecipeCard } from "@/features/recipes/presentation/RecipeCard";
+import { colors, radius, spacing, typography } from "@/core/theme";
+import type { Recipe } from "@/features/recipes/domain/recipe.types";
+
+type DiscoverSectionProps = Readonly<{
+  recipes: Recipe[];
+  onPressRecipe: (recipeId: string) => void;
+  onPressSeeAll: () => void;
+  previewLimit?: number;
+}>;
+
+const DEFAULT_PREVIEW_LIMIT = 5;
+
+/**
+ * Hub section #2 of the Mes Recettes screen (Issue #740 Round 2).
+ *
+ * Static curated discovery surface — the top N public recipes
+ * (`listPublicRecipes`, capped at `previewLimit`) shown directly in
+ * the hub so a new user (Léa, Nicolas) sees brewable recipes
+ * immediately, without leaving Mes Recettes. The "Voir tout" pill
+ * links to the existing CatalogScreen for the full list.
+ */
+export function DiscoverSection({
+  recipes,
+  onPressRecipe,
+  onPressSeeAll,
+  previewLimit = DEFAULT_PREVIEW_LIMIT,
+}: DiscoverSectionProps) {
+  const preview = recipes.slice(0, previewLimit);
+
+  return (
+    <View testID="hub-discover-section" style={styles.container}>
+      <View style={styles.headerRow}>
+        <View style={styles.headerText}>
+          <Text style={styles.sectionTitle}>Découvrir</Text>
+          <Text style={styles.sectionSubtitle}>
+            Recettes publiques curées par Brasse-Bouillon.
+          </Text>
+        </View>
+
+        <Pressable
+          testID="hub-discover-see-all"
+          accessibilityRole="button"
+          accessibilityLabel="Voir tout le catalogue de recettes"
+          style={styles.seeAllPill}
+          onPress={onPressSeeAll}
+        >
+          <Text style={styles.seeAllPillText}>Voir tout</Text>
+          <Ionicons
+            name="chevron-forward"
+            size={16}
+            color={colors.brand.secondary}
+          />
+        </Pressable>
+      </View>
+
+      {preview.length === 0 ? (
+        <Text style={styles.emptyText}>Le catalogue arrive bientôt.</Text>
+      ) : (
+        preview.map((recipe) => (
+          <RecipeCard
+            key={recipe.id}
+            recipe={recipe}
+            badgeLabel="Public"
+            onPress={() => onPressRecipe(recipe.id)}
+          />
+        ))
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.sm,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: spacing.sm,
+  },
+  headerText: {
+    flex: 1,
+    marginRight: spacing.sm,
+  },
+  sectionTitle: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+  },
+  sectionSubtitle: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    marginTop: spacing.xxs,
+  },
+  seeAllPill: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xxs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: radius.full,
+    borderWidth: 1,
+    borderColor: colors.brand.secondary,
+    backgroundColor: colors.brand.background,
+  },
+  seeAllPillText: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.caption,
+    fontWeight: typography.weight.medium,
+  },
+  emptyText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/sections/DiscoverSection.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/sections/DiscoverSection.tsx
@@ -8,6 +8,7 @@ import type { Recipe } from "@/features/recipes/domain/recipe.types";
 
 type DiscoverSectionProps = Readonly<{
   recipes: Recipe[];
+  isLoading: boolean;
   onPressRecipe: (recipeId: string) => void;
   onPressSeeAll: () => void;
   previewLimit?: number;
@@ -23,14 +24,25 @@ const DEFAULT_PREVIEW_LIMIT = 5;
  * the hub so a new user (Léa, Nicolas) sees brewable recipes
  * immediately, without leaving Mes Recettes. The "Voir tout" pill
  * links to the existing CatalogScreen for the full list.
+ *
+ * The empty-state placeholder is only rendered once the query has
+ * settled (`!isLoading && recipes.length === 0`) so the user never
+ * sees "Le catalogue arrive bientôt." flash during the initial fetch
+ * (Copilot review on PR #917).
+ *
+ * Horizontal padding is applied by the parent FlatList's
+ * `contentContainerStyle`; this section only owns its vertical
+ * spacing (Copilot review on PR #917).
  */
 export function DiscoverSection({
   recipes,
+  isLoading,
   onPressRecipe,
   onPressSeeAll,
   previewLimit = DEFAULT_PREVIEW_LIMIT,
 }: DiscoverSectionProps) {
   const preview = recipes.slice(0, previewLimit);
+  const showEmptyPlaceholder = preview.length === 0 && !isLoading;
 
   return (
     <View testID="hub-discover-section" style={styles.container}>
@@ -58,25 +70,24 @@ export function DiscoverSection({
         </Pressable>
       </View>
 
-      {preview.length === 0 ? (
+      {showEmptyPlaceholder ? (
         <Text style={styles.emptyText}>Le catalogue arrive bientôt.</Text>
-      ) : (
-        preview.map((recipe) => (
-          <RecipeCard
-            key={recipe.id}
-            recipe={recipe}
-            badgeLabel="Publique"
-            onPress={() => onPressRecipe(recipe.id)}
-          />
-        ))
-      )}
+      ) : null}
+
+      {preview.map((recipe) => (
+        <RecipeCard
+          key={recipe.id}
+          recipe={recipe}
+          badgeLabel="Publique"
+          onPress={() => onPressRecipe(recipe.id)}
+        />
+      ))}
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: spacing.sm,
     paddingTop: spacing.md,
     paddingBottom: spacing.lg,
   },

--- a/packages/mobile-app/src/features/recipes/presentation/sections/MyRecipesSection.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/sections/MyRecipesSection.tsx
@@ -3,30 +3,29 @@ import { StyleSheet, Text, View } from "react-native";
 
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
-import { RecipeCard } from "@/features/recipes/presentation/RecipeCard";
 import { colors, spacing, typography } from "@/core/theme";
-import type { Recipe } from "@/features/recipes/domain/recipe.types";
 
-type MyRecipesSectionProps = Readonly<{
-  recipes: Recipe[];
-  onPressRecipe: (recipeId: string) => void;
+type MyRecipesSectionHeaderProps = Readonly<{
+  isEmpty: boolean;
   onPressScanCta: () => void;
 }>;
 
 /**
- * Hub section #1 of the Mes Recettes screen (Issue #740 Round 2).
+ * Hub section #1 header of the Mes Recettes screen (Issue #740 Round 2).
  *
- * Lists the user's own recipes (private + scan-imported). When the
- * carnet is empty, surfaces the "Scanner ta 1ère bière" CTA wired to
- * the scan flow — Pattern A landing per the issue: a new user lands
- * on Mes recettes, sees an empty state, and the only forward action
- * is to scan a bottle to bootstrap their first recipe.
+ * Renders the section title + subtitle + (when the carnet is empty)
+ * the "Scanner ta 1ère bière" CTA wired to the scan flow.
+ *
+ * Designed to be used as the `ListHeaderComponent` of the parent
+ * FlatList in `RecipesScreen`, so the FlatList native virtualization
+ * still applies to the recipe items themselves (Codex P2 review on
+ * PR #917 — pre-hub `RecipesScreen` used a FlatList; the v0.1 hub
+ * preserves it by lifting the list to the orchestrator).
  */
-export function MyRecipesSection({
-  recipes,
-  onPressRecipe,
+export function MyRecipesSectionHeader({
+  isEmpty,
   onPressScanCta,
-}: MyRecipesSectionProps) {
+}: MyRecipesSectionHeaderProps) {
   return (
     <View testID="hub-my-recipes-section" style={styles.container}>
       <Text style={styles.sectionTitle}>Mes recettes</Text>
@@ -34,7 +33,7 @@ export function MyRecipesSection({
         Ton carnet personnel — recettes brassées et imports scan.
       </Text>
 
-      {recipes.length === 0 ? (
+      {isEmpty ? (
         <EmptyStateCard
           title="Aucune recette pour l'instant"
           description="Scanne ta 1ère bière pour démarrer ton carnet de brasseur."
@@ -46,15 +45,7 @@ export function MyRecipesSection({
             />
           }
         />
-      ) : (
-        recipes.map((recipe) => (
-          <RecipeCard
-            key={recipe.id}
-            recipe={recipe}
-            onPress={() => onPressRecipe(recipe.id)}
-          />
-        ))
-      )}
+      ) : null}
     </View>
   );
 }

--- a/packages/mobile-app/src/features/recipes/presentation/sections/MyRecipesSection.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/sections/MyRecipesSection.tsx
@@ -7,25 +7,31 @@ import { colors, spacing, typography } from "@/core/theme";
 
 type MyRecipesSectionHeaderProps = Readonly<{
   isEmpty: boolean;
+  isLoading: boolean;
   onPressScanCta: () => void;
 }>;
 
 /**
  * Hub section #1 header of the Mes Recettes screen (Issue #740 Round 2).
  *
- * Renders the section title + subtitle + (when the carnet is empty)
- * the "Scanner ta 1ère bière" CTA wired to the scan flow.
+ * Renders the section title + subtitle + (when the carnet is empty
+ * and the query has settled) the "Scanner ta 1ère bière" CTA wired to
+ * the scan flow. The `isLoading` guard avoids flashing the empty state
+ * during the initial fetch even when the user actually has recipes
+ * (Copilot review on PR #917).
  *
  * Designed to be used as the `ListHeaderComponent` of the parent
- * FlatList in `RecipesScreen`, so the FlatList native virtualization
- * still applies to the recipe items themselves (Codex P2 review on
- * PR #917 — pre-hub `RecipesScreen` used a FlatList; the v0.1 hub
- * preserves it by lifting the list to the orchestrator).
+ * FlatList in `RecipesScreen`. Horizontal padding is applied by the
+ * parent FlatList's `contentContainerStyle` — the header only owns
+ * the vertical breathing room (Copilot review on PR #917).
  */
 export function MyRecipesSectionHeader({
   isEmpty,
+  isLoading,
   onPressScanCta,
 }: MyRecipesSectionHeaderProps) {
+  const showEmptyState = isEmpty && !isLoading;
+
   return (
     <View testID="hub-my-recipes-section" style={styles.container}>
       <Text style={styles.sectionTitle}>Mes recettes</Text>
@@ -33,7 +39,7 @@ export function MyRecipesSectionHeader({
         Ton carnet personnel — recettes brassées et imports scan.
       </Text>
 
-      {isEmpty ? (
+      {showEmptyState ? (
         <EmptyStateCard
           title="Aucune recette pour l'instant"
           description="Scanne ta 1ère bière pour démarrer ton carnet de brasseur."
@@ -52,7 +58,6 @@ export function MyRecipesSectionHeader({
 
 const styles = StyleSheet.create({
   container: {
-    paddingHorizontal: spacing.sm,
     paddingTop: spacing.md,
     paddingBottom: spacing.sm,
   },

--- a/packages/mobile-app/src/features/recipes/presentation/sections/MyRecipesSection.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/sections/MyRecipesSection.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { RecipeCard } from "@/features/recipes/presentation/RecipeCard";
+import { colors, spacing, typography } from "@/core/theme";
+import type { Recipe } from "@/features/recipes/domain/recipe.types";
+
+type MyRecipesSectionProps = Readonly<{
+  recipes: Recipe[];
+  onPressRecipe: (recipeId: string) => void;
+  onPressScanCta: () => void;
+}>;
+
+/**
+ * Hub section #1 of the Mes Recettes screen (Issue #740 Round 2).
+ *
+ * Lists the user's own recipes (private + scan-imported). When the
+ * carnet is empty, surfaces the "Scanner ta 1ère bière" CTA wired to
+ * the scan flow — Pattern A landing per the issue: a new user lands
+ * on Mes recettes, sees an empty state, and the only forward action
+ * is to scan a bottle to bootstrap their first recipe.
+ */
+export function MyRecipesSection({
+  recipes,
+  onPressRecipe,
+  onPressScanCta,
+}: MyRecipesSectionProps) {
+  return (
+    <View testID="hub-my-recipes-section" style={styles.container}>
+      <Text style={styles.sectionTitle}>Mes recettes</Text>
+      <Text style={styles.sectionSubtitle}>
+        Ton carnet personnel — recettes brassées et imports scan.
+      </Text>
+
+      {recipes.length === 0 ? (
+        <EmptyStateCard
+          title="Aucune recette pour l'instant"
+          description="Scanne ta 1ère bière pour démarrer ton carnet de brasseur."
+          action={
+            <PrimaryButton
+              accessibilityLabel="Scanner ta 1ère bière"
+              label="Scanner ta 1ère bière"
+              onPress={onPressScanCta}
+            />
+          }
+        />
+      ) : (
+        recipes.map((recipe) => (
+          <RecipeCard
+            key={recipe.id}
+            recipe={recipe}
+            onPress={() => onPressRecipe(recipe.id)}
+          />
+        ))
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: spacing.sm,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.sm,
+  },
+  sectionTitle: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+  },
+  sectionSubtitle: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    marginTop: spacing.xxs,
+    marginBottom: spacing.sm,
+  },
+});


### PR DESCRIPTION
## Summary

Replaces the flat *My Recipes* list with the **Round 2 hub** from Issue #740: a vertical layout with two sections — **Mes recettes** (the user's carnet, with a *Scanner ta 1ère bière* empty-state CTA wired to `/(app)/dashboard/scan` per Pattern A landing) and **Découvrir** (top 5 public recipes via `listPublicRecipes`, with a *Voir tout* pill linking to the existing `CatalogScreen`).

This is the second slice of #740 v0.1 for the soutenance demo on 2026-05-27 — the first slice (4-tab detail screen + EBC hero + sticky CTA) shipped in #916.

Migrates the screen header from `My Recipes` (English) to `Mes Recettes` so the mobile UI stays French per the project convention. Code, comments, and tests remain English.

## Scope

**Refactor**
- `presentation/RecipesScreen.tsx` — orchestrator now fetches both `listRecipes` and `listPublicRecipes` via TanStack Query and composes the two sections inside a `ScrollView` with pull-to-refresh

**New components**
- `presentation/sections/MyRecipesSection.tsx` — user's carnet preview with the new scan-CTA empty state
- `presentation/sections/DiscoverSection.tsx` — top-5 public-recipe preview with *Voir tout* pill, header, and a friendly empty placeholder when the catalog is empty

The Stats / Brouillons / Favoris / Tutoriels sections are explicitly **deferred to v0.2** per the section tier table on Issue #740.

## v0.1 acceptance criteria (#740 Round 2) — status

| Criterion | Status |
|---|---|
| Hub Mes Recettes shows 2 sections | ✅ Mes recettes + Découvrir |
| Mes recettes (perso + scan-imported) — rebrand into hub | ✅ |
| Découvrir (admin-curated, top public) | ✅ Top 5 from `listPublicRecipes`, capped, "Voir tout" link |
| Empty-state CTA `[Scanner ta 1ère bière]` → scan flow | ✅ Pattern A landing |
| `[Lancer un brassin]` CTA on detail screen only (not hub) | ✅ Honored — Hub never shows the CTA |

## Tests

- 8 new hub tests cover happy / sad / edge: rendering both sections, empty-state CTA, scan navigation, recipe-card navigation, *Voir tout* pill, public-card navigation, 5-card preview cap, empty Découvrir placeholder
- Full recipes presentation suite green (RecipesScreen + RecipeDetailsScreen + CatalogScreen + recipe-details.utils)
- Full mobile suite: 76 suites / 746 tests green
- \`npm run ci:check\` green (lint + typecheck + format)

## Checklist

- [x] Happy path + sad path + edge cases covered
- [x] \`tsc --noEmit\` passes
- [x] Build passes (\`npm run ci:check\`)
- [x] Existing tests still green (746/746)
- [x] No \`any\`, no inline styles introduced
- [x] No hardcoded colors / spacing / fonts (all from design tokens)
- [x] Named exports only

Refs #740