### PR TITLE
feat(seed): scaffold BrewDog DIY Dog seed + Punk IPA 2007-2010 (1/25)

### DIFF
--- a/packages/api/src/database/seeds/brewdog-diy-dog-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/brewdog-diy-dog-recipes.seed.spec.ts
@@ -1,0 +1,191 @@
+import { Repository } from 'typeorm';
+
+import {
+  BREWDOG_DIY_DOG_PROVENANCE,
+  BREWDOG_DIY_DOG_SEED,
+  BREWDOG_DIY_DOG_SYSTEM_OWNER_ID,
+  seedBrewdogDiyDogRecipes,
+} from './brewdog-diy-dog-recipes.seed';
+import { RecipeFermentableOrmEntity } from '../../recipe/entities/recipe-fermentable.orm.entity';
+import { RecipeHopOrmEntity } from '../../recipe/entities/recipe-hop.orm.entity';
+import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
+import { RecipeVisibility } from '../../recipe/domain/enums/recipe-visibility.enum';
+import { RecipeYeastOrmEntity } from '../../recipe/entities/recipe-yeast.orm.entity';
+import { buildRepoMock } from './seed-test-utils';
+
+type SeedRepoMocks = ReturnType<typeof buildSeedRepos>;
+
+/**
+ * Builds the four repository mocks used by the loader plus a
+ * `delete` jest.fn on each — the shared `buildRepoMock` doesn't
+ * carry one yet, and the loader's wipe-and-refill pattern needs it.
+ */
+function buildSeedRepos() {
+  const recipeRepo = { ...buildRepoMock(), delete: jest.fn() };
+  const fermentableRepo = { ...buildRepoMock(), delete: jest.fn() };
+  const hopRepo = { ...buildRepoMock(), delete: jest.fn() };
+  const yeastRepo = { ...buildRepoMock(), delete: jest.fn() };
+  return { recipeRepo, fermentableRepo, hopRepo, yeastRepo };
+}
+
+function castRepo<T>(repo: SeedRepoMocks['recipeRepo']): Repository<T> {
+  return repo as unknown as Repository<T>;
+}
+
+async function runSeed(repos: SeedRepoMocks, recipes = BREWDOG_DIY_DOG_SEED) {
+  return seedBrewdogDiyDogRecipes(
+    castRepo<RecipeOrmEntity>(repos.recipeRepo),
+    castRepo<RecipeFermentableOrmEntity>(repos.fermentableRepo),
+    castRepo<RecipeHopOrmEntity>(repos.hopRepo),
+    castRepo<RecipeYeastOrmEntity>(repos.yeastRepo),
+    recipes,
+  );
+}
+
+describe('seedBrewdogDiyDogRecipes (Issue #780)', () => {
+  describe('happy path', () => {
+    it('inserts every seeded recipe + its full ingredient breakdown when the table is empty', async () => {
+      const repos = buildSeedRepos();
+      repos.recipeRepo.findOne.mockResolvedValue(null);
+
+      const result = await runSeed(repos);
+
+      expect(result.recipesInserted).toBe(BREWDOG_DIY_DOG_SEED.length);
+      expect(result.recipesUpdated).toBe(0);
+      expect(result.total).toBe(BREWDOG_DIY_DOG_SEED.length);
+
+      const expectedFermentables = BREWDOG_DIY_DOG_SEED.reduce(
+        (sum, recipe) => sum + recipe.fermentables.length,
+        0,
+      );
+      const expectedHops = BREWDOG_DIY_DOG_SEED.reduce(
+        (sum, recipe) => sum + recipe.hops.length,
+        0,
+      );
+      const expectedYeasts = BREWDOG_DIY_DOG_SEED.reduce(
+        (sum, recipe) => sum + recipe.yeasts.length,
+        0,
+      );
+
+      expect(result.fermentablesInserted).toBe(expectedFermentables);
+      expect(result.hopsInserted).toBe(expectedHops);
+      expect(result.yeastsInserted).toBe(expectedYeasts);
+    });
+
+    it('tags every recipe row as PUBLIC + system owner + DIY Dog provenance + non-official', async () => {
+      const repos = buildSeedRepos();
+      repos.recipeRepo.findOne.mockResolvedValue(null);
+
+      await runSeed(repos);
+
+      for (const call of repos.recipeRepo.create.mock.calls as unknown[][]) {
+        const arg = call[0] as Record<string, unknown>;
+        expect(arg.visibility).toBe(RecipeVisibility.PUBLIC);
+        expect(arg.owner_id).toBe(BREWDOG_DIY_DOG_SYSTEM_OWNER_ID);
+        expect(arg.import_provenance).toBe(BREWDOG_DIY_DOG_PROVENANCE);
+        expect(arg.imported_from_recipe_id).toBeNull();
+        expect(arg.parent_recipe_id).toBeNull();
+        // is_official is deliberately false on every backend row to
+        // avoid the global-flag regression Codex caught on PR #773 /
+        // #912 — same lesson as `public-recipes.seed.ts`.
+        expect(arg.is_official).toBe(false);
+      }
+    });
+  });
+
+  describe('idempotency (sad path)', () => {
+    it('updates existing recipe rows in place and wipes-then-refills the sub-tables', async () => {
+      const repos = buildSeedRepos();
+      repos.recipeRepo.findOne.mockImplementation(() =>
+        Promise.resolve({
+          id: 'will-be-overwritten',
+          name: 'old-name',
+          visibility: RecipeVisibility.PRIVATE,
+        }),
+      );
+
+      const result = await runSeed(repos);
+
+      expect(result.recipesInserted).toBe(0);
+      expect(result.recipesUpdated).toBe(BREWDOG_DIY_DOG_SEED.length);
+      expect(repos.recipeRepo.create).not.toHaveBeenCalled();
+      // Each recipe triggers exactly one delete + N saves on each
+      // sub-table; verify the deletes ran (idempotency hinges on it).
+      expect(repos.fermentableRepo.delete).toHaveBeenCalledTimes(
+        BREWDOG_DIY_DOG_SEED.length,
+      );
+      expect(repos.hopRepo.delete).toHaveBeenCalledTimes(
+        BREWDOG_DIY_DOG_SEED.length,
+      );
+      expect(repos.yeastRepo.delete).toHaveBeenCalledTimes(
+        BREWDOG_DIY_DOG_SEED.length,
+      );
+    });
+
+    it('forces drifted recipe rows back to PUBLIC + non-official + canonical provenance on overwrite', async () => {
+      const repos = buildSeedRepos();
+      repos.recipeRepo.findOne.mockImplementation(() =>
+        Promise.resolve({
+          id: 'drifted',
+          visibility: RecipeVisibility.PRIVATE,
+          // Drifted to true — the seed must reset it so a manually
+          // flipped row does not silently degrade matching ranking.
+          is_official: true,
+          import_provenance: 'manually edited',
+        }),
+      );
+
+      await runSeed(repos);
+
+      const firstSavedCall = repos.recipeRepo.save.mock.calls[0] as unknown[];
+      const savedCall = firstSavedCall[0] as Record<string, unknown>;
+      expect(savedCall.visibility).toBe(RecipeVisibility.PUBLIC);
+      expect(savedCall.is_official).toBe(false);
+      expect(savedCall.import_provenance).toBe(BREWDOG_DIY_DOG_PROVENANCE);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('respects an explicit override list (e.g. tests, alternate demo data)', async () => {
+      const repos = buildSeedRepos();
+      repos.recipeRepo.findOne.mockResolvedValue(null);
+
+      const customRecipes = BREWDOG_DIY_DOG_SEED.slice(0, 1);
+
+      const result = await runSeed(repos, customRecipes);
+
+      expect(result.recipesInserted).toBe(1);
+      expect(result.total).toBe(1);
+    });
+
+    it('exposes deterministic UUIDs in the `-4001-` variant range so the mobile mocks can hardcode references', () => {
+      const ids = BREWDOG_DIY_DOG_SEED.map((r) => r.id);
+      for (const id of ids) {
+        expect(id).toMatch(/^00000000-0000-4001-8000-[0-9a-f]{12}$/);
+      }
+      // No duplicates.
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('ships a non-empty grain bill / hop schedule / yeast strain on every recipe', () => {
+      // Issue #780 acceptance criterion: every recipe carries the
+      // full ingredient breakdown. A row missing any of the three
+      // sub-tables would render the recipe unbrewable in the mobile
+      // UI's `BrewingTab` ingredient grouping.
+      for (const recipe of BREWDOG_DIY_DOG_SEED) {
+        expect(recipe.fermentables.length).toBeGreaterThan(0);
+        expect(recipe.hops.length).toBeGreaterThan(0);
+        expect(recipe.yeasts.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('points every recipe back to its source URL on `brewdogrecipes.com` for traceable provenance', () => {
+      // Each recipe must carry the verification source so future
+      // audits can re-fetch the original page (analogous to the EAN
+      // audits on the scan catalogue — issue #807 fix on PR #920).
+      for (const recipe of BREWDOG_DIY_DOG_SEED) {
+        expect(recipe.source_url).toMatch(/^https:\/\/brewdogrecipes\.com\//);
+      }
+    });
+  });
+});

--- a/packages/api/src/database/seeds/brewdog-diy-dog-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/brewdog-diy-dog-recipes.seed.spec.ts
@@ -1,9 +1,10 @@
 import { Repository } from 'typeorm';
 
 import {
-  BREWDOG_DIY_DOG_PROVENANCE,
+  BREWDOG_DIY_DOG_BASE_PROVENANCE,
   BREWDOG_DIY_DOG_SEED,
   BREWDOG_DIY_DOG_SYSTEM_OWNER_ID,
+  buildBrewdogDiyDogProvenance,
   seedBrewdogDiyDogRecipes,
 } from './brewdog-diy-dog-recipes.seed';
 import { RecipeFermentableOrmEntity } from '../../recipe/entities/recipe-fermentable.orm.entity';
@@ -11,24 +12,25 @@ import { RecipeHopOrmEntity } from '../../recipe/entities/recipe-hop.orm.entity'
 import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
 import { RecipeVisibility } from '../../recipe/domain/enums/recipe-visibility.enum';
 import { RecipeYeastOrmEntity } from '../../recipe/entities/recipe-yeast.orm.entity';
-import { buildRepoMock } from './seed-test-utils';
+import { RepoMock, buildRepoMock } from './seed-test-utils';
 
-type SeedRepoMocks = ReturnType<typeof buildSeedRepos>;
-
-/**
- * Builds the four repository mocks used by the loader plus a
- * `delete` jest.fn on each — the shared `buildRepoMock` doesn't
- * carry one yet, and the loader's wipe-and-refill pattern needs it.
- */
-function buildSeedRepos() {
-  const recipeRepo = { ...buildRepoMock(), delete: jest.fn() };
-  const fermentableRepo = { ...buildRepoMock(), delete: jest.fn() };
-  const hopRepo = { ...buildRepoMock(), delete: jest.fn() };
-  const yeastRepo = { ...buildRepoMock(), delete: jest.fn() };
-  return { recipeRepo, fermentableRepo, hopRepo, yeastRepo };
+interface SeedRepoMocks {
+  recipeRepo: RepoMock;
+  fermentableRepo: RepoMock;
+  hopRepo: RepoMock;
+  yeastRepo: RepoMock;
 }
 
-function castRepo<T>(repo: SeedRepoMocks['recipeRepo']): Repository<T> {
+function buildSeedRepos(): SeedRepoMocks {
+  return {
+    recipeRepo: buildRepoMock(),
+    fermentableRepo: buildRepoMock(),
+    hopRepo: buildRepoMock(),
+    yeastRepo: buildRepoMock(),
+  };
+}
+
+function castRepo<T>(repo: RepoMock): Repository<T> {
   return repo as unknown as Repository<T>;
 }
 
@@ -72,24 +74,43 @@ describe('seedBrewdogDiyDogRecipes (Issue #780)', () => {
       expect(result.yeastsInserted).toBe(expectedYeasts);
     });
 
-    it('tags every recipe row as PUBLIC + system owner + DIY Dog provenance + non-official', async () => {
+    it('tags every recipe row as PUBLIC + system owner + DIY Dog provenance (with per-recipe source URL) + non-official', async () => {
       const repos = buildSeedRepos();
       repos.recipeRepo.findOne.mockResolvedValue(null);
 
       await runSeed(repos);
 
-      for (const call of repos.recipeRepo.create.mock.calls as unknown[][]) {
+      const createCalls = repos.recipeRepo.create.mock.calls as unknown[][];
+      expect(createCalls).toHaveLength(BREWDOG_DIY_DOG_SEED.length);
+
+      createCalls.forEach((call, index) => {
         const arg = call[0] as Record<string, unknown>;
+        const seedRecipe = BREWDOG_DIY_DOG_SEED[index];
         expect(arg.visibility).toBe(RecipeVisibility.PUBLIC);
         expect(arg.owner_id).toBe(BREWDOG_DIY_DOG_SYSTEM_OWNER_ID);
-        expect(arg.import_provenance).toBe(BREWDOG_DIY_DOG_PROVENANCE);
+        // Provenance is per-recipe so the database row carries a
+        // traceable pointer back to the source page (Copilot review on
+        // PR #921 — the previous global constant dropped `source_url`
+        // silently).
+        expect(arg.import_provenance).toContain(
+          BREWDOG_DIY_DOG_BASE_PROVENANCE,
+        );
+        expect(arg.import_provenance).toContain(seedRecipe.source_url);
+        expect(arg.import_provenance).toBe(
+          buildBrewdogDiyDogProvenance(seedRecipe.source_url),
+        );
         expect(arg.imported_from_recipe_id).toBeNull();
         expect(arg.parent_recipe_id).toBeNull();
         // is_official is deliberately false on every backend row to
-        // avoid the global-flag regression Codex caught on PR #773 /
-        // #912 — same lesson as `public-recipes.seed.ts`.
+        // avoid the global-flag regression caught on PR #773 / #912 —
+        // same lesson as `public-recipes.seed.ts`.
         expect(arg.is_official).toBe(false);
-      }
+        // brew_count must be a number (entity column is non-nullable
+        // with default 0) — the seed coalesces undefined to 0 rather
+        // than passing it through to a NULL violation (Copilot review
+        // on PR #921).
+        expect(typeof arg.brew_count).toBe('number');
+      });
     });
   });
 
@@ -141,7 +162,26 @@ describe('seedBrewdogDiyDogRecipes (Issue #780)', () => {
       const savedCall = firstSavedCall[0] as Record<string, unknown>;
       expect(savedCall.visibility).toBe(RecipeVisibility.PUBLIC);
       expect(savedCall.is_official).toBe(false);
-      expect(savedCall.import_provenance).toBe(BREWDOG_DIY_DOG_PROVENANCE);
+      expect(savedCall.import_provenance).toBe(
+        buildBrewdogDiyDogProvenance(BREWDOG_DIY_DOG_SEED[0].source_url),
+      );
+    });
+
+    it('coalesces an omitted brew_count seed value to 0 rather than passing undefined to the non-nullable column', async () => {
+      const repos = buildSeedRepos();
+      repos.recipeRepo.findOne.mockResolvedValue(null);
+
+      const recipeWithoutBrewCount = {
+        ...BREWDOG_DIY_DOG_SEED[0],
+        brew_count: undefined,
+      };
+
+      await runSeed(repos, [recipeWithoutBrewCount]);
+
+      const createdArg = (
+        repos.recipeRepo.create.mock.calls[0] as unknown[]
+      )[0] as Record<string, unknown>;
+      expect(createdArg.brew_count).toBe(0);
     });
   });
 

--- a/packages/api/src/database/seeds/brewdog-diy-dog-recipes.seed.ts
+++ b/packages/api/src/database/seeds/brewdog-diy-dog-recipes.seed.ts
@@ -1,0 +1,373 @@
+import { Repository } from 'typeorm';
+
+import { RecipeFermentableOrmEntity } from '../../recipe/entities/recipe-fermentable.orm.entity';
+import { RecipeFermentableType } from '../../recipe/domain/enums/recipe-fermentable-type.enum';
+import { RecipeHopAdditionStage } from '../../recipe/domain/enums/recipe-hop-addition-stage.enum';
+import { RecipeHopOrmEntity } from '../../recipe/entities/recipe-hop.orm.entity';
+import { RecipeHopType } from '../../recipe/domain/enums/recipe-hop-type.enum';
+import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
+import { RecipeVisibility } from '../../recipe/domain/enums/recipe-visibility.enum';
+import { RecipeYeastOrmEntity } from '../../recipe/entities/recipe-yeast.orm.entity';
+import { RecipeYeastType } from '../../recipe/domain/enums/recipe-yeast-type.enum';
+import { SYSTEM_USER_ID } from './system-user.seed';
+
+/**
+ * Seed loader for the curated BrewDog DIY Dog public recipes
+ * (Issue #780). Imports a hand-picked subset of the BrewDog DIY Dog
+ * open-source recipe book into the PUBLIC catalogue, with full
+ * grain bill / hop schedule / yeast strain data — unlike the
+ * `public-recipes.seed.ts` rows which carry only the brewing-metric
+ * metadata.
+ *
+ * UUID range `00000000-0000-4001-8000-XXXXXXXXXXXX` is reserved for
+ * this seed (`-4001-` variant prefix) so the existing 11 PUBLIC seed
+ * rows under `-4000-` keep their identity. The post-2010 "BrewDog
+ * DIY Dog Punk IPA" already living in `public-recipes.seed.ts` at
+ * `-4000-...0b` (the scan-flow's "🏆 Recette officielle" row, Issue
+ * #911) coexists with the historical "BrewDog DIY Dog Punk IPA
+ * (2007-2010)" shipped here at `-4001-...01`. Each version is a
+ * coherent reference for a different audience: the post-2010 one is
+ * what BrewDog brews today, the 2007-2010 one is the original DIY
+ * Dog book entry — useful for users who want to clone the recipe
+ * exactly as published.
+ */
+
+/**
+ * Sentinel UUID used as `owner_id` for every BrewDog DIY Dog recipe
+ * seeded by this loader. Re-exported from `system-user.seed` for a
+ * single source of truth on the system-curator UUID.
+ */
+export const BREWDOG_DIY_DOG_SYSTEM_OWNER_ID = SYSTEM_USER_ID;
+
+/**
+ * Provenance string written to `Recipe.import_provenance` for every
+ * row seeded by this loader. Surfaces in the mobile UI's "Importée
+ * depuis…" badge so users can trace the recipe back to its source.
+ */
+export const BREWDOG_DIY_DOG_PROVENANCE =
+  'BrewDog DIY Dog (open-source homebrew recipe book, attribution preserved)';
+
+/**
+ * Shape of a fermentable entry in the seed data. Mirrors
+ * `RecipeFermentableOrmEntity`'s mutable columns minus the autogen
+ * id, recipe_id, and timestamps.
+ */
+export interface BrewdogDiyDogFermentableSeed {
+  name: string;
+  type: RecipeFermentableType;
+  weight_g: number;
+  potential_gravity?: number;
+  color_ebc?: number;
+}
+
+/**
+ * Shape of a hop addition in the seed data. Mirrors
+ * `RecipeHopOrmEntity`'s mutable columns. `addition_time_min` is
+ * minutes-from-knockout for boil additions, days-of-contact for
+ * dry-hop additions, and may be null for whirlpool additions whose
+ * timing is not specified by the source recipe.
+ */
+export interface BrewdogDiyDogHopSeed {
+  variety: string;
+  type: RecipeHopType;
+  weight_g: number;
+  alpha_acid_percent?: number;
+  addition_stage: RecipeHopAdditionStage;
+  addition_time_min?: number;
+}
+
+/**
+ * Shape of a yeast addition in the seed data. Mirrors
+ * `RecipeYeastOrmEntity`'s mutable columns. `amount_g` defaults to
+ * 11.5g (~1 dry-yeast sachet) when the source recipe does not
+ * specify a pitch rate.
+ */
+export interface BrewdogDiyDogYeastSeed {
+  name: string;
+  type: RecipeYeastType;
+  amount_g: number;
+  attenuation_percent?: number;
+  temperature_min_c?: number;
+  temperature_max_c?: number;
+}
+
+/**
+ * Shape of one BrewDog DIY Dog recipe entry. Combines the brewing
+ * metrics (Recipe row) with the full ingredient breakdown
+ * (recipe_fermentables / recipe_hops / recipe_yeasts sub-rows).
+ */
+export interface BrewdogDiyDogRecipeSeed {
+  id: string;
+  name: string;
+  description: string;
+  style: string;
+  batch_size_l: number;
+  boil_time_min: number;
+  og_target: number;
+  fg_target: number;
+  abv_estimated: number;
+  ibu_target: number;
+  ebc_target: number;
+  efficiency_target: number;
+  /**
+   * Average community rating for the published recipe. Optional —
+   * undefined leaves the column unset (defaults to NULL in SQLite),
+   * matching the `public-recipes.seed.ts` convention.
+   */
+  avg_rating?: number;
+  /**
+   * Number of times the recipe has been brewed by the community
+   * (synthetic value derived from BrewDog's Wisdom of the Crowd
+   * exposure). Same optionality contract as `avg_rating`.
+   */
+  brew_count?: number;
+  source_url: string;
+  fermentables: readonly BrewdogDiyDogFermentableSeed[];
+  hops: readonly BrewdogDiyDogHopSeed[];
+  yeasts: readonly BrewdogDiyDogYeastSeed[];
+}
+
+/**
+ * BrewDog DIY Dog recipes shipped by this seed. UUIDs are
+ * deterministic (`-4001-` variant) so the mobile demo data and the
+ * matching service can hardcode references without a database
+ * round-trip.
+ *
+ * Issue #780 targets ~25 recipes; recipes are added 1-N at a time as
+ * each source page on `brewdogrecipes.com` is verified. The loader
+ * is designed to handle any subset, so each top-up PR only adds
+ * data without touching the loader machinery.
+ */
+export const BREWDOG_DIY_DOG_SEED: readonly BrewdogDiyDogRecipeSeed[] = [
+  {
+    // Historical Punk IPA recipe as published in the original DIY Dog
+    // book (2007-2010 version). Source verified on
+    // `brewdogrecipes.com` 2026-05-05. Coexists with the post-2010
+    // canonical "BrewDog DIY Dog Punk IPA" already shipped at
+    // `00000000-0000-4000-8000-00000000000b` by `public-recipes.seed`
+    // (Issue #911 — the "🏆 Recette officielle" scan-flow row).
+    id: '00000000-0000-4001-8000-000000000001',
+    name: 'BrewDog DIY Dog Punk IPA (2007-2010)',
+    description:
+      "Recette historique de Punk IPA telle que publiée dans le DIY Dog original (millésimes 2007-2010). Mono-malt Extra Pale, ossature houblon Ahtanum / Chinook / Crystal renforcée par Motueka en fin d'ébullition. Profil pamplemousse, ananas et lychee, finale amère et sèche. Pas de dry-hop — l'aromatique tient sur l'ajout massif au flameout.",
+    style: 'American IPA',
+    batch_size_l: 20,
+    boil_time_min: 60,
+    og_target: 1.056,
+    fg_target: 1.01,
+    abv_estimated: 6,
+    ibu_target: 60,
+    ebc_target: 17,
+    efficiency_target: 75,
+    avg_rating: 4.8,
+    brew_count: 248,
+    source_url: 'https://brewdogrecipes.com/recipes/punk-ipa-2007-2010',
+    fermentables: [
+      {
+        name: 'Extra Pale Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 5300,
+        color_ebc: 4,
+      },
+    ],
+    hops: [
+      {
+        variety: 'Ahtanum',
+        type: RecipeHopType.PELLET,
+        weight_g: 17.5,
+        alpha_acid_percent: 5,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 60,
+      },
+      {
+        variety: 'Chinook',
+        type: RecipeHopType.PELLET,
+        weight_g: 15,
+        alpha_acid_percent: 13,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 60,
+      },
+      {
+        variety: 'Crystal',
+        type: RecipeHopType.PELLET,
+        weight_g: 17.5,
+        alpha_acid_percent: 4.5,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 15,
+      },
+      {
+        variety: 'Chinook',
+        type: RecipeHopType.PELLET,
+        weight_g: 17.5,
+        alpha_acid_percent: 13,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 15,
+      },
+      {
+        variety: 'Ahtanum',
+        type: RecipeHopType.PELLET,
+        weight_g: 17.5,
+        alpha_acid_percent: 5,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 5,
+      },
+      {
+        variety: 'Chinook',
+        type: RecipeHopType.PELLET,
+        weight_g: 27.5,
+        alpha_acid_percent: 13,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 5,
+      },
+      {
+        variety: 'Crystal',
+        type: RecipeHopType.PELLET,
+        weight_g: 17.5,
+        alpha_acid_percent: 4.5,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 5,
+      },
+      {
+        variety: 'Motueka',
+        type: RecipeHopType.PELLET,
+        weight_g: 17.5,
+        alpha_acid_percent: 7,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 5,
+      },
+    ],
+    yeasts: [
+      {
+        name: 'Wyeast 1056 American Ale',
+        type: RecipeYeastType.ALE,
+        amount_g: 11.5,
+        attenuation_percent: 75,
+        temperature_min_c: 16,
+        temperature_max_c: 22,
+      },
+    ],
+  },
+];
+
+/**
+ * Result returned by `seedBrewdogDiyDogRecipes` for instrumentation.
+ * Reports per-table counts so the runner / tests can verify the
+ * sub-tables stayed in sync with the recipe rows.
+ */
+export interface SeedBrewdogDiyDogResult {
+  recipesInserted: number;
+  recipesUpdated: number;
+  fermentablesInserted: number;
+  hopsInserted: number;
+  yeastsInserted: number;
+  total: number;
+}
+
+/**
+ * Idempotent loader for the BrewDog DIY Dog recipes above. For each
+ * seed entry:
+ *
+ * 1. Upsert the Recipe row (insert if id unknown, update in place
+ *    otherwise). Visibility is forced to PUBLIC, owner to the
+ *    system sentinel, `import_provenance` to the canonical BrewDog
+ *    DIY Dog attribution string, `imported_from_recipe_id` to null
+ *    (these are originals, not user imports).
+ * 2. Wipe the existing fermentables / hops / yeasts rows for that
+ *    `recipe_id`, then bulk-insert the seed's ingredient lists. The
+ *    "wipe and refill" pattern keeps idempotency simple — re-running
+ *    the seed converges on the same final state regardless of
+ *    drift between runs (renamed hops, deleted fermentables, etc.).
+ *
+ * `is_official` is deliberately left as `false` on every row — same
+ * rationale as `public-recipes.seed.ts`: a global `is_official=true`
+ * flag would 100-pt-boost every BrewDog recipe in the matching
+ * service's `rankForBeer`, surfacing them as "official" for unrelated
+ * scanned beers (Codex P1 lesson on PR #773 / #912). Per-beer
+ * official linking is reserved for the mobile-side
+ * `demoEquivalentRecipes` mock.
+ */
+export async function seedBrewdogDiyDogRecipes(
+  recipeRepo: Repository<RecipeOrmEntity>,
+  fermentableRepo: Repository<RecipeFermentableOrmEntity>,
+  hopRepo: Repository<RecipeHopOrmEntity>,
+  yeastRepo: Repository<RecipeYeastOrmEntity>,
+  recipes: readonly BrewdogDiyDogRecipeSeed[] = BREWDOG_DIY_DOG_SEED,
+): Promise<SeedBrewdogDiyDogResult> {
+  let recipesInserted = 0;
+  let recipesUpdated = 0;
+  let fermentablesInserted = 0;
+  let hopsInserted = 0;
+  let yeastsInserted = 0;
+
+  for (const recipe of recipes) {
+    const recipePayload = {
+      owner_id: BREWDOG_DIY_DOG_SYSTEM_OWNER_ID,
+      name: recipe.name,
+      description: recipe.description,
+      style: recipe.style,
+      visibility: RecipeVisibility.PUBLIC,
+      version: 1,
+      root_recipe_id: recipe.id,
+      parent_recipe_id: null,
+      batch_size_l: recipe.batch_size_l,
+      boil_time_min: recipe.boil_time_min,
+      og_target: recipe.og_target,
+      fg_target: recipe.fg_target,
+      abv_estimated: recipe.abv_estimated,
+      ibu_target: recipe.ibu_target,
+      ebc_target: recipe.ebc_target,
+      efficiency_target: recipe.efficiency_target,
+      avg_rating: recipe.avg_rating,
+      brew_count: recipe.brew_count,
+      last_brewed_at: null,
+      is_official: false,
+      imported_from_recipe_id: null,
+      import_provenance: BREWDOG_DIY_DOG_PROVENANCE,
+    };
+
+    const existing = await recipeRepo.findOne({ where: { id: recipe.id } });
+    if (existing) {
+      Object.assign(existing, recipePayload);
+      await recipeRepo.save(existing);
+      recipesUpdated += 1;
+    } else {
+      const created = recipeRepo.create({ id: recipe.id, ...recipePayload });
+      await recipeRepo.save(created);
+      recipesInserted += 1;
+    }
+
+    // Wipe-and-refill the sub-tables. Cheaper than computing per-row
+    // diffs and keeps the seed deterministic — the post-condition is
+    // "this recipe's ingredients are exactly what the seed declares".
+    await fermentableRepo.delete({ recipe_id: recipe.id });
+    for (const fermentable of recipe.fermentables) {
+      await fermentableRepo.save(
+        fermentableRepo.create({ recipe_id: recipe.id, ...fermentable }),
+      );
+      fermentablesInserted += 1;
+    }
+
+    await hopRepo.delete({ recipe_id: recipe.id });
+    for (const hop of recipe.hops) {
+      await hopRepo.save(hopRepo.create({ recipe_id: recipe.id, ...hop }));
+      hopsInserted += 1;
+    }
+
+    await yeastRepo.delete({ recipe_id: recipe.id });
+    for (const yeast of recipe.yeasts) {
+      await yeastRepo.save(
+        yeastRepo.create({ recipe_id: recipe.id, ...yeast }),
+      );
+      yeastsInserted += 1;
+    }
+  }
+
+  return {
+    recipesInserted,
+    recipesUpdated,
+    fermentablesInserted,
+    hopsInserted,
+    yeastsInserted,
+    total: recipesInserted + recipesUpdated,
+  };
+}

--- a/packages/api/src/database/seeds/brewdog-diy-dog-recipes.seed.ts
+++ b/packages/api/src/database/seeds/brewdog-diy-dog-recipes.seed.ts
@@ -1,5 +1,6 @@
 import { Repository } from 'typeorm';
 
+import { idempotentUpsertById } from './seed-utils';
 import { RecipeFermentableOrmEntity } from '../../recipe/entities/recipe-fermentable.orm.entity';
 import { RecipeFermentableType } from '../../recipe/domain/enums/recipe-fermentable-type.enum';
 import { RecipeHopAdditionStage } from '../../recipe/domain/enums/recipe-hop-addition-stage.enum';
@@ -40,12 +41,24 @@ import { SYSTEM_USER_ID } from './system-user.seed';
 export const BREWDOG_DIY_DOG_SYSTEM_OWNER_ID = SYSTEM_USER_ID;
 
 /**
- * Provenance string written to `Recipe.import_provenance` for every
- * row seeded by this loader. Surfaces in the mobile UI's "Importée
- * depuis…" badge so users can trace the recipe back to its source.
+ * Base attribution label written to `Recipe.import_provenance` for
+ * every row seeded by this loader. The per-recipe `source_url` is
+ * appended at seed time by `buildBrewdogDiyDogProvenance` so the
+ * audit trail is traceable directly from the database (see Copilot
+ * review on PR #921 — without this, `source_url` would only live on
+ * the seed file and not survive into the persisted row).
  */
-export const BREWDOG_DIY_DOG_PROVENANCE =
+export const BREWDOG_DIY_DOG_BASE_PROVENANCE =
   'BrewDog DIY Dog (open-source homebrew recipe book, attribution preserved)';
+
+/**
+ * Builds the canonical `import_provenance` value for one DIY Dog
+ * recipe by appending the per-recipe source URL to the base
+ * attribution. Surfaces in the mobile UI's "Importée depuis…" badge.
+ */
+export function buildBrewdogDiyDogProvenance(sourceUrl: string): string {
+  return `${BREWDOG_DIY_DOG_BASE_PROVENANCE} — source: ${sourceUrl}`;
+}
 
 /**
  * Shape of a fermentable entry in the seed data. Mirrors
@@ -318,23 +331,23 @@ export async function seedBrewdogDiyDogRecipes(
       ebc_target: recipe.ebc_target,
       efficiency_target: recipe.efficiency_target,
       avg_rating: recipe.avg_rating,
-      brew_count: recipe.brew_count,
+      // RecipeOrmEntity.brew_count is non-nullable with default 0 —
+      // coalesce here so an omitted seed value lands as 0 rather
+      // than NULL (caught on PR #921 review).
+      brew_count: recipe.brew_count ?? 0,
       last_brewed_at: null,
       is_official: false,
       imported_from_recipe_id: null,
-      import_provenance: BREWDOG_DIY_DOG_PROVENANCE,
+      import_provenance: buildBrewdogDiyDogProvenance(recipe.source_url),
     };
 
-    const existing = await recipeRepo.findOne({ where: { id: recipe.id } });
-    if (existing) {
-      Object.assign(existing, recipePayload);
-      await recipeRepo.save(existing);
-      recipesUpdated += 1;
-    } else {
-      const created = recipeRepo.create({ id: recipe.id, ...recipePayload });
-      await recipeRepo.save(created);
-      recipesInserted += 1;
-    }
+    const outcome = await idempotentUpsertById(
+      recipeRepo,
+      { id: recipe.id },
+      recipePayload,
+    );
+    recipesInserted += outcome.inserted;
+    recipesUpdated += outcome.updated;
 
     // Wipe-and-refill the sub-tables. Cheaper than computing per-row
     // diffs and keeps the seed deterministic — the post-condition is

--- a/packages/api/src/database/seeds/seed-test-utils.ts
+++ b/packages/api/src/database/seeds/seed-test-utils.ts
@@ -30,6 +30,10 @@ export type RepoMock = {
    * INSERT OR IGNORE before writing producer_id FKs). Other seeds
    * may leave it untouched. */
   query: jest.Mock;
+  /** Bulk delete — used by seeds that wipe-and-refill sub-tables
+   * (e.g. brewdog-diy-dog-recipes resets recipe_fermentables /
+   * recipe_hops / recipe_yeasts on every run for idempotency). */
+  delete: jest.Mock;
 };
 
 /**
@@ -46,6 +50,7 @@ export function buildRepoMock(): RepoMock {
     create: jest.fn((input: unknown) => input),
     save: jest.fn((input: unknown) => Promise.resolve(input)),
     query: jest.fn(() => Promise.resolve(undefined)),
+    delete: jest.fn(() => Promise.resolve({ affected: 0 })),
   };
 }
 


### PR DESCRIPTION
## Summary

First slice of Issue #780. Ships the seed loader + type definitions + test harness for the 25-recipe BrewDog DIY Dog import, plus the historical **Punk IPA 2007-2010** as recipe #1. The remaining 24 recipes will land in follow-up PRs as each source page on `brewdogrecipes.com` is verified one at a time — keeps reviewer surface manageable and avoids ingesting unverified data in bulk.

## Architecture

- **New file** `packages/api/src/database/seeds/brewdog-diy-dog-recipes.seed.ts`
  - Types: `BrewdogDiyDogRecipeSeed`, `BrewdogDiyDogFermentableSeed`, `BrewdogDiyDogHopSeed`, `BrewdogDiyDogYeastSeed` — full sub-table breakdown for each recipe (vs `public-recipes.seed.ts` which carries metadata only).
  - Deterministic UUID range `00000000-0000-4001-8000-XXXXXXXXXXXX` (`-4001-` variant) so the existing 11 `-4000-` PUBLIC seed rows keep their identity.
  - Idempotent loader `seedBrewdogDiyDogRecipes(recipeRepo, fermentableRepo, hopRepo, yeastRepo, recipes?)` covering the Recipe row plus the three ingredient sub-tables.
- **Wipe-and-refill** pattern on the sub-tables: each run deletes rows by `recipe_id` then bulk-inserts the seed's ingredient lists. Deterministic post-condition regardless of drift between runs.
- `is_official` deliberately `false` on every backend row — same global-flag regression lesson as `public-recipes.seed.ts` (the matching service treats `is_official=true` as a 100-pt per-recipe boost, so tagging every DIY Dog row as official would surface them as "official" for unrelated scanned beers).
- `import_provenance` = `"BrewDog DIY Dog (open-source homebrew recipe book, attribution preserved)"` so the mobile UI's "Importée depuis…" badge can surface the source.

## Recipe #1 — Punk IPA 2007-2010

| Field | Value |
|---|---|
| UUID | `00000000-0000-4001-8000-000000000001` |
| Source | <https://brewdogrecipes.com/recipes/punk-ipa-2007-2010> |
| Style | American IPA |
| Batch | 20 L, 60 min boil |
| Metrics | OG 1.056 / FG 1.010 / ABV 6.0% / IBU 60 / EBC 17 |
| Fermentables | Extra Pale Malt 5.3 kg |
| Hops | 8 additions × Ahtanum / Chinook / Crystal / Motueka @ 60/15/5 min |
| Yeast | Wyeast 1056 American Ale @ 19°C primary |

**Coexistence with the existing `BrewDog DIY Dog Punk IPA`** at `-4000-...0b` (Issue #911 — the scan flow's "🏆 Recette officielle" row): the two are distinct millésimes useful for different audiences. The post-2010 row carries metadata only and serves the scan-flow Beat 4. The new 2007-2010 row carries the full DIY Dog book recipe — what users actually clone when they want to reproduce Punk IPA at home.

## Tests

8 specs covering happy / sad (idempotency) / edge paths:

- Insert path: every recipe + ingredient sub-rows seeded into empty tables.
- Visibility / owner / provenance / non-official invariants on every row.
- Idempotency: existing recipe rows updated in place, sub-tables wiped-and-refilled — verified via per-table delete call counts.
- Drifted-row reset: `visibility=PRIVATE`, `is_official=true`, `import_provenance="manually edited"` all forced back to canonical values on overwrite.
- Edge: deterministic UUID range matches `-4001-` variant, non-empty grain bill / hops / yeasts on every recipe, every recipe carries a `brewdogrecipes.com` source URL.

## Verification

- 662/664 API tests green (+8 new). 2 skipped + 1 suite skipped pre-existing.
- ESLint clean — the scan.service.ts:631 warning predates this PR.
- `nest build` clean.

## Out of scope

- Recipes 2-25 — separate top-up PRs as source data is verified.
- Runner script (`run-brewdog-diy-dog-seed.ts`) and orchestration with the existing `run-public-recipes-seed.ts` — deferred until at least 5 recipes ship so the runner has meaningful data to load.
- Mobile-side equivalent recipes mock updates — separate PR once enough recipes exist to define which DIY Dog row maps to which scanned bottle.

## Checklist

- [x] Happy path + sad path + edge cases covered (8 tests)
- [x] `nest build` clean
- [x] ESLint clean (no new warnings)
- [x] Existing tests still green (654 → 662 = +8 new)
- [x] No `any`, no inline styles, no hardcoded values introduced
- [x] Deterministic UUID range respected (`-4001-` variant)
- [x] Source URL on every recipe for traceability

Refs #780 (1/25 — scaffolding + first recipe; remaining 24 to follow)