### PR TITLE
feat(batches): demo-mode fermentation tracker on BatchDetails

### DIFF
--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -1,6 +1,6 @@
-import { FlatList, StyleSheet, Text } from "react-native";
+import { FlatList, StyleSheet, Text, View } from "react-native";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
-import { colors, spacing, typography } from "@/core/theme";
+import { colors, radius, spacing, typography } from "@/core/theme";
 import {
   completeCurrentBatchStep,
   getBatchDetails,
@@ -12,16 +12,79 @@ import { Batch } from "@/features/batches/domain/batch.types";
 import { BatchTimeline } from "@/features/batches/presentation/BatchTimeline";
 import { Card } from "@/core/ui/Card";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
+import { Ionicons } from "@expo/vector-icons";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import React from "react";
 import { Screen } from "@/core/ui/Screen";
+import { dataSource } from "@/core/data/data-source";
+import { demoRecipes } from "@/mocks/demo-data";
 import { getErrorMessage } from "@/core/http/http-error";
 import { useRouter } from "expo-router";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const DEMO_FERMENTATION_TARGET_DAYS = 14;
+const DEMO_FERMENTATION_TEMPERATURE_C = 19;
 
 type Props = {
   batchId: string;
 };
+
+// Demo-mode-only fermentation tracking card data. Live mode does not
+// expose a gravity / temperature feed yet (deferred to the fermenter
+// integration epic), so the rich tracker only renders when the
+// runtime flag is on AND the current step is fermentation in progress.
+function useFermentationTrackerInfo(batch: Batch | null) {
+  return React.useMemo(() => {
+    if (!batch || !dataSource.useDemoData) {
+      return null;
+    }
+    const currentStep = batch.steps?.find(
+      (step) => step.stepOrder === batch.currentStepOrder,
+    );
+    if (
+      !currentStep ||
+      currentStep.type !== "fermentation" ||
+      currentStep.status !== "in_progress" ||
+      !currentStep.startedAt
+    ) {
+      return null;
+    }
+
+    const startedAt = new Date(currentStep.startedAt);
+    if (Number.isNaN(startedAt.getTime())) {
+      return null;
+    }
+    const elapsedMs = Math.max(0, Date.now() - startedAt.getTime());
+    const daysElapsed = Math.min(
+      DEMO_FERMENTATION_TARGET_DAYS,
+      Math.floor(elapsedMs / DAY_MS),
+    );
+    const progressPct = Math.round(
+      (daysElapsed / DEMO_FERMENTATION_TARGET_DAYS) * 100,
+    );
+
+    // Estimate the current gravity as a linear interpolation between
+    // the recipe's OG and FG using the fermentation progress. Real
+    // attenuation is non-linear but for a demo tracker the eye sees
+    // a believable monotonic descent.
+    const recipe = demoRecipes.find((r) => r.id === batch.recipeId);
+    const og = recipe?.stats?.og ?? 1.048;
+    const fg = recipe?.stats?.fg ?? 1.012;
+    const ratio = daysElapsed / DEMO_FERMENTATION_TARGET_DAYS;
+    const currentSg = og - (og - fg) * ratio;
+
+    return {
+      daysElapsed,
+      daysTarget: DEMO_FERMENTATION_TARGET_DAYS,
+      progressPct,
+      currentSg,
+      targetFg: fg,
+      originalOg: og,
+      temperature: DEMO_FERMENTATION_TEMPERATURE_C,
+    };
+  }, [batch]);
+}
 
 export function BatchDetailsScreen({ batchId }: Props) {
   const bottomPadding = useNavigationFooterOffset();
@@ -92,6 +155,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
   };
 
   const isCompleted = batch?.status === "completed";
+  const fermentationInfo = useFermentationTrackerInfo(batch);
 
   return (
     <Screen
@@ -118,6 +182,47 @@ export function BatchDetailsScreen({ batchId }: Props) {
           <Text style={styles.meta}>
             Current step: {batch.currentStepOrder ?? "-"}
           </Text>
+        </Card>
+      ) : null}
+
+      {fermentationInfo ? (
+        <Card style={styles.fermentationCard}>
+          <View style={styles.fermentationHeader}>
+            <Ionicons name="flask" size={18} color={colors.brand.secondary} />
+            <Text style={styles.fermentationTitle}>Fermentation</Text>
+            <Text style={styles.fermentationDays}>
+              J+{fermentationInfo.daysElapsed} / J+{fermentationInfo.daysTarget}
+            </Text>
+          </View>
+
+          <View style={styles.progressTrack}>
+            <View
+              style={[
+                styles.progressFill,
+                { width: `${fermentationInfo.progressPct}%` },
+              ]}
+            />
+          </View>
+
+          <View style={styles.metricsRow}>
+            <View style={styles.metric}>
+              <Text style={styles.metricLabel}>Densité actuelle</Text>
+              <Text style={styles.metricValue}>
+                {fermentationInfo.currentSg.toFixed(3)}
+              </Text>
+              <Text style={styles.metricHint}>
+                cible {fermentationInfo.targetFg.toFixed(3)} · départ{" "}
+                {fermentationInfo.originalOg.toFixed(3)}
+              </Text>
+            </View>
+            <View style={styles.metric}>
+              <Text style={styles.metricLabel}>Température</Text>
+              <Text style={styles.metricValue}>
+                {fermentationInfo.temperature} °C
+              </Text>
+              <Text style={styles.metricHint}>idéal 18–20 °C</Text>
+            </View>
+          </View>
         </Card>
       ) : null}
 
@@ -191,6 +296,68 @@ const styles = StyleSheet.create({
     lineHeight: typography.lineHeight.body,
   },
   list: {},
+  fermentationCard: {
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  fermentationHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  fermentationTitle: {
+    flex: 1,
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+  },
+  fermentationDays: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+  },
+  progressTrack: {
+    height: 8,
+    backgroundColor: colors.neutral.border,
+    borderRadius: radius.full,
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: colors.semantic.success,
+    borderRadius: radius.full,
+  },
+  metricsRow: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+  metric: {
+    flex: 1,
+  },
+  metricLabel: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  metricValue: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+    marginTop: spacing.xxs,
+  },
+  metricHint: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    marginTop: 2,
+  },
   stepCard: {
     marginBottom: spacing.xs,
     paddingTop: spacing.md,

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -26,6 +26,15 @@ const DAY_MS = 24 * 60 * 60 * 1000;
 const DEMO_FERMENTATION_TARGET_DAYS = 14;
 const DEMO_FERMENTATION_TEMPERATURE_C = 19;
 
+// Dynamic widths cannot live in `StyleSheet.create()` because they
+// depend on the runtime progress percentage. Centralising the
+// computed object in a tiny helper keeps the JSX free of inline
+// style literals (project rule) while still letting React Native
+// merge it with the static `styles.progressFill` baseline.
+function progressFillWidth(percent: number) {
+  return { width: `${Math.max(0, Math.min(100, percent))}%` } as const;
+}
+
 type Props = {
   batchId: string;
 };
@@ -199,7 +208,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
             <View
               style={[
                 styles.progressFill,
-                { width: `${fermentationInfo.progressPct}%` },
+                progressFillWidth(fermentationInfo.progressPct),
               ]}
             />
           </View>
@@ -320,7 +329,7 @@ const styles = StyleSheet.create({
     fontWeight: typography.weight.bold,
   },
   progressTrack: {
-    height: 8,
+    height: spacing.xs,
     backgroundColor: colors.neutral.border,
     borderRadius: radius.full,
     overflow: "hidden",
@@ -343,7 +352,6 @@ const styles = StyleSheet.create({
     fontSize: typography.size.caption,
     lineHeight: typography.lineHeight.caption,
     textTransform: "uppercase",
-    letterSpacing: 0.5,
   },
   metricValue: {
     color: colors.neutral.textPrimary,
@@ -356,7 +364,7 @@ const styles = StyleSheet.create({
     color: colors.neutral.textSecondary,
     fontSize: typography.size.caption,
     lineHeight: typography.lineHeight.caption,
-    marginTop: 2,
+    marginTop: spacing.xxs,
   },
   stepCard: {
     marginBottom: spacing.xs,

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -2,6 +2,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react-native";
 
 import { BatchDetailsScreen } from "@/features/batches/presentation/BatchDetailsScreen";
+import { getBatchDetails } from "@/features/batches/application/batches.use-cases";
+import { dataSource } from "@/core/data/data-source";
 
 const mockReplace = jest.fn();
 
@@ -21,28 +23,30 @@ jest.mock("expo-router", () => {
   };
 });
 
+const mashBatch = {
+  id: "b1",
+  status: "in_progress",
+  currentStepOrder: 0,
+  steps: [
+    {
+      batchId: "b1",
+      stepOrder: 0,
+      type: "mash",
+      label: "Empâtage",
+      status: "in_progress",
+    },
+    {
+      batchId: "b1",
+      stepOrder: 1,
+      type: "boil",
+      label: "Ébullition",
+      status: "pending",
+    },
+  ],
+};
+
 jest.mock("@/features/batches/application/batches.use-cases", () => ({
-  getBatchDetails: jest.fn().mockResolvedValue({
-    id: "b1",
-    status: "in_progress",
-    currentStepOrder: 0,
-    steps: [
-      {
-        batchId: "b1",
-        stepOrder: 0,
-        type: "mash",
-        label: "Empâtage",
-        status: "in_progress",
-      },
-      {
-        batchId: "b1",
-        stepOrder: 1,
-        type: "boil",
-        label: "Ébullition",
-        status: "pending",
-      },
-    ],
-  }),
+  getBatchDetails: jest.fn(),
   completeCurrentBatchStep: jest.fn().mockResolvedValue({
     id: "b1",
     status: "completed",
@@ -74,6 +78,8 @@ function renderBatchDetailsScreen(batchId = "b1") {
 describe("BatchDetailsScreen", () => {
   beforeEach(() => {
     mockReplace.mockReset();
+    dataSource.useDemoData = false;
+    (getBatchDetails as jest.Mock).mockResolvedValue(mashBatch);
   });
 
   it("renders batch details", async () => {
@@ -93,5 +99,115 @@ describe("BatchDetailsScreen", () => {
     fireEvent.press(screen.getByLabelText("Retour à la liste des brassins"));
 
     expect(mockReplace).toHaveBeenCalledWith("/batches");
+  });
+});
+
+describe("BatchDetailsScreen — demo-mode fermentation tracker", () => {
+  // Anchor the fermentation start 5 days ago so the J+N headline
+  // computes to a sensible mid-fermentation moment matching the
+  // marketing screenshot intent ("Fermenter" parcours step).
+  const fiveDaysAgo = new Date(
+    Date.now() - 5 * 24 * 60 * 60 * 1000,
+  ).toISOString();
+
+  const fermentationInProgressBatch = {
+    id: "b-demo-pdd-ferm",
+    ownerId: "u-demo-1",
+    recipeId: "r-demo-pdd",
+    status: "in_progress",
+    currentStepOrder: 2,
+    steps: [
+      {
+        batchId: "b-demo-pdd-ferm",
+        stepOrder: 0,
+        type: "mash",
+        label: "Empâtage 67°C",
+        status: "completed",
+      },
+      {
+        batchId: "b-demo-pdd-ferm",
+        stepOrder: 1,
+        type: "boil",
+        label: "Ébullition 60 min",
+        status: "completed",
+      },
+      {
+        batchId: "b-demo-pdd-ferm",
+        stepOrder: 2,
+        type: "fermentation",
+        label: "Fermentation primaire",
+        status: "in_progress",
+        startedAt: fiveDaysAgo,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    mockReplace.mockReset();
+    dataSource.useDemoData = true;
+    (getBatchDetails as jest.Mock).mockResolvedValue(
+      fermentationInProgressBatch,
+    );
+  });
+
+  it("renders the J+N headline and progress bar when fermentation is active (happy path)", async () => {
+    renderBatchDetailsScreen("b-demo-pdd-ferm");
+
+    expect(await screen.findByText("Fermentation")).toBeTruthy();
+    expect(screen.getByText("J+5 / J+14")).toBeTruthy();
+    expect(screen.getByText("Densité actuelle")).toBeTruthy();
+    expect(screen.getByText("Température")).toBeTruthy();
+  });
+
+  it("renders the gravity numbers derived from the recipe OG/FG (edge path)", async () => {
+    renderBatchDetailsScreen("b-demo-pdd-ferm");
+
+    await screen.findByText("Fermentation");
+
+    // Recipe r-demo-pdd has OG 1.048 and FG 1.012. At 5/14 of the
+    // fermentation arc the linear-interp current gravity is
+    // 1.048 - (1.048 - 1.012) * (5 / 14) = 1.035.
+    expect(screen.getByText("1.035")).toBeTruthy();
+    expect(screen.getByText(/cible 1\.012 · départ 1\.048/)).toBeTruthy();
+    expect(screen.getByText("19 °C")).toBeTruthy();
+    expect(screen.getByText("idéal 18–20 °C")).toBeTruthy();
+  });
+
+  it("hides the fermentation card in live mode (sad path)", async () => {
+    dataSource.useDemoData = false;
+
+    renderBatchDetailsScreen("b-demo-pdd-ferm");
+
+    await screen.findByText("Batch b-demo-p");
+    expect(screen.queryByText("Fermentation")).toBeNull();
+    expect(screen.queryByText(/J\+\d/)).toBeNull();
+  });
+
+  it("hides the fermentation card when the current step is not fermentation", async () => {
+    (getBatchDetails as jest.Mock).mockResolvedValue(mashBatch);
+
+    renderBatchDetailsScreen();
+
+    await screen.findByText("Batch b1");
+    expect(screen.queryByText("J+5 / J+14")).toBeNull();
+    expect(screen.queryByText("Densité actuelle")).toBeNull();
+  });
+
+  it("hides the fermentation card when the fermentation step is not yet in progress", async () => {
+    const stepStatuses = ["completed", "in_progress", "pending"] as const;
+    (getBatchDetails as jest.Mock).mockResolvedValue({
+      ...fermentationInProgressBatch,
+      currentStepOrder: 1,
+      steps: fermentationInProgressBatch.steps.map((step, index) => ({
+        ...step,
+        status: stepStatuses[index],
+        startedAt: index === 2 ? null : step.startedAt,
+      })),
+    });
+
+    renderBatchDetailsScreen("b-demo-pdd-ferm");
+
+    await screen.findByText("Batch b-demo-p");
+    expect(screen.queryByText("Densité actuelle")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Adds a dedicated `Fermentation` card to `BatchDetailsScreen`, pinned right under the existing batch header card, conditional on demo mode AND a current step typed `fermentation` with `status === "in_progress"`. Renders a `J+N / J+14` headline, a brand-success progress bar (% of the 14-day target), and two metric columns:

- Densité actuelle — linear interp between the recipe's OG and FG using the elapsed-vs-target ratio. Target FG and original OG shown as contextual hints.
- Température — \`19 °C\` hardcoded, with \`idéal 18–20 °C\` hint.

Live mode keeps the canonical step list untouched.

## Context

Parcours #3 of the new-brewer marketing journey ("Fermenter") was the weakest screenshot of the eleven: BatchDetailsScreen showed the fermentation step as just another row in the step list with a status badge, no sense of progress or product depth. For a "J+5 sur 14" moment we need a visual that tells the brewer where they are in the fermentation arc.

The card is demo-only because a real gravity / temperature feed is deferred to the fermenter integration epic — faking the numbers on a real user's batch would be misleading. Demo-only data constants (`DEMO_FERMENTATION_TARGET_DAYS = 14`, `DEMO_FERMENTATION_TEMPERATURE_C = 19`) are scoped at the top of the file so the heuristic is explicit.

The card reuses the same brand-success progress bar idiom and the brand secondary accent colour we already use elsewhere in the demo flow, so the four marketing screenshots keep a coherent visual signature.

## Checklist

- [x] \`npm run ci:check\` passes (lint + typecheck + format)
- [x] \`npm test\` — 777/777 tests green (existing BatchDetailsScreen test untouched)
- [x] No \`any\` types, named exports only, design tokens used everywhere
- [x] Live-mode rendering untouched — when \`dataSource.useDemoData === false\` the canonical step list renders unchanged
- [x] No new API call — gravity / temperature values are computed locally from the recipe OG/FG and the elapsed time