### PR TITLE
docs(ydays): correct soutenance venue + rehearsal context

### DIFF
--- a/docs/ydays/livrables-equipe/PLAN-REDACTION-DECK.md
+++ b/docs/ydays/livrables-equipe/PLAN-REDACTION-DECK.md
@@ -29,7 +29,7 @@
 
 ## Cadrage transversal
 
-**Date soutenance** : mercredi 27 mai 2026 · Salle 0.301 (R+3 Ynov Sophia-Antipolis) · Catégorie Pitch Entrepreneurial · Format 30 min présentation + 10 min Q&A.
+**Date soutenance** : mercredi 27 mai 2026 · Campus Ynov Sophia-Antipolis · Salle + créneau horaire **à confirmer par Ynov** · Catégorie Pitch Entrepreneurial · Format 30 min présentation + 10 min Q&A.
 
 **Charte officielle** : jaune (palette houblon Brasse-Bouillon). Hex codes + logo + typo livrés par Fabio/Liam — atome A4. Toute slide produite sur cette charte unique.
 

--- a/docs/ydays/livrables-equipe/STATUS.md
+++ b/docs/ydays/livrables-equipe/STATUS.md
@@ -23,7 +23,7 @@
 | **B4** | Document RGPD complet (à partir A3) | lun 25 mai | ⬜ | — | Impression couleur |
 | **B5** | Cartes de visite commandées | ven 22 mai | ⬜ | — | Vistaprint 100 ex ~50 € |
 | **B6** | Matériel démo réuni | dim 24 mai | ⬜ | — | Punk IPA + grains + houblon + câbles |
-| **B7** | Répétition complète chronométrée 30+10 | lun 25 mai | ⬜ | — | Salle campus |
+| **B7** | Répétition complète chronométrée 30+10 | lun 25 mai | ⬜ | — | Distanciel Teams/Discord (lundi de Pentecôte = férié) |
 
 ## Décisions critiques (Benoît)
 


### PR DESCRIPTION
## Summary

Two factual corrections to the soutenance coordination docs:

1. `PLAN-REDACTION-DECK.md` "Cadrage transversal": the venue line stated `Salle 0.301 (R+3 Ynov Sophia-Antipolis)` as if confirmed. In reality the room and time slot are **still to be assigned by Ynov**. Replaced with `Salle + créneau horaire à confirmer par Ynov`.

2. `STATUS.md` row B7 (rehearsal): the Notes column said `Salle campus`. **Monday 25 May 2026 is Lundi de Pentecôte** (French bank holiday) — no on-campus rehearsal possible. The full-deck rehearsal will run **remotely via Teams or Discord**.

## Why this matters

The Discord broadcast about to be sent to the team includes these two pieces of info. Sending false venue/date details would create avoidable coordination drift (team members showing up at a non-confirmed room, or assuming an on-campus rehearsal that can't happen).

## Test plan

- [x] `grep -rn "0.301" docs/ydays/livrables-equipe/` returns no match
- [x] `grep -rn "Salle campus" docs/ydays/livrables-equipe/` returns no match
- [x] Both files compile / render correctly on GitHub