### PR TITLE
fix(eas): anchor /packages/beer-encyclopedia/.venv/ explicitly

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -48,8 +48,15 @@
 /packages/api/fly.toml
 /packages/website/
 !/packages/website/package.json
+# IMPORTANT: explicit anchored .venv exclusion. The `**/.venv/` glob below
+# does not always reach this deep on EAS's tarballer (observed in the APK
+# rebuild after PR #964 — upload was 170 MB instead of <20 MB because the
+# 5.6 GB Python virtualenv with CUDA + PyTorch libs leaked through). Anchor
+# explicitly to be safe.
+/packages/beer-encyclopedia/.venv/
 /packages/beer-encyclopedia/scan-photos/
 /packages/beer-encyclopedia/.ruff_cache/
+/packages/beer-encyclopedia/.pytest_cache/
 /packages/beer-encyclopedia/migrations/
 /packages/beer-encyclopedia/tests/
 /packages/beer-encyclopedia/api/


### PR DESCRIPTION
## Summary

The first APK rebuild after PR #964 (Expo SDK 54 patch sync) tried to
upload a **170 MB** tarball to EAS Build and **failed twice with
`ECONNRESET` / `EAI_AGAIN storage.googleapis.com`** mid-upload. The
expected baseline per `EAS_BUILD.md` is **5–15 MB**, so something
heavy was leaking through.

## Diagnosis

Tarballed the workspace locally with the same exclusion patterns and
inspected the largest entries. Every top-20 file sat under
`packages/beer-encyclopedia/.venv/lib/python3.12/site-packages/`:

```
541 MB  libcublasLt.so.13
456 MB  libtorch_cuda.so
451 MB  libtorch_cpu.so
416 MB  libtriton.so
286 MB  libcufft.so.12
245 MB  libcudnn_engines_precompiled.so.9
234 MB  libcusparseLt.so.0
218 MB  libnccl.so.2
175 MB  _polars_runtime.abi3.so
163 MB  libcusparse.so.12
... (more CUDA + PyTorch libs)
```

The 5.6 GB Python virtualenv (CUDA + PyTorch + Triton bundled by the
ML pipeline of the beer-encyclopedia FastAPI service) was being
**included** in the EAS upload even though `.easignore` already had a
`**/.venv/` glob.

## Root cause

EAS's tarballer accepts the gitignore syntax but does **not** always
evaluate `**/` recursively to that depth on monorepo uploads. The
existing `**/.venv/` rule worked for shallower locations (e.g. a
\`packages/mobile-app/.venv/\`) but missed
\`packages/beer-encyclopedia/.venv/\` for some reason. **Explicit
anchored paths are the reliable pattern.**

## Fix

Add to `.easignore` (workspace root):

```
/packages/beer-encyclopedia/.venv/
/packages/beer-encyclopedia/.pytest_cache/
```

Inline comment documents the rationale and the symptom (170 MB upload)
that surfaced this incident, so the next person hitting a 100+ MB
upload knows where to look first.

## Verification

After this PR lands, the next `eas build --platform android --profile
preview` should produce an upload tarball in the documented 5–15 MB
range. CI doesn't catch this (the failure mode is a network upload,
not a build error).

## Checklist

- [x] No code changes
- [x] Existing `**/.venv/` rule kept as a defence-in-depth
- [x] Inline comment documents the failure mode