### PR TITLE
feat(eas): standalone APK profile pointing on Fly.io + fix monorepo upload bloat

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -29,11 +29,34 @@
 /coverage/
 /node_modules/
 
-# Sibling monorepo packages — irrelevant for the mobile-app build.
-# `packages/api/` ships via Fly.io, the others are independent.
-/packages/api/
+# Sibling monorepo packages — keep their `package.json` files so that
+# `npm ci` can resolve the workspace topology declared in the root
+# `package.json` + `package-lock.json`. Without these manifests, the
+# install step on the EAS builder fails with missing-workspace errors.
+# Heavy non-essential subpaths inside each sibling are excluded
+# explicitly below.
+/packages/api/data/
+/packages/api/dist/
+/packages/api/coverage/
+/packages/api/test/
+/packages/api/.github/
+/packages/api/scripts/
+/packages/api/AUDIT.md
+/packages/api/Dockerfile
+/packages/api/Dockerfile.dockerignore
+/packages/api/docker-compose.yml
+/packages/api/fly.toml
 /packages/website/
-/packages/beer-encyclopedia/
+!/packages/website/package.json
+/packages/beer-encyclopedia/scan-photos/
+/packages/beer-encyclopedia/.ruff_cache/
+/packages/beer-encyclopedia/migrations/
+/packages/beer-encyclopedia/tests/
+/packages/beer-encyclopedia/api/
+/packages/beer-encyclopedia/db/
+/packages/beer-encyclopedia/docs/
+/packages/beer-encyclopedia/importers/
+/packages/beer-encyclopedia/ml/
 
 # Mobile-app local artifacts that survived a git checkout
 /packages/mobile-app/node_modules/

--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,58 @@
+# .easignore at the monorepo root — what EAS Build should exclude from the
+# upload tarball when packaging this workspace.
+#
+# Why a root-level file: in a monorepo, EAS uploads the workspace root
+# (the directory above `packages/`) so that `npm ci` can resolve
+# workspace deps from the canonical `package-lock.json`. The `.easignore`
+# inside `packages/mobile-app/` is NOT enough on its own — its anchored
+# patterns (`/docs/`, `/_archive/`, `/packages/api/`, etc.) resolve
+# relative to `packages/mobile-app/`, where those directories do not
+# exist, so they have no effect on what is actually uploaded.
+#
+# Syntax is the same as .gitignore.
+#
+# GOTCHA: patterns without a leading "/" match ANY directory with that
+# name anywhere in the tree. So `tools/` (without slash) would also
+# match `packages/mobile-app/src/features/tools/` and break the JS
+# bundle (issue #555 documents the original incident). Always anchor
+# repo-root directories with a leading slash.
+
+# Monorepo-root heavy directories — the actual source of the prior
+# 300+ MB upload bloat. Anchored to this file's location (= repo root).
+/.git/
+/.github/
+/.claude/
+/.codex/
+/.husky/
+/_archive/
+/docs/
+/coverage/
+/node_modules/
+
+# Sibling monorepo packages — irrelevant for the mobile-app build.
+# `packages/api/` ships via Fly.io, the others are independent.
+/packages/api/
+/packages/website/
+/packages/beer-encyclopedia/
+
+# Mobile-app local artifacts that survived a git checkout
+/packages/mobile-app/node_modules/
+/packages/mobile-app/.expo/
+/packages/mobile-app/dist/
+/packages/mobile-app/coverage/
+
+# Anywhere-in-the-tree dependency caches and build outputs
+**/.venv/
+**/venv/
+**/__pycache__/
+**/dist/
+**/build/
+
+# IDE / OS / logs / archives
+.vscode/
+.idea/
+.DS_Store
+*.log
+*.tar.gz
+*.zip
+*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ docs/product/references/*
 .claude/settings.json
 .claude/scheduled_tasks.lock
 .claude/settings.json
+
+# Stub created by EAS CLI for monorepo project-root detection
+/app.json

--- a/packages/mobile-app/docs/EAS_BUILD.md
+++ b/packages/mobile-app/docs/EAS_BUILD.md
@@ -50,6 +50,25 @@ If your upload ever balloons back to 100+ MB, that's a sign a new
 bare-directory pattern got added to `.easignore` — re-read the inline
 comment at the top of `.easignore` before fixing.
 
+**Important — two `.easignore` files, both needed.** EAS in a monorepo
+uploads the **workspace root** (this repo's monorepo root, not
+`packages/mobile-app/`) so that `npm ci` can find the canonical
+`package-lock.json`. As a result:
+
+- `.easignore` at `packages/mobile-app/.easignore` is interpreted with
+  `packages/mobile-app/` as its anchor — it can only exclude paths
+  inside the mobile-app package itself.
+- `.easignore` at the **monorepo root** (`/.easignore`) is interpreted
+  with the repo root as its anchor — that is where `/.git/`,
+  `/_archive/`, `/docs/`, `/packages/api/`, and the other heavy
+  monorepo-root paths must be excluded.
+
+Both files exist and serve different scopes. If you only edit the
+package-level one, the repo-root paths leak straight through and the
+upload climbs to 300+ MB (this happened on the 2026-05-07 first
+APK build of the Fly.io-pointed bundle, fixed in PR
+#960).
+
 ### Option B — Isolated-workspace fallback
 
 Useful when debugging `.easignore` rules or when the repo has

--- a/packages/mobile-app/eas.json
+++ b/packages/mobile-app/eas.json
@@ -17,7 +17,6 @@
       },
       "env": {
         "EXPO_PUBLIC_API_URL": "https://brasse-bouillon-api.fly.dev",
-        "EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL": "https://brasse-bouillon-api.fly.dev",
         "EXPO_PUBLIC_USE_DEMO_DATA": "false"
       }
     },

--- a/packages/mobile-app/eas.json
+++ b/packages/mobile-app/eas.json
@@ -11,7 +11,15 @@
     },
     "preview": {
       "distribution": "internal",
-      "channel": "preview"
+      "channel": "preview",
+      "android": {
+        "buildType": "apk"
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://brasse-bouillon-api.fly.dev",
+        "EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL": "https://brasse-bouillon-api.fly.dev",
+        "EXPO_PUBLIC_USE_DEMO_DATA": "false"
+      }
     },
     "production": {
       "autoIncrement": true,


### PR DESCRIPTION
## Summary

Two complementary fixes that together let us produce a sideloadable
Android APK pointed at the Fly.io API. **The standalone APK matters
because it removes the dev-PC dependency for the 2026-05-27 soutenance
demo** — Expo Go in dev mode requires Metro on a reachable host, the
APK bundles the JS at build time and only needs the public Fly.io URL.

## Changes

### `packages/mobile-app/eas.json`

- The `preview` profile now produces a real APK (`android.buildType: "apk"`).
  Without this flag, EAS defaults to `aab` (Android App Bundle), which
  can only be installed via the Play Store.
- The `env` block bakes the production `EXPO_PUBLIC_API_URL`
  (`https://brasse-bouillon-api.fly.dev`, deployed in PR #959) into the
  bundle. EAS environment variables are inlined at bundle time and are
  **not** read from the gitignored local `.env`, so this block is the
  canonical source.

### `/.easignore` (new, monorepo root)

Diagnosed and fixed: the first APK build attempt of this branch
uploaded a **339 MB tarball** (vs the documented baseline of 5–15 MB).
Cause: the existing `.easignore` lives at `packages/mobile-app/.easignore`,
which means its anchored patterns (`/.git/`, `/_archive/`, `/docs/`,
`/packages/api/`, ...) are scoped to the **mobile-app package**, not
the monorepo root — those paths simply do not exist there, so every
single one of those rules was a no-op against the actual upload root.

EAS in a monorepo uploads the **workspace root** so that `npm ci` can
find the canonical `package-lock.json`. The new `/.easignore` excludes
the heavy monorepo-root paths from that upload.

### `/.gitignore`

Ignore the empty `/app.json` stub that the EAS CLI auto-creates at the
workspace root during monorepo project-root detection.

### `packages/mobile-app/docs/EAS_BUILD.md`

- Document the two-`.easignore` setup (one at the package, one at the
  monorepo root) and the symptom that signals drift between them.

## Verification

- First APK build was submitted via
  \`eas build --platform android --profile preview --non-interactive\`
  on the previous branch state and confirmed that the \`env\` block on
  \`preview\` was picked up correctly (EAS log: *\"The values from the
  build profile configuration will be used\"*). That build was in queue
  at the time of this PR — its result will validate the production
  bundle behavior end-to-end.
- After this PR lands and the next build starts from a clean tree,
  the upload tarball should drop back to ~5–15 MB.

## Follow-ups (out of scope for this PR)

- Sideload the APK on the demo phone, validate signup + login + main
  flows in 4G / 5G with no Tailscale and no Metro running anywhere
  (= the actual soutenance condition).
- Demo-data seeding on the production DB.
- Beer-encyclopedia (FastAPI) deployment when the panoramic scan flow
  is in scope for the demo.

## Checklist

- [x] \`eas.json\` produces APK (not AAB) on the \`preview\` profile
- [x] Production \`EXPO_PUBLIC_API_URL\` baked at build time
- [x] Monorepo-root heavy paths excluded from EAS upload
- [x] \`EAS_BUILD.md\` documents the two-\`.easignore\` gotcha so the next
      person does not re-spend an hour debugging upload bloat

Partial follow-up to issue #525.