### PR TITLE
docs(specs): redefine panoramic capture algorithm (D1-D7)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,25 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-05-08
 
+### PR #981 merged (`d9511c9`) — docs(specs): scan feature development roadmap
+
+- Branch `docs/scan-roadmap`, 2 commits (`494d304`, `2e88330`). Companion to `scan-consolidation.md`. Sequences the scan backlog into 6 phases (0 quick wins → 1 data foundations → 2 enrichment pipeline → 3 mobile capture → 4 OCR + AI vision → 5 polish + community → 6 post-MVP) with explicit dependencies, sub-issue mappings, effort estimates, and exit criteria per phase. Adds the soutenance strategy (Plan A live demo / Plan B degraded / Plan C demo override), end-to-end verification gates, and a risk register.
+- Round-1 review fix in `2e88330`: 6 inline comments addressed (1 Codex P2 + 5 Copilot Should Have). (1) §12 Phase 1 SSE gate aggressive vs scope (Codex + Copilot duplicates) — gate aligned with Phase 1's actual deliverables (`upload.received` + `stitching.completed`), other 5 events come online with later phases. (2) §2 vs §12 rehearsal count mismatch — both now read "minimum 2 full rehearsals" matching #642 AC. (3) §8 fixture count contradiction — now "the 6 fixture panoramas, at least 5 of 6 times". (4) French agreement Plan A "Live demo idéal" → "idéale". (5) French agreement Plan B "Demo dégradé" → "dégradée".
+
+### Algorithm redefinition session (decisions D1–D7)
+
+User-journey-first revisit of the panoramic capture algorithm before sending an agent to implement `scan-algorithms.md`. Persona retained: **Léa la curieuse au bar** (single optimisation target — phone in one hand, bottle in the other, 30 s attention, bar context distraction). The 7 decisions below are recorded here and applied to `scan-algorithms.md` in a follow-up PR.
+
+- `D1 — Point d'entrée` — **Barcode-first** + auto-switch silencieux on lookup miss. Status quo, aligned with `scan-consolidation.md` §2 canonical decree.
+- `D2 — Pre-capture indicators` — **Soft-gate visuel only**. Distance + blur indicators stay visible to coach, but the **Commencer** CTA is always enabled. Léa taps when she wants. Frame-quality filtering (Laplacian variance + central-region hash) runs at burst-capture time and rejects unusable frames silently. Rationale: the target persona has no patience for a 1-second alignment gate.
+- `D3 — Rotation metaphor` — **Permissive**. The coaching string says *"tourne doucement"* without specifying whether to turn the bottle or the phone. The gyro-derived progress gauge measures the angular delta either way.
+- `D4 — Live OCR during capture` — **Drop**. `tesseract.js` removed from the burst flow. The gyro gauge filling 0° → 360° plus the adaptive coaching strings are sufficient feedback that capture is working. Removes a real risk of freezing the JS thread on Android mid-range. Preserved as a debug-mode flag for field testing only.
+- `D5 — Pre-upload preview` — **None in the MVP**. Capture transitions directly from *"Capture terminée ✅"* to the analysis screen. Quality gate is server-side: if `cv2.Stitcher_create` returns an error, the response surfaces *"On n'a pas pu reconstituer l'étiquette"* with a retry CTA. To be revisited only if OCR success rate is poor post-launch.
+- `D6 — "Continuer ailleurs" button` — **Mandatory MVP**, surfaces at T+10 s of analysis screen. Upgrade from "optional" in the original spec. Driven by the persona constraint (Léa abandons after ~15 s of perceived blocking wait). Couples with #939 in-app notifications — the suggestion arrives via the bell when ready.
+- `D7 — Offline upload queue` — **Yes in the MVP** via `AsyncStorage`. New Phase 2.5 in the spec: if the network is unavailable when the burst completes, frames are persisted locally (3 captures FIFO, 7-day TTL) and retried on next app launch or network state change. Bar-context connectivity flakiness justifies the ~1-day effort. Implementation lands with #946 unless scope splits out.
+
+All seven decisions follow the contextualised recommendation made by the planning agent. They are non-reopenable without revising this log entry.
+
 ### PR #979 merged (`f41ac26`) — docs(specs): scan feature consolidation snapshot
 
 - Branch `docs/scan-consolidation`, 4 commits (`324cc12`, `87c90c3`, `4e406b7`, `5caea4c`). Companion to [scan-algorithms.md](docs/architecture/specs/scan-algorithms.md). Single visible artefact mapping the scan feature backlog: 4 active epics ([#751](https://github.com/benoit-bremaud/brasse-bouillon/issues/751) panoramic, [#934](https://github.com/benoit-bremaud/brasse-bouillon/issues/934) enrichment, [#803](https://github.com/benoit-bremaud/brasse-bouillon/issues/803) community, [#878](https://github.com/benoit-bremaud/brasse-bouillon/issues/878) freemium), 17 sub-issues sequenced under #751 / #934, the canonical decree (auto-switch when barcode lookup misses), the structuring constraints (ADR-0005 backend split + Expo Managed pure + persistence imperative + craft-beer audience), target architecture, critical files, and the open decisions blocking dev-plan finalisation.

--- a/docs/architecture/specs/scan-algorithms.md
+++ b/docs/architecture/specs/scan-algorithms.md
@@ -92,7 +92,7 @@ The panoramic flow is designed for **Expo Managed** (no eject, no custom dev cli
   - `40–70%` → "*Distance optimale ✅*"
   - `> 70%` → "*Recule un peu, tout le label doit être visible*"
 - A live blur indicator (Laplacian variance via on-device JS) shows a red dot if the frame is too blurry to capture. Fades to green when sharp.
-- A "**Commencer**" button is **always enabled** (decision **D2**, 2026-05-08). The distance and blur indicators stay visible to coach the user but do not gate the CTA. The underlying frame-quality filter (Laplacian variance + central-region hash) runs at burst-capture time and rejects unusable frames silently. Rationale: the target persona (Léa la curieuse au bar) does not have the patience to wait for an alignment gate; better to accept that the first attempt may be a poor capture and let her retry than to block the CTA for ~3 s upfront.
+- A "**Commencer**" button is **always enabled** (decision **D2**, 2026-05-08). The distance and blur indicators stay visible to coach the user but do not gate the CTA. The underlying frame-quality filter (Laplacian variance + central-region hash) runs at burst-capture time and rejects unusable frames silently. Rationale: the target persona (Léa la curieuse au bar) does not have the patience to wait for the previously specified alignment gate (≥ 1 s of stable distance + blur); better to accept that the first attempt may be a poor capture and let her retry than to block the CTA upfront.
 
 **Why on-device:** the user cannot wait for backend round-trips during a guidance loop. All the heuristics here run in pure JS over `expo-camera` frames sampled at ~5 fps (we down-sample because we don't need 30 fps for guidance).
 
@@ -120,12 +120,17 @@ The panoramic flow is designed for **Expo Managed** (no eject, no custom dev cli
 
 **Mobile:**
 
-- If the network is unavailable when the burst completes, the captured frames are persisted locally via `AsyncStorage` keyed by a client-generated `capture_id` (UUID v4).
+- If the network is unavailable when the burst completes, the captured frame **JPEGs** are written to the app's document directory via [`expo-file-system`](https://docs.expo.dev/versions/latest/sdk/filesystem/) (typical payload ~1.2 MB / capture — comfortably within the filesystem; AsyncStorage's ~6 MB Android cap would be exceeded by 3 captures).
+- A lightweight **queue manifest** is persisted in `AsyncStorage` containing only:
+  - `capture_id` (client-generated UUID v4)
+  - `file_uris[]` (paths under the document directory)
+  - `created_at` (ISO timestamp)
+  - `attempts` (retry counter, capped at 5)
 - The mobile retries the upload on:
   - Next app launch
   - Network state change → online (`@react-native-community/netinfo` listener)
-- The queue holds **at most 3 captures** (FIFO eviction) to bound storage.
-- Each capture survives **at most 7 days** (TTL) before being dropped silently.
+- The queue holds **at most 3 captures** (FIFO eviction at enqueue time) to bound disk usage.
+- Each capture survives **at most 7 days** (TTL evaluated at retry time) before its files and manifest entry are dropped silently.
 - A `pending` badge in the scan history indicates a capture is queued.
 
 **MVP scope:** the queue logic ships with [#946](https://github.com/benoit-bremaud/brasse-bouillon/issues/946) (or as a dedicated sub-issue if scope grows). It is mandatory for the panoramic flow because the target persona is bar-context-prone to flaky connectivity.

--- a/docs/architecture/specs/scan-algorithms.md
+++ b/docs/architecture/specs/scan-algorithms.md
@@ -92,7 +92,7 @@ The panoramic flow is designed for **Expo Managed** (no eject, no custom dev cli
   - `40–70%` → "*Distance optimale ✅*"
   - `> 70%` → "*Recule un peu, tout le label doit être visible*"
 - A live blur indicator (Laplacian variance via on-device JS) shows a red dot if the frame is too blurry to capture. Fades to green when sharp.
-- A "**Commencer**" button is enabled only when both indicators are green for ≥ 1 s.
+- A "**Commencer**" button is **always enabled** (decision **D2**, 2026-05-08). The distance and blur indicators stay visible to coach the user but do not gate the CTA. The underlying frame-quality filter (Laplacian variance + central-region hash) runs at burst-capture time and rejects unusable frames silently. Rationale: the target persona (Léa la curieuse au bar) does not have the patience to wait for an alignment gate; better to accept that the first attempt may be a poor capture and let her retry than to block the CTA for ~3 s upfront.
 
 **Why on-device:** the user cannot wait for backend round-trips during a guidance loop. All the heuristics here run in pure JS over `expo-camera` frames sampled at ~5 fps (we down-sample because we don't need 30 fps for guidance).
 
@@ -114,6 +114,22 @@ The panoramic flow is designed for **Expo Managed** (no eject, no custom dev cli
 - We cannot run native frame processors (e.g. `react-native-vision-camera`'s `useFrameProcessor`). We rely on `expo-camera`'s `takePictureAsync` in a loop.
 - The 5–10 fps target is realistic with Expo Managed; 30 fps is not.
 
+### Phase 2.5 — Offline upload queue (decision D7, 2026-05-08)
+
+**Goal:** never lose ~25 s of user-captured frames to a transient network failure (Léa at the bar on a saturated 4G).
+
+**Mobile:**
+
+- If the network is unavailable when the burst completes, the captured frames are persisted locally via `AsyncStorage` keyed by a client-generated `capture_id` (UUID v4).
+- The mobile retries the upload on:
+  - Next app launch
+  - Network state change → online (`@react-native-community/netinfo` listener)
+- The queue holds **at most 3 captures** (FIFO eviction) to bound storage.
+- Each capture survives **at most 7 days** (TTL) before being dropped silently.
+- A `pending` badge in the scan history indicates a capture is queued.
+
+**MVP scope:** the queue logic ships with [#946](https://github.com/benoit-bremaud/brasse-bouillon/issues/946) (or as a dedicated sub-issue if scope grows). It is mandatory for the panoramic flow because the target persona is bar-context-prone to flaky connectivity.
+
 ### Phase 3 — Loop-closure detection (live, on-device)
 
 **Goal:** detect that the user has done a full revolution and the latest frame visually matches the first frame, then end capture automatically.
@@ -133,12 +149,15 @@ The panoramic flow is designed for **Expo Managed** (no eject, no custom dev cli
 - A list of 15–30 JPEGs locally on the device.
 - Capture metadata: per-frame timestamp, gyro-derived angle estimate, perceptual hash.
 
-### Phase 4 — Live OCR snapshot (UX-only feedback)
+### Phase 4 — Live OCR snapshot — DROPPED (decision D4, 2026-05-08)
 
-**Goal:** show the user that text is being detected so they trust the capture is working. No durable artifact.
+Live on-device OCR via `tesseract.js` was originally specified to display detected text as a translucent overlay during burst capture, providing user reassurance that the capture was working. **Decision D4 removed it from the MVP** for the following reasons:
 
-- After every 5th accepted frame, run an async OCR pass on that frame using a pure-JS library (`tesseract.js` configured for French + English). The recognised text is shown briefly as a translucent overlay ("*Texte détecté: 'Brasserie Chouffe — Belgian Strong Ale'*").
-- **This OCR result is NOT persisted.** It is purely UX feedback. The authoritative OCR runs server-side in phase 6.
+- The gyro-derived progress gauge (Phase 2 circular indicator filling 0° → 360°) and the adaptive coaching strings (*"Continue, tu y es presque..."*, etc.) are sufficient feedback that the capture is progressing.
+- `tesseract.js` carries non-trivial CPU cost and a real risk of freezing the JS thread on Android mid-range devices, which would degrade the burst-capture frame rate.
+- The authoritative OCR runs server-side in [Phase 6](#phase-6--server-side-ocr); a degraded preview adds no enrichment value, only reassurance — and the gauge already provides the latter.
+
+**Preserved as debug-mode flag.** A development build flag may re-enable `tesseract.js` for field testing of OCR feasibility on real bottles, but it is never shipped to production users.
 
 ### Phase 4.5 — Streaming progression (anti-spinner UX)
 
@@ -172,10 +191,12 @@ The panoramic flow is designed for **Expo Managed** (no eject, no custom dev cli
 - The mobile displays this partial card immediately, with the other fields shown as `⏳` placeholders. The user sees a real result long before the full enrichment completes.
 - When `suggestion.created` fires, the placeholders fill in.
 
-#### Lever C — "Fire and forget" mode (optional, user-toggleable)
+#### Lever C — "Fire and forget" mode (mandatory MVP per decision D6, 2026-05-08)
 
-- Once `upload.received` fires (the frames are safely on the server, even if stitching has not yet completed), the user can tap a **"Continuer ailleurs"** button.
-- The mobile closes the scan screen and returns the user to the home page. The SSE is dropped.
+- The **"Continuer ailleurs"** button is **mandatory** in the MVP (upgraded from "optional" by decision D6, 2026-05-08). It surfaces as soon as the analysis screen has been visible for ≥ 10 s.
+- Rationale: the target persona (Léa la curieuse au bar) abandons the app after ~15 s of perceived blocking wait. Surfacing the escape hatch at T+10 s gives her control without forcing her to stare at a progress bar.
+- Implementation: once `upload.received` fires (the frames are safely on the server, even if stitching has not yet completed) AND ≥ 10 s have elapsed on the analysis screen, the button becomes tappable.
+- On tap: the mobile closes the scan screen and returns the user to the home page. The SSE is dropped client-side, but the backend pipeline continues.
 - When the suggestion is finally created, a notification (per [#939](https://github.com/benoit-bremaud/brasse-bouillon/issues/939)) lets the user know it is ready to review.
 
 #### Visual coupling with the BeerMugLoader
@@ -205,6 +226,8 @@ If the BeerMugLoader animation lands (Lottie of a beer mug filling), the SSE eve
   - `stitching_metadata` — the per-frame transformations OpenCV computed (useful for debugging).
 
 **Why Python:** beer-encyclopedia is the canonical home for catalog + ML work per ADR-0005. OpenCV is a first-class dependency there. NestJS would have required Node FFI or sub-process — Python avoids all of that.
+
+**No on-device preview between burst capture and upload (decision D5, 2026-05-08).** The user transitions directly from *"Capture terminée ✅"* (end of Phase 3) to the analysis screen — the panorama is never rendered on the device before being sent. Rationale: for the target persona, a "review your capture" step adds visual friction without adding value, and the local stitching needed to render a preview is not feasible in Expo Managed pure. **Quality gate is server-side**: if `cv2.Stitcher_create` returns an error, the response surfaces *"On n'a pas pu reconstituer l'étiquette. Réessaie en tournant plus lentement."* on the mobile, which then offers a retry path.
 
 ### Phase 6 — Server-side OCR
 
@@ -435,6 +458,8 @@ The two epics converge at sub-issues #938 (shared pipeline) and #940 (shared rev
 - Machine learning that learns from the maintainer's approve/refuse decisions to auto-approve high-confidence suggestions.
 - Push notifications. The MVP relies on in-app polling per #939.
 - Verified-brewery accounts (KYB).
+- Live on-device OCR feedback during burst capture (`tesseract.js` integration). Removed from the MVP per decision D4 (2026-05-08); preserved as a debug-mode flag for field testing only.
+- On-device preview of the stitched panorama before upload. Removed from the MVP per decision D5 (2026-05-08); quality gate is server-side via OpenCV stitcher result.
 
 ---
 


### PR DESCRIPTION
## Summary

User-journey-first revisit of [`scan-algorithms.md`](docs/architecture/specs/scan-algorithms.md) before any implementation. The 9 sub-issues of epic [#751](https://github.com/benoit-bremaud/brasse-bouillon/issues/751) need a clean spec to land against; this PR encodes 7 decisions taken in a planning session and applies them to the spec.

**Persona retained:** *Léa la curieuse au bar* — single optimisation target, phone in one hand, bottle in the other, 30 s attention, bar-context distraction. If Léa succeeds, *Brasseur posé chez lui* succeeds too. The inverse is not true.

## Decisions captured

| # | Decision | Resolution |
|---|---|---|
| D1 | Point d'entrée | Barcode-first + auto-switch silencieux. Status quo, aligned with `scan-consolidation.md` §2 canonical decree. **No spec change.** |
| D2 | Pre-capture indicators | Soft-gate visuel only — CTA Commencer always enabled. Frame-quality filtering moves to burst time. |
| D3 | Rotation metaphor | Permissive — coaching says *"tourne doucement"* without specifying bottle vs phone. Gyro measures angular delta either way. **No spec change.** |
| D4 | Live OCR during capture | **Drop** `tesseract.js` from the burst flow. Gyro gauge + adaptive coaching suffice. Preserved as debug-only flag. |
| D5 | Pre-upload preview | **None** in the MVP. Quality gate is server-side via `cv2.Stitcher_create` result. |
| D6 | "Continuer ailleurs" button | **Mandatory** MVP, surfaces at T+10 s of analysis. Couples with #939 in-app notifications. |
| D7 | Offline upload queue | **Yes** in the MVP via `AsyncStorage`. New §3 Phase 2.5: 3 captures FIFO, 7-day TTL, retry on app launch + network state change. |

## Spec patches applied

- `§3 Phase 1` — CTA gating relaxed (D2)
- `§3 Phase 2.5` (NEW) — Offline upload queue section (D7)
- `§3 Phase 4` — Live OCR snapshot dropped, replaced with explanatory note (D4)
- `§3 Phase 4.5 Lever C` — "Continuer ailleurs" promoted from optional to mandatory MVP with explicit T+10 s gate (D6)
- `§3 Phase 5` — Explicit "no on-device preview between burst capture and upload" + server-side quality gate (D5)
- `§10 Out of scope` — Adds tesseract.js live OCR + on-device preview as explicitly removed

## Why now

PR #979 (consolidation snapshot) and PR #981 (development roadmap) merged today. Before sending an agent to implement Phase 3 (mobile capture), the spec needs to reflect the actual UX choices made for the target persona — not the original draft assumptions. The 7 decisions were taken in a structured planning session this morning.

## Impact on sub-issues

| Sub-issue | Change | Effort delta |
|---|---|---|
| #945 (Pre-capture screen) | AC update: indicators stay informative, CTA always active | -0.5 d (simplification) |
| #946 (Burst capture) | Drop `tesseract.js` integration. Add offline upload queue (D7). | net 0 |
| #947 (Loop closure) | No change | 0 |
| #948 (Backend stitching + SSE) | Confirm Lever C mandatory MVP | 0 (already decided) |

A follow-up comment will be posted on #945 and #946 once this PR merges.

## Checklist

- [x] Documentation only — no code change
- [x] All cross-references (decisions, phases, sub-issues) clickable
- [x] No AI tool attribution
- [x] PROJECT_LOG.md updated with the algorithm redefinition session + PR #981 merge entry
- [x] Decisions documented inline in the spec body so future readers see the rationale, not just the rules