### PR TITLE
docs(ydays): add PLAN-REDACTION-DECK.md as single source of truth for 15 slides

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -5,6 +5,15 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ---
 
+## 2026-05-18
+
+### PR #1004 merged (`f398fa3`) — docs(ydays): add livrables-equipe coordination folder for 27 May soutenance
+
+- Branch `docs/ydays-livrables-equipe`, 2 commits (`a0b6c10`, `7d75bd1`). Adds `docs/ydays/livrables-equipe/` with 4 atomic-deliverable subfolders (A1 screenshots app, A2 screenshots GitHub+Discord, A3 RGPD bullets, A4 charte) + `STATUS.md` tracking grid (6 team atoms A1–A6, 7 Benoît tasks B1–B7, 3 critical decisions C1–C3). Spoonfed coordination: Benoît absorbs 90 % of the deck production, each team member contributes one ≤30 min atomic input. FR-language content (soutenance demo script exception per memory rule).
+- Round-1 review fix in `7d75bd1`: 7 inline comments addressed (5 Copilot + 2 Codex). (1) STATUS A5/A6 deadline `sam 24 mai` → `dim 24 mai` (Codex P1 calendar correction). (2) STATUS B2 deadline `sam 22 mai` → `ven 22 mai` (Codex P1 calendar correction). (3) README dead local-path bullet `~/.claude/plans/...` removed (Copilot P1). (4) README "6 atomes" wording reworded to clarify 4 file deliverables + 2 Discord-only confirmations (Copilot P2). (5) A3 README format restricted to Markdown only (was "markdown ou Word", Copilot P2). (6) A4 README logo split into `logo-bb.png` (required) + `logo-bb.svg` (optional source) + `logo-bb-dark.png` (optional variant) (Copilot P2). (7) STATUS single-editor convention documented (Benoît centralises updates) to prevent Git merge conflicts on parallel edits (Copilot P3).
+
+---
+
 ## 2026-05-08
 
 ### PR #981 merged (`d9511c9`) — docs(specs): scan feature development roadmap

--- a/docs/ydays/livrables-equipe/PLAN-REDACTION-DECK.md
+++ b/docs/ydays/livrables-equipe/PLAN-REDACTION-DECK.md
@@ -1,0 +1,955 @@
+# Plan de rédaction du deck — Soutenance Y Days 27 mai 2026
+
+> **Source unique de vérité** pour la production des 15 slides du deck Canva.
+>
+> Toute évolution d'une slide passe d'abord par ce document. La slide Canva n'est qu'un rendu.
+
+## Table des matières
+
+- [Cadrage transversal](#cadrage-transversal)
+- [Convention annotation Canva](#convention-annotation-canva)
+- [Légende statuts](#légende-statuts)
+- [S0 — Titre muet](#s0--titre-muet)
+- [S1 — Démo live](#s1--démo-live)
+- [S2 — Qui fait quoi](#s2--qui-fait-quoi)
+- [S3 — Accroche raccourcie / pourquoi BB](#s3--accroche-raccourcie--pourquoi-bb)
+- [S4 — Pour qui (3 personas)](#s4--pour-qui-3-personas)
+- [S5 — SMART (3 objectifs)](#s5--smart-3-objectifs)
+- [S6 — Le marché documenté + sondages équipe](#s6--le-marché-documenté--sondages-équipe)
+- [S7 — Notre réponse (proposition de valeur)](#s7--notre-réponse-proposition-de-valeur)
+- [S8 — Produit / UX](#s8--produit--ux)
+- [S9 — Tech / Architecture](#s9--tech--architecture)
+- [S10 — Qualité + engagement tests utilisateurs](#s10--qualité--engagement-tests-utilisateurs)
+- [S11 — Modèle économique](#s11--modèle-économique)
+- [S12 — Plan de communication](#s12--plan-de-communication)
+- [S13 — Perspectives 4 quadrants](#s13--perspectives-4-quadrants)
+- [S14 — Conclusion + CTA + QR](#s14--conclusion--cta--qr)
+
+---
+
+## Cadrage transversal
+
+**Date soutenance** : mercredi 27 mai 2026 · Salle 0.301 (R+3 Ynov Sophia-Antipolis) · Catégorie Pitch Entrepreneurial · Format 30 min présentation + 10 min Q&A.
+
+**Charte officielle** : jaune (palette houblon Brasse-Bouillon). Hex codes + logo + typo livrés par Fabio/Liam — atome A4. Toute slide produite sur cette charte unique.
+
+**Densité visuelle** : ≤ 50 mots visibles par slide. Le détail va dans les notes orales, jamais sur la slide.
+
+**Lisibilité** : police ≥ 24 pt minimum (titre ≥ 36 pt). Doit être lisible à 5 m de l'écran.
+
+**Structure 15 slides — Bloc démo (5 min) + Bloc contenu (25 min)** :
+
+| # | Slide | Durée | Plage |
+|---|---|---|---|
+| S0 | Titre muet | 30 s | -0:30 → 0:00 (hors chrono) |
+| S1 | **DÉMO LIVE** | **5:00** | 0:00 → 5:00 (ouverture) |
+| S2 | Qui fait quoi | 1:00 | 5:00 → 6:00 |
+| S3 | Accroche raccourcie | 1:30 | 6:00 → 7:30 |
+| S4 | Pour qui (3 personas) | 1:30 | 7:30 → 9:00 |
+| S5 | SMART | 1:00 | 9:00 → 10:00 |
+| S6 | Marché documenté + sondages | 2:00 | 10:00 → 12:00 |
+| S7 | Notre réponse | 1:00 | 12:00 → 13:00 |
+| S8 | Produit / UX | 1:30 | 13:00 → 14:30 |
+| S9 | Tech / Architecture | 1:30 | 14:30 → 16:00 |
+| S10 | Qualité + engagement tests user | 1:00 | 16:00 → 17:00 |
+| S11 | Modèle économique | 3:00 | 17:00 → 20:00 |
+| S12 | Plan de communication | 2:00 | 20:00 → 22:00 |
+| S13 | Perspectives 4 quadrants | 3:00 | 22:00 → 25:00 |
+| S14 | Conclusion + CTA + QR | 1:00 | 25:00 → 26:00 |
+| — | Marge / Q&A préparées | 4:00 | 26:00 → 30:00 |
+
+**Total** : 5:00 démo + 21:00 narratif + 4:00 marge = 30:00 strict.
+
+**4 orateurs maximum** : Benoît (PO · narratif central) · Kévin (co-démo + Tech) · Sara **ou** Thaïs (UX + personas) · Fabien (Cyber/RGPD).
+
+**Mise en scène physique** : bouteille Punk IPA BrewDog capsulée (alcool 0 % si dégustation) · paquet grains · paquet houblon · cartes de visite Brasse-Bouillon · câble miroir HDMI + adaptateur USB-C.
+
+---
+
+## Convention annotation Canva
+
+Chaque slide Canva affiche un **bandeau d'instructions** en bas, sur fond gris clair, qui sera retiré en batch avant le rendu final (entre J-2 et J-1).
+
+**Format type à coller au bas de chaque slide** :
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsable : [Nom(s)] · Échéance : [J-X] · Statut : [✅ / 🔄 / 🆕]
+Idée centrale : [phrase unique]
+→ Détails complets : PLAN-REDACTION-DECK.md §[SX]
+```
+
+**Règles** :
+
+- Bandeau en bas de slide, fond gris clair (#E0E0E0), texte ≥ 12 pt mais lisible
+- Toujours présent pendant la phase de production
+- **Retrait en batch** par Fabio/Liam (charte) à J-2, après validation finale du contenu
+- **JAMAIS** projeté devant le jury
+
+---
+
+## Légende statuts
+
+- ✅ **Rédigée** — contenu existe, à transposer dans Canva sur charte jaune
+- 🔄 **À adapter** — contenu existe partiellement, à modifier
+- 🆕 **À créer ex nihilo**
+
+---
+
+## S0 — Titre muet
+
+**Statut** : 🔄 À adapter · **Responsable** : Fabio + Liam · **Échéance** : J-7 (vendredi 22 mai 2026) · **Durée** : 30 s (hors chronomètre, projetée avant entrée)
+
+### Idée centrale
+
+> Voici qui on est avant même de commencer.
+
+### Layout
+
+Slide muette, ultra-épurée, fond jaune charte BB. Centrée :
+
+1. Logo Brasse-Bouillon (chef BB sur chope) — gros
+2. Titre principal — **Brasse-Bouillon**
+3. Sous-titre — *L'application des brasseurs amateurs francophones*
+4. Tagline — *Moins d'erreurs. Plus de maîtrise. Plus de fierté.*
+5. Pied — *Pitch Entrepreneurial · Y Days · Ynov Sophia-Antipolis · 27 mai 2026 · Benoît Bremaud, fondateur*
+
+### Notes orales
+
+Aucune — slide muette. Projetée 30 s avant l'entrée des orateurs.
+
+### À NE PAS faire
+
+- ❌ Aucun encart "SUGGESTIONS" / "Proposition deck KISS" résiduel du brouillon actuel
+- ❌ Pas de tableau de structure visible (c'était une note interne)
+- ❌ Pas d'orateur sur scène pendant cette slide
+
+### Ressources
+
+- Logo + hex codes + typo : livrable A4 (Fabio/Liam)
+- Tagline issue de l'ancien deck orange (p43) — récupération validée
+- Charte : [packages/mobile-app/docs/design-system.md](../../../packages/mobile-app/docs/design-system.md)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsable : Fabio + Liam · Échéance : J-7 · Statut : 🔄
+Idée centrale : Slide muette d'accueil (30s avant entrée)
+→ Détails complets : PLAN-REDACTION-DECK.md §S0
+```
+
+---
+
+## S1 — Démo live
+
+**Statut** : 🔄 À adapter · **Responsable** : Benoît + Kévin · **Échéance** : J-7 (script) + J-2 (répétition) · **Durée** : 5:00 (ouverture de la soutenance)
+
+### Idée centrale
+
+> Avant tout discours, voici ce qu'on a construit.
+
+### Layout
+
+Slide sombre minimaliste affichée pendant que le téléphone miroité prend le relais.
+
+1. Mot géant centré : **DÉMONSTRATION**
+2. Sous-titre : *Suivez l'écran — je suis Léa.*
+3. Logo BB discret en coin
+4. Le téléphone via mirroring HDMI/AirPlay prend le relais visuel
+
+### Texte exact slide
+
+| Bloc | Contenu |
+|---|---|
+| Titre central | **DÉMONSTRATION** |
+| Sous-titre | *Suivez l'écran — je suis Léa.* |
+| Logo | BB coin bas droit |
+
+### Notes orales (5:00 chronométrées)
+
+**Setup (30 s)** :
+> "Avant tout discours, je vais vous montrer ce qu'on a construit. Voici Léa, jeune active urbaine, jamais brassé, et qui voudrait reproduire chez elle la bière qu'elle a goûtée chez une amie. *(Prend le téléphone, active le miroir.)* Vous voyez mon écran en temps réel."
+
+**Lancement app (30 s)** :
+> "L'app charge. Voici l'écran d'accueil de Léa : deux options — Explorer des recettes, ou Scanner une bouteille. Elle choisit Scanner. Pas de configuration, pas de profil équipement, pas de douze paramètres à renseigner. Un bouton."
+
+**Scan (1:00)** :
+> "*(Prend la bouteille Punk IPA BrewDog.)* Voici une Punk IPA — six euros en supermarché. Je scanne. *(Scanne.)* Résultat en moins de 3 secondes : style IPA américaine, ABV 5,6 %, IBU 35, profil aromatique — agrumes, résine, fruits tropicaux. Et surtout, une recette équivalente à brasser chez elle. En français."
+
+**Recette + adaptation volume (1:00)** :
+> "Je tape sur la recette. Composition complète : malts Pale Ale et Crystal, houblons Chinook Cascade Simcoe, levure American Ale. Léa a une marmite de 8 litres. Elle tape '8' — les quantités s'ajustent automatiquement depuis le batch de référence à 20 litres. Aucun calcul manuel. Coût estimé : 8 à 10 euros d'ingrédients pour 16 bouteilles. La même bière coûte 6 euros la bouteille en magasin."
+
+**Mode Batch (1:00)** :
+> "Elle lance le Mode Batch. Étape 1 : empâtage, 67 °C, 60 min, timer qui démarre. Étape 2 : rinçage. Étape 3 : ébullition. Chaque transition est guidée, chaque étape expliquée. Elle ne peut pas rater une étape critique. L'app est son assistant de brassin."
+
+**Calculateurs (30 s)** :
+> "En temps réel : ABV prévu 5,4 %, IBU 33, couleur SRM 8 ambre clair. Elle voit à l'avance exactement ce qu'elle va produire."
+
+**Conclusion démo (30 s)** :
+> "Du scan à la recette adaptée à sa marmite : moins de 2 minutes. Sans jargon, sans configuration, sans avoir jamais brassé. *(Repose le téléphone — geste visible.)* C'est ça, Brasse-Bouillon."
+
+### À NE PAS faire
+
+- ❌ Pas d'écran de login devant le jury — l'auth est bypassée via mode démo (PR #823 demo trigger credentials)
+- ❌ Pas de pré-cadrage du type "On a vu les features..." — la démo OUVRE, pas de discours préalable
+- ❌ Pas de consommation d'alcool — la bouteille reste capsulée
+
+### Plan B en cas de plantage
+
+1. **Live échoue** → bascule en mode avion + données seedées locales
+2. **Mode avion échoue** → demo trigger credentials (PR #823)
+3. **Tout échoue** → lecture de la vidéo backup 5 min (livrable B3 de Benoît)
+
+### Ressources
+
+- Script complet existant : [docs/ydays/outputs/pitch-script-bloc3-demo-live.md](../outputs/pitch-script-bloc3-demo-live.md) sur branche `docs/soutenance-27-mai`
+- Matériel : Punk IPA BrewDog (EAN 5060277380019) + paquet grains + paquet houblon + câble HDMI
+- Backend mode démo : PR #823
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsables : Benoît + Kévin · Échéance : J-7 (script) + J-2 (répétition) · Statut : 🔄
+Idée centrale : Ouverture immersive — démo live en 5 min
+→ Détails complets : PLAN-REDACTION-DECK.md §S1
+```
+
+---
+
+## S2 — Qui fait quoi
+
+**Statut** : 🆕 À créer · **Responsables** : Catarina + Clément (captures) + Benoît (montage) · **Échéance** : J-5 (dimanche 24 mai) · **Durée** : 1:00
+
+### Idée centrale
+
+> 9 contributeurs, 5 pôles, 1 produit — voici comment on s'est organisés.
+
+### Layout
+
+Slide en 2 zones horizontales.
+
+**Zone haut (60 %)** — Grille 3 × 3 des 9 contributeurs (avatar ou initiales · prénom · badge rôle) :
+
+| | | |
+|---|---|---|
+| **Benoît** · PO + Dev Full Stack | **Kévin** · Dev Backend | **Sara** · Dev Frontend |
+| **Thaïs** · Dev Frontend | **Clément** · DevOps | **Catarina** · DevOps |
+| **Fabien** · Cybersécurité | **Fabio** · Design UX | **Liam** · Design UX |
+
+**Zone bas (40 %)** — Preuve d'organisation, 2 captures côte à côte :
+
+1. GitHub repo avec issues, labels, projet visible
+2. Channel Discord avec notifications GitHub Actions (front/back/infra/cyber)
+
+**Bandeau pied** : *GitHub + Discord = organisation et coordination quotidienne.*
+
+### Notes orales (50-55 s, dit par Benoît)
+
+> "Nous sommes 9, organisés en 5 pôles : développement, design, cybersécurité, DevOps, et pilotage produit. Je suis Benoît, fondateur et product owner — je piloterai cette présentation. Tout notre code est versionné sur GitHub. Notre coordination passe par Discord — vous voyez ici les notifications CI qui prouvent qu'à chaque commit, tests et review se déclenchent automatiquement. Pour la démo technique, Kévin prendra la parole avec moi."
+
+### À NE PAS faire
+
+- ❌ Pas de listing exhaustif des contributions par personne (surcharge)
+- ❌ Pas de nom complet — juste prénom + rôle
+- ❌ Pas de données sensibles dans les captures (token, secret, email perso)
+- ❌ Pas d'orateurs multiples sur cette slide (juste Benoît)
+
+### Ressources
+
+- Captures à produire par Catarina/Clément (livrable A2) — drop dans [A2-screenshots-organisation/](A2-screenshots-organisation/)
+- Mapping équipe complet : voir mémoire `reference_team_mapping.md`
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Captures : Catarina ou Clément · Montage : Benoît · Échéance : J-5 · Statut : 🆕
+Idée centrale : Notre équipe + preuve d'organisation outillée
+→ Détails complets : PLAN-REDACTION-DECK.md §S2
+```
+
+---
+
+## S3 — Accroche raccourcie / pourquoi BB
+
+**Statut** : 🔄 À adapter · **Responsable** : Benoît · **Échéance** : J-7 (vendredi 22 mai) · **Durée** : 1:30
+
+### Idée centrale
+
+> Voici pourquoi BB existe — et pourquoi c'est moi qui le construis.
+
+### Layout
+
+Photo plein-fond brasseur amateur (cuisine/garage, regard téléphone). 3 phrases en surimpression jaune charte BB :
+
+1. *J'ai voulu brasser ma première bière.*
+2. *J'ai cherché l'app qui m'aiderait.*
+3. *Elle n'existait pas.*
+
+Logo BB + tagline en pied de slide.
+
+### Notes orales (1:30 chronométrées)
+
+**Segment A — Fondateur (30 s)** :
+> "Je suis Benoît Bremaud. Je ne suis pas brasseur de profession — je suis développeur en reconversion, passionné de bière artisanale. Il y a trois ans, j'ai voulu brasser ma première bière chez moi. Une lager simple, quelques litres. Et j'ai cherché une application qui m'aide. En français. Mobile. Accessible à un débutant."
+
+**Segment B — La décision (45 s)** :
+> "Vous venez de voir ce que ça donne aujourd'hui. Il y a trois ans, ça n'existait pas. Alors j'ai pris la décision qui résume cette reconversion : construire l'outil qui me manquait. Pas pour lever des fonds. Pour résoudre un vrai problème que je vivais. Brasse-Bouillon est né de là."
+
+**Segment C — Pivot vers personas (15 s)** :
+> "Et je n'étais pas le seul dans cette situation. Voici les trois profils que Brasse-Bouillon accompagne."
+
+### À NE PAS faire
+
+- ❌ Pas de comparaison concurrentielle ici (Brewfather / Little Bock / Joliebulle = c'est S6 marché)
+- ❌ Pas de listing produit (la démo S1 a déjà montré)
+- ❌ Pas d'accroche en anglais (figé depuis 2026-05-05)
+
+### Ressources
+
+- Photo plein-fond : à choisir/commander (banque d'images libre — Unsplash "homebrew")
+- Script existant à raccourcir : [docs/ydays/outputs/pitch-hook-saynete-v1-cut.md](../outputs/pitch-hook-saynete-v1-cut.md)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsable : Benoît · Échéance : J-7 · Statut : 🔄
+Idée centrale : Founder-fit + pourquoi BB existe (post-démo)
+→ Détails complets : PLAN-REDACTION-DECK.md §S3
+```
+
+---
+
+## S4 — Pour qui (3 personas)
+
+**Statut** : 🔄 À adapter · **Responsables** : Sara + Thaïs (rédaction visuelle Canva) · **Échéance** : J-5 (dimanche 24 mai) · **Durée** : 1:30
+
+### Idée centrale
+
+> 3 profils, 1 app, 3 tiers.
+
+### Layout
+
+3 cartes verticales côte à côte, équilibrées (icône ou silhouette + 4 éléments max chacune).
+
+### Texte exact
+
+| LÉA — La Curieuse | NICOLAS — Le Débutant | MARC — L'Expert |
+|---|---|---|
+| 28 ans · Zéro expérience | 28-35 ans · 1-2 ans pratique | 40-55 ans · 8-15 ans expérience |
+| *« Je veux brasser comme je cuisine — sans me noyer dans la technique. »* | *« Je veux comprendre pourquoi mon brassin était différent du précédent. »* | *« Je veux migrer depuis Brewfather sans perdre 10 ans de recettes. »* |
+| 🟢 **Free** · Scanner illimité · 5 recettes gratuites | 🟡 **Premium 2,99 €/mois** · Recettes illimitées · Journal fermentation · Calculateurs | 🟠 **Pro 5,99 €/mois** · Export BeerXML · IoT · IA FR |
+
+### Notes orales (1:30 chronométrées, dites par Sara ou Thaïs)
+
+**Intro (10 s)** :
+> "Brasse-Bouillon accompagne trois profils, du premier brassin à l'expertise."
+
+**Léa (25 s)** :
+> "Léa a 28 ans, elle n'a jamais brassé. Elle a scanné une bouteille chez une amie et voulu reproduire cette bière chez elle. Elle a besoin que ce soit simple, immédiatement. C'est elle qu'on vient de voir dans la démo."
+
+**Nicolas (25 s)** :
+> "Nicolas brasse depuis 1-2 ans. Il veut comprendre pourquoi son brassin varie d'une fois à l'autre — ABV, IBU, densité de fermentation. Il cherche de la régularité. C'est notre cœur de cible Premium à 2,99 € par mois."
+
+**Marc (25 s)** :
+> "Marc brasse depuis 8 à 15 ans avec un matériel semi-professionnel. Il est abonné Brewfather mais cherche un outil francophone avec des profils d'eau régionaux France. Il représente notre tier Pro à 5,99 € par mois."
+
+**Transition (15 s)** :
+> "Trois profils, un seul principe : simple par défaut, expert sur demande. Voici nos objectifs concrets."
+
+### À NE PAS faire
+
+- ❌ **NE PAS** utiliser les anciens personas Paul Ochon / Justin Tipeu (incohérents avec les tiers, à supprimer du draft actuel)
+- ❌ Pas de photo réaliste (icônes / silhouettes stylisées suffisent)
+- ❌ Pas plus de 4 lignes par carte
+
+### Ressources
+
+- Personas v3 source : [docs/personas/user_personas.md](../../personas/user_personas.md)
+- Charte couleurs tiers : 🟢 Free / 🟡 Premium / 🟠 Pro (à respecter sur S11 modèle éco aussi)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsables : Sara + Thaïs · Échéance : J-5 · Statut : 🔄
+Idée centrale : 3 personas alignés 1:1 avec les 3 tiers freemium
+→ Détails complets : PLAN-REDACTION-DECK.md §S4
+```
+
+---
+
+## S5 — SMART (3 objectifs)
+
+**Statut** : ✅ Rédigée · **Responsable** : Benoît · **Échéance** : J-7 (vendredi 22 mai) · **Durée** : 1:00
+
+### Idée centrale
+
+> 3 objectifs concrets, datés, mesurables.
+
+### Layout
+
+3 blocs verticaux empilés (icône + objectif + métrique + date), chaque bloc équilibré.
+
+### Texte exact
+
+| Bloc 1 — 🚀 LANCEMENT | Bloc 2 — 👥 TRACTION | Bloc 3 — 💰 BREAK-EVEN |
+|---|---|---|
+| Publier BB v1.0 sur App Store + Google Play | Atteindre 500 utilisateurs actifs (≥ 1 brassin réalisé) | Revenus freemium couvrant l'intégralité des OPEX |
+| 11 fonctionnalités validées · note ≥ 4/5 à J+30 | Dans les 3 mois post-lancement | CA cible : 14 k€ an 1 |
+| **→ Avant le 30/09/2026** | **→ Avant le 31/12/2026** | **→ Avant mars 2027 (mois 6 post-lancement)** |
+
+### Notes orales (1:00 chronométrée)
+
+**Intro (10 s)** :
+> "Trois objectifs SMART pour les douze mois qui suivent la soutenance."
+
+**Objectif 1 (15 s)** :
+> "Lancement. Publier Brasse-Bouillon v1.0 sur les deux stores avant le 30 septembre 2026. Les onze fonctionnalités validées, une note utilisateurs supérieure à 4 sur 5 à 30 jours."
+
+**Objectif 2 (15 s)** :
+> "Traction. Atteindre 500 utilisateurs actifs — ayant réalisé au moins un brassin complet — dans les trois premiers mois post-lancement. Avant le 31 décembre 2026."
+
+**Objectif 3 (15 s)** :
+> "Break-even. Revenus freemium couvrant les coûts d'exploitation avant le mois 6. 14 000 euros de chiffre d'affaires en an 1, documenté dans nos projections."
+
+**Conclusion + transition (5 s)** :
+> "Trois objectifs, des dates, des métriques. Pas de vœux pieux."
+
+### À NE PAS faire
+
+- ❌ **NE PAS** utiliser l'ancien SMART orange (3000 inscrits / 60 % actifs / 600 ou 3600 recettes) — incohérent en interne et non SMART
+- ❌ Pas de 4ᵉ objectif ajouté à la dernière minute
+
+### Ressources
+
+- Contenu rédigé : draft PDF p36 (à transposer en charte jaune)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsable : Benoît · Échéance : J-7 · Statut : ✅
+Idée centrale : 3 objectifs SMART (Lancement / Traction / Break-even)
+→ Détails complets : PLAN-REDACTION-DECK.md §S5
+```
+
+---
+
+## S6 — Le marché documenté + sondages équipe
+
+**Statut** : 🔄 À adapter (enrichissement avec sondages équipe) · **Responsable** : Benoît · **Échéance** : J-5 (dimanche 24 mai) · **Durée** : 2:00
+
+### Idée centrale
+
+> Notre cible n'est pas hypothétique — elle est documentée et sondée.
+
+### Layout
+
+2 colonnes verticales équilibrées.
+
+**Colonne gauche — Chiffres macro** :
+
+- 📊 **200-300 k brasseurs amateurs FR**
+- 📈 **36 378 inscrits Little Bock** (demande documentée)
+- 💶 **2-8 Mds€ marché craft FR** · +8-12 %/an
+
+**Colonne droite — Notre étude équipe** :
+
+- 🔍 *« Nous avons interrogé directement notre cible. »*
+- **54 répondants** sondage *« Avez-vous déjà brassé ? »* → 27 % oui (8,3 % régulièrement + 18,8 % quelques fois) · 42 % *« ça m'intéresse »*
+- **30 répondants** sondage freins → **63 % « appréhension du brassage maison »** · 43 % *« suivi temps/étapes »*
+- **48 répondants** intérêt app mobile → **58 % positifs** (20,8 % très intéressé + 37,5 % pourquoi pas)
+
+**Bandeau pied** : *Sources : Little Bock 2026 · brulosophy.com (1 500 brasseurs) · sondages équipe Brasse-Bouillon 2026.*
+
+### Notes orales (2:00 chronométrées)
+
+**Segment macro (45 s)** :
+> "En France, entre 200 et 300 mille personnes brassent chez elles. 36 378 d'entre elles sont inscrites sur Little Bock — c'est notre marché documenté, mesurable, accessible dès aujourd'hui. Le marché de la bière artisanale française pèse entre 2 et 8 milliards d'euros selon les sources, et croît de 8 à 12 % par an."
+
+**Segment sondages équipe (1:00)** :
+> "Et au-delà des chiffres macro, on a fait notre propre travail terrain. 54 personnes interrogées sur la pratique : 27 % brassent déjà, 42 % nous disent que ça les intéresse. 30 personnes interrogées sur les freins : 63 % évoquent l'appréhension du brassage maison — c'est exactement ce que Brasse-Bouillon vient résoudre. 48 personnes interrogées sur l'intérêt d'une app mobile : 58 % positives. Ce n'est pas une étude tierce — c'est notre propre travail de recherche utilisateur qui confirme l'opportunité."
+
+**Transition (15 s)** :
+> "Voilà la demande. Voici notre réponse."
+
+### À NE PAS faire
+
+- ❌ Pas la slide bruloosophy démographie complète (p45 du draft orange) — c'est une étude US, on cite juste la source
+- ❌ Pas de gap concurrentiel détaillé ici (c'est diffus dans S3 et S7)
+- ❌ Pas plus de 3 chiffres par colonne (densité)
+
+### Ressources
+
+- Sondages bruts : pages 45-48 du draft Canva orange (à récupérer auprès de Fabio/Liam)
+- Chiffres macro : [docs/ydays/outputs/chiffres-marche-sources-rigoureuses.md](../outputs/chiffres-marche-sources-rigoureuses.md)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsable : Benoît · Échéance : J-5 · Statut : 🔄
+Idée centrale : Marché documenté + preuve qualitative équipe (recherche UX)
+→ Détails complets : PLAN-REDACTION-DECK.md §S6
+```
+
+---
+
+## S7 — Notre réponse (proposition de valeur)
+
+**Statut** : ✅ Rédigée · **Responsable** : Benoît · **Échéance** : J-7 (vendredi 22 mai) · **Durée** : 1:00
+
+### Idée centrale
+
+> Brasse-Bouillon en 3 promesses.
+
+### Layout
+
+Slide en 2 zones.
+
+**Zone gauche (40 %)** — 3 blocs verticaux (icône + titre + 1 ligne sous-titre) :
+
+1. 📸 **Scannez une bouteille** → Recette équivalente en français, instantanément
+2. 🍺 **Guidé de A à Z** → Ingrédients, brassage, fermentation, dégustation
+3. 🇫🇷 **Gratuit pour commencer** → Freemium, mobile natif, aucun expert requis
+
+**Zone droite (60 %)** — Screenshot mobile de l'écran scanner ou recette (cohérent avec démo S1).
+
+### Notes orales (1:00 chronométrée)
+
+**3 points (45 s)** :
+> "Brasse-Bouillon répond à ce vide en trois points. Un : vous scannez n'importe quelle bouteille — l'app identifie le style, le profil aromatique, et propose une recette équivalente. En français. C'est notre différenciant absolu — aucune application francophone ne fait ça aujourd'hui. Deux : l'app guide de A à Z — choix des ingrédients, calculs automatisés ABV/IBU/densité, suivi étape par étape avec timers, jusqu'à la dégustation. Trois : gratuit pour démarrer. Freemium, mobile natif iOS et Android, pensé pour quelqu'un qui n'a jamais brassé."
+
+**Transition (15 s)** :
+> "Voyons ce qu'on a concrètement livré."
+
+### À NE PAS faire
+
+- ❌ Pas de listing exhaustif des 11 fonctionnalités (c'est S8)
+- ❌ Pas de comparaison frontale avec les concurrents
+
+### Ressources
+
+- Contenu rédigé : draft PDF p10 (à transposer en charte jaune)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsable : Benoît · Échéance : J-7 · Statut : ✅
+Idée centrale : 3 promesses (Scan / Guidé / Gratuit)
+→ Détails complets : PLAN-REDACTION-DECK.md §S7
+```
+
+---
+
+## S8 — Produit / UX
+
+**Statut** : 🔄 À adapter · **Responsables** : Sara + Thaïs (rédaction visuelle Canva) · **Échéance** : J-5 (dimanche 24 mai) · **Durée** : 1:30
+
+### Idée centrale
+
+> Le parcours de Léa, en 3 écrans.
+
+### Layout
+
+3 captures d'écran mobile alignées (chacune ~30 % largeur), légende minimale sous chaque (3 mots max).
+
+| Capture 1 — Scanner | Capture 2 — Recette | Capture 3 — Mode Batch |
+|---|---|---|
+| Overlay caméra + viseur | Ingrédients + adaptation volume | Timer actif + étape en cours |
+
+**Bandeau pied** : *8 features livrées · 3 en v0.2.*
+
+### Notes orales (1:30 chronométrées, dites par Sara **ou** Thaïs)
+
+**Écran 1 Scanner (25 s)** :
+> "Léa pointe son téléphone vers une bouteille. En moins de 3 secondes : la fiche complète — style, ABV, profil aromatique, et surtout une recette équivalente à brasser chez elle. En français. Sans compte, sans configuration."
+
+**Écran 2 Recette (30 s)** :
+> "La recette s'affiche avec ingrédients et quantités. Léa a une marmite de 8 litres — elle tape '8', les quantités s'ajustent automatiquement depuis le batch de référence à 20 litres. Aucun calcul manuel."
+
+**Écran 3 Mode Batch (25 s)** :
+> "Elle lance le Mode Batch. L'app la guide étape par étape : empâtage, rinçage, ébullition, refroidissement, ensemencement de la levure. Chaque étape a son timer. Elle ne peut pas oublier une étape critique."
+
+**Transition (10 s)** :
+> "Ce parcours complet, en moins de 2 minutes. Voyons l'architecture qui le soutient."
+
+### À NE PAS faire
+
+- ❌ Pas de listing des 11 features sur la slide (le bandeau "8/11" suffit)
+- ❌ Pas de wireframe brut (mockups finaux app uniquement)
+- ❌ Pas de palette/typo détaillée affichée (le design est implicite dans les captures)
+
+### Ressources
+
+- Screenshots livrables A1 (Sara/Thaïs) — drop dans [A1-screenshots-app/](A1-screenshots-app/)
+- Design system : [packages/mobile-app/docs/design-system.md](../../../packages/mobile-app/docs/design-system.md)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsables : Sara + Thaïs · Échéance : J-5 · Statut : 🔄
+Idée centrale : Le parcours UX de Léa en 3 écrans (visuel only)
+→ Détails complets : PLAN-REDACTION-DECK.md §S8
+```
+
+---
+
+## S9 — Tech / Architecture
+
+**Statut** : 🆕 À créer · **Responsables** : Kévin + Clément · **Échéance** : J-5 (dimanche 24 mai) · **Durée** : 1:30
+
+### Idée centrale
+
+> Voici comment l'app tient debout techniquement.
+
+### Layout
+
+Schéma d'infrastructure plein écran (Excalidraw ou Mermaid exporté SVG) + 2 lignes de sous-titre.
+
+**Schéma cible** :
+
+```
+📱 Mobile App (React Native + Expo)
+       ↓ HTTPS
+🛡️ API NestJS (backend.brasse-bouillon.com sur Klouders)
+       ↓
+   ├─ 🗄️ Postgres/SQLite (TypeORM)
+   └─ 🤖 Encyclopédie FastAPI (YOLOv8 + EasyOCR)
+```
+
+Alternative : reprendre le schéma p17 du draft actuel (Klouders + LB + Backend + Semaphore runner + Wifi Ynov) et le propre-iser.
+
+**Titre slide** : *Architecture monorepo, backend centralisé*
+**Sous-titre** : *4 packages · 0 appel tiers direct depuis mobile · ADR-0002*
+
+### Notes orales (1:30 chronométrées, dites par Kévin)
+
+> "Côté technique, monorepo qui regroupe quatre packages : mobile React Native et Expo, API NestJS, encyclopédie bière Python avec FastAPI plus YOLOv8 et EasyOCR, et le site vitrine VitePress. Le mobile ne parle qu'à notre API — jamais à un service tiers directement. C'est une décision documentée (ADR-0002) : centraliser pour valider, mettre en cache, garantir la conformité RGPD. Quand un utilisateur scanne une bouteille, le mobile interroge l'API, qui interroge l'encyclopédie Python — qui combine YOLOv8 pour la détection visuelle et EasyOCR pour la lecture des étiquettes."
+
+### À NE PAS faire
+
+- ❌ Pas de listing de bibliothèques / dépendances
+- ❌ Pas de diagramme UML détaillé
+- ❌ Pas l'ERD database (backup Q&A uniquement)
+
+### Ressources
+
+- Schéma source à propre-iser : p17 PDF draft actuel
+- ADR : [docs/architecture/decisions/0002-centralized-nestjs-backend.md](../../architecture/decisions/0002-centralized-nestjs-backend.md)
+- Outils suggérés : Excalidraw (export SVG) ou Mermaid (rendu GitHub natif)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsables : Kévin + Clément · Échéance : J-5 · Statut : 🆕
+Idée centrale : Architecture monorepo + backend centralisé (schéma uniquement)
+→ Détails complets : PLAN-REDACTION-DECK.md §S9
+```
+
+---
+
+## S10 — Qualité + engagement tests utilisateurs
+
+**Statut** : 🆕 À créer · **Responsables** : Clément + Catarina · **Échéance** : J-5 (dimanche 24 mai) · **Durée** : 1:00
+
+### Idée centrale
+
+> On ne déclare pas la qualité — on la prouve.
+
+### Layout
+
+3 chiffres géants alignés horizontalement (police ≥ 96 pt) + ligne basse en plus petit.
+
+| Chiffre 1 | Chiffre 2 | Chiffre 3 |
+|---|---|---|
+| **647** | **0** | **100 %** |
+| tests automatisés | type `any` TypeScript | CI sur chaque PR |
+| *(407 mobile + 240 API)* | *(strict mode partout)* | *(GitHub Actions · lint + typecheck + tests)* |
+
+**Ligne basse (engagement futur)** :
+> 🔬 *Tests utilisateurs : 4-5 sessions planifiées sur bêta — méthodologie : prototype Figma + enregistrement + synthèse des récurrences (coordination Pablo).*
+
+### Notes orales (1:00 chronométrée, dites par Benoît ou Kévin)
+
+> "647 tests automatisés tournent à chaque pull request — 407 sur le mobile, 240 sur l'API. Aucun type approximatif : TypeScript strict partout. Et au-delà des tests automatiques, on s'engage sur 4 à 5 sessions de tests utilisateurs sur version bêta avant le lancement. Méthodologie classique : prototype, enregistrement de session, synthèse des récurrences. Pablo coordonne cette phase."
+
+### À NE PAS faire
+
+- ❌ **NE PAS** prétendre avoir réalisé des tests utilisateurs (le CR jury 2026-05-06 dit explicitement qu'ils ne sont pas faits — honnêteté = crédibilité)
+- ❌ Pas de coverage % (chiffre fragile / non disponible)
+- ❌ Pas de listing des frameworks de test (Jest, supertest, etc.)
+
+### Ressources
+
+- Chiffres à confirmer la veille via `npm run test:all` (ajuster si différent)
+- Convention test H/S/E : [memory `feedback_test_happy_sad_edge`]
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsables : Clément + Catarina · Échéance : J-5 · Statut : 🆕
+Idée centrale : Qualité prouvée (3 chiffres) + engagement tests utilisateurs
+→ Détails complets : PLAN-REDACTION-DECK.md §S10
+```
+
+---
+
+## S11 — Modèle économique
+
+**Statut** : ✅ Rédigée · **Responsable** : Benoît · **Échéance** : J-7 (vendredi 22 mai) · **Durée** : 3:00
+
+### Idée centrale
+
+> Freemium 3 paliers · 3 leviers d'amorçage · trajectoire autofinancée.
+
+### Layout
+
+Slide en 3 zones horizontales empilées.
+
+**Zone 1 — Les paliers (haut, 40 %)** — tableau 3 colonnes :
+
+| 🟢 FREE | 🟡 PREMIUM 2,99 €/mois | 🟠 PRO 5,99 €/mois |
+|---|---|---|
+| Scanner illimité | + Recettes illimitées | + Export BeerXML / JSON |
+| 5 recettes gratuites | + Journal fermentation | + Intégrations IoT (Tilt, iSpindel) |
+| Mode Batch 3 sessions | + Calculateurs avancés | + Assistant IA FR |
+| Encyclopédie lecture | + Communauté écriture | + Support prioritaire |
+
+**Zone 2 — Les leviers (milieu, 25 %)** — 3 pastilles côte à côte :
+
+- 🎯 **Lifetime Deal lancement** — 100 × 99 € = **9 900 € au J0** (couvre CAPEX)
+- 🛒 **Partenariats LHBS** — affiliation boutiques d'ingrédients
+- 🔄 **Marc-Switcher** — −50 % Pro an 1 avec preuve abonnement Brewfather/BeerSmith
+
+**Zone 3 — La trajectoire (bas, 35 %)** — frise temporelle :
+
+| An 1 | An 3 | An 5 |
+|---|---|---|
+| **14 k€** | **57 k€** | **108 k€** |
+| break-even mois 5-6 | 3 400 €/mois net | 6 000 €/mois net |
+| | *seuil « vivre de BB »* | *seuil premier recrutement* |
+
+### Notes orales (3:00 chronométrées)
+
+**Segment A — Les 3 paliers (1:00)** :
+> "Le modèle repose sur un freemium à trois paliers. Le tier Free est généreux — scanner illimité, 5 recettes gratuites, 3 sessions Mode Batch. L'objectif : convertir Léa sans friction. Le tier Premium à 2,99 € par mois débloque les recettes illimitées, le journal de fermentation, les calculateurs avancés et la communauté. C'est le tier Nicolas. Le tier Pro à 5,99 € ajoute l'export BeerXML pour migrer depuis Brewfather sans perte de données, les intégrations IoT, l'assistant IA en français et le support prioritaire. C'est le tier Marc."
+
+**Segment B — Leviers complémentaires (45 s)** :
+> "Trois leviers accélèrent la trésorerie sans dépendance externe. Un Lifetime Deal au lancement : 100 places à 99 € — 9 900 euros de revenus immédiats au jour zéro, qui couvrent le CAPEX. Les partenariats LHBS — les boutiques d'ingrédients référencées dans l'app, avec commission sur les commandes. Et le discount Marc-Switcher : −50 % sur le Pro la première année avec preuve d'abonnement Brewfather ou BeerSmith actif. On capture la base existante là où elle est frustrée."
+
+**Segment C — Trajectoire financière (1:00)** :
+> "La trajectoire est progressive et autofinancée. An 1 : 14 000 euros — break-even atteint mois 5 ou 6. An 3 : 57 000 euros annualisés, soit 3 400 euros par mois net — c'est le seuil « vivre de Brasse-Bouillon ». An 5 : 108 000 euros — 6 000 euros par mois net, seuil du premier recrutement si la traction le justifie. Aucune levée de fonds. Aucune dilution. Modèle volontairement progressif — Brewfather lui-même génère environ 520 000 dollars par an avec moins de 20 000 abonnés premium. Le marché est bootstrappable."
+
+**Transition (15 s)** :
+> "Pour atteindre cette trajectoire, voici notre plan d'acquisition."
+
+### À NE PAS faire
+
+- ❌ **NE PAS** utiliser l'ancien modèle orange (4,99 €/mois + starter pack — incohérent)
+- ❌ Pas de pub in-app (figé : CR jury 2026-05-06)
+- ❌ Pas de kit matériel détaillé (différé v0.2 si temps disponible)
+
+### Ressources
+
+- Contenu rédigé : draft PDF p22-27 (à transposer en charte jaune + structurer en 3 zones)
+- BMC source : [docs/ydays/outputs/business-model-canvas.md](../outputs/business-model-canvas.md)
+- Projections : [docs/ydays/outputs/financial-projections.md](../outputs/financial-projections.md)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsable : Benoît · Échéance : J-7 · Statut : ✅
+Idée centrale : Modèle économique en 3 zones (paliers · leviers · trajectoire)
+→ Détails complets : PLAN-REDACTION-DECK.md §S11
+```
+
+---
+
+## S12 — Plan de communication
+
+**Statut** : 🆕 À créer · **Responsable** : Benoît · **Échéance** : J-5 (dimanche 24 mai) · **Durée** : 2:00
+
+### Idée centrale
+
+> 5 leviers d'acquisition, par priorité, chiffrés.
+
+### Layout
+
+Tableau 3 colonnes × 5 lignes + ligne total.
+
+| # | Levier | Budget an 1 | Projection téléchargements an 1 |
+|---|---|---|---|
+| 1 | 🔍 **SEO + ASO** (blog brassage FR, ASO stores) | **0 €** (temps) | 2 000-5 000 DL (montée progressive) |
+| 2 | 💬 **Communauté FR** (BrassageAmateur, Reddit, Discord) | **0 €** (temps) | 500-1 500 DL (lancement) |
+| 3 | 🛒 **Partenariats LHBS** (boutiques ingrédients) | **0 €** + commission | 300-800 DL (3-5 partenariats signés) |
+| 4 | 🎯 **Orphelins Joliebulle 2025** (ciblage Reddit/forums) | **0 €** | 500-1 000 DL (boost lancement) |
+| 5 | 📹 **Influenceurs YouTube brasseurs FR** | **600-1 500 €** (3 campagnes × 200-500 €) | 1 500-4 000 DL |
+| **Total** | | **600-1 500 €** | **4 800-12 300 DL** → 500-1 500 users actifs an 1 (taux conv 10-15 %) |
+
+### Notes orales (2:00 chronométrées)
+
+**Intro + 5 leviers (1:30)** :
+> "Cinq canaux d'acquisition par ordre de priorité. Quatre coûtent zéro euro et reposent sur le temps investi. Un seul levier payant — les influenceurs YouTube — chiffré à environ 1 000 euros sur l'année. Un : SEO et App Store Optimization — blog brassage FR, tutoriels, recettes — trafic organique long terme. Deux : la communauté existante — BrassageAmateur.com, Reddit r/Brassage, Discord brassicoles — milliers de brasseurs FR actifs, sans outil mobile natif. Trois : partenariats LHBS — boutiques d'ingrédients comme ambassadeurs naturels, leurs clients sont notre cible. Quatre : un segment d'acquisition immédiat — les orphelins de Joliebulle, le seul logiciel gratuit en français fermé en 2025. Cinq : influenceurs YouTube brasseurs FR, 2-3 chaînes ciblées."
+
+**Cohérence avec SMART (15 s)** :
+> "Coût total maîtrisé. Retombée projetée : 500 à 1 500 utilisateurs actifs an 1 — cohérent avec notre objectif SMART de 500 users actifs."
+
+**Transition (15 s)** :
+> "Pour soutenir cette croissance, voici nos perspectives."
+
+### À NE PAS faire
+
+- ❌ Pas de SEM / Meta Ads / TikTok Ads payantes (hors budget solo founder)
+- ❌ Pas de chiffres marketing irréalistes (3 000 inscrits orange = aspirational, pas SMART)
+- ❌ Pas d'influenceurs non identifiés — viser 2-3 chaînes FR concrètes
+
+### Ressources
+
+- GTM source : draft PDF p28-35 segment C (à extraire et chiffrer)
+- Influenceurs FR pistes : [docs/ydays/outputs/influenceurs-canaux-fr.md](../outputs/influenceurs-canaux-fr.md)
+- Outil estimation coûts : Gemini (recommandé par CR jury) pour préciser les tarifs influenceurs
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsable : Benoît · Échéance : J-5 · Statut : 🆕
+Idée centrale : Plan d'acquisition 5 canaux chiffrés
+→ Détails complets : PLAN-REDACTION-DECK.md §S12
+```
+
+---
+
+## S13 — Perspectives 4 quadrants
+
+**Statut** : 🔄 À adapter · **Responsables** : Fabien (quadrant Cyber/RGPD) + Benoît (3 autres quadrants) · **Échéance** : J-5 (dimanche 24 mai) · **Durée** : 3:00
+
+### Idée centrale
+
+> Comment Brasse-Bouillon se structure et se déploie.
+
+### Layout
+
+Grille 2 × 2 équilibrée.
+
+| **Q1 — ⚖️ Légal** (haut gauche) | **Q2 — 👤 RH** (haut droit) |
+|---|---|
+| Micro-entreprise BNC an 1 (plafond 77 k€, charges 22 %) | Solo fondateur an 1 |
+| Dépôt INPI première trésorerie stable | Autofinancement (LTD couvre CAPEX) |
+| **Bascule SASU si CA > 50 k€** | **1ᵉʳ recrutement an 3 si traction** (design ou marketing) |
+| **Q3 — 🛡️ Cyber / RGPD** (bas gauche) | **Q4 — 💰 Budget + Financement** (bas droit) |
+| Document conformité RGPD/OWASP en cours | OPEX 50 €/mois hosting + 124 €/an stores |
+| Mentions légales + CGU + politique données | 3 dossiers fin 2026 : **JEI** (6-8 k€ charges/an) |
+| Authentification chiffrée + HTTPS partout | **BPI French Tech** |
+| Tests de pénétration différés v0.2 | **Incubateur Sophia Antipolis** |
+
+### Notes orales (3:00 chronométrées)
+
+**Q1 — Légal (45 s, Benoît)** :
+> "Sur le plan juridique : micro-entreprise BNC an 1 — plafond 77 000 euros, charges à 22 %. C'est la structure optimale pour un lancement solo autofinancé — simple, réversible, immédiatement opérationnelle. Dépôt de la marque à l'INPI dès la première trésorerie stable. Si le chiffre d'affaires dépasse 50 000 euros ou si le premier recrutement arrive : bascule en SASU."
+
+**Q2 — RH (45 s, Benoît)** :
+> "Sur les ressources humaines : solo fondateur an 1. Brasse-Bouillon se finance lui-même. Le Lifetime Deal couvre le CAPEX. Break-even mois 5-6, puis les revenus récurrents alimentent le développement. An 3, à 3 400 euros par mois net, la question du premier recrutement se pose — design ou marketing communauté, selon où est la friction. Pas avant."
+
+**Q3 — Cyber/RGPD (45 s, Fabien)** :
+> "Côté sécurité, on a fait le choix de l'intégration dès la conception plutôt que l'ajout après coup. Un document de conformité RGPD/OWASP en cours de rédaction. Les mentions légales, CGU et politique de protection des données prêtes pour le dépôt. Authentification chiffrée et HTTPS partout. Les tests de pénétration sont volontairement différés en v0.2 — on a priorisé la robustesse produit avant la sécurité offensive."
+
+**Q4 — Budget + Financement (45 s, Benoît)** :
+> "Le budget d'exploitation est volontairement minimal : 50 euros par mois d'hébergement, 124 euros par an pour les deux app stores. Pas de bureau, pas de charges fixes lourdes. Sur le financement public : trois dossiers à déposer fin 2026 — le statut JEI Jeune Entreprise Innovante, qui peut représenter 6 à 8 mille euros d'économies de charges par an. BPI French Tech. Et l'incubateur régional de Sophia Antipolis — réseau, mentorat, potentiellement du financement amorçage non dilutif."
+
+### À NE PAS faire
+
+- ❌ **NE PAS** prétendre avoir réalisé des tests de sécurité — CR jury 2026-05-06 dit explicitement qu'ils ne sont pas faits
+- ❌ Pas de quadrant GTM ici — c'est S12 désormais
+- ❌ Pas plus de 4 bullets par quadrant (densité)
+- ❌ Pas de chiffres irréalistes sur les financements publics
+
+### Ressources
+
+- Contenu rédigé partiellement : draft PDF p28-35 (segments A, B, D — retirer segment C qui passe en S12)
+- Bullets RGPD : livrable A3 (Fabien) — drop dans [A3-rgpd-bullets/](A3-rgpd-bullets/)
+- Détail légal : [docs/ydays/outputs/legal-structure-options.md](../outputs/legal-structure-options.md)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsables : Fabien (Q3) + Benoît (Q1/Q2/Q4) · Échéance : J-5 · Statut : 🔄
+Idée centrale : 4 quadrants (Légal / RH / Cyber/RGPD / Budget+Financement)
+→ Détails complets : PLAN-REDACTION-DECK.md §S13
+```
+
+---
+
+## S14 — Conclusion + CTA + QR
+
+**Statut** : 🔄 À adapter · **Responsables** : Benoît + Fabio/Liam (visuel) · **Échéance** : J-3 (dimanche 24 mai pour la matière, J-1 pour le QR définitif) · **Durée** : 1:00
+
+### Idée centrale
+
+> Brasser. Partager. Recommencer.
+
+### Layout
+
+**Fond sombre #1A1A1A** (contraste fort avec le jaune dominant — slide finale qui marque).
+
+1. Logo BB centré haut (variante sombre)
+2. **Tagline grand format au centre** : *Brasser. Partager. Recommencer.*
+3. QR code (lien repo GitHub ou landing jury)
+4. Ligne contact basse : *Benoît Bremaud · LinkedIn · GitHub · brasse-bouillon.com*
+5. Tout en bas discret : *Des questions ?*
+
+### Notes orales (1:00 chronométrée)
+
+**Tagline (20 s)** :
+> "Brasse-Bouillon, c'est trois mots. Brasser — l'acte, la passion, le premier brassin de Léa. Partager — la recette, la bouteille, la communauté. Recommencer — parce qu'on s'améliore à chaque brassin. C'est aussi ce que j'ai fait pendant cette reconversion : apprendre, construire, recommencer."
+
+**CTA (25 s)** :
+> "Si vous voulez tester l'application aujourd'hui — le QR code vous emmène directement sur le dépôt GitHub, avec le lien de téléchargement APK et la documentation complète. J'ai des cartes de visite pour chacun d'entre vous."
+
+**Remerciements + ouverture Q&A (15 s)** :
+> "Merci à vous. Merci à mon équipe. Je suis prêt pour vos questions."
+
+### À NE PAS faire
+
+- ❌ Pas de bullets de S7 répétés (la tagline suffit)
+- ❌ Pas de listing membres équipe ici (c'est S2)
+- ❌ Pas de QR code générique non testé (à scanner soi-même avant J-0)
+
+### Ressources
+
+- Contenu rédigé : draft PDF p37 (à transposer en charte jaune sur fond sombre)
+- Logo variante sombre : livrable A4 (Fabio/Liam)
+- URL QR à figer (décision C1 STATUS) : `brasse-bouillon.com/jury` OU repo GitHub direct
+- Cartes de visite : commande Vistaprint à passer J-7 (~50 €)
+
+### Annotation Canva
+
+```
+📋 INSTRUCTIONS — à retirer avant J-0
+Responsables : Benoît + Fabio/Liam (visuel) · Échéance : J-3 · Statut : 🔄
+Idée centrale : Tagline finale + CTA QR + remerciements
+→ Détails complets : PLAN-REDACTION-DECK.md §S14
+```
+
+---
+
+## Note de maintenance
+
+Ce document est la source unique de vérité. À chaque modification d'une slide :
+
+1. Modifier d'abord ce document (PR avec revue Copilot/Codex)
+2. Mettre à jour la slide Canva correspondante
+3. Mettre à jour [STATUS.md](STATUS.md) si statut change
+
+Pour la liste des tâches atomiques équipe et leur suivi : voir [README.md](README.md) et [STATUS.md](STATUS.md).

--- a/docs/ydays/livrables-equipe/PLAN-REDACTION-DECK.md
+++ b/docs/ydays/livrables-equipe/PLAN-REDACTION-DECK.md
@@ -620,8 +620,10 @@ Schéma d'infrastructure plein écran (Excalidraw ou Mermaid exporté SVG) + 2 l
        ↓ HTTPS
 🛡️ API NestJS (backend.brasse-bouillon.com sur Klouders)
        ↓
-   ├─ 🗄️ Postgres/SQLite (TypeORM)
+   ├─ 🗄️ SQLite (TypeORM + better-sqlite3)
    └─ 🤖 Encyclopédie FastAPI (YOLOv8 + EasyOCR)
+
+🌐 Site vitrine statique HTML/CSS/JS (Cloudflare Pages)
 ```
 
 Alternative : reprendre le schéma p17 du draft actuel (Klouders + LB + Backend + Semaphore runner + Wifi Ynov) et le propre-iser.
@@ -631,7 +633,7 @@ Alternative : reprendre le schéma p17 du draft actuel (Klouders + LB + Backend 
 
 ### Notes orales (1:30 chronométrées, dites par Kévin)
 
-> "Côté technique, monorepo qui regroupe quatre packages : mobile React Native et Expo, API NestJS, encyclopédie bière Python avec FastAPI plus YOLOv8 et EasyOCR, et le site vitrine VitePress. Le mobile ne parle qu'à notre API — jamais à un service tiers directement. C'est une décision documentée (ADR-0002) : centraliser pour valider, mettre en cache, garantir la conformité RGPD. Quand un utilisateur scanne une bouteille, le mobile interroge l'API, qui interroge l'encyclopédie Python — qui combine YOLOv8 pour la détection visuelle et EasyOCR pour la lecture des étiquettes."
+> "Côté technique, monorepo qui regroupe quatre packages : mobile React Native et Expo, API NestJS avec base SQLite via TypeORM, encyclopédie bière Python avec FastAPI plus YOLOv8 et EasyOCR, et le site vitrine en HTML/CSS/JS statique servi par Cloudflare Pages. Le mobile ne parle qu'à notre API — jamais à un service tiers directement. C'est une décision documentée (ADR-0002) : centraliser pour valider, mettre en cache, garantir la conformité RGPD. Quand un utilisateur scanne une bouteille, le mobile interroge l'API, qui interroge l'encyclopédie Python — qui combine YOLOv8 pour la détection visuelle et EasyOCR pour la lecture des étiquettes."
 
 ### À NE PAS faire
 
@@ -670,27 +672,29 @@ Idée centrale : Architecture monorepo + backend centralisé (schéma uniquement
 
 | Chiffre 1 | Chiffre 2 | Chiffre 3 |
 |---|---|---|
-| **647** | **0** | **100 %** |
-| tests automatisés | type `any` TypeScript | CI sur chaque PR |
-| *(407 mobile + 240 API)* | *(strict mode partout)* | *(GitHub Actions · lint + typecheck + tests)* |
+| **647** | **strict** | **100 %** |
+| tests automatisés | TypeScript mode | CI sur chaque PR |
+| *(407 mobile + 240 API)* | *(règle `no-explicit-any` ESLint, exceptions tracées)* | *(GitHub Actions · lint + typecheck + tests)* |
 
 **Ligne basse (engagement futur)** :
 > 🔬 *Tests utilisateurs : 4-5 sessions planifiées sur bêta — méthodologie : prototype Figma + enregistrement + synthèse des récurrences (coordination Pablo).*
 
 ### Notes orales (1:00 chronométrée, dites par Benoît ou Kévin)
 
-> "647 tests automatisés tournent à chaque pull request — 407 sur le mobile, 240 sur l'API. Aucun type approximatif : TypeScript strict partout. Et au-delà des tests automatiques, on s'engage sur 4 à 5 sessions de tests utilisateurs sur version bêta avant le lancement. Méthodologie classique : prototype, enregistrement de session, synthèse des récurrences. Pablo coordonne cette phase."
+> "647 tests automatisés tournent à chaque pull request — 407 sur le mobile, 240 sur l'API. TypeScript strict mode partout, règle `no-explicit-any` activée — les rares exceptions sont documentées dans le code. Et au-delà des tests automatiques, on s'engage sur 4 à 5 sessions de tests utilisateurs sur version bêta avant le lancement. Méthodologie classique : prototype, enregistrement de session, synthèse des récurrences. Pablo coordonne cette phase."
 
 ### À NE PAS faire
 
 - ❌ **NE PAS** prétendre avoir réalisé des tests utilisateurs (le CR jury 2026-05-06 dit explicitement qu'ils ne sont pas faits — honnêteté = crédibilité)
+- ❌ **NE PAS** prétendre "0 type any" — il reste 1 cast assumé dans `packages/api/src/auth/decorators/current-user.decorator.ts:55` (Express Request augmenté) à corriger en v0.2
 - ❌ Pas de coverage % (chiffre fragile / non disponible)
 - ❌ Pas de listing des frameworks de test (Jest, supertest, etc.)
 
 ### Ressources
 
 - Chiffres à confirmer la veille via `npm run test:all` (ajuster si différent)
-- Convention test H/S/E : [memory `feedback_test_happy_sad_edge`]
+- Convention test H/S/E (Happy / Sad / Edge cases) — chaque suite couvre les 3 chemins. Voir [packages/mobile-app/CLAUDE.md](../../../packages/mobile-app/CLAUDE.md) §Testing
+- Audit des `any` résiduels (1 occurrence) : `packages/api/src/auth/decorators/current-user.decorator.ts:55` — à corriger en v0.2
 
 ### Annotation Canva
 
@@ -878,7 +882,9 @@ Grille 2 × 2 équilibrée.
 
 - Contenu rédigé partiellement : draft PDF p28-35 (segments A, B, D — retirer segment C qui passe en S12)
 - Bullets RGPD : livrable A3 (Fabien) — drop dans [A3-rgpd-bullets/](A3-rgpd-bullets/)
-- Détail légal : [docs/ydays/outputs/legal-structure-options.md](../outputs/legal-structure-options.md)
+- Détail légal : [docs/ydays/outputs/statut-juridique-analyse.md](../outputs/statut-juridique-analyse.md)
+- Capex + financement : [docs/ydays/outputs/capex-financement.md](../outputs/capex-financement.md)
+- Options de financement public : [docs/ydays/outputs/financement-options-fr.md](../outputs/financement-options-fr.md)
 
 ### Annotation Canva
 

--- a/docs/ydays/livrables-equipe/README.md
+++ b/docs/ydays/livrables-equipe/README.md
@@ -21,6 +21,10 @@
 | [`A3-rgpd-bullets/`](A3-rgpd-bullets/) | **Fabien** | 1 page A4 bullets RGPD | dim 24 mai 2026 |
 | [`A4-charte/`](A4-charte/) | **Fabio ou Liam** | Hex codes + logo PNG + typo | ven 22 mai 2026 |
 
+## Plan de rédaction détaillé du deck
+
+Voir [`PLAN-REDACTION-DECK.md`](PLAN-REDACTION-DECK.md) — document de référence avec **1 chapitre par slide** (S0 à S14) : idée centrale · layout · texte exact · notes orales · à ne pas faire · ressources · responsable · deadline. C'est la source unique de vérité avant toute modification de slide.
+
 ## Suivi en temps réel
 
 Voir [`STATUS.md`](STATUS.md) pour l'état d'avancement (cochage manuel à chaque livraison).


### PR DESCRIPTION
## Summary

Adds `docs/ydays/livrables-equipe/PLAN-REDACTION-DECK.md` — the reference document containing one chapter per slide (S0-S14) for the 27 May soutenance deck. Each Canva slide will carry a small "INSTRUCTIONS" footer pointing to its chapter in this file; the spec itself stays in this single Markdown.

## Why

The previous coordination model had spec details scattered across Discord threads, READMEs, and Canva slides themselves. That created drift risk (Discord != README != slide) and forced each Canva slide to embed enough information to be self-explanatory. Single source of truth fixes both: the Markdown is the spec, the Canva slide is the rendering.

## What's in this PR

- `PLAN-REDACTION-DECK.md` (new, ~860 lines)
  - Cadrage transversal (charte, density, timing 5+25)
  - Canva annotation convention (visible footer block, removed before J-0)
  - 15 chapters (S0-S14), each with: central idea, layout, exact text, timed oral notes, what-not-to-do, resources, responsible, deadline, status, Canva annotation snippet
- `README.md` — adds a link to the new plan
- `PROJECT_LOG.md` — log entry for the just-merged PR #1004 (folder structure + round-1 review fixes)

## Test plan

- [x] All 15 slides have a chapter
- [x] Each chapter follows the same structure (idée centrale / layout / texte / notes orales / à ne pas faire / ressources / annotation Canva)
- [x] Status flags consistent (rédigée / à adapter / à créer)
- [x] Responsibles match the team distribution acted on PR #1004
- [x] PROJECT_LOG entry follows the project-log-entry skill convention
- [ ] PR reviewed by Copilot + Codex