### PR TITLE
chore(claude-tooling): per-package CLAUDE.md + pr-pre-reviewer subagent

### DIFF
--- a/.claude/agents/pr-pre-reviewer.md
+++ b/.claude/agents/pr-pre-reviewer.md
@@ -1,0 +1,136 @@
+---
+name: pr-pre-reviewer
+description: Use this agent BEFORE pushing a feature branch to GitHub, to catch issues that Copilot or Codex would flag in their automated review. Produces a structured review (Must Have / Should Have / Nice to Have / Disagree) of the diff between the current branch and `main`, citing ADR violations and forbidden patterns by `file:line`. Read-only; never edits files. Trigger this agent when the user is about to push or open a PR.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# PR Pre-Reviewer — local review before pushing
+
+You are a strict, read-only code reviewer for the **brasse-bouillon** monorepo. You run on the local working copy before the developer pushes a branch. Your goal is to surface every issue that Copilot or Codex would catch in their automated review, so the developer can fix them in Round-0 instead of Round-1.
+
+You **never** edit files. You produce a single review report.
+
+## Mandatory context to load before reviewing
+
+Read these files **once** at the start of every run (do not re-read between sections):
+
+1. `CLAUDE.md` (monorepo root) — project-wide rules
+2. The `CLAUDE.md` of each touched package (`packages/api/CLAUDE.md`, `packages/mobile-app/CLAUDE.md`, `packages/website/CLAUDE.md`, `packages/beer-encyclopedia/CLAUDE.md`)
+3. `docs/architecture/decisions/0001-build-for-today-design-for-tomorrow.md`
+4. `docs/architecture/decisions/0002-centralized-nestjs-backend.md`
+5. `docs/architecture/decisions/0003-consent-single-source-of-truth.md`
+6. `CONTRIBUTING.md` — PR conventions and labels
+
+If any of these files is missing, note it in the report and continue with what's available.
+
+## Diff to review
+
+Use these read-only commands (none of them mutate state):
+
+- `git rev-parse --abbrev-ref HEAD` — current branch (must not be `main`)
+- `git fetch origin main` (read-only fetch) is acceptable; do **not** rebase or merge
+- `git diff --stat origin/main...HEAD` — high-level summary
+- `git diff origin/main...HEAD` — full diff (chunk by file as needed)
+- `git log --oneline origin/main..HEAD` — commits to be reviewed
+
+If `origin/main` is not available, fall back to `main`.
+
+## Review checklist — what to flag
+
+For every file in the diff, check the points below. Group findings by priority.
+
+### Must Have — blocking
+
+- **ADR-0001 violations**: violation of the 5-clause rule or any of the 4 forbidden anti-patterns
+- **ADR-0002 violation**: direct call to a third-party HTTP service from `packages/mobile-app/` (anything not going through `packages/api/`)
+- **ADR-0003 violation**: writes to the consent store outside the canonical feature-namespaced API; non-append-only consent mutations
+- **`any` TypeScript type** introduced anywhere
+- **Default export** for a screen, use-case, controller, service, module, or DTO
+- **Direct `fetch()` call** outside `packages/mobile-app/src/core/http/http-client.ts`
+- **Raw SQL string** outside repository / query-builder methods in `packages/api/`
+- **Hardcoded secret, token, or credential**
+- **Hardcoded color, spacing, or font value** in `packages/mobile-app/` (must use tokens from `src/core/theme/`)
+- **Inline `style={{ ... }}`** in React Native (must use `StyleSheet.create()`)
+- **Inline `style="..."`** in `packages/website/` HTML
+- **Bypass of the response envelope** in `packages/api/` (controller returning a raw object that doesn't flow through the interceptor)
+- **Skipped or `xit`/`xdescribe` tests** introduced
+- **Missing migration** when a TypeORM entity adds, removes, or renames a column
+- **Direct commit to `main`** detectable in the commit history
+
+### Should Have — recommended before merge
+
+- **Tests not following H/S/E** (Happy / Sad / Edge) for new units
+- **Persistence imperative violation** (memory `feedback_persistence_imperative.md`): a new mobile feature that doesn't persist via the API from day one
+- **Missing Swagger / OpenAPI decorator** on a new API endpoint
+- **Naming convention deviations**:
+  - components in `PascalCase`, files in `kebab-case.ts` (logic) or `PascalCase.tsx` (components)
+  - constants in `SCREAMING_SNAKE_CASE`
+- **Conventional Commits not respected** on any commit of the branch
+- **Imports out of order** (React/RN → third-party → `@/core` → `@/features` → relative)
+- **Missing French/English mirror** in `packages/website/` (a public page edited only on one language side)
+- **No PROJECT_LOG.md entry** drafted when this PR would merge a significant change
+- **AI attribution** (`Co-Authored-By`, "Generated with", "Claude", "Copilot", "Codex", "GPT") in any commit message or file under git
+
+### Nice to Have — cosmetic / optional
+
+- Long functions that would benefit from extraction
+- Comments that explain WHAT instead of WHY
+- Minor readability or consistency improvements
+
+### Disagree — points where the diff appears intentional
+
+If something looks unusual but is justified by a tolerated ADR-0001 exception, a memory rule, or a pattern already established elsewhere in the codebase, list it under **Disagree** with a one-line rationale and a pointer to the precedent.
+
+## Output format
+
+Return a single Markdown report with the following structure. Use `path/to/file.ts:42` anchors (clickable in the IDE).
+
+```markdown
+# PR Pre-Review — `<current-branch>`
+
+**Diff stats**: <N> files, <+X / -Y> lines, <Z> commits
+
+## Must Have (<count>)
+
+- **packages/api/src/recipe/recipe.controller.ts:84** — Description of the issue, citing the ADR / rule violated. Suggested fix in one line.
+- ...
+
+## Should Have (<count>)
+
+- **packages/mobile-app/src/features/scan/application/use-cases.ts:31** — ...
+
+## Nice to Have (<count>)
+
+- ...
+
+## Disagree / Intentional (<count>)
+
+- **packages/api/src/scan/scan.service.ts:120** — Looks like an ADR-0001 exception, justified because <rationale>.
+
+## Summary
+
+- ADRs honoured: yes / no (cite the breaches)
+- Forbidden patterns present: yes / no (cite the patterns)
+- Tests H/S/E covered for new units: yes / no
+- Branch is from `main` and commits follow Conventional Commits: yes / no
+- Ready for push: yes / no
+
+## Suggested next steps
+
+1. Fix the Must Have items above
+2. Run `npm run lint:check` and `npm run test:cov` in the touched packages
+3. Push only after all Must Have are resolved
+```
+
+If there are no findings in a section, write `_None._` rather than omitting the section.
+
+## Rules for this agent
+
+- **Read-only.** Never run `git push`, `git commit`, `git checkout`, `git reset`, `git rebase`, `git merge`, `npm install`, or anything that mutates the working copy, the index, or remote refs.
+- **Never edit files.** Your only output is the Markdown report.
+- **Cite, don't paraphrase.** When flagging an ADR violation, quote the ADR clause briefly.
+- **Be specific.** Always provide `file:line`. Never say "somewhere in the recipes module".
+- **English only** in the report. The developer reads it in the editor; GitHub-bound artefacts are English.
+- **No AI attribution** in any text you produce.
+- **Stop early** if the diff is empty (no commits between `origin/main` and `HEAD`). Report it and exit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,8 @@ brasse-bouillon/
 Each package has its own CLAUDE.md with detailed conventions:
 
 - **Mobile App:** [packages/mobile-app/CLAUDE.md](packages/mobile-app/CLAUDE.md)
-- **API:** No CLAUDE.md yet — follow NestJS conventions, TypeORM patterns, and the rules below
+- **API:** [packages/api/CLAUDE.md](packages/api/CLAUDE.md)
+- **Website:** [packages/website/CLAUDE.md](packages/website/CLAUDE.md)
 - **Beer Encyclopedia:** [packages/beer-encyclopedia/CLAUDE.md](packages/beer-encyclopedia/CLAUDE.md)
 
 ---
@@ -194,3 +195,9 @@ this project.
 
 When reviewing a PR, flag any diff that violates these ADRs. Cite the
 ADR number and clause in the review comment.
+
+---
+
+## Project-local Claude tooling
+
+- Subagent `pr-pre-reviewer` — local pre-push review in Copilot/Codex style; flags ADR violations and forbidden patterns. See [.claude/agents/pr-pre-reviewer.md](.claude/agents/pr-pre-reviewer.md).

--- a/packages/api/CLAUDE.md
+++ b/packages/api/CLAUDE.md
@@ -1,0 +1,173 @@
+# CLAUDE.md — brasse-bouillon-backend
+
+## Project Overview
+
+**Name:** Brasse Bouillon — Backend API
+**Stack:** NestJS 11 + TypeORM + SQLite + TypeScript (strict) + Jest
+**Domain:** Homebrewing platform — recipes, batches, ingredients catalogues, beer scan, label drafts, water profiles, equipment templates
+**Consumers:** mobile-app (React Native) and beer-encyclopedia (Python FastAPI, ADR-0005 fallback)
+**Auth:** JWT via `@nestjs/passport` + `@nestjs/jwt`
+**Tests:** Jest unit + e2e (in-memory SQLite, migrations run, synchronize off)
+
+## Response Envelope
+
+Every controller response is wrapped by a global interceptor as:
+
+```json
+{ "success": true, "statusCode": 200, "message": "...", "data": { ... } }
+```
+
+The mobile HTTP client (`packages/mobile-app/src/core/http/http-client.ts`) auto-unwraps `data`. Never bypass the envelope. Errors flow through the global exception filter and produce the same shape with `success: false`.
+
+## Module Structure
+
+```
+src/
+  auth/                → Sign in, sign up, JWT strategy, password reset, guards
+  batch/               → Brewing batch tracking (steps, narratives, demo seed)
+  beer-contribution/   → Community contributions to the beer catalogue
+  catalog/             → Reference catalogues (hops, fermentables, yeasts, styles, mash, water, equipment, misc, producers, distributors)
+  common/              → constants, dto, enums, exceptions, filters, interceptors (response envelope, logging)
+  config/              → @nestjs/config schema, env validation
+  database/            → data-source.ts, migrations/, seeders
+  equipment/           → User equipment profiles
+  label/               → Label draft generation
+  recipe/              → Recipe CRUD, ingredients, steps, import (BeerXML / BeerJSON), catalog lookup
+  scan/                → Barcode + label panoramic scan endpoints (with beer-encyclopedia fallback)
+  user/                → User profile management
+  water/               → Brewing water profile calculator
+  main.ts              → Bootstrap, global pipes, filters, interceptors
+```
+
+### Inside each feature module
+
+- `<feature>.module.ts` — provider registration
+- `<feature>.controller.ts` — HTTP routing, decorated DTOs, `@nestjs/swagger`
+- `<feature>.service.ts` (and optional sub-services like `recipe-import.service.ts`)
+- `dto/` — request/response shapes, validated via `class-validator`
+- `entity/` (or `entities/`) — TypeORM entities
+- `*.spec.ts` colocated with implementation — H/S/E unit tests (Happy / Sad / Edge)
+
+## Database
+
+- **TypeORM data source:** `src/database/data-source.ts`
+- **Migrations folder:** `src/database/migrations/` (timestamp-prefixed, e.g. `1791000000000-AddProducersAndCatalogueFks.ts`)
+- **Migration commands:**
+  - `npm run migration:create` — empty migration file
+  - `npm run migration:generate` — generate from entity diff
+  - `npm run migration:run` — apply pending migrations
+  - `npm run migration:revert` — revert the last migration
+- **Synchronize is OFF in test and prod.** E2E tests run migrations explicitly (`TYPEORM_MIGRATIONS_RUN=true`).
+- **SQLite path** comes from `DATABASE_PATH` env var. Production uses a persistent path; tests use `:memory:`.
+
+## Auth & Guards
+
+- JWT secret from `JWT_SECRET`, expiration from `JWT_EXPIRATION` (default `86400s`).
+- Use the `@UseGuards(JwtAuthGuard)` pattern (or the route-level `@Public()` decorator if exposing an endpoint).
+- Throttling via `@nestjs/throttler` is wired globally; per-route overrides via `@Throttle()`.
+- Password reset flow stores reset tokens on the `User` entity (see migration `1778000000000-AddPasswordResetFieldsToUser.ts`).
+
+## Coding Conventions
+
+### TypeScript
+
+- Strict mode is ON — never use `any`. Type explicitly.
+- `interface` for object shapes (DTO bodies, repository contracts).
+- `type` for unions, mapped types, utility types.
+- Named exports only — no default exports for controllers, services, modules, DTOs.
+
+### DTOs
+
+- All input DTOs validated with `class-validator` decorators (`@IsString()`, `@IsEnum()`, `@IsOptional()`, etc.).
+- DTOs live in `dto/` next to the feature module.
+- Output DTOs / view models follow the same naming convention.
+
+### Services
+
+- Inject repositories via `@InjectRepository(EntityName)`.
+- Never use raw SQL outside repository / query-builder methods. No string concatenation for SQL.
+- Throw domain-specific exceptions from `src/common/exceptions/` rather than generic `HttpException`.
+
+### Imports
+
+1. NestJS (`@nestjs/*`)
+2. Third-party libraries
+3. Internal `src/common/...`
+4. Internal feature-local
+5. Relative imports
+
+## Testing
+
+Tests are **mandatory for every new feature**. Convention is **H/S/E** (memory `feedback_test_happy_sad_edge.md`):
+
+- **Happy path** — the nominal scenario
+- **Sad path** — expected error cases (validation failures, missing entities, unauthorised access)
+- **Edge cases** — boundary inputs, empty collections, concurrent writes, etc.
+
+```bash
+npm test               # all unit tests
+npm run test:cov       # with coverage
+npm run test:e2e       # e2e suite (in-memory DB, migrations applied)
+npm run test:watch     # watch mode
+```
+
+E2E tests use `test/jest-e2e.json`, run with `--runInBand`, and rely on environment variables defined in the `test` and `test:e2e` scripts of `package.json`.
+
+## CI Check (must pass before every PR)
+
+```bash
+npm run lint:check     # ESLint
+npm run build          # nest build
+npm run test:cov       # unit tests + coverage
+```
+
+The coverage artifact is consumed by SonarQube in CI.
+
+## Environment Variables
+
+`.env.example` is the source of truth. Required variables:
+
+```bash
+APP_ENV=development
+NODE_ENV=development
+JWT_SECRET=replace-with-a-long-random-secret
+JWT_EXPIRATION=86400s
+PORT=3000
+DATABASE_PATH=./data/brasse-bouillon.db
+```
+
+Never commit `.env`. Never edit `.env.example` except to add a newly documented variable with a placeholder value.
+
+## Architecture Decision Records — mandatory reading
+
+Before touching any module, read the accepted ADRs under [docs/architecture/decisions/](../../docs/architecture/decisions/):
+
+- **ADR-0001** — Build for today, design for tomorrow: 5-clause rule, 4 forbidden anti-patterns, 3 tolerated exceptions
+- **ADR-0002** — Centralized NestJS backend for all external data sources: mobile talks only to this API; external services (Open Food Facts, beer-encyclopedia) are proxied here
+- **ADR-0003** — Consent as a single source of truth: not directly enforced by the API, but consent-gated endpoints must respect the mobile-side store
+
+Any diff that violates an ADR must be flagged in review (cite the ADR number and clause).
+
+## Forbidden — Never Without Explicit User Request
+
+### Config files — do not modify
+
+- `nest-cli.json`, `tsconfig*.json`, `eslint.config.*`, `jest.config.*`, `test/jest-e2e.json`
+- `.env`, `.env.example` (except to add a newly documented variable)
+
+### Directories — never touch
+
+- `node_modules/`, `dist/`, `.git/`, `data/`, `coverage/`
+
+### Patterns — never introduce
+
+- `any` TypeScript type
+- Default exports for controllers, services, modules, or DTOs
+- Raw SQL strings outside repository / query-builder methods
+- Hardcoded secrets, tokens, or credentials
+- Direct calls to third-party HTTP services from controllers (proxy through a dedicated service module — ADR-0002)
+- Skipping the response envelope (every controller method returns plain data; the interceptor wraps it)
+
+## Project-local Claude tooling
+
+- Subagent `pr-pre-reviewer` — local pre-push review in Copilot/Codex style; flags ADR violations and forbidden patterns. See [.claude/agents/pr-pre-reviewer.md](../../.claude/agents/pr-pre-reviewer.md).

--- a/packages/mobile-app/CLAUDE.md
+++ b/packages/mobile-app/CLAUDE.md
@@ -170,3 +170,7 @@ npm test           # all tests green
 - Direct `fetch()` calls outside `src/core/http/http-client.ts`
 - Business logic inside `app/` route files
 - Hardcoded colors, spacing, or font values (use theme tokens)
+
+## Project-local Claude tooling
+
+- Subagent `pr-pre-reviewer` — local pre-push review in Copilot/Codex style; flags ADR violations and forbidden patterns. See [.claude/agents/pr-pre-reviewer.md](../../.claude/agents/pr-pre-reviewer.md).

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md — brasse-bouillon-website
+
+## Project Overview
+
+**Name:** Brasse Bouillon — Marketing Website
+**Stack:** Static HTML/CSS/JS, no framework. Hosted on GitHub Pages with custom domain via `CNAME`.
+**Deployment:** PR merge to `main` triggers GitHub Pages publication.
+**Quality gate:** Python script under `scripts/quality_gate.py`, tested in `tests/test_quality_gate.py`.
+
+The site is a thin marketing surface — not a SaaS frontend. Persistent product UX lives in `packages/mobile-app`.
+
+## Structure
+
+```
+packages/website/
+  index.html / index-en.html        → Landing pages (FR + EN)
+  legal.html / legal-en.html        → Legal notice
+  privacy.html / privacy-en.html    → Privacy policy
+  cookies.html / cookies-en.html    → Cookie policy
+  site.css                          → Stylesheet (CSS custom properties for tokens)
+  site.js                           → Light interactivity (no framework)
+  logo*.png / logo*.svg / og-image  → Brand assets
+  favicon.ico                       → Tab icon
+  CNAME                             → Custom domain (brasse-bouillon.com)
+  package.json                      → @brasse-bouillon/website
+  CONTRIBUTING.md                   → Website-specific contribution guide
+  CHANGELOG.md                      → Website release notes
+  docs/                             → Governance (GOVERNANCE.md), roadmap (ROADMAP.md + roadmap-feed.json), SEO runbook, weekly digests
+  scripts/                          → Python utilities (quality_gate.py, roadmap_sync.py, weekly_digest.py)
+  tests/                            → Python tests for the quality gate
+  seo/                              → SEO assets (sitemap, robots, schema.org)
+```
+
+## Languages
+
+- **UI default:** French. All public-facing copy is French (memory `feedback_ui_french_only.md`).
+- **English mirrors:** every public page has a `-en.html` twin. Keep them in sync — any FR change requires an EN update in the same PR.
+- **Internal artefacts (commits, PR bodies, comments, docs/, CHANGELOG.md):** English only (memory `feedback_github_artifacts_english_only.md`).
+
+## Design Tokens
+
+- All colors, spacing, typography defined as CSS custom properties at the top of `site.css`.
+- Never hardcode hex colors, px spacing, or font sizes inside selectors — reference the variables.
+- Mirror the mobile design system tokens conceptually so the brand stays consistent (mobile tokens live in `packages/mobile-app/src/core/theme/`).
+
+## Styling Rules
+
+- No inline `style="..."` attributes in HTML.
+- No external CSS frameworks (no Tailwind, no Bootstrap). The site is intentionally lean.
+- Use semantic HTML (`<header>`, `<nav>`, `<main>`, `<article>`, `<section>`, `<footer>`).
+- Forms use native validation attributes; JS only enhances, never replaces.
+
+## Accessibility
+
+- All images require meaningful `alt` text (decorative images use `alt=""`).
+- Contrast ratio ≥ AA (WCAG 2.1) for every text/background pair.
+- Headings respect a single `<h1>` per page and a logical hierarchy.
+- Keyboard navigation must reach every interactive element; visible focus states required.
+- Language attribute set per page (`<html lang="fr">` or `<html lang="en">`).
+
+## Privacy & Consent
+
+- **No third-party tracking** without explicit consent. GA4 and any analytics removed in PR #817.
+- Cookie banner and consent storage are mandatory before loading any non-essential script.
+- The cookie / privacy / legal pages must list every actual cookie set; never describe categories that aren't used.
+
+## SEO
+
+- `seo/` holds sitemap, robots, and schema.org JSON-LD snippets.
+- `SEO_RUNBOOK.md` documents the operational steps for SEO audits.
+- Every public page must include the standard meta tags: `description`, Open Graph (`og:title`, `og:description`, `og:image`), Twitter Card.
+
+## Quality Gate
+
+`scripts/quality_gate.py` runs in CI and checks structural invariants (presence of meta tags, language attribute, alt text, etc.). Modify the gate when adding a new structural rule; never disable it.
+
+```bash
+cd packages/website
+python scripts/quality_gate.py        # run the gate locally
+python -m pytest tests/               # run the gate tests
+```
+
+## Feedback Widget
+
+The `@brasse-bouillon/feedback-widget` (separate repo `benoit-bremaud/feedback-widget`) is planned for integration. When wiring it:
+
+- Pin the version exactly (no floating tags).
+- Use the `IssueTracker` adapter so feedback lands in the `audit-nvnc` GitHub Project (`PVT_kwHOB8rwIc4BVe-g`).
+- Initialise only after the consent banner has accepted the relevant cookie category.
+
+## Forbidden — Never Without Explicit User Request
+
+### Files — do not modify
+
+- `CNAME` (custom domain)
+- `favicon.ico`, brand logo assets (request a design pass before touching)
+- `.git/`, `.github/`
+
+### Patterns — never introduce
+
+- Inline `style="..."` attributes
+- External JavaScript frameworks
+- Third-party tracking scripts loaded before consent
+- Hardcoded color, spacing, or font values (use CSS custom properties)
+- English-only public pages without their French counterpart
+- French commit messages, PR titles, or PR bodies (English only on GitHub)
+
+## Project-local Claude tooling
+
+- Subagent `pr-pre-reviewer` — local pre-push review in Copilot/Codex style; flags forbidden patterns. See [.claude/agents/pr-pre-reviewer.md](../../.claude/agents/pr-pre-reviewer.md).


### PR DESCRIPTION
## Summary

- Adds **per-package CLAUDE.md** for `packages/api/` and `packages/website/` (covering NestJS modules / response envelope / TypeORM migrations / H/S/E tests for the API, and FR/EN static structure / design tokens / accessibility / consent rules for the website).
- Refreshes `packages/mobile-app/CLAUDE.md` and the root `CLAUDE.md` with a **Project-local Claude tooling** pointer and adds the API + Website entries to the per-package index at the root.
- Adds `.claude/agents/pr-pre-reviewer.md`: a **read-only subagent** that produces a Copilot/Codex-style review of the current branch (Must / Should / Nice / Disagree), citing ADR-0001/0002/0003 violations and forbidden patterns (no `any`, no default exports, no hardcoded tokens, no direct `fetch` outside `http-client.ts`, etc.) before pushing.

Goal: cut the recurring **Round-1 → Round-0** loop on automated reviews. The skill that automates the review-cycle itself is intentionally deferred — see the plan in `~/.claude/plans/` for the next iteration.

No change to `.claude/settings.json` (already git-ignored on this project).

## Checklist

- [x] Happy path + sad path + edge cases covered — N/A (docs/config only, no executable code paths)
- [x] `tsc --noEmit` passes — N/A (no TS changes)
- [x] Build passes — N/A (no source build affected)
- [x] Existing tests still green — N/A (no source affected)
- [x] No `any`, no inline styles introduced — N/A (markdown only)

No linked issue — internal Claude tooling scaffolding.