### PR TITLE
ci(website): GitHub Pages deploy workflow + reclaim brasse-bouillon.com from archived repo

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,0 +1,86 @@
+name: Website Deploy
+
+# Deploy the marketing site under `packages/website/` to GitHub Pages
+# whenever website assets change on `main`, or manually via the Actions
+# tab.
+#
+# The site used to live in a separate `brasse-bouillon-website` repo
+# (archived) which still owns the `brasse-bouillon.com` CNAME from its
+# legacy "Deploy from branch" Pages configuration. This workflow
+# replaces that legacy setup: it stages only the public files
+# (HTML / CSS / JS / images / CNAME / sitemap / screenshots / seo),
+# uploads them as a Pages artifact, and lets `actions/deploy-pages`
+# publish them as the canonical site source.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/website/**"
+      - ".github/workflows/website-deploy.yml"
+  workflow_dispatch:
+
+# A single in-flight Pages deployment at a time.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/configure-pages@v5
+
+      # Stage only the public-facing site under `_site/`. Everything that
+      # ships to the browser is whitelisted here; internal repo files
+      # (docs/, scripts/, tests/, CHANGELOG.md, CONTRIBUTING.md, README.md,
+      # CLAUDE.md, package.json, sonar-project.properties) stay out of
+      # the deployment.
+      - name: Stage public site assets
+        run: |
+          set -euo pipefail
+          mkdir -p _site
+          src=packages/website
+
+          # HTML / CSS / JS at the root of the website package
+          cp "$src"/*.html _site/
+          cp "$src"/site.css _site/
+          cp "$src"/site.js _site/
+
+          # Brand + tab assets
+          cp "$src"/*.png _site/
+          cp "$src"/*.svg _site/
+          cp "$src"/favicon.ico _site/
+          cp "$src"/CNAME _site/
+
+          # SEO surface and screenshots
+          cp "$src"/sitemap.xml _site/
+          cp "$src"/robots.txt _site/
+          # Optional dirs — copied when present, skipped silently otherwise.
+          [ -d "$src/seo" ] && cp -R "$src/seo" _site/seo || true
+          [ -d "$src/screenshots" ] && cp -R "$src/screenshots" _site/screenshots || true
+
+          echo "::group::Deployment payload"
+          find _site -maxdepth 2 -type f | sort
+          echo "::endgroup::"
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -37,32 +37,46 @@ jobs:
 
       # Stage only the public-facing site under `_site/`. Everything that
       # ships to the browser is whitelisted here; internal repo files
-      # (docs/, scripts/, tests/, CHANGELOG.md, CONTRIBUTING.md, README.md,
-      # CLAUDE.md, package.json, sonar-project.properties) stay out of
-      # the deployment.
+      # (scripts/, tests/, CHANGELOG.md, CONTRIBUTING.md, README.md,
+      # CLAUDE.md, package.json, sonar-project.properties, and the
+      # internal portion of docs/ such as GOVERNANCE.md, SEO_RUNBOOK.md,
+      # weekly/) stay out of the deployment.
       - name: Stage public site assets
         run: |
           set -euo pipefail
+          # Empty globs become empty lists (instead of leaving the literal
+          # in place), so `cp` is not called with a missing source if an
+          # asset class disappears one day — Codex P2 on PR #1020.
+          shopt -s nullglob
+
           mkdir -p _site
           src=packages/website
 
-          # HTML / CSS / JS at the root of the website package
-          cp "$src"/*.html _site/
-          cp "$src"/site.css _site/
-          cp "$src"/site.js _site/
+          # Glob copies — tolerate empty matches.
+          for f in "$src"/*.html "$src"/*.css "$src"/*.js "$src"/*.png "$src"/*.svg; do
+            cp "$f" _site/
+          done
 
-          # Brand + tab assets
-          cp "$src"/*.png _site/
-          cp "$src"/*.svg _site/
-          cp "$src"/favicon.ico _site/
-          cp "$src"/CNAME _site/
+          # Required scalar files — fail loudly if any go missing.
+          for required in favicon.ico CNAME sitemap.xml robots.txt; do
+            cp "$src/$required" _site/
+          done
 
-          # SEO surface and screenshots
-          cp "$src"/sitemap.xml _site/
-          cp "$src"/robots.txt _site/
-          # Optional dirs — copied when present, skipped silently otherwise.
-          [ -d "$src/seo" ] && cp -R "$src/seo" _site/seo || true
-          [ -d "$src/screenshots" ] && cp -R "$src/screenshots" _site/screenshots || true
+          # Optional public directories.
+          if [ -d "$src/seo" ]; then
+            cp -R "$src/seo" _site/seo
+          fi
+          if [ -d "$src/screenshots" ]; then
+            cp -R "$src/screenshots" _site/screenshots
+          fi
+
+          # Public docs explicitly linked from the homepage. ROADMAP.md
+          # is reachable via `<a href="docs/ROADMAP.md">` on both
+          # index.html (line 316) and index-en.html (line 253) — without
+          # this copy the link 404s after deploy. Other docs/ contents
+          # (GOVERNANCE.md, SEO_RUNBOOK.md, weekly/) stay internal.
+          mkdir -p _site/docs
+          cp "$src/docs/ROADMAP.md" _site/docs/ROADMAP.md
 
           echo "::group::Deployment payload"
           find _site -maxdepth 2 -type f | sort

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -25,14 +25,11 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -78,6 +75,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -4,8 +4,8 @@
 
 **Name:** Brasse Bouillon — Marketing Website
 **Stack:** Static HTML/CSS/JS, no framework. Hosted on GitHub Pages with custom domain via `CNAME`.
-**Deployment:** PR merge to `main` triggers GitHub Pages publication.
-**Quality gate:** Python script under `scripts/quality_gate.py`, tested in `tests/test_quality_gate.py`.
+**Deployment:** any push to `main` whose diff touches `packages/website/**` triggers the [`website-deploy.yml`](../../.github/workflows/website-deploy.yml) workflow, which stages the public files into `_site/` and publishes via `actions/deploy-pages`. Can also be re-run manually from the Actions tab (`workflow_dispatch`).
+**Quality gate:** Python script under `scripts/quality_gate.py`, tested in `tests/test_quality_gate.py`, executed by the `website:` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) on every PR that touches the package.
 
 The site is a thin marketing surface — not a SaaS frontend. Persistent product UX lives in `packages/mobile-app`.
 

--- a/packages/website/CONTRIBUTING.md
+++ b/packages/website/CONTRIBUTING.md
@@ -10,17 +10,20 @@ This document describes the Git workflow, branch/commit conventions, and quality
 
 | Branch | Role |
 |---|---|
-| `main` | Production (GitHub Pages deployment) |
-| `develop` | Continuous integration |
-| `feature/*` | Feature work |
+| `main` | Production (auto-deployed by [`website-deploy.yml`](../../.github/workflows/website-deploy.yml)) |
+| `feat/*` | Feature work |
+| `fix/*` | Targeted fixes |
 | `docs/*` | Documentation and governance |
-| `bugfix/*` | Targeted fixes |
+| `refactor/*` | Refactors with no behaviour change |
+| `chore/*` | Maintenance, CI, dependencies |
 
 Rules:
 1. Do not push directly to `main`.
-2. Open a PR to `develop`.
+2. Open a PR to `main`.
 3. Link the PR to its issue (example: `Refs #52`).
 4. Wait for green CI checks before merge.
+
+The `develop` integration branch from the standalone-website era no longer exists — the monorepo uses a single trunk model.
 
 ---
 
@@ -28,9 +31,9 @@ Rules:
 
 Use `kebab-case`:
 
-- `feature/epic-c-website-ci-cd`
-- `docs/epic-d-governance`
-- `bugfix/fix-french-cta-spacing`
+- `feat/website-pages-deploy`
+- `docs/website-governance`
+- `fix/french-cta-spacing`
 
 ---
 

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -1,8 +1,8 @@
 # Brasse-Bouillon Website
 
-Official website repository for the **Brasse-Bouillon** project.
+Marketing site package inside the **Brasse-Bouillon** monorepo (imported from the standalone `brasse-bouillon-website` repo on 2026-03-24 via `git subtree`).
 
-This repository contains a bilingual static landing page (FR/EN) and its CI/CD pipeline (quality gates + GitHub Pages deployment).
+This package contains a bilingual static landing page (FR/EN). Quality gates run in the monorepo CI (`website:` job in [`../../.github/workflows/ci.yml`](../../.github/workflows/ci.yml)); GitHub Pages deployment runs in [`../../.github/workflows/website-deploy.yml`](../../.github/workflows/website-deploy.yml).
 
 ---
 
@@ -32,37 +32,28 @@ It is maintained with a **build-in-public** approach and an epic-based simplifie
 - `docs/ROADMAP.md`: product roadmap
 - `docs/roadmap-feed.json`: machine-readable roadmap sync feed
 - `docs/GOVERNANCE.md`: backlog conventions, runbook, and repository governance
-- `.github/workflows/website-ci-cd.yml`: CI/CD pipeline
-- `.github/workflows/ingest-roadmap-update.yml`: roadmap auto-ingest pipeline
+- `../../.github/workflows/ci.yml` (`website:` job): quality gate runner on every PR
+- `../../.github/workflows/website-deploy.yml`: GitHub Pages publication pipeline
 - `scripts/quality_gate.py`: dependency-free local/CI quality gate
 - `scripts/roadmap_sync.py`: roadmap ingest and markdown table sync script
 - `CONTRIBUTING.md`: contribution conventions
 
 ---
 
-## ⚙️ CI/CD (Epic C)
-
-Workflows:
-- `.github/workflows/website-ci-cd.yml`
-- `.github/workflows/ingest-roadmap-update.yml`
+## ⚙️ CI/CD
 
 ### Quality gates
 
-Executed on `push` (`develop`, `main`) and `pull_request` (`develop`, `main`):
+The monorepo CI runs `scripts/quality_gate.py` (via the `website:` job in [`ci.yml`](../../.github/workflows/ci.yml)) on every PR whose diff touches `packages/website/**`. It checks:
+
 - presence of critical files,
 - minimal FR/EN HTML structure,
-- no Git conflict markers.
+- no Git conflict markers,
+- per-page structural rules (lang attribute, canonical, schema.org, etc.).
 
 ### Deployment
 
-The GitHub Pages deployment job runs only on:
-- `push` to `main`.
-
-### Roadmap auto-ingest
-
-The roadmap sync workflow ingests user-facing updates via `repository_dispatch` (`roadmap_user_facing_update`) and updates:
-- `docs/roadmap-feed.json`
-- `docs/ROADMAP.md` (Done table between dedicated markers)
+Any push to `main` whose diff touches `packages/website/**` (and `workflow_dispatch` for manual reruns) triggers [`website-deploy.yml`](../../.github/workflows/website-deploy.yml), which stages the public files (HTML, CSS, JS, brand assets, favicon, CNAME, sitemap, robots, `seo/`, `screenshots/`) into `_site/` and publishes via `actions/deploy-pages`. The repo's GitHub Pages source must be set to **"GitHub Actions"** in the Settings page for the deploy job to succeed.
 
 ---
 
@@ -79,11 +70,10 @@ python3 -m py_compile scripts/roadmap_sync.py
 
 ## 🔀 Workflow Git
 
-- `main`: production
-- `develop`: integration
-- `feature/*`, `docs/*`, `bugfix/*`: working branches
+- `main`: production (auto-deployed by `website-deploy.yml`)
+- `feat/*`, `fix/*`, `docs/*`, `refactor/*`, `chore/*`: working branches per the monorepo branch-naming convention
 
-All contributions go through a PR to `develop` (unless an explicit exception is decided).
+All contributions go through a PR to `main` (the `develop` integration branch from the standalone website repo era no longer exists).
 
 ---
 


### PR DESCRIPTION
## Summary

Adds the GitHub Pages deployment pipeline the monorepo has never had. After this PR is merged AND three manual follow-ups are done on GitHub (see Checklist), every change under `packages/website/**` on `main` is published to `brasse-bouillon.com` within minutes.

## Context

The marketing site used to live in the standalone `brasse-bouillon-website` repo. That repo had a legacy "Deploy from branch" Pages config + the `brasse-bouillon.com` CNAME. On 2026-03-24 commit `cbf82cc` imported its history into this monorepo via `git subtree`, but only the source files (no workflow). The original repo was then archived, freezing its last deploy (30 March 2026) at `brasse-bouillon.com`.

Concretely:

- `gh api repos/benoit-bremaud/brasse-bouillon/pages` → **404**.
- `gh api repos/benoit-bremaud/brasse-bouillon-website/pages` → `status: built`, `cname: brasse-bouillon.com`, `archived: true`.
- `curl -sI https://brasse-bouillon.com/` → `last-modified: Mon, 30 Mar 2026 11:50:44 GMT`.

Every website PR merged on this monorepo since the subtree merge (PR #1018 included) has therefore not been published.

## What this PR does

- Adds `.github/workflows/website-deploy.yml` that:
  - triggers on push to `main` with `paths: packages/website/**` (and `workflow_dispatch`),
  - stages only the public surface into `_site/` (HTML, CSS, JS, brand assets, favicon, CNAME, sitemap, robots, the optional `seo/` directory, the `screenshots/` directory) — internal repo files (`docs/`, `scripts/`, `tests/`, `CHANGELOG.md`, `CONTRIBUTING.md`, `README.md`, `CLAUDE.md`, `package.json`, `sonar-project.properties`) stay out of the artifact,
  - uploads via `actions/upload-pages-artifact@v3` and publishes via `actions/deploy-pages@v4`,
  - uses the canonical `github-pages` environment + `concurrency: pages` so a single deploy runs at a time,
  - scopes `pages: write` + `id-token: write` only on the `deploy` job (SonarLint S8264 / S8233 compliant).

## Manual follow-ups required on GitHub

This PR alone does not bring the site online — three settings clicks are required AFTER merge:

- [ ] **On the archived `brasse-bouillon-website` repo** — Settings ➜ Pages ➜ Unpublish (or DELETE the `cname` via API). This releases the `brasse-bouillon.com` CNAME.
- [ ] **On this monorepo** — Settings ➜ Pages ➜ Source = "GitHub Actions". The `CNAME` file under `packages/website/` will reattach the custom domain on the first deploy.
- [ ] **Trigger the first deploy** — Actions ➜ "Website Deploy" ➜ Run workflow on `main`. Subsequent merges that touch `packages/website/**` deploy automatically.

After the third step, `brasse-bouillon.com` serves the monorepo build (PR #1018 journey section + feature cards finally visible) and the archived repo's Pages can stay disabled forever.

## Checklist

- [x] Workflow respects path-filter scope (no useless runs on mobile-app / api / beer-encyclopedia changes)
- [x] Internal repo files excluded from the published artifact
- [x] Permissions scoped per job (SonarLint S8264 / S8233)
- [x] `concurrency: pages` to prevent racing deploys
- [x] Quality gate still green locally