### PR TITLE
fix(scan): correct invalid EAN-13 checksums for Karmeliet, Westmalle, Duvel

### DIFF
--- a/packages/api/src/database/seeds/scan-catalog.seed.ts
+++ b/packages/api/src/database/seeds/scan-catalog.seed.ts
@@ -87,7 +87,9 @@ export const SCAN_CATALOG_SEED_BEERS: readonly ScanCatalogSeedBeer[] = [
     notes_source: 'Trappist Rochefort public datasheet',
   },
   {
-    barcode: '5414352120063',
+    // 75cl — verified on OpenFoodFacts 2026-05-05, EAN-13 mod-10 valid.
+    // Replaces the invalid '5414352120063' shipped in PR #768 (issue #807).
+    barcode: '5410693100553',
     name: 'Karmeliet Tripel',
     brewery: 'Brouwerij Bosteels',
     style: 'Belgian Tripel',
@@ -99,7 +101,10 @@ export const SCAN_CATALOG_SEED_BEERS: readonly ScanCatalogSeedBeer[] = [
     notes_source: 'Brouwerij Bosteels public datasheet',
   },
   {
-    barcode: '5410702000125',
+    // 33cl — only OFF-verified Westmalle EAN as of 2026-05-05; the 75cl
+    // SKU has no OFF entry. Replaces the invalid '5410702000125' shipped
+    // in PR #768 (issue #807).
+    barcode: '5412343201337',
     name: 'Westmalle Tripel',
     brewery: 'Abdij der Trappisten van Westmalle',
     style: 'Belgian Tripel',
@@ -111,7 +116,9 @@ export const SCAN_CATALOG_SEED_BEERS: readonly ScanCatalogSeedBeer[] = [
     notes_source: 'Trappist Westmalle public datasheet',
   },
   {
-    barcode: '5410702000026',
+    // 75cl — verified on OpenFoodFacts 2026-05-05, EAN-13 mod-10 valid.
+    // Replaces the invalid '5410702000026' shipped in PR #768 (issue #807).
+    barcode: '5411681402635',
     name: 'Duvel',
     brewery: 'Brouwerij Duvel Moortgat',
     style: 'Belgian Strong Pale Ale',

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2656,9 +2656,12 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
   // the backend seed so `EXPO_PUBLIC_USE_DEMO_DATA=true` covers the
   // same 9-bottle demo as production. Same field order as
   // packages/api/src/database/seeds/scan-catalog.seed.ts.
-  "5414352120063": buildDemoScanCatalogItem({
+  // Karmeliet Tripel 75cl — verified on OpenFoodFacts 2026-05-05,
+  // EAN-13 mod-10 valid. Replaces the invalid '5414352120063' shipped
+  // in PR #768 (issue #807).
+  "5410693100553": buildDemoScanCatalogItem({
     id: "demo-scan-karmeliet-tripel",
-    barcode: "5414352120063",
+    barcode: "5410693100553",
     name: "Karmeliet Tripel",
     brewery: "Brouwerij Bosteels",
     style: "Belgian Tripel",
@@ -2668,9 +2671,12 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     aromaticTags: "wheat, oat, banana, vanilla",
     notesSource: "Brouwerij Bosteels public datasheet",
   }),
-  "5410702000125": buildDemoScanCatalogItem({
+  // Westmalle Tripel 33cl — only OFF-verified Westmalle EAN as of
+  // 2026-05-05; the 75cl SKU has no OFF entry. Replaces the invalid
+  // '5410702000125' shipped in PR #768 (issue #807).
+  "5412343201337": buildDemoScanCatalogItem({
     id: "demo-scan-westmalle-tripel",
-    barcode: "5410702000125",
+    barcode: "5412343201337",
     name: "Westmalle Tripel",
     brewery: "Abdij der Trappisten van Westmalle",
     style: "Belgian Tripel",
@@ -2680,9 +2686,12 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     aromaticTags: "fruity esters, peppery, dry finish",
     notesSource: "Trappist Westmalle public datasheet",
   }),
-  "5410702000026": buildDemoScanCatalogItem({
+  // Duvel 75cl — verified on OpenFoodFacts 2026-05-05, EAN-13 mod-10
+  // valid. Replaces the invalid '5410702000026' shipped in PR #768
+  // (issue #807).
+  "5411681402635": buildDemoScanCatalogItem({
     id: "demo-scan-duvel",
-    barcode: "5410702000026",
+    barcode: "5411681402635",
     name: "Duvel",
     brewery: "Brouwerij Duvel Moortgat",
     style: "Belgian Strong Pale Ale",


### PR DESCRIPTION
## Summary

Three of the nine demo bottles seeded in PR #768 carried EAN-13 barcodes that fail the standard mod-10 checksum (audit on PR #806). Replaced each with an OpenFoodFacts-verified, mod-10-valid code looked up by name on 2026-05-05.

| Beer | Old (invalid) | New (OFF-verified) | Format | OFF page |
|---|---|---|---|---|
| Karmeliet Tripel | `5414352120063` | `5410693100553` | 75cl | [link](https://world.openfoodfacts.org/product/5410693100553) |
| Westmalle Tripel | `5410702000125` | `5412343201337` | 33cl | [link](https://world.openfoodfacts.org/product/5412343201337) |
| Duvel | `5410702000026` | `5411681402635` | 75cl | [link](https://world.openfoodfacts.org/product/5411681402635) |

The Westmalle 75cl SKU has no OFF entry as of 2026-05-05; the verified 33cl code is the most reliable fallback. Inline comment in the seed flags this for future audits.

## Why it matters for the soutenance demo (2026-05-27)

A jury scanning a real Karmeliet / Westmalle / Duvel bottle would have:
1. Hit a cache miss on `scan_catalog_items` (our seed had a typo)
2. Fall through to OpenFoodFacts → also cache miss (OFF doesn't carry the typo'd codes either)
3. Land on scenario B (unknown beer, mailto CTA)

With this fix the nominal scan flow matches on the first try.

## Scope

Both lockstep targets updated:

- **`packages/api/src/database/seeds/scan-catalog.seed.ts`** — persisted into the `scan_catalog_items` table by the seed runner (real backend mode)
- **`packages/mobile-app/src/mocks/demo-data.ts`** — demo-mode catalogue (`EXPO_PUBLIC_USE_DEMO_DATA=true` or demo-trigger credentials)

Each replacement is annotated inline with a provenance comment (verification date, OFF source, format, original invalid code, issue + PR references) so future audits can trace the change without `git blame`.

## Verification

- EAN-13 mod-10 checksum manually computed for each of the 3 new codes — all valid
- Manufacturer cross-checked against the seed's `brewery` field for each entry (Brouwerij Bosteels / Abdij der Trappisten van Westmalle / Brouwerij Duvel Moortgat — all match the OFF "Manufacturing or processing places" field)
- Mobile suite: 750/750 green
- API suite: 654/656 green (2 skipped, 1 suite skipped — pre-existing)
- `npm run ci:check` (mobile-app): green (lint + typecheck + format)
- `npm run lint:check` (api): pre-existing warning on `scan.service.ts:631` only, unchanged

## Checklist

- [x] Each replacement EAN-13 verified with mod-10 checksum
- [x] Manufacturer cross-checked between seed `brewery` field and OFF "Manufacturing or processing places"
- [x] Both lockstep targets updated (API seed + mobile mock)
- [x] Provenance comments added inline next to each entry
- [x] All tests green on both packages
- [x] No `any`, no inline styles, no hardcoded values introduced
- [x] PR title follows Conventional Commits format

Closes #807