### PR TITLE
docs(ydays): add livrables-equipe coordination folder for 27 May soutenance

### DIFF
--- a/docs/ydays/livrables-equipe/A1-screenshots-app/README.md
+++ b/docs/ydays/livrables-equipe/A1-screenshots-app/README.md
@@ -1,0 +1,55 @@
+# A1 — Screenshots application mobile
+
+> **Pour** : Sara **ou** Thaïs (un.e des deux suffit, vous vous coordonnez)
+> **Effort estimé** : 15-20 minutes
+> **Deadline** : dimanche 24 mai 2026 (J-3)
+
+## Ce qu'on attend de toi
+
+**Exactement 3 screenshots** de l'application Brasse-Bouillon, dans l'ordre suivant :
+
+1. **`scanner.png`** — Écran scanner de code-barre, idéalement en action (overlay caméra visible, ou viseur centré)
+2. **`recette.png`** — Une recette ouverte avec les ingrédients visibles (malts, houblons, levure) et le bouton d'adaptation de volume si possible
+3. **`mode-batch.png`** — Mode Batch en cours avec un timer actif (étape empâtage ou ébullition de préférence — quelque chose de "vivant")
+
+## Critères techniques
+
+- **Résolution** : full résolution mobile (1080 × 1920 minimum, ou plus haut si Pixel/iPhone récent)
+- **Format** : PNG (préféré) ou JPG haute qualité
+- **Statut barres** : peu importe (Benoît crop si besoin)
+- **Données affichées** : utilise le mode démo (PR #823 — credentials demo) pour avoir des données propres et cohérentes
+
+## Comment livrer
+
+**Option 1 — Git (recommandé)** :
+
+```bash
+cd brasse-bouillon
+git checkout -b a1-screenshots
+cp ~/Downloads/scanner.png docs/ydays/livrables-equipe/A1-screenshots-app/
+cp ~/Downloads/recette.png docs/ydays/livrables-equipe/A1-screenshots-app/
+cp ~/Downloads/mode-batch.png docs/ydays/livrables-equipe/A1-screenshots-app/
+git add docs/ydays/livrables-equipe/A1-screenshots-app/
+git commit -m "docs(ydays): A1 — livre les 3 screenshots app"
+git push -u origin a1-screenshots
+```
+
+Puis ouvre une PR ciblant `main`, je merge.
+
+**Option 2 — Discord** :
+
+Drop les 3 fichiers sur canal `#ydays-soutenance` en mentionnant `@Benoît` — je les uploade ici.
+
+## Ce qu'il NE faut PAS faire
+
+- Pas de retouche/édition (je m'en occupe pour harmoniser avec la charte)
+- Pas de mise en mockup téléphone (juste l'écran brut, je l'encadre côté Canva)
+- Pas plus de 3 screenshots (1 par écran demandé suffit)
+
+## À quoi ça sert
+
+Ces 3 screenshots sont le **cœur visuel de la slide S8 "Produit / UX"** du deck soutenance. C'est ce que le jury verra pour comprendre concrètement ce que fait Brasse-Bouillon. La démo live racontera la même histoire, mais les screenshots prouvent que c'est livré.
+
+## Si tu ne peux pas livrer
+
+Ping `@Benoît` sur Discord, je capture moi-même depuis Expo dev en 15 min (plan B prévu).

--- a/docs/ydays/livrables-equipe/A2-screenshots-organisation/README.md
+++ b/docs/ydays/livrables-equipe/A2-screenshots-organisation/README.md
@@ -1,0 +1,60 @@
+# A2 — Screenshots organisation GitHub + Discord
+
+> **Pour** : Clément **ou** Catarina (un.e des deux suffit)
+> **Effort estimé** : 10-15 minutes
+> **Deadline** : dimanche 24 mai 2026 (J-3)
+
+## Ce qu'on attend de toi
+
+**Exactement 2 screenshots** prouvant notre organisation projet :
+
+1. **`github-issues.png`** — Capture de l'onglet **Issues** du repo `benoit-bremaud/brasse-bouillon` avec :
+   - Les labels visibles (priority, scope, area, type)
+   - Le filtre projet GitHub Projects appliqué si possible
+   - Au moins une dizaine d'issues visibles pour montrer le volume de travail
+
+2. **`discord-ci.png`** — Capture du canal Discord `#ci-notifications` (ou équivalent) montrant :
+   - Plusieurs notifications GitHub Actions consécutives (succès / pull requests / déploiements)
+   - L'horodatage visible pour prouver la fréquence
+   - Idéalement un mix de types (front / back / infra / cyber)
+
+## Critères techniques
+
+- **Résolution** : full HD minimum (1920 × 1080)
+- **Format** : PNG (préféré) ou JPG haute qualité
+- **Lisibilité** : zoom navigateur ~110 % pour que ce soit lisible à 5 m sur la slide
+- **Anonymisation** : aucune donnée sensible (token, secret, mail perso) ne doit apparaître
+
+## Comment livrer
+
+**Option 1 — Git (recommandé)** :
+
+```bash
+cd brasse-bouillon
+git checkout -b a2-screenshots-org
+cp ~/Downloads/github-issues.png docs/ydays/livrables-equipe/A2-screenshots-organisation/
+cp ~/Downloads/discord-ci.png docs/ydays/livrables-equipe/A2-screenshots-organisation/
+git add docs/ydays/livrables-equipe/A2-screenshots-organisation/
+git commit -m "docs(ydays): A2 — livre les 2 screenshots organisation"
+git push -u origin a2-screenshots-org
+```
+
+Puis PR vers `main`.
+
+**Option 2 — Discord** :
+
+Drop les 2 fichiers sur canal `#ydays-soutenance` avec `@Benoît`, je les uploade ici.
+
+## Ce qu'il NE faut PAS faire
+
+- Pas de zoom excessif (le jury doit comprendre que c'est GitHub / Discord du premier coup d'œil)
+- Pas de capture avec données personnelles d'autres membres en surimpression
+- Pas d'édition / retouche (je crop côté Canva si besoin)
+
+## À quoi ça sert
+
+Ces 2 captures sont le **cœur visuel de la slide S2 "Qui fait quoi"** du deck soutenance. Le CR jury du 6 mai a explicitement demandé : *"montrer captures des salons et notifications"*. C'est notre preuve de coordination outillée.
+
+## Si tu ne peux pas livrer
+
+Ping `@Benoît` sur Discord, je capture moi-même depuis mes accès admin en 10 min (plan B prévu).

--- a/docs/ydays/livrables-equipe/A3-rgpd-bullets/README.md
+++ b/docs/ydays/livrables-equipe/A3-rgpd-bullets/README.md
@@ -6,7 +6,7 @@
 
 ## Ce qu'on attend de toi
 
-**Un fichier `rgpd-bullets.md`** (markdown ou Word, peu importe) de **1 page A4 maximum**, contenant des bullets factuels sur ce qu'on a fait côté conformité.
+**Un fichier `rgpd-bullets.md`** au format **Markdown uniquement** (rendu propre sur GitHub, zéro conversion côté Benoît) de **1 page A4 maximum**, contenant des bullets factuels sur ce qu'on a fait côté conformité.
 
 ## Trame proposée (copier-coller, complète chaque section)
 

--- a/docs/ydays/livrables-equipe/A3-rgpd-bullets/README.md
+++ b/docs/ydays/livrables-equipe/A3-rgpd-bullets/README.md
@@ -1,0 +1,98 @@
+# A3 — Bullets RGPD / Cybersécurité
+
+> **Pour** : Fabien
+> **Effort estimé** : 30 minutes
+> **Deadline** : dimanche 24 mai 2026 (J-3)
+
+## Ce qu'on attend de toi
+
+**Un fichier `rgpd-bullets.md`** (markdown ou Word, peu importe) de **1 page A4 maximum**, contenant des bullets factuels sur ce qu'on a fait côté conformité.
+
+## Trame proposée (copier-coller, complète chaque section)
+
+```markdown
+# Brasse-Bouillon — Conformité RGPD & sécurité
+
+## Documents produits / en cours
+
+- [ ] Mentions légales — statut : [À démarrer / En cours / Prêt]
+- [ ] CGU (Conditions Générales d'Utilisation) — statut : [...]
+- [ ] Politique de protection des données — statut : [...]
+- [ ] Document de conformité RGPD/OWASP — statut : [...]
+
+## Mesures techniques en place
+
+- Authentification : [méthode utilisée — JWT / sessions / OAuth ?]
+- Stockage mots de passe : [bcrypt / argon2 / autre ?]
+- Communications réseau : [HTTPS partout / HTTPS frontend uniquement / autre ?]
+- Stockage données utilisateur : [chiffré au repos ? localisation FR/EU ?]
+- Logs et données personnelles : [anonymisation prévue ? durée conservation ?]
+
+## Droits utilisateurs implémentés ou prévus
+
+- Droit d'accès : [implémenté / à faire]
+- Droit de rectification : [implémenté / à faire]
+- Droit à l'effacement (RGPD art. 17) : [implémenté / à faire]
+- Droit à la portabilité : [implémenté / à faire / différé v0.2]
+
+## Différé en v0.2 (à mentionner en transparence)
+
+- Tests de pénétration (pentest) — non réalisés
+- Audit OWASP Top 10 formel — non réalisé
+- Certification ISO 27001 — non visée à court terme
+- [Autres choses honnêtement non couvertes]
+
+## Estimation OWASP Top 10 (couverture déclarative)
+
+| # | Catégorie OWASP | Couvert ? | Note |
+|---|---|---|---|
+| A01 | Broken Access Control | [oui/non/partiel] | [commentaire] |
+| A02 | Cryptographic Failures | [...] | [...] |
+| A03 | Injection | [...] | [...] |
+| A07 | Identification & Auth Failures | [...] | [...] |
+| (compléter ce qui est pertinent) | | | |
+```
+
+## Critères de qualité
+
+- **Honnête** : si quelque chose n'est pas fait, écris "à faire" ou "différé v0.2". Le jury déteste les mensonges, il aime la lucidité.
+- **Concis** : 1 page A4, pas un mémoire. Bullets > paragraphes.
+- **Factuel** : pas de marketing, pas de "nous avons une approche premium de la sécurité". On dit ce qu'on a, point.
+
+## Comment livrer
+
+**Option 1 — Git (recommandé)** :
+
+```bash
+cd brasse-bouillon
+git checkout -b a3-rgpd-bullets
+# Copier ton fichier rgpd-bullets.md dans le dossier
+git add docs/ydays/livrables-equipe/A3-rgpd-bullets/rgpd-bullets.md
+git commit -m "docs(ydays): A3 — livre la synthèse RGPD"
+git push -u origin a3-rgpd-bullets
+```
+
+Puis PR vers `main`.
+
+**Option 2 — Discord** :
+
+Drop le fichier sur canal `#ydays-soutenance` avec `@Benoît`.
+
+## À quoi ça sert
+
+Tes bullets servent à 2 livrables :
+
+1. **Slide S13 (quadrant Cyber/RGPD)** du deck soutenance — 4 bullets max sur la slide
+2. **Document PDF de conformité 5-10 pages** que Benoît va rédiger à partir de ta synthèse — pour avoir un livrable physique imprimé à montrer au jury en backup Q&A
+
+Tu produis la matière brute, je transforme en deck slide + PDF présentable.
+
+## Ce qu'il NE faut PAS faire
+
+- Pas de prétention sur des tests de sécurité non réalisés (le CR jury du 6 mai dit explicitement : *"Pas de tests de sécurité réalisés sur l'application à ce stade"* — on respecte ça)
+- Pas plus d'1 page (la slide n'en mérite pas plus)
+- Pas de jargon hermétique (le jury comprend les bases mais n'est pas une autorité de certification)
+
+## Si tu ne peux pas livrer
+
+Ping `@Benoît` sur Discord, je rédige à partir de templates RGPD standards (1 h de boulot). Mais ta connaissance terrain du projet est meilleure que mes templates — si tu peux livrer, c'est mieux.

--- a/docs/ydays/livrables-equipe/A4-charte/README.md
+++ b/docs/ydays/livrables-equipe/A4-charte/README.md
@@ -1,0 +1,96 @@
+# A4 — Charte officielle Brasse-Bouillon
+
+> **Pour** : Fabio **ou** Liam (un.e des deux suffit)
+> **Effort estimé** : 10-15 minutes
+> **Deadline** : vendredi 22 mai 2026 (J-5)
+
+## Ce qu'on attend de toi
+
+**3 éléments** déposés dans ce dossier :
+
+1. **`charte.md`** — Document texte court avec :
+   - **Hex codes** des couleurs officielles BB (jaune principal, accents secondaires, texte, fond, etc.)
+   - **Typographie** officielle (nom de la fonte + poids utilisés) — si on n'est pas sur Inter
+   - **Logo principal** : nom de fichier dans ce dossier
+   - **Logo monochrome / variante sombre** : si existe
+
+2. **`logo-bb.png`** — Logo Brasse-Bouillon en **PNG transparent haute résolution** (1024 × 1024 minimum, ou SVG si dispo)
+
+3. **`logo-bb-dark.png`** *(optionnel mais utile)* — Variante du logo sur fond sombre (pour la slide S14 conclusion qui sera sur fond noir)
+
+## Format attendu pour `charte.md`
+
+Trame à compléter :
+
+```markdown
+# Brasse-Bouillon — Charte officielle
+
+## Couleurs
+
+| Usage | Hex | Aperçu |
+|---|---|---|
+| Jaune principal (fond slides) | #?????? | (couleur dominante du logo BB) |
+| Accent secondaire | #?????? | (orange du chef ? brun du houblon ?) |
+| Texte foncé (sur fond jaune) | #?????? | (typiquement #1A1A1A ou #2D2D2D) |
+| Texte clair (sur fond sombre) | #?????? | (typiquement #FFFFFF ou #F5F5F5) |
+| Fond sombre (slide finale) | #1A1A1A | (par défaut, à confirmer) |
+
+## Typographie
+
+- **Police principale** : [Inter ? Autre ?]
+- **Poids utilisés** : Regular / Medium / Bold
+- **Tailles** : titre ≥ 36 pt · sous-titre ≥ 24 pt · texte courant ≥ 18 pt
+
+## Logo
+
+- Fichier principal : `logo-bb.png` (PNG transparent 1024 × 1024)
+- Variante sombre : `logo-bb-dark.png` (si dispo)
+- Source vectorielle : [lien Figma / Adobe / dossier repo si dispo]
+```
+
+## Critères techniques
+
+- **PNG transparent** obligatoire (pas de fond blanc)
+- **Résolution minimale** : 1024 × 1024 (sera redimensionné dans Canva)
+- **Pas de compression abusive** : on veut un logo net à grande taille
+
+## Comment livrer
+
+**Option 1 — Git (recommandé)** :
+
+```bash
+cd brasse-bouillon
+git checkout -b a4-charte
+# Copier tes fichiers dans le dossier
+cp charte.md docs/ydays/livrables-equipe/A4-charte/
+cp logo-bb.png docs/ydays/livrables-equipe/A4-charte/
+git add docs/ydays/livrables-equipe/A4-charte/
+git commit -m "docs(ydays): A4 — livre la charte officielle"
+git push -u origin a4-charte
+```
+
+Puis PR vers `main`.
+
+**Option 2 — Discord** :
+
+Drop les fichiers sur canal `#ydays-soutenance` avec `@Benoît`.
+
+## Ce qu'il NE faut PAS faire
+
+- Pas de logo JPG (transparent obligatoire)
+- Pas le logo orange/ancien (on est sur la charte jaune définitive)
+- Pas d'inventer des couleurs nouvelles — référer à ce qui existe déjà dans le repo (cherche dans [packages/mobile-app/docs/design-system.md](../../../../packages/mobile-app/docs/design-system.md) ou dans le code des thèmes)
+
+## À quoi ça sert
+
+Cette charte est la **référence unique** que Benoît va appliquer sur **les 15 slides du deck** pour garantir la cohérence visuelle (vs le draft actuel qui mélange jaune + orange/crème = pas pro).
+
+C'est aussi la base pour :
+- S0 Titre muet
+- S14 Conclusion (fond sombre avec logo)
+- Background de toutes les slides intermédiaires
+- Cartes de visite (cohérence print/digital)
+
+## Si tu ne peux pas livrer
+
+Ping `@Benoît` sur Discord. Plan B : il utilise les couleurs déclarées dans [packages/mobile-app/docs/design-system.md](../../../../packages/mobile-app/docs/design-system.md) + extrait le logo depuis le repo. ~30 min de boulot supplémentaire.

--- a/docs/ydays/livrables-equipe/A4-charte/README.md
+++ b/docs/ydays/livrables-equipe/A4-charte/README.md
@@ -14,9 +14,11 @@
    - **Logo principal** : nom de fichier dans ce dossier
    - **Logo monochrome / variante sombre** : si existe
 
-2. **`logo-bb.png`** — Logo Brasse-Bouillon en **PNG transparent haute résolution** (1024 × 1024 minimum, ou SVG si dispo)
+2. **`logo-bb.png`** — Logo Brasse-Bouillon en **PNG transparent haute résolution** (1024 × 1024 minimum). **Obligatoire** (format directement importable dans Canva).
 
-3. **`logo-bb-dark.png`** *(optionnel mais utile)* — Variante du logo sur fond sombre (pour la slide S14 conclusion qui sera sur fond noir)
+3. **`logo-bb.svg`** *(optionnel mais bienvenu)* — Même logo en **SVG vectoriel** si tu en as la source — sert d'archive pour les futurs supports print/grand format.
+
+4. **`logo-bb-dark.png`** *(optionnel mais utile)* — Variante du logo sur fond sombre (pour la slide S14 conclusion qui sera sur fond noir).
 
 ## Format attendu pour `charte.md`
 

--- a/docs/ydays/livrables-equipe/README.md
+++ b/docs/ydays/livrables-equipe/README.md
@@ -1,0 +1,39 @@
+# Livrables équipe — Soutenance Y Days 27 mai 2026
+
+> Dossier centralisé pour la collecte des **6 atomes de livraison** demandés à chaque membre de l'équipe avant la soutenance.
+>
+> Principe : Benoît + outillage IA produisent 90 % du deck. Chaque membre fournit **un atome précis** que lui seul peut livrer (≤ 30 min d'effort).
+
+## Comment ça marche
+
+1. Tu lis le `README.md` du sous-dossier qui te concerne (A1, A2, A3 ou A4)
+2. Tu produis exactement ce qui est demandé (rien de plus)
+3. Tu déposes le fichier directement dans le sous-dossier (`git add` + commit + push) **ou** tu le drop sur Discord canal `#ydays-soutenance` et Benoît s'occupe d'uploader
+4. Tu coches ta ligne dans `STATUS.md` (à la racine de ce dossier)
+
+## Structure
+
+| Sous-dossier | Pour qui | Quoi | Deadline |
+|---|---|---|---|
+| [`A1-screenshots-app/`](A1-screenshots-app/) | **Sara ou Thaïs** | 3 screenshots HD de l'app mobile | dim 24 mai 2026 |
+| [`A2-screenshots-organisation/`](A2-screenshots-organisation/) | **Clément ou Catarina** | 2 screenshots GitHub + Discord | dim 24 mai 2026 |
+| [`A3-rgpd-bullets/`](A3-rgpd-bullets/) | **Fabien** | 1 page A4 bullets RGPD | dim 24 mai 2026 |
+| [`A4-charte/`](A4-charte/) | **Fabio ou Liam** | Hex codes + logo PNG + typo | ven 22 mai 2026 |
+
+## Suivi en temps réel
+
+Voir [`STATUS.md`](STATUS.md) pour l'état d'avancement (cochage manuel à chaque livraison).
+
+## Plan B si tu ne peux pas livrer
+
+Pas de panique : Benoît a un fallback prévu pour chaque atome (entre 10 min et 1 h de boulot supplémentaire pour lui). Préviens simplement sur Discord que tu décroches, on ajuste.
+
+## Qui orchestre
+
+Benoît Bremaud (PO + fondateur) centralise. Toute question / blocage → ping `@Benoît` sur Discord `#ydays-soutenance`.
+
+## Pour contexte plus large
+
+- Plan complet : `~/.claude/plans/j-aimerai-qu-on-revienne-sur-crystalline-snail.md` (côté Benoît)
+- Grille évaluation jury : [docs/ydays/references/grille-pitch-entrepreneurial.md](../references/grille-pitch-entrepreneurial.md)
+- Structure du deck : [docs/ydays/outputs/plan-de-soutenance-finalise.md](../outputs/plan-de-soutenance-finalise.md) *(à mettre à jour sur la nouvelle structure 15 slides)*

--- a/docs/ydays/livrables-equipe/README.md
+++ b/docs/ydays/livrables-equipe/README.md
@@ -1,6 +1,6 @@
 # Livrables équipe — Soutenance Y Days 27 mai 2026
 
-> Dossier centralisé pour la collecte des **6 atomes de livraison** demandés à chaque membre de l'équipe avant la soutenance.
+> Dossier centralisé pour la collecte des **4 livrables fichiers (A1-A4)** demandés à chaque membre de l'équipe avant la soutenance, complétés par **2 confirmations de présence (A5-A6)** via Discord — soit **6 atomes** au total dans la grille de suivi `STATUS.md`.
 >
 > Principe : Benoît + outillage IA produisent 90 % du deck. Chaque membre fournit **un atome précis** que lui seul peut livrer (≤ 30 min d'effort).
 
@@ -9,7 +9,8 @@
 1. Tu lis le `README.md` du sous-dossier qui te concerne (A1, A2, A3 ou A4)
 2. Tu produis exactement ce qui est demandé (rien de plus)
 3. Tu déposes le fichier directement dans le sous-dossier (`git add` + commit + push) **ou** tu le drop sur Discord canal `#ydays-soutenance` et Benoît s'occupe d'uploader
-4. Tu coches ta ligne dans `STATUS.md` (à la racine de ce dossier)
+4. Tu ping `@Benoît` sur Discord pour signaler ta livraison — Benoît met à jour `STATUS.md` (édition centralisée pour éviter les conflits Git)
+5. Pour A5/A6 (présences répétition + soutenance) : juste un ✅ emoji sur le message Discord dédié
 
 ## Structure
 
@@ -34,6 +35,5 @@ Benoît Bremaud (PO + fondateur) centralise. Toute question / blocage → ping `
 
 ## Pour contexte plus large
 
-- Plan complet : `~/.claude/plans/j-aimerai-qu-on-revienne-sur-crystalline-snail.md` (côté Benoît)
 - Grille évaluation jury : [docs/ydays/references/grille-pitch-entrepreneurial.md](../references/grille-pitch-entrepreneurial.md)
 - Structure du deck : [docs/ydays/outputs/plan-de-soutenance-finalise.md](../outputs/plan-de-soutenance-finalise.md) *(à mettre à jour sur la nouvelle structure 15 slides)*

--- a/docs/ydays/livrables-equipe/STATUS.md
+++ b/docs/ydays/livrables-equipe/STATUS.md
@@ -10,15 +10,15 @@
 | **A2** | 2 screenshots GitHub + Discord notifs CI | Clément ou Catarina | dim 24 mai | ⬜ | — | — |
 | **A3** | 1 page A4 bullets RGPD | Fabien | dim 24 mai | ⬜ | — | — |
 | **A4** | Hex codes charte + logo PNG + typo | Fabio ou Liam | ven 22 mai | ⬜ | — | — |
-| **A5** | ✅ Présence répétition lundi 25 mai | Tous (9 personnes) | sam 24 mai | ⬜ | — | À cocher sur Discord |
-| **A6** | ✅ Présence soutenance mercredi 27 mai | Tous (9 personnes) | sam 24 mai | ⬜ | — | À cocher sur Discord |
+| **A5** | ✅ Présence répétition lundi 25 mai | Tous (9 personnes) | dim 24 mai | ⬜ | — | À cocher sur Discord |
+| **A6** | ✅ Présence soutenance mercredi 27 mai | Tous (9 personnes) | dim 24 mai | ⬜ | — | À cocher sur Discord |
 
 ## Tâches Benoît (la part lourde)
 
 | # | Tâche | Deadline | Statut | Date | Notes |
 |---|---|---|---|---|---|
 | **B1** | Production 15 slides Canva (charte jaune unifiée) | dim 24 mai | ⬜ | — | — |
-| **B2** | Schéma archi propre (Excalidraw/Mermaid) | sam 22 mai | ⬜ | — | Kévin valide |
+| **B2** | Schéma archi propre (Excalidraw/Mermaid) | ven 22 mai | ⬜ | — | Kévin valide |
 | **B3** | Vidéo backup démo 5 min | dim 24 mai | ⬜ | — | Avec Kévin co-tournage |
 | **B4** | Document RGPD complet (à partir A3) | lun 25 mai | ⬜ | — | Impression couleur |
 | **B5** | Cartes de visite commandées | ven 22 mai | ⬜ | — | Vistaprint 100 ex ~50 € |
@@ -42,5 +42,8 @@
 
 ## Process de mise à jour
 
-1. Tu livres → tu modifies ce fichier (remplace ⬜ par ✅ + date) + tu commit *("docs(ydays): A1 livré"*) — ou tu drop sur Discord et Benoît met à jour
-2. Benoît passe en revue chaque soir et update les ⚠️ si retard
+> **Benoît est le seul éditeur de ce fichier** pour éviter les conflits Git en cas de modifications parallèles.
+
+1. Tu livres ton atome → tu ping `@Benoît` sur Discord canal `#ydays-soutenance` (ou tu drop directement le fichier dans le sous-dossier git via PR)
+2. Benoît met à jour ce `STATUS.md` (coche ⬜ → ✅ + date) en fin de journée
+3. Benoît passe en revue chaque soir et update les ⚠️ si retard

--- a/docs/ydays/livrables-equipe/STATUS.md
+++ b/docs/ydays/livrables-equipe/STATUS.md
@@ -1,0 +1,46 @@
+# STATUS — Livrables équipe soutenance 27 mai
+
+> Cocher la case dès la livraison + dater. Mise à jour manuelle.
+
+## Atomes équipe (livrables membres)
+
+| # | Atome | Responsable | Deadline | Statut | Date livraison | Notes |
+|---|---|---|---|---|---|---|
+| **A1** | 3 screenshots app HD (scanner / recette / mode batch) | Sara ou Thaïs | dim 24 mai | ⬜ | — | — |
+| **A2** | 2 screenshots GitHub + Discord notifs CI | Clément ou Catarina | dim 24 mai | ⬜ | — | — |
+| **A3** | 1 page A4 bullets RGPD | Fabien | dim 24 mai | ⬜ | — | — |
+| **A4** | Hex codes charte + logo PNG + typo | Fabio ou Liam | ven 22 mai | ⬜ | — | — |
+| **A5** | ✅ Présence répétition lundi 25 mai | Tous (9 personnes) | sam 24 mai | ⬜ | — | À cocher sur Discord |
+| **A6** | ✅ Présence soutenance mercredi 27 mai | Tous (9 personnes) | sam 24 mai | ⬜ | — | À cocher sur Discord |
+
+## Tâches Benoît (la part lourde)
+
+| # | Tâche | Deadline | Statut | Date | Notes |
+|---|---|---|---|---|---|
+| **B1** | Production 15 slides Canva (charte jaune unifiée) | dim 24 mai | ⬜ | — | — |
+| **B2** | Schéma archi propre (Excalidraw/Mermaid) | sam 22 mai | ⬜ | — | Kévin valide |
+| **B3** | Vidéo backup démo 5 min | dim 24 mai | ⬜ | — | Avec Kévin co-tournage |
+| **B4** | Document RGPD complet (à partir A3) | lun 25 mai | ⬜ | — | Impression couleur |
+| **B5** | Cartes de visite commandées | ven 22 mai | ⬜ | — | Vistaprint 100 ex ~50 € |
+| **B6** | Matériel démo réuni | dim 24 mai | ⬜ | — | Punk IPA + grains + houblon + câbles |
+| **B7** | Répétition complète chronométrée 30+10 | lun 25 mai | ⬜ | — | Salle campus |
+
+## Décisions critiques (Benoît)
+
+| # | Décision | Deadline | Statut | Notes |
+|---|---|---|---|---|
+| **C1** | URL QR code finale | dim 24 mai | ⬜ | `brasse-bouillon.com/jury` OU repo GitHub |
+| **C2** | Repo public vs privé | dim 24 mai | ⬜ | Pesée privacy vs jury accessibility |
+| **C3** | Backend démo (Klouders actif vs bypass mode démo PR #823) | dim 24 mai | ⬜ | Test grandeur réelle |
+
+## Légende
+
+- ⬜ Non livré
+- ✅ Livré (renseigner la date)
+- ⚠️ En retard (au-delà de la deadline)
+- ❌ Abandonné (passer en plan B — préciser dans notes)
+
+## Process de mise à jour
+
+1. Tu livres → tu modifies ce fichier (remplace ⬜ par ✅ + date) + tu commit *("docs(ydays): A1 livré"*) — ou tu drop sur Discord et Benoît met à jour
+2. Benoît passe en revue chaque soir et update les ⚠️ si retard


### PR DESCRIPTION
## Summary

Adds a spoonfed coordination folder under `docs/ydays/livrables-equipe/` to collect 6 atomic team inputs (≤30 min effort each) ahead of the 27 May 2026 soutenance. Each subfolder ships a self-contained README detailing the exact deliverable, format, deadline, and fallback plan.

## Why

The 51-page Canva draft we share for the soutenance contains two parallel non-reconciled versions (yellow recent / orange legacy). Producing a coherent 15-slide deck in 9 days with a 9-person team requires minimizing what we ask each member to do — Benoît absorbs the bulk of the deck production, and the team only contributes what only they can produce (their environment screenshots, their domain expertise).

## What's in this PR

- `README.md` — overview + table of subfolders
- `STATUS.md` — at-a-glance live tracking grid (A1-A6 atoms + B1-B7 Benoît tasks + C1-C3 critical decisions)
- `A1-screenshots-app/` — Sara or Thaïs: 3 app screenshots (scanner / recipe / batch mode)
- `A2-screenshots-organisation/` — Clément or Catarina: 2 org screenshots (GitHub issues + Discord CI notifs)
- `A3-rgpd-bullets/` — Fabien: 1-page bullet list on RGPD compliance status
- `A4-charte/` — Fabio or Liam: hex codes + logo PNG + typography

## Test plan

- [x] Folder structure created and committed
- [x] All 6 READMEs include: target person, effort estimate, exact deliverable spec, delivery options (Git PR or Discord drop), what NOT to do, fallback plan
- [x] Brasse-Bouillon project conventions followed (FR content for FR team coordination — falls under the soutenance demo script exception)
- [ ] Team members reach their respective READMEs from the Discord broadcast message (to be sent after merge)
- [ ] STATUS.md gets ticked as deliveries land