### PR TITLE
feat(website): home simplification + Kinetic editorial design refresh

### DIFF
--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -3,514 +3,57 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Brasse-Bouillon — Homebrewing app (recipes, IBU/ABV, guided brewing)</title>
+  <title>Brasse-Bouillon — English version coming soon</title>
 
-  <!-- SEO Meta Tags -->
-  <meta name="description" content="Brasse-Bouillon is the homebrewing mobile app for recipes, IBU/ABV calculations, fermentation tracking, and step-by-step brew guidance.">
-  <meta name="keywords" content="homebrewing app, beer recipe app, IBU calculator, ABV calculator, brew day assistant, fermentation tracking">
+  <meta name="description" content="Brasse-Bouillon is the homebrewing mobile app for recipes, IBU/ABV calculations and fermentation tracking. English version coming soon — French homepage available now.">
   <meta name="robots" content="noindex,follow">
   <link rel="canonical" href="https://brasse-bouillon.com/">
   <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/">
-  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/index-en.html">
   <link rel="alternate" hreflang="x-default" href="https://brasse-bouillon.com/">
 
-  <!-- Open Graph / Facebook -->
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="https://brasse-bouillon.com/">
-  <meta property="og:title" content="Brasse-Bouillon — The homebrewing co-pilot app">
-  <meta property="og:description" content="Plan recipes, follow step-by-step brew sessions, and improve every batch with confidence.">
-  <meta property="og:image" content="https://brasse-bouillon.com/og-image.png">
-  <meta property="og:image:alt" content="Brasse-Bouillon, homebrewing mobile app">
-
-  <!-- Twitter -->
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:url" content="https://brasse-bouillon.com/">
-  <meta name="twitter:title" content="Brasse-Bouillon — The homebrewing co-pilot app">
-  <meta name="twitter:description" content="From first kit to advanced all-grain batches: brew with confidence and consistency.">
-  <meta name="twitter:image" content="https://brasse-bouillon.com/og-image.png">
-  <meta name="twitter:image:alt" content="Brasse-Bouillon, homebrewing mobile app">
-
-  <!-- Favicon -->
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
-  <link rel="apple-touch-icon" href="logo-icon-32.png">
 
-  <!-- Preconnect for performance -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="site.css">
-
-  <!-- Organization Schema -->
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@id": "https://brasse-bouillon.com/#organization",
-    "@type": "Organization",
-    "name": "Brasse-Bouillon",
-    "url": "https://brasse-bouillon.com/",
-    "logo": "https://brasse-bouillon.com/logo.png",
-    "description": "Project building a mobile app dedicated to homebrewing recipes and fermentation tracking.",
-    "email": "contact@brasse-bouillon.com",
-    "founder": {
-      "@type": "Person",
-      "name": "Benoît Bremaud",
-      "url": "https://www.linkedin.com/in/benoit-bremaud"
-    },
-    "contactPoint": {
-      "@type": "ContactPoint",
-      "email": "contact@brasse-bouillon.com",
-      "contactType": "customer service"
-    },
-    "sameAs": [
-      "https://www.linkedin.com/in/benoit-bremaud"
-    ]
-  }
-  </script>
 </head>
 <body>
   <a class="skip-link" href="#mainContentEn">Skip to main content</a>
 
   <header class="site-header">
     <div class="header-inner">
-      <a href="index-en.html" class="header-logo">
+      <a href="index.html" class="header-logo">
         <img src="logo-hero.png" alt="Brasse-Bouillon" width="50" height="50">
         <span>Brasse-Bouillon</span>
       </a>
-      <nav class="header-nav">
-        <a href="#features">Features</a>
-        <a href="#brewAssistantEn">Assistant</a>
-        <a href="#roadmapHeadingEn">Roadmap</a>
-        <a href="#faq">FAQ</a>
-        <a href="#newsletterEn">Newsletter</a>
-        <a href="#contact">Contact</a>
-      </nav>
-      <div class="header-right">
-        <div class="language-switch" role="navigation" aria-label="Language selection">
-          <a href="index.html" aria-label="French version">🇫🇷 FR</a> ·
-          <a href="index-en.html" aria-label="English version">🇬🇧 EN</a>
-        </div>
-      </div>
     </div>
   </header>
 
   <main class="page" id="mainContentEn">
     <div class="shell">
-      <p class="responsibility-banner">
-        🍺 Brasse-Bouillon is intended for adults (18+) and promotes responsible drinking.
-        Alcohol abuse is harmful to your health.
-      </p>
-
       <section class="hero">
-        <div class="logo-wrap">
+        <span class="pill">Heads up</span>
+        <h1>English version <em>coming soon.</em></h1>
+        <p class="intro">
+          Brasse-Bouillon is currently presented in French only. An English edition is on the roadmap.
+          In the meantime, visit the French homepage or email us directly.
+        </p>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="index.html">Voir le site (FR)</a>
+          <a class="btn btn-ghost" href="mailto:contact@brasse-bouillon.com">Email us</a>
+        </div>
+        <div class="hero-mascot">
           <img class="logo" src="logo-hero.png" alt="Official Brasse-Bouillon mascot" loading="eager" width="180" height="180">
         </div>
-        <p class="pill">🚀 Beta 2026 • Limited early access</p>
-        <h1>Brasse-Bouillon: your brewing co-pilot for every successful batch</h1>
-        <p class="intro">
-          From first extract kits to advanced all-grain recipes, Brasse-Bouillon guides and supports every step.
-          Goal: simpler brewing, better consistency, and a lot more fun on brew day.
-        </p>
-        <div class="actions">
-          <a class="btn btn-secondary" href="#brewAssistantEn">Explore the step-by-step guide</a>
-          <a class="btn btn-primary" href="#newsletterEn">Join the waitlist</a>
-          <a class="btn btn-secondary" href="#questionnaireEn">Shape the roadmap</a>
-        </div>
-        <p class="badge">🔥 Newsletter + questionnaire + direct contact: 3 ways to contribute.</p>
-      </section>
-
-      <section class="section-block" id="journeyEn">
-        <h2 class="section-title">🧭 How your first brew unfolds, step by step</h2>
-        <p class="section-intro">From the recipe you pick to the first sip, Brasse-Bouillon walks beside you at every step — so you can start without fearing a botched brew.</p>
-        <ol class="journey-grid">
-          <li class="journey-step">
-            <div class="journey-screenshot">
-              <img src="screenshots/journey-1-catalog.png" alt="Recipe catalogue screen with “La Première du dimanche” selected from the guided catalogue" loading="lazy" width="320" height="640">
-            </div>
-            <h3>1. Pick your first recipe</h3>
-            <p>A catalogue of recipes calibrated to succeed on the first try — no jargon, no surprise.</p>
-          </li>
-          <li class="journey-step">
-            <div class="journey-screenshot">
-              <img src="screenshots/journey-2-brewing.png" alt="Brew session screen during the 67°C mash step, with active timer and step list" loading="lazy" width="320" height="640">
-            </div>
-            <h3>2. Brew step by step</h3>
-            <p>The app tells you what to do, when, and why — mash, boil, cool down — without skipping a beat.</p>
-          </li>
-          <li class="journey-step">
-            <div class="journey-screenshot">
-              <img src="screenshots/journey-3-fermenting.png" alt="Fermentation tracker screen showing day 5 of 14 progress bar with current gravity" loading="lazy" width="320" height="640">
-            </div>
-            <h3>3. Track fermentation</h3>
-            <p>Days of fermentation, current gravity, temperature — one glance and you know where you stand.</p>
-          </li>
-          <li class="journey-step">
-            <div class="journey-screenshot">
-              <img src="screenshots/journey-4-deguste.png" alt="Brew finished celebration screen with the bottled beer and its custom label" loading="lazy" width="320" height="640">
-            </div>
-            <h3>4. Bottle it, savour it</h3>
-            <p>Stick on your label, share with friends, savour your first creation — pride included.</p>
-          </li>
-        </ol>
-      </section>
-
-      <section class="section-block" id="features">
-        <h2 class="section-title">🍻 Features that make every brew day smoother</h2>
-        <p class="section-intro">Designed to save time, reduce mistakes, and help you improve batch after batch.</p>
-        <div class="features-grid">
-          <article class="feature-card">
-            <div class="feature-screenshot">
-              <img src="screenshots/feature-studio-recipes.png" alt="Recipe Studio screen with Ingredients tab and live calculations" loading="lazy" width="280" height="560">
-            </div>
-            <h3>Practical recipe studio</h3>
-            <p>Create, duplicate, tweak, and version recipes quickly—without getting lost in complex screens.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-screenshot">
-              <img src="screenshots/feature-calculs-hops.png" alt="Hop calculator screen with Quick, Reverse and BU:GU tabs and interactive sliders" loading="lazy" width="280" height="560">
-            </div>
-            <h3>Reliable brewing calculations</h3>
-            <p>IBU, ABV, color, volumes, and efficiency in one place, so you can make better decisions faster.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-screenshot">
-              <img src="screenshots/feature-pilotage-batches.png" alt="Real-time brew session screen with timeline of steps and statuses" loading="lazy" width="280" height="560">
-            </div>
-            <h3>Real-time brew session control</h3>
-            <p>Clear timeline, helpful reminders, and critical checkpoints: know what to do, when, and why.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-screenshot">
-              <img src="screenshots/feature-academy-empatage.png" alt="Academy screen with a mash topic detail and its pedagogical content" loading="lazy" width="280" height="560">
-            </div>
-            <h3>Guided brew assistant</h3>
-            <p>Choose your path (All-grain, BIAB, or Kit/Extract) and follow guided steps to avoid costly mistakes.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-screenshot">
-              <img src="screenshots/feature-batches-history.png" alt="My Brews screen with three “La Première du dimanche” batches at different stages" loading="lazy" width="280" height="560">
-            </div>
-            <h3>History that helps you improve</h3>
-            <p>Compare batches, understand your decisions, and repeat what works with confidence.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-screenshot">
-              <img src="screenshots/feature-social-feed.png" alt="Community screen with shared brews, their reactions and comments" loading="lazy" width="280" height="560">
-            </div>
-            <h3>Community sharing & feedback</h3>
-            <p>Share your brews, get practical feedback, and discover new inspiration for your next session.</p>
-          </article>
-        </div>
-      </section>
-
-      <section class="section-block" id="brewAssistantEn">
-        <h2 class="section-title">🧭 Step-by-step brewing guide: 3 paths, one objective</h2>
-        <p class="section-intro">Pick your method and level; Brasse-Bouillon guides every critical step through fermentation.</p>
-        <div class="guide-grid">
-          <article class="guide-card">
-            <h3>Classic all-grain</h3>
-            <ul>
-              <li>Water prep + pH + milling</li>
-              <li>Mash schedule, sparging, gravity checks</li>
-              <li>Boil, hop additions, cooling</li>
-              <li>Fermentation, tracking, packaging</li>
-            </ul>
-          </article>
-          <article class="guide-card">
-            <h3>BIAB (Brew In A Bag)</h3>
-            <ul>
-              <li>Fast BIAB setup with safety prompts</li>
-              <li>Temperature and extraction guidance</li>
-              <li>Simplified hop schedule</li>
-              <li>Anti-miss checklist through cold crash</li>
-            </ul>
-          </article>
-          <article class="guide-card">
-            <h3>Kits / Extracts (beginners)</h3>
-            <ul>
-              <li>Easy start without unnecessary jargon</li>
-              <li>Guided volumes, dilution, sanitization</li>
-              <li>Timing and key temperature cues</li>
-              <li>First successful batch with less stress</li>
-            </ul>
-          </article>
-        </div>
-        <p class="badge">✅ Contextual reminders, required steps, and quality checkpoints from start to bottling.</p>
-      </section>
-
-      <section class="section-block">
-        <h2 class="section-title" id="roadmapHeadingEn">🗺️ Project roadmap</h2>
-        <div class="roadmap-controls" id="roadmapControlsEn" role="toolbar" aria-label="Roadmap filters">
-          <button class="chip active" data-filter="all" aria-pressed="true" onclick="filterRoadmapEn('all', this)">All</button>
-          <button class="chip" data-filter="current" aria-pressed="false" onclick="filterRoadmapEn('current', this)">In progress</button>
-          <button class="chip" data-filter="next" aria-pressed="false" onclick="filterRoadmapEn('next', this)">Next</button>
-          <button class="chip" data-filter="done" aria-pressed="false" onclick="filterRoadmapEn('done', this)">Done</button>
-        </div>
-        <div id="roadmapTrackEn" class="roadmap-track" role="region" aria-live="polite" aria-labelledby="roadmapHeadingEn"></div>
-        <p class="badge">
-          Detailed history of completed actions:
-          <a href="docs/ROADMAP.md" target="_blank" rel="noopener noreferrer">roadmap “Done” section</a>.
-        </p>
-      </section>
-
-      <section class="section-block">
-        <h2 class="section-title">🧪 Development log</h2>
-        <div class="section-grid">
-          <div class="mini-card">
-            <h3>Late February 2026 · Product</h3>
-            Brewing tools suite completed (color/hops/water/conversions), richer shop flows (categories + kits + demo content), streamlined Academy/Tools hubs, and a reading-first dashboard with ingredient discovery.
-          </div>
-          <div class="mini-card">
-            <h3>Late February 2026 · Platform</h3>
-            Product APIs expanded (Hub'Eau water profile + recipe ingredients + brewing metrics), recipe detail “My Book” enhanced with must-have malt sheets, and roadmap/devlog synchronization maintained.
-          </div>
-        </div>
-      </section>
-
-      <section class="section-block">
-        <h2 class="section-title" id="faq">❓ Quick FAQ</h2>
-        <div class="section-grid">
-          <div class="mini-card">
-            <h3>When will the app be available?</h3>
-            We ship in phases. A beta will be shared as soon as the core is stable.
-          </div>
-          <div class="mini-card">
-            <h3>Can I contribute?</h3>
-            Yes—through the questionnaire, UX feedback, and direct contact.
-          </div>
-          <div class="mini-card">
-            <h3>Who is it for?</h3>
-            Beginners and experienced homebrewers alike.
-          </div>
-          <div class="mini-card">
-            <h3>iOS, Android… or both?</h3>
-            The product target is availability on both platforms. Rollout will be progressive, starting with a beta phase.
-          </div>
-          <div class="mini-card">
-            <h3>Will my recipes and batches be saved?</h3>
-            Yes. The product direction includes structured recipe/batch history with persistence, so it is easier to track and reproduce brew sessions.
-          </div>
-          <div class="mini-card">
-            <h3>How can I follow upcoming updates?</h3>
-            The roadmap and development log are continuously updated on the website, with a traceable history of delivered improvements.
-          </div>
-        </div>
-      </section>
-
-      <section class="section-block">
-        <h2 class="section-title">🍺 Featured recipe</h2>
-        <div class="mini-card">
-          <h3>Session IPA “Citrus Bloom” (sample)</h3>
-          Light, aromatic, and perfect to discover recipe tracking in Brasse-Bouillon.
-          More detailed recipes and brew sheets are coming soon.
-        </div>
-      </section>
-
-      <section class="section-block" id="newsletterEn">
-        <h2 class="section-title">📮 Brasse-Bouillon Newsletter</h2>
-        <p class="section-intro">
-          Receive notable product and roadmap updates (light cadence, no spam).
-        </p>
-        <form id="newsletterFormEn" class="contact-form">
-          <input type="hidden" name="_subject" value="Brasse-Bouillon newsletter signup (EN)">
-          <input type="hidden" name="lang" value="en">
-          <input type="hidden" name="source" value="newsletter">
-          <input type="hidden" name="message" value="New newsletter signup from website (EN)">
-
-          <label class="sr-only" for="newsletterEmailEn">Newsletter email address</label>
-          <input id="newsletterEmailEn" type="email" name="email" placeholder="Your email to receive updates" required>
-
-          <label class="consent">
-            <input type="checkbox" name="newsletter_consent" value="accepted" required>
-            I agree to receive Brasse-Bouillon updates and understand I can unsubscribe at any time.
-          </label>
-          <p class="consent-note">
-            By subscribing, you accept our
-            <a href="terms-en.html" target="_blank" rel="noopener noreferrer">Terms of Use</a>,
-            our <a href="privacy-en.html" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
-            and our <a href="cookies-en.html" target="_blank" rel="noopener noreferrer">Cookie Policy</a>.
-          </p>
-
-          <div class="actions actions-compact">
-            <button class="btn btn-primary" type="submit">Subscribe to newsletter</button>
-          </div>
-        </form>
-        <p id="newsletterStatusEn" class="form-status" role="status" aria-live="polite"></p>
-      </section>
-
-      <section class="section-block" id="questionnaireEn">
-        <h2 class="section-title">🧾 Community questionnaire</h2>
-        <p class="section-intro">
-          It only takes 2 minutes to help us build Brasse-Bouillon. Your answers stay confidential.
-        </p>
-        <div class="actions">
-          <button class="btn btn-primary" id="questionnaireToggleEn" type="button" aria-expanded="false" onclick="toggleQuestionnaire('en')">
-            Open questionnaire
-          </button>
-          <a class="btn btn-secondary" href="mailto:contact@brasse-bouillon.com">Contact us</a>
-        </div>
-
-        <form id="questionnaireFormEn" class="questionnaire-form" hidden>
-          <input type="hidden" name="_subject" value="New response - Brasse-Bouillon questionnaire (EN)">
-          <input type="hidden" name="lang" value="en">
-          <input class="honeypot" type="text" name="_gotcha">
-
-          <div class="questionnaire-grid">
-            <fieldset class="form-field-full">
-              <legend>1. Your profile</legend>
-              <div class="radio-list">
-                <label><input type="radio" name="profil" value="Beginner" required>Beginner (&lt; 1 year)</label>
-                <label><input type="radio" name="profil" value="Confirmed amateur">Confirmed amateur</label>
-                <label><input type="radio" name="profil" value="Advanced enthusiast">Advanced enthusiast</label>
-                <label><input type="radio" name="profil" value="Professional">Microbrewery / Professional</label>
-              </div>
-              <div class="form-field form-field-spacing-sm">
-                <label for="qProfilAutreEn">Other</label>
-                <input id="qProfilAutreEn" type="text" name="profil_autre" placeholder="Tell us your profile if needed">
-              </div>
-            </fieldset>
-
-            <div class="form-field form-field-full">
-              <label for="qFrequencyEn">2. Brewing frequency</label>
-              <select id="qFrequencyEn" name="frequence" required>
-                <option value="">Select…</option>
-                <option value="1-2 times per year">1-2 times per year</option>
-                <option value="3-6 times per year">3-6 times per year</option>
-                <option value="Once a month">Once a month</option>
-                <option value="More than once a month">More than once a month</option>
-                <option value="I do not brew yet">I do not brew yet</option>
-              </select>
-            </div>
-
-            <fieldset class="form-field-full">
-              <legend>3. Main pain points (max 3)</legend>
-              <div class="checkbox-list">
-                <label><input type="checkbox" name="difficultes[]" value="IBU ABV calculations">IBU / ABV calculations</label>
-                <label><input type="checkbox" name="difficultes[]" value="Recipe management">Recipe management</label>
-                <label><input type="checkbox" name="difficultes[]" value="Inventory management">Inventory management</label>
-                <label><input type="checkbox" name="difficultes[]" value="Brew logs">Brew logging</label>
-                <label><input type="checkbox" name="difficultes[]" value="Reproducibility">Reproducibility</label>
-                <label><input type="checkbox" name="difficultes[]" value="No pain point">No major pain point</label>
-              </div>
-              <div class="form-field form-field-spacing-sm">
-                <label for="qDifficultesAutreEn">Other</label>
-                <input id="qDifficultesAutreEn" type="text" name="difficultes_autre" placeholder="Any other pain point">
-              </div>
-            </fieldset>
-
-            <fieldset class="form-field-full">
-              <legend>4. Tools you currently use</legend>
-              <div class="checkbox-list">
-                <label><input type="checkbox" name="outils[]" value="Excel">Excel / Google Sheets</label>
-                <label><input type="checkbox" name="outils[]" value="BeerSmith">BeerSmith</label>
-                <label><input type="checkbox" name="outils[]" value="Brewfather">Brewfather</label>
-                <label><input type="checkbox" name="outils[]" value="Paper notebook">Paper notebook</label>
-                <label><input type="checkbox" name="outils[]" value="Mobile app">Mobile app</label>
-                <label><input type="checkbox" name="outils[]" value="No structured tool">No structured tool</label>
-              </div>
-            </fieldset>
-
-            <fieldset class="form-field-full">
-              <legend>5. Feature importance (1 to 5)</legend>
-              <div class="form-field">
-                <label for="qCalcIbuEn">IBU / ABV calculator</label>
-                <input id="qCalcIbuEn" type="range" name="calc_ibu" min="1" max="5" value="3">
-              </div>
-              <div class="form-field">
-                <label for="qRecettesEn">Recipes</label>
-                <input id="qRecettesEn" type="range" name="recettes" min="1" max="5" value="3">
-              </div>
-              <div class="form-field">
-                <label for="qJournalEn">Brew log</label>
-                <input id="qJournalEn" type="range" name="journal" min="1" max="5" value="3">
-              </div>
-              <div class="form-field">
-                <label for="qStockEn">Inventory</label>
-                <input id="qStockEn" type="range" name="stock" min="1" max="5" value="3">
-              </div>
-              <div class="form-field">
-                <label for="qPartageEn">Sharing</label>
-                <input id="qPartageEn" type="range" name="partage" min="1" max="5" value="3">
-              </div>
-            </fieldset>
-
-            <fieldset class="form-field-full">
-              <legend>6. Your top 3 priorities</legend>
-              <div class="checkbox-list">
-                <label><input type="checkbox" name="priorites[]" value="IBU ABV calculator">IBU / ABV calculator</label>
-                <label><input type="checkbox" name="priorites[]" value="Recipes">Recipes</label>
-                <label><input type="checkbox" name="priorites[]" value="Logbook">Logbook</label>
-                <label><input type="checkbox" name="priorites[]" value="Inventory">Inventory</label>
-                <label><input type="checkbox" name="priorites[]" value="Sharing">Sharing</label>
-              </div>
-              <p class="helper-text">Pick 1 to 3 priorities so we can better scope the roadmap.</p>
-            </fieldset>
-
-            <fieldset class="form-field-full">
-              <legend>7. Mobile application</legend>
-              <div class="radio-list">
-                <label><input type="radio" name="mobile" value="Yes absolutely" required>Yes absolutely</label>
-                <label><input type="radio" name="mobile" value="Yes if clear added value">Yes if clear added value</label>
-                <label><input type="radio" name="mobile" value="Maybe">Maybe</label>
-                <label><input type="radio" name="mobile" value="No">No</label>
-              </div>
-            </fieldset>
-
-            <div class="form-field form-field-full">
-              <label for="qSuggestionEn">8. Your dream feature?</label>
-              <textarea id="qSuggestionEn" name="suggestion" rows="4" placeholder="Tell us the one feature that would save you time"></textarea>
-            </div>
-
-            <div class="form-field form-field-full">
-              <label for="qEmailEn">9. Stay informed (optional)</label>
-              <input id="qEmailEn" type="email" name="email" placeholder="Your email (optional)">
-            </div>
-          </div>
-
-          <label class="consent">
-            <input type="checkbox" name="rgpd" value="accepted" required>
-            I agree that my data can be used for Brasse-Bouillon product development.
-          </label>
-          <p class="consent-note">
-            See our <a href="privacy-en.html" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
-            and <a href="terms-en.html" target="_blank" rel="noopener noreferrer">Terms of Use</a>.
-          </p>
-
-          <div class="actions actions-compact">
-            <button class="btn btn-primary" type="submit">Contribute 🍻</button>
-          </div>
-        </form>
-
-        <p id="questionnaireStatusEn" class="form-status" role="status" aria-live="polite"></p>
-      </section>
-
-      <section class="section-block">
-        <h2 class="section-title" id="contact">📬 Contact us directly</h2>
-        <form class="contact-form" action="https://formspree.io/f/mqaqqvab" method="POST">
-          <label class="sr-only" for="emailEn">Email address</label>
-          <input id="emailEn" type="email" name="email" placeholder="Your email" required>
-          <label class="sr-only" for="messageEn">Message</label>
-          <textarea id="messageEn" name="message" placeholder="Your message" required></textarea>
-          <label class="consent">
-            <input type="checkbox" name="contact_legal_acceptance" value="accepted" required>
-            I accept the Terms of Use and Privacy Policy.
-          </label>
-          <p class="consent-note">
-            By sending this message, you accept our
-            <a href="terms-en.html" target="_blank" rel="noopener noreferrer">Terms of Use</a>,
-            our <a href="privacy-en.html" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
-            and our <a href="cookies-en.html" target="_blank" rel="noopener noreferrer">Cookie Policy</a>.
-          </p>
-          <button class="btn btn-primary" type="submit">Send</button>
-        </form>
       </section>
 
       <footer class="footer">
-        Stay connected! You can also reach us at: <strong>contact@brasse-bouillon.com</strong>
-        <div class="badge">
-          Made with ❤️ by
-          <a href="https://www.linkedin.com/in/benoit-bremaud" target="_blank" rel="noopener noreferrer">Brasse-Bouillon</a>
+        <div class="footer-brand">
+          <span class="footer-mark">B·B</span>
+          <p>Contact: <strong>contact@brasse-bouillon.com</strong></p>
         </div>
         <div class="footer-links">
           <a href="legal-en.html">Legal Notice</a>
@@ -521,106 +64,5 @@
       </footer>
     </div>
   </main>
-
-  <script src="site.js"></script>
-  <script>
-    const QUESTIONNAIRE_ENDPOINT = 'https://formspree.io/f/xeellqan';
-    const NEWSLETTER_ENDPOINT = 'https://formspree.io/f/mqaqqvab';
-
-    const ROADMAP_PHASES_EN = [
-      { phase: 1, title: 'Ideation & positioning', state: 'done', points: ['MVP definition', 'User survey', 'Founding manifesto'] },
-      { phase: 2, title: 'Communication channels analysis', state: 'done', points: ['Target audiences', 'Editorial strategy', 'Public summary'] },
-      { phase: 3, title: 'Design & preparation', state: 'done', points: ['UI/UX mockups', 'Technical architecture', 'Visual roadmap'] },
-      { phase: 4, title: 'MVP development', state: 'done', points: ['Auth/JWT + secure API baseline', 'Recipe CRUD + persisted recipe steps', 'Batch module (workflow + persistence + endpoints)', 'Brewing calculator v1 (IBU/ABV/conversions)'] },
-      { phase: 5, title: 'Product consolidation & public website', state: 'current', points: ['Tools suite completed (color/hops/water/conversion calculators)', 'Shop and demo content expanded (categories/kits + recipes + batches)', 'Academy/Tools hubs UX consolidated (clickable cards + reliable navigation)', 'Reading-first dashboard + discovery spaces + progressive live ingredient data', 'Recipe detail “My Book” enhanced with must-have malt product sheets', 'Product APIs expanded (Hub\'Eau water profile + recipe ingredients + brewing metrics)', 'Roadmap and devlog kept in sync'] },
-      { phase: 6, title: 'Beta tests & community', state: 'next', points: ['Public beta', 'Feedback loop', 'Community space'] },
-      { phase: 7, title: 'Official launch', state: 'next', points: ['App stores', 'Public demo', 'Multi-channel communication'] },
-      { phase: 8, title: 'Documentation & ecosystem', state: 'next', points: ['Brew sheets', 'Glossary', 'Recipe sharing space'] },
-      { phase: 9, title: 'Improvements & openness', state: 'next', points: ['UX optimizations', 'Extra modules', 'Open API'] },
-      { phase: 10, title: 'Partnerships & impact', state: 'next', points: ['Microbreweries', 'Studio B22 kit', 'Open impact indicators'] }
-    ];
-
-    const TOGGLE_LABELS = {
-      fr: { open: 'Ouvrir le questionnaire', close: 'Fermer le questionnaire' },
-      en: { open: 'Open questionnaire', close: 'Close questionnaire' }
-    };
-
-    function stateLabelEn(state) {
-      if (state === 'done') return 'Done';
-      if (state === 'current') return 'In progress';
-      return 'Next';
-    }
-
-    function renderRoadmapEn(filter = 'all') {
-      BBShared.renderRoadmap({
-        rootId: 'roadmapTrackEn',
-        phases: ROADMAP_PHASES_EN,
-        filter,
-        getStateLabel: stateLabelEn
-      });
-    }
-
-    function filterRoadmapEn(filter, el) {
-      BBShared.setActiveRoadmapFilter({
-        controlsSelector: '#roadmapControlsEn .chip',
-        activeElement: el
-      });
-      renderRoadmapEn(filter);
-    }
-
-    function toggleQuestionnaire(lang) {
-      BBShared.toggleQuestionnaire({
-        lang,
-        labels: TOGGLE_LABELS
-      });
-    }
-
-    renderRoadmapEn();
-
-    BBShared.setupQuestionnaire({
-      formId: 'questionnaireFormEn',
-      statusId: 'questionnaireStatusEn',
-      endpoint: QUESTIONNAIRE_ENDPOINT,
-      checkboxLimits: [
-        { fieldName: 'difficultes[]', maxChoices: 3, message: 'Maximum 3 choices allowed for this question.' },
-        { fieldName: 'priorites[]', maxChoices: 3, message: 'Maximum 3 choices allowed for this question.' }
-      ],
-      requiredCheckboxGroups: [
-        { fieldName: 'priorites[]', minRequired: 1, message: 'Please select at least 1 priority before submitting the questionnaire.' }
-      ],
-      messages: {
-        endpointMissing: 'Questionnaire Formspree endpoint is not configured yet.',
-        sending: 'Sending…',
-        success: 'Thanks! Your feedback has been sent.',
-        http400: 'Some information looks invalid. Please review the form and try again.',
-        http429: 'Too many requests. Please wait a moment before trying again.',
-        http5xx: 'Server error. Please try again in a few minutes or contact support.',
-        httpGeneric: 'Unable to send right now. Please try again in a few minutes.',
-        offline: 'You appear to be offline. Check your internet connection and try again.',
-        aborted: 'The request was interrupted. Please submit the form again.',
-        networkOrCors: 'Unable to reach the server (network or CORS issue). Please try again soon.',
-        unexpected: 'An unexpected error occurred while sending. Please try again shortly.'
-      }
-    });
-
-    BBShared.setupQuestionnaire({
-      formId: 'newsletterFormEn',
-      statusId: 'newsletterStatusEn',
-      endpoint: NEWSLETTER_ENDPOINT,
-      messages: {
-        endpointMissing: 'Newsletter endpoint is not configured yet.',
-        sending: 'Subscribing…',
-        success: 'Great! Your newsletter subscription is confirmed.',
-        http400: 'Invalid or incomplete email address. Please review and try again.',
-        http429: 'Too many attempts. Please wait a moment before trying again.',
-        http5xx: 'Newsletter service is temporarily unavailable. Please try again later.',
-        httpGeneric: 'Unable to save your subscription right now. Please try again in a few minutes.',
-        offline: 'You appear offline. Check your connection and try again.',
-        aborted: 'The request was interrupted. Please try subscribing again.',
-        networkOrCors: 'Unable to reach newsletter service (network/CORS issue). Please try again soon.',
-        unexpected: 'An unexpected error occurred. Please try again shortly.'
-      }
-    });
-  </script>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -78,23 +78,28 @@
     "mainEntity": [
       {
         "@type": "Question",
+        "name": "Faut-il être bricoleur pour brasser sa bière ?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Pas du tout. Une casserole, un fermenteur, des bouteilles — et l’app qui te dit quoi faire à chaque étape. Si tu sais cuisiner des pâtes, tu sais brasser une bière." }
+      },
+      {
+        "@type": "Question",
+        "name": "Combien ça coûte de se lancer ?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Entre 60 et 120 € pour un kit débutant complet. Tu refais 5-6 brassins avec, et le matos est largement amorti par rapport au prix d’une bonne bière artisanale." }
+      },
+      {
+        "@type": "Question",
+        "name": "Combien de temps dure un brassin (la première fois) ?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Une demi-journée pour la session de brassage (4-5h), puis 2 à 3 semaines de fermentation où tu n’as quasiment rien à faire. L’app te rappelle les checkpoints critiques." }
+      },
+      {
+        "@type": "Question",
+        "name": "Et si je rate mon premier brassin ?",
+        "acceptedAnswer": { "@type": "Answer", "text": "Ça arrive, et c’est presque toujours buvable. L’app fait le point sur chaque étape pour t’aider à comprendre ce qui s’est passé — et le brassin suivant repart meilleur." }
+      },
+      {
+        "@type": "Question",
         "name": "Quand l’app sera disponible ?",
-        "acceptedAnswer": { "@type": "Answer", "text": "Nous avançons par phases. Une version bêta sera proposée dès qu’un socle stable sera prêt." }
-      },
-      {
-        "@type": "Question",
-        "name": "Pour quel niveau ?",
-        "acceptedAnswer": { "@type": "Answer", "text": "Débutants comme confirmés : l’objectif est d’aider tout le monde à mieux brasser." }
-      },
-      {
-        "@type": "Question",
-        "name": "iOS, Android… ou les deux ?",
-        "acceptedAnswer": { "@type": "Answer", "text": "L’objectif produit est une disponibilité sur les deux plateformes, avec une phase bêta en amont." }
-      },
-      {
-        "@type": "Question",
-        "name": "Mes recettes et brassins seront-ils sauvegardés ?",
-        "acceptedAnswer": { "@type": "Answer", "text": "Oui. Tes recettes et brassins sont historisés pour suivre et reproduire facilement tes sessions." }
+        "acceptedAnswer": { "@type": "Answer", "text": "Bêta progressive en 2026. Les inscrits à la waitlist passent en priorité." }
       }
     ]
   }
@@ -303,7 +308,7 @@
         </form>
         <p id="newsletterStatusFr" class="form-status" role="status" aria-live="polite"></p>
 
-        <form id="questionnaireFormFr" class="questionnaire-form" data-open="false">
+        <form id="questionnaireFormFr" class="questionnaire-form" data-open="false" inert>
           <div class="questionnaire-inner">
             <input type="hidden" name="_subject" value="Nouvelle réponse - Questionnaire Brasse-Bouillon (FR)">
             <input type="hidden" name="lang" value="fr">
@@ -313,7 +318,7 @@
               <fieldset class="form-field-full">
                 <legend>Tu en es où dans le brassage ?</legend>
                 <div class="chip-list">
-                  <label><input type="radio" name="profil" value="Curieux">Curieux, j’hésite à me lancer</label>
+                  <label><input type="radio" name="profil" value="Curieux" required>Curieux, j’hésite à me lancer</label>
                   <label><input type="radio" name="profil" value="Kit teste">J’ai testé un kit, j’ai envie d’aller plus loin</label>
                   <label><input type="radio" name="profil" value="Regulier">Je brasse régulièrement, j’ai ma routine</label>
                   <label><input type="radio" name="profil" value="Pro">Pro / micro-brasserie</label>
@@ -421,6 +426,9 @@
       formId: 'questionnaireFormFr',
       statusId: 'questionnaireStatusFr',
       endpoint: QUESTIONNAIRE_ENDPOINT,
+      checkboxLimits: [
+        { fieldName: 'blocages[]', maxChoices: 3, message: 'Maximum 3 choix pour cette question.' }
+      ],
       messages: {
         endpointMissing: 'Endpoint Formspree du questionnaire non configuré.',
         sending: 'Envoi en cours…',

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -126,6 +126,9 @@
       </p>
 
       <section class="hero">
+        <div class="hero-embers" aria-hidden="true">
+          <span></span><span></span><span></span><span></span><span></span><span></span>
+        </div>
         <span class="pill">Bêta 2026 · Places limitées</span>
         <h1>
           Brasse ta première bière <em>sans peur de rater.</em>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -243,20 +243,24 @@
         <h2 class="section-title" id="faq">Les <em>doutes</em> avant de se lancer</h2>
         <div class="faq-grid">
           <details class="faq-item">
+            <summary>Faut-il être bricoleur pour brasser sa bière ?</summary>
+            <p>Pas du tout. Une casserole, un fermenteur, des bouteilles — et l’app qui te dit quoi faire à chaque étape. Si tu sais cuisiner des pâtes, tu sais brasser une bière.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Combien ça coûte de se lancer ?</summary>
+            <p>Entre 60 et 120 € pour un kit débutant complet. Tu refais 5-6 brassins avec, et le matos est largement amorti par rapport au prix d’une bonne bière artisanale.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Combien de temps dure un brassin (la première fois) ?</summary>
+            <p>Une demi-journée pour la session de brassage (4-5h), puis 2 à 3 semaines de fermentation où tu n’as quasiment rien à faire. L’app te rappelle les checkpoints critiques.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Et si je rate mon premier brassin ?</summary>
+            <p>Ça arrive, et c’est presque toujours buvable. L’app post-mortem chaque étape pour t’aider à comprendre ce qui s’est passé — et le brassin suivant repart meilleur.</p>
+          </details>
+          <details class="faq-item">
             <summary>Quand l’app sera disponible ?</summary>
-            <p>Nous avançons par phases. Une version bêta sera proposée dès qu’un socle stable sera prêt — la waitlist est prioritaire.</p>
-          </details>
-          <details class="faq-item">
-            <summary>Pour quel niveau ?</summary>
-            <p>Débutants comme confirmés. L’objectif est d’aider tout le monde à mieux brasser, sans imposer un seul chemin.</p>
-          </details>
-          <details class="faq-item">
-            <summary>iOS, Android… ou les deux ?</summary>
-            <p>Les deux plateformes sont visées, avec une phase bêta progressive.</p>
-          </details>
-          <details class="faq-item">
-            <summary>Mes recettes et brassins seront-ils sauvegardés ?</summary>
-            <p>Oui. Tes recettes et brassins sont historisés pour suivre et reproduire facilement tes sessions.</p>
+            <p>Bêta progressive en 2026. Les inscrits à la waitlist passent en priorité.</p>
           </details>
         </div>
       </section>
@@ -290,64 +294,96 @@
 
           <div class="actions actions-compact">
             <button class="btn btn-primary" type="submit">Rejoindre la waitlist</button>
-            <button class="btn btn-ghost" id="questionnaireToggleFr" type="button" aria-expanded="false" onclick="toggleQuestionnaire('fr')">
-              Partager ton avis
+            <button class="btn btn-ghost btn-toggle" id="questionnaireToggleFr" type="button" aria-expanded="false" aria-controls="questionnaireFormFr" onclick="toggleQuestionnaire('fr')">
+              <span>Partager ton avis</span>
+              <svg class="btn-chevron" viewBox="0 0 12 8" fill="none" aria-hidden="true"><path d="M1 1.5L6 6.5L11 1.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
             </button>
             <a class="btn btn-ghost" href="mailto:contact@brasse-bouillon.com">Nous écrire</a>
           </div>
         </form>
         <p id="newsletterStatusFr" class="form-status" role="status" aria-live="polite"></p>
 
-        <form id="questionnaireFormFr" class="questionnaire-form" hidden>
-          <input type="hidden" name="_subject" value="Nouvelle réponse - Questionnaire Brasse-Bouillon (FR)">
-          <input type="hidden" name="lang" value="fr">
-          <input class="honeypot" type="text" name="_gotcha">
+        <form id="questionnaireFormFr" class="questionnaire-form" data-open="false">
+          <div class="questionnaire-inner">
+            <input type="hidden" name="_subject" value="Nouvelle réponse - Questionnaire Brasse-Bouillon (FR)">
+            <input type="hidden" name="lang" value="fr">
+            <input class="honeypot" type="text" name="_gotcha">
 
-          <div class="questionnaire-grid">
-            <fieldset class="form-field-full">
-              <legend>Ton profil</legend>
-              <div class="radio-list">
-                <label><input type="radio" name="profil" value="Debutant" required>Débutant (-1 an)</label>
-                <label><input type="radio" name="profil" value="Amateur confirme">Amateur confirmé</label>
-                <label><input type="radio" name="profil" value="Passionne avance">Passionné avancé</label>
-                <label><input type="radio" name="profil" value="Professionnel">Micro-brasserie / Pro</label>
+            <div class="questionnaire-grid">
+              <fieldset class="form-field-full">
+                <legend>Tu en es où dans le brassage ?</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="profil" value="Curieux">Curieux, j’hésite à me lancer</label>
+                  <label><input type="radio" name="profil" value="Kit teste">J’ai testé un kit, j’ai envie d’aller plus loin</label>
+                  <label><input type="radio" name="profil" value="Regulier">Je brasse régulièrement, j’ai ma routine</label>
+                  <label><input type="radio" name="profil" value="Pro">Pro / micro-brasserie</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>Combien de brassins par an, en moyenne ?</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="frequence" value="Aucun">Aucun pour l’instant</label>
+                  <label><input type="radio" name="frequence" value="1-3">1 à 3</label>
+                  <label><input type="radio" name="frequence" value="4-10">4 à 10</label>
+                  <label><input type="radio" name="frequence" value="10+">Plus de 10</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>Ce qui te bloque le plus <span class="legend-hint">(jusqu’à 3 choix)</span></legend>
+                <div class="chip-list chip-list-multi">
+                  <label><input type="checkbox" name="blocages[]" value="Calculs">Les calculs (IBU, ABV, densité)</label>
+                  <label><input type="checkbox" name="blocages[]" value="Recette">Choisir une recette adaptée</label>
+                  <label><input type="checkbox" name="blocages[]" value="Pilotage">Le pilotage des étapes le jour J</label>
+                  <label><input type="checkbox" name="blocages[]" value="Fermentation">Le suivi de la fermentation</label>
+                  <label><input type="checkbox" name="blocages[]" value="Materiel">Choisir mon matériel</label>
+                  <label><input type="checkbox" name="blocages[]" value="Reproduire">Reproduire un brassin réussi</label>
+                  <label><input type="checkbox" name="blocages[]" value="Partage">Échanger avec d’autres brasseurs</label>
+                  <label><input type="checkbox" name="blocages[]" value="Aucun">Rien, tout roule</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>Si tu n’avais qu’une seule fonction dans l’app, ce serait…</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="killer" value="Guide">Un guide pas-à-pas pendant le brassin</label>
+                  <label><input type="radio" name="killer" value="Calculs">Un calculateur fiable (IBU/ABV/couleur)</label>
+                  <label><input type="radio" name="killer" value="Recettes">Un livre de recettes prêtes à brasser</label>
+                  <label><input type="radio" name="killer" value="Fermentation">Un suivi de fermentation visuel</label>
+                  <label><input type="radio" name="killer" value="Journal">Un journal de mes brassins</label>
+                  <label><input type="radio" name="killer" value="Social">Un espace pour partager / comparer</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>Tu serais prêt(e) à payer pour la version complète ?</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="payant" value="Gratuit">Non, je veux du gratuit</label>
+                  <label><input type="radio" name="payant" value="Quelques euros">Quelques € / an</label>
+                  <label><input type="radio" name="payant" value="5-10">5 à 10 € / mois</label>
+                  <label><input type="radio" name="payant" value="Sais pas">Je ne sais pas encore</label>
+                </div>
+              </fieldset>
+
+              <div class="form-field form-field-full">
+                <label for="qEmailFr">Email <span class="legend-hint">(optionnel — pour rester informé(e))</span></label>
+                <input id="qEmailFr" type="email" name="email" placeholder="ton@email.fr">
               </div>
-            </fieldset>
-
-            <div class="form-field form-field-full">
-              <label for="qFrequencyFr">Fréquence de brassage</label>
-              <select id="qFrequencyFr" name="frequence" required>
-                <option value="">Choisir…</option>
-                <option value="1-2 fois par an">1-2 fois par an</option>
-                <option value="3-6 fois par an">3-6 fois par an</option>
-                <option value="1 fois par mois">1 fois par mois</option>
-                <option value="Plus d'une fois par mois">Plus d'une fois par mois</option>
-                <option value="Je ne brasse pas encore">Je ne brasse pas encore</option>
-              </select>
             </div>
 
-            <div class="form-field form-field-full">
-              <label for="qSuggestionFr">Une fonctionnalité idéale ?</label>
-              <textarea id="qSuggestionFr" name="suggestion" rows="4" placeholder="Partage ton idée la plus utile pour ton quotidien de brasseur"></textarea>
+            <label class="consent">
+              <input type="checkbox" name="rgpd" value="accepted" required>
+              J’accepte que mes données soient utilisées dans le cadre du développement de Brasse-Bouillon.
+            </label>
+            <p class="consent-note">
+              Voir notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">politique de confidentialité</a>
+              et nos <a href="terms.html" target="_blank" rel="noopener noreferrer">conditions</a>.
+            </p>
+
+            <div class="actions actions-compact">
+              <button class="btn btn-primary" type="submit">Envoyer mon retour</button>
             </div>
-
-            <div class="form-field form-field-full">
-              <label for="qEmailFr">Rester informé (optionnel)</label>
-              <input id="qEmailFr" type="email" name="email" placeholder="ton@email.fr">
-            </div>
-          </div>
-
-          <label class="consent">
-            <input type="checkbox" name="rgpd" value="accepted" required>
-            J’accepte que mes données soient utilisées dans le cadre du développement de Brasse-Bouillon.
-          </label>
-          <p class="consent-note">
-            Voir notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">politique de confidentialité</a>
-            et nos <a href="terms.html" target="_blank" rel="noopener noreferrer">conditions</a>.
-          </p>
-
-          <div class="actions actions-compact">
-            <button class="btn btn-primary" type="submit">Envoyer mon retour</button>
           </div>
         </form>
         <p id="questionnaireStatusFr" class="form-status" role="status" aria-live="polite"></p>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -102,6 +102,7 @@
 </head>
 <body>
   <a class="skip-link" href="#mainContentFr">Aller au contenu principal</a>
+  <div class="scroll-progress" aria-hidden="true"><span></span></div>
 
   <header class="site-header">
     <div class="header-inner">
@@ -181,6 +182,29 @@
           </li>
         </ol>
       </section>
+
+      <div class="marquee" aria-hidden="true">
+        <div class="marquee-track">
+          <span>Empâtage</span><span aria-hidden="true">·</span>
+          <span>Houblonnage</span><span aria-hidden="true">·</span>
+          <span>IBU 22</span><span aria-hidden="true">·</span>
+          <span>ABV 4.8 %</span><span aria-hidden="true">·</span>
+          <span>EBC 8</span><span aria-hidden="true">·</span>
+          <span>Fermentation</span><span aria-hidden="true">·</span>
+          <span>Cold crash</span><span aria-hidden="true">·</span>
+          <span>Refermentation</span><span aria-hidden="true">·</span>
+          <span>Mise en bouteille</span><span aria-hidden="true">·</span>
+          <span>Empâtage</span><span aria-hidden="true">·</span>
+          <span>Houblonnage</span><span aria-hidden="true">·</span>
+          <span>IBU 22</span><span aria-hidden="true">·</span>
+          <span>ABV 4.8 %</span><span aria-hidden="true">·</span>
+          <span>EBC 8</span><span aria-hidden="true">·</span>
+          <span>Fermentation</span><span aria-hidden="true">·</span>
+          <span>Cold crash</span><span aria-hidden="true">·</span>
+          <span>Refermentation</span><span aria-hidden="true">·</span>
+          <span>Mise en bouteille</span><span aria-hidden="true">·</span>
+        </div>
+      </div>
 
       <section class="section-block" id="features">
         <p class="section-eyebrow">Trois outils, un copilote</p>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -4,22 +4,22 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Brasse-Bouillon — Application de brassage amateur (recettes bière, IBU/ABV, fermentation)</title>
-  
+
   <!-- SEO Meta Tags -->
   <meta name="description" content="Brasse-Bouillon est l’application de brassage amateur pour créer des recettes de bière, calculer IBU/ABV, suivre la fermentation et réussir chaque brassin pas à pas.">
   <meta name="keywords" content="application brassage amateur, brassage maison, recette bière, calcul IBU, calcul ABV, suivi fermentation, guide brassage, journal de brassins, homebrew">
   <link rel="canonical" href="https://brasse-bouillon.com/">
   <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/">
   <link rel="alternate" hreflang="x-default" href="https://brasse-bouillon.com/">
-  
-  <!-- Open Graph / Facebook -->
+
+  <!-- Open Graph -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://brasse-bouillon.com/">
   <meta property="og:title" content="Brasse-Bouillon | Application de brassage amateur">
   <meta property="og:description" content="Crée des recettes de bière, calcule IBU/ABV et suis la fermentation avec un guide de brassage pas à pas.">
   <meta property="og:image" content="https://brasse-bouillon.com/og-image.png">
   <meta property="og:image:alt" content="Brasse-Bouillon, application mobile de brassage amateur">
-  
+
   <!-- Twitter -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:url" content="https://brasse-bouillon.com/">
@@ -27,19 +27,19 @@
   <meta name="twitter:description" content="L’application des brasseurs amateurs : recettes de bière, calculs IBU/ABV, suivi fermentation et guide pas à pas.">
   <meta name="twitter:image" content="https://brasse-bouillon.com/og-image.png">
   <meta name="twitter:image:alt" content="Brasse-Bouillon, application mobile de brassage amateur">
-  
+
   <!-- Favicon -->
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
   <link rel="apple-touch-icon" href="logo-icon-32.png">
-  
-  <!-- Preconnect for performance -->
+
+  <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="site.css">
-  
+
   <!-- Organization Schema -->
   <script type="application/ld+json">
   {
@@ -53,8 +53,7 @@
     "email": "contact@brasse-bouillon.com",
     "founder": {
       "@type": "Person",
-      "name": "Benoît Bremaud",
-      "url": "https://www.linkedin.com/in/benoit-bremaud"
+      "name": "Benoît Bremaud"
     },
     "contactPoint": {
       "@type": "ContactPoint",
@@ -67,9 +66,6 @@
       "Calcul IBU",
       "Calcul ABV",
       "Suivi de fermentation"
-    ],
-    "sameAs": [
-      "https://www.linkedin.com/in/benoit-bremaud"
     ]
   }
   </script>
@@ -83,50 +79,22 @@
       {
         "@type": "Question",
         "name": "Quand l’app sera disponible ?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Nous avançons par phases. Une version bêta sera proposée dès qu’un socle stable sera prêt."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Puis-je participer ?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Oui : via le questionnaire, les retours UX et le contact direct."
-        }
+        "acceptedAnswer": { "@type": "Answer", "text": "Nous avançons par phases. Une version bêta sera proposée dès qu’un socle stable sera prêt." }
       },
       {
         "@type": "Question",
         "name": "Pour quel niveau ?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Débutants comme confirmés : l’objectif est d’aider tout le monde à mieux brasser."
-        }
+        "acceptedAnswer": { "@type": "Answer", "text": "Débutants comme confirmés : l’objectif est d’aider tout le monde à mieux brasser." }
       },
       {
         "@type": "Question",
         "name": "iOS, Android… ou les deux ?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "L’objectif produit est une disponibilité sur les deux plateformes. Le déploiement se fera progressivement avec une phase bêta en amont."
-        }
+        "acceptedAnswer": { "@type": "Answer", "text": "L’objectif produit est une disponibilité sur les deux plateformes, avec une phase bêta en amont." }
       },
       {
         "@type": "Question",
         "name": "Mes recettes et brassins seront-ils sauvegardés ?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Oui. La trajectoire produit prévoit un historique structuré des recettes/brassins avec persistance pour suivre et reproduire plus facilement tes sessions."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Comment suivre les nouveautés ?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "La roadmap et le journal de développement sont mis à jour en continu sur le site, avec un historique traçable des évolutions livrées."
-        }
+        "acceptedAnswer": { "@type": "Answer", "text": "Oui. Tes recettes et brassins sont historisés pour suivre et reproduire facilement tes sessions." }
       }
     ]
   }
@@ -142,306 +110,166 @@
         <span>Brasse-Bouillon</span>
       </a>
       <nav class="header-nav">
-        <a href="#features">Fonctionnalités</a>
-        <a href="#brewAssistantFr">Assistant</a>
-        <a href="#roadmapHeadingFr">Roadmap</a>
+        <a href="#journeyFr">Parcours</a>
+        <a href="#features">L’app</a>
         <a href="#faq">FAQ</a>
-        <a href="#newsletterFr">Newsletter</a>
-        <a href="#contact">Contact</a>
+        <a href="#participerFr" class="header-cta">Rejoindre la waitlist</a>
       </nav>
-      <div class="header-right">
-        <div class="language-switch" role="navigation" aria-label="Choix de langue">
-          <a href="index.html" aria-label="Version française">🇫🇷 FR</a> ·
-          <a href="index-en.html" aria-label="Version anglaise">🇬🇧 EN</a>
-        </div>
-      </div>
     </div>
   </header>
 
   <main class="page" id="mainContentFr">
     <div class="shell">
       <p class="responsibility-banner">
-        🍺 Brasse-Bouillon s’adresse aux adultes (18+) et promeut une consommation responsable.
-        L’abus d’alcool est dangereux pour la santé.
+        Brasse-Bouillon s’adresse aux adultes (18+) et promeut une consommation responsable. L’abus d’alcool est dangereux pour la santé.
       </p>
 
       <section class="hero">
-        <div class="logo-wrap">
+        <span class="pill">Bêta 2026 · Places limitées</span>
+        <h1>
+          Brasse ta première bière <em>sans peur de rater.</em>
+        </h1>
+        <p class="intro">
+          De la recette choisie à la première gorgée, l’app te dit quoi faire, quand, et pourquoi.
+          Sans jargon, sans calcul de tête, sans surprise.
+        </p>
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="#participerFr">Rejoindre la waitlist</a>
+          <a class="btn btn-ghost" href="#journeyFr">Voir comment ça se passe</a>
+        </div>
+        <div class="hero-mascot">
           <img class="logo" src="logo-hero.png" alt="Mascotte officielle Brasse-Bouillon" loading="eager" width="180" height="180">
         </div>
-        <p class="pill">🚀 Bêta 2026 • Places limitées</p>
-        <h1>Brasse-Bouillon : ton copilote brassage pour réussir chaque brassin</h1>
-        <p class="intro">
-          Du premier kit à la recette avancée all-grain, Brasse-Bouillon te guide, t’assiste et te motive.
-          Objectif : un brassage plus simple, plus fun, plus précis — et des résultats dont tu es fier à chaque session.
-        </p>
-        <div class="actions">
-          <a class="btn btn-secondary" href="#brewAssistantFr">Voir le guide pas-à-pas</a>
-          <a class="btn btn-primary" href="#newsletterFr">Rejoindre la waitlist</a>
-          <a class="btn btn-secondary" href="#questionnaireFr">Influencer la roadmap</a>
-        </div>
-        <p class="badge">🔥 Newsletter + questionnaire + contact direct : 3 façons de participer au projet.</p>
       </section>
 
       <section class="section-block" id="journeyFr">
-        <h2 class="section-title">🧭 Comment ça se passe, ton premier brassin</h2>
-        <p class="section-intro">De la recette choisie à la première gorgée, Brasse-Bouillon t’accompagne à chaque étape — pour que tu te lances sans peur de rater.</p>
+        <p class="section-eyebrow">Le parcours</p>
+        <h2 class="section-title">De la recette à la <em>dégustation</em></h2>
+        <p class="section-intro">Quatre étapes, un copilote à chaque moment. Tu n’es jamais seul devant tes cuves.</p>
         <ol class="journey-grid">
           <li class="journey-step">
+            <span class="journey-num" aria-hidden="true">01</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-1-catalog.png" alt="Capture de l’écran Recettes avec « La Première du dimanche » sélectionnée dans le catalogue guidé" loading="lazy" width="320" height="640">
             </div>
-            <h3>1. Choisis ta première recette</h3>
-            <p>Un catalogue de recettes calibrées pour réussir dès le premier brassin — sans jargon, sans surprise.</p>
+            <h3>Choisis ta recette</h3>
+            <p>Un catalogue calibré pour réussir dès le premier brassin — sans jargon, sans surprise.</p>
           </li>
           <li class="journey-step">
+            <span class="journey-num" aria-hidden="true">02</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-2-brewing.png" alt="Capture de l’écran de pilotage du brassin pendant l’empâtage à 67°C, avec timer et étapes" loading="lazy" width="320" height="640">
             </div>
-            <h3>2. Brasse pas à pas</h3>
-            <p>L’app te dit quoi faire, quand, et pourquoi — empâtage, ébullition, refroidissement, sans louper une étape.</p>
+            <h3>Brasse pas à pas</h3>
+            <p>L’app te dit quoi faire, quand, et pourquoi — empâtage, ébullition, refroidissement.</p>
           </li>
           <li class="journey-step">
+            <span class="journey-num" aria-hidden="true">03</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-3-fermenting.png" alt="Capture de l’écran de fermentation avec la barre de progression jour 5 sur 14 et la densité actuelle" loading="lazy" width="320" height="640">
             </div>
-            <h3>3. Suis la fermentation</h3>
-            <p>Jours de fermentation, densité actuelle, température — un coup d’œil et tu sais où tu en es.</p>
+            <h3>Suis la fermentation</h3>
+            <p>Jours, densité, température. Un coup d’œil et tu sais où tu en es.</p>
           </li>
           <li class="journey-step">
+            <span class="journey-num" aria-hidden="true">04</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-4-deguste.png" alt="Capture de l’écran de célébration « brassin terminé » avec la bouteille et l’étiquette personnalisée" loading="lazy" width="320" height="640">
             </div>
-            <h3>4. Mets en bouteille, savoure</h3>
-            <p>Colle ton étiquette, partage avec tes amis, et savoure ta première création — la fierté en plus.</p>
+            <h3>Mets en bouteille, savoure</h3>
+            <p>Colle ton étiquette, partage avec tes amis, savoure ta première création.</p>
           </li>
         </ol>
       </section>
 
       <section class="section-block" id="features">
-        <h2 class="section-title">🍻 Les fonctionnalités qui vont te faire aimer chaque brassin</h2>
-        <p class="section-intro">Tout est pensé pour te faire gagner du temps, réduire les erreurs et progresser brassin après brassin.</p>
+        <p class="section-eyebrow">Trois outils, un copilote</p>
+        <h2 class="section-title">L’<em>essentiel</em>, rien que l’essentiel</h2>
+        <p class="section-intro">Pas de bardage de fonctionnalités. Trois piliers, pensés pour te faire gagner du temps et progresser.</p>
         <div class="features-grid">
           <article class="feature-card">
             <div class="feature-screenshot">
               <img src="screenshots/feature-studio-recipes.png" alt="Capture de l’écran Studio de recettes avec onglets Ingrédients et calculs en direct" loading="lazy" width="280" height="560">
             </div>
-            <h3>Studio de recettes ultra pratique</h3>
-            <p>Crée, duplique, ajuste et versionne tes recettes en quelques taps, sans te perdre dans des écrans complexes.</p>
+            <h3>Studio de recettes</h3>
+            <p>Crée, duplique, ajuste tes recettes en quelques taps. Versionne et compare sans te perdre.</p>
           </article>
           <article class="feature-card">
             <div class="feature-screenshot">
               <img src="screenshots/feature-calculs-hops.png" alt="Capture de l’écran Calcul houblons avec onglets Rapide, Inversé et BU:GU et sliders interactifs" loading="lazy" width="280" height="560">
             </div>
-            <h3>Calculs brassage fiables</h3>
-            <p>IBU, ABV, couleur, volumes, rendements : tous les indicateurs essentiels au même endroit pour décider vite.</p>
+            <h3>Calculs brassage</h3>
+            <p>IBU, ABV, couleur, volumes, rendements. Tous les indicateurs au même endroit, fiables.</p>
           </article>
           <article class="feature-card">
             <div class="feature-screenshot">
               <img src="screenshots/feature-pilotage-batches.png" alt="Capture de l’écran Pilotage temps réel avec timeline des étapes et statuts" loading="lazy" width="280" height="560">
             </div>
-            <h3>Pilotage temps réel de session</h3>
-            <p>Timeline claire, rappels utiles, checkpoints critiques : tu sais exactement quoi faire, quand, et pourquoi.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-screenshot">
-              <img src="screenshots/feature-academy-empatage.png" alt="Capture de l’écran Académie avec un sujet d’empâtage détaillé et son contenu pédagogique" loading="lazy" width="280" height="560">
-            </div>
-            <h3>Assistant de brassage guidé</h3>
-            <p>Choisis ton parcours (All-grain, BIAB ou Kit/Extrait) et laisse-toi guider pas à pas : impossible de rater ton brassin.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-screenshot">
-              <img src="screenshots/feature-batches-history.png" alt="Capture de l’écran Mes Brassins avec trois brassins « La Première du dimanche » à différents stades" loading="lazy" width="280" height="560">
-            </div>
-            <h3>Historique qui fait progresser</h3>
-            <p>Compare tes lots, retrouve tes décisions, identifie ce qui marche et améliore objectivement tes futures recettes.</p>
-          </article>
-          <article class="feature-card">
-            <div class="feature-screenshot">
-              <img src="screenshots/feature-social-feed.png" alt="Capture de l’écran Communauté avec des brassins partagés, leurs réactions et commentaires" loading="lazy" width="280" height="560">
-            </div>
-            <h3>Partage & feedback communauté</h3>
-            <p>Montre tes créations, récupère des retours utiles et découvre des idées inspirantes pour ton prochain brassin.</p>
+            <h3>Pilotage guidé</h3>
+            <p>Timeline claire, rappels utiles, checkpoints critiques. Tu sais quoi faire, quand, pourquoi.</p>
           </article>
         </div>
       </section>
 
-      <section class="section-block" id="brewAssistantFr">
-        <h2 class="section-title">🧭 Guide de brassage pas-à-pas : 3 parcours, un seul objectif</h2>
-        <p class="section-intro">Tu choisis ton niveau et ta méthode, Brasse-Bouillon te guide sur chaque étape critique jusqu’à la fermentation.</p>
-        <div class="guide-grid">
-          <article class="guide-card">
-            <h3>All-grain classique</h3>
-            <ul>
-              <li>Préparation eau + pH + concassage</li>
-              <li>Empâtage, paliers, rinçage et densités</li>
-              <li>Ébullition, houblonnage, refroidissement</li>
-              <li>Fermentation + suivi + conditionnement</li>
-            </ul>
-          </article>
-          <article class="guide-card">
-            <h3>BIAB (Brew In A Bag)</h3>
-            <ul>
-              <li>Setup BIAB rapide et sécurisant</li>
-              <li>Gestion température et extraction</li>
-              <li>Plan de houblonnage simplifié</li>
-              <li>Checklist anti-oubli jusqu’au cold crash</li>
-            </ul>
-          </article>
-          <article class="guide-card">
-            <h3>Kits / Extraits (débutants)</h3>
-            <ul>
-              <li>Démarrage facile sans jargon inutile</li>
-              <li>Volumes, dilution et sanitisation guidés</li>
-              <li>Aide aux timings et températures clés</li>
-              <li>Première réussite sans stress</li>
-            </ul>
-          </article>
-        </div>
-        <p class="badge">✅ Rappels contextuels, étapes obligatoires et points de contrôle : Brasse-Bouillon t’assiste du début à la mise en bouteille.</p>
-      </section>
-
-      <section class="section-block">
-        <h2 class="section-title" id="roadmapHeadingFr">🗺️ Roadmap du projet</h2>
-        <div class="roadmap-controls" id="roadmapControlsFr" role="toolbar" aria-label="Filtres de la roadmap">
-          <button class="chip active" data-filter="all" aria-pressed="true" onclick="filterRoadmapFr('all', this)">Toutes</button>
-          <button class="chip" data-filter="current" aria-pressed="false" onclick="filterRoadmapFr('current', this)">En cours</button>
-          <button class="chip" data-filter="next" aria-pressed="false" onclick="filterRoadmapFr('next', this)">À venir</button>
-          <button class="chip" data-filter="done" aria-pressed="false" onclick="filterRoadmapFr('done', this)">Terminées</button>
-        </div>
-        <div id="roadmapTrackFr" class="roadmap-track" role="region" aria-live="polite" aria-labelledby="roadmapHeadingFr"></div>
-        <p class="badge">
-          Historique détaillé des actions réalisées :
-          <a href="docs/ROADMAP.md" target="_blank" rel="noopener noreferrer">section “Done” de la feuille de route</a>.
-        </p>
-      </section>
-
-      <section class="section-block">
-        <h2 class="section-title">🧪 Journal de développement</h2>
-        <div class="section-grid">
-          <div class="mini-card">
-            <h3>Fin février 2026 · Côté produit</h3>
-            Suite des calculateurs finalisée (couleur/houblons/eau/conversions), expérience boutique enrichie (catégories + kits + contenus démo), hubs Académie/Outils simplifiés et accueil repensé en mode lecture avec découverte ingrédients.
-          </div>
-          <div class="mini-card">
-            <h3>Fin février 2026 · Côté plateforme</h3>
-            APIs produit étendues (Hub’Eau + ingrédients recette + métriques de brassage), détail recette “Mon livre” complété par des fiches malts “must-have”, et synchronisation roadmap/devlog maintenue.
-          </div>
+      <section class="section-block" id="faqSection">
+        <p class="section-eyebrow">Questions fréquentes</p>
+        <h2 class="section-title" id="faq">Les <em>doutes</em> avant de se lancer</h2>
+        <div class="faq-grid">
+          <details class="faq-item">
+            <summary>Quand l’app sera disponible ?</summary>
+            <p>Nous avançons par phases. Une version bêta sera proposée dès qu’un socle stable sera prêt — la waitlist est prioritaire.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Pour quel niveau ?</summary>
+            <p>Débutants comme confirmés. L’objectif est d’aider tout le monde à mieux brasser, sans imposer un seul chemin.</p>
+          </details>
+          <details class="faq-item">
+            <summary>iOS, Android… ou les deux ?</summary>
+            <p>Les deux plateformes sont visées, avec une phase bêta progressive.</p>
+          </details>
+          <details class="faq-item">
+            <summary>Mes recettes et brassins seront-ils sauvegardés ?</summary>
+            <p>Oui. Tes recettes et brassins sont historisés pour suivre et reproduire facilement tes sessions.</p>
+          </details>
         </div>
       </section>
 
-      <section class="section-block" id="guideBrassageSeoFr">
-        <h2 class="section-title">📘 Guide brassage amateur : réussir sa recette de bière de A à Z</h2>
+      <section class="section-block participate" id="participerFr">
+        <p class="section-eyebrow">Participer</p>
+        <h2 class="section-title">Rejoins la <em>première fournée</em></h2>
         <p class="section-intro">
-          Tu veux améliorer ton brassage maison ? Cette méthode simple t’aide à structurer chaque session :
-          préparation, calculs IBU/ABV, suivi fermentation et analyse post-brassin.
+          Laisse ton email pour entrer dans la boucle bêta. Tu peux aussi partager ton avis ou nous écrire en direct.
         </p>
-        <div class="section-grid">
-          <div class="mini-card">
-            <h3>1. Préparer une recette de bière claire et reproductible</h3>
-            Définis style, volume, densité cible et houblonnage, puis garde un historique propre pour comparer tes brassins.
-          </div>
-          <div class="mini-card">
-            <h3>2. Fiabiliser les calculs IBU, ABV et volumes</h3>
-            Vérifie les indicateurs clés avant l’ébullition pour limiter les écarts et garder le contrôle sur le résultat final.
-          </div>
-          <div class="mini-card">
-            <h3>3. Suivre la fermentation sans rien oublier</h3>
-            Utilise une timeline d’étapes, des checkpoints et des rappels pour sécuriser les décisions critiques jusqu’au conditionnement.
-          </div>
-        </div>
-        <p class="badge">
-          Pour aller plus loin :
-          <a href="#brewAssistantFr">assistant de brassage guidé</a>,
-          <a href="#faq">FAQ</a>,
-          <a href="#newsletterFr">newsletter</a>
-          et <a href="#contact">contact direct</a>.
-        </p>
-      </section>
 
-      <section class="section-block">
-        <h2 class="section-title" id="faq">❓ FAQ rapide</h2>
-        <div class="section-grid">
-          <div class="mini-card">
-            <h3>Quand l’app sera disponible ?</h3>
-            Nous avançons par phases. Une version bêta sera proposée dès qu’un socle stable sera prêt.
-          </div>
-          <div class="mini-card">
-            <h3>Puis-je participer ?</h3>
-            Oui : via le questionnaire, les retours UX et le contact direct.
-          </div>
-          <div class="mini-card">
-            <h3>Pour quel niveau ?</h3>
-            Débutants comme confirmés : l’objectif est d’aider tout le monde à mieux brasser.
-          </div>
-          <div class="mini-card">
-            <h3>iOS, Android… ou les deux ?</h3>
-            L’objectif produit est une disponibilité sur les deux plateformes. Le déploiement se fera progressivement avec une phase bêta en amont.
-          </div>
-          <div class="mini-card">
-            <h3>Mes recettes et brassins seront-ils sauvegardés ?</h3>
-            Oui. La trajectoire produit prévoit un historique structuré des recettes/brassins avec persistance pour suivre et reproduire plus facilement tes sessions.
-          </div>
-          <div class="mini-card">
-            <h3>Comment suivre les nouveautés ?</h3>
-            La roadmap et le journal de développement sont mis à jour en continu sur le site, avec un historique traçable des évolutions livrées.
-          </div>
-        </div>
-      </section>
-
-      <section class="section-block">
-        <h2 class="section-title">🍺 Recette mise en avant</h2>
-        <div class="mini-card">
-          <h3>Session IPA “Citrus Bloom” (exemple)</h3>
-          Légère, aromatique, parfaite pour découvrir le suivi de recette dans Brasse-Bouillon.
-          Plus de recettes et de fiches détaillées arrivent bientôt.
-        </div>
-      </section>
-
-      <section class="section-block" id="newsletterFr">
-        <h2 class="section-title">📮 Newsletter Brasse-Bouillon</h2>
-        <p class="section-intro">
-          Reçois les avancées notables du produit et de la roadmap (rythme léger, sans spam).
-        </p>
-        <form id="newsletterFormFr" class="contact-form">
+        <form id="newsletterFormFr" class="contact-form" aria-describedby="newsletterStatusFr">
           <input type="hidden" name="_subject" value="Inscription newsletter Brasse-Bouillon (FR)">
           <input type="hidden" name="lang" value="fr">
           <input type="hidden" name="source" value="newsletter">
           <input type="hidden" name="message" value="Nouvelle inscription newsletter via le site (FR)">
 
-          <label class="sr-only" for="newsletterEmailFr">Adresse email newsletter</label>
-          <input id="newsletterEmailFr" type="email" name="email" placeholder="Ton email pour recevoir les nouveautés" required>
+          <label class="sr-only" for="newsletterEmailFr">Adresse email pour la waitlist</label>
+          <input id="newsletterEmailFr" type="email" name="email" placeholder="ton@email.fr" required>
 
           <label class="consent">
             <input type="checkbox" name="newsletter_consent" value="accepted" required>
-            J’accepte de recevoir les nouvelles de Brasse-Bouillon et je pourrai me désinscrire à tout moment.
+            J’accepte de recevoir les nouvelles de Brasse-Bouillon et je peux me désinscrire à tout moment.
           </label>
           <p class="consent-note">
-            En t’abonnant, tu acceptes notre
-            <a href="terms.html" target="_blank" rel="noopener noreferrer">Conditions d’utilisation</a>,
-            notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">Politique de confidentialité</a>
-            et notre <a href="cookies.html" target="_blank" rel="noopener noreferrer">Politique cookies</a>.
+            En t’abonnant, tu acceptes nos
+            <a href="terms.html" target="_blank" rel="noopener noreferrer">conditions</a>,
+            notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">politique de confidentialité</a>
+            et notre <a href="cookies.html" target="_blank" rel="noopener noreferrer">politique cookies</a>.
           </p>
 
           <div class="actions actions-compact">
-            <button class="btn btn-primary" type="submit">S’abonner à la newsletter</button>
+            <button class="btn btn-primary" type="submit">Rejoindre la waitlist</button>
+            <button class="btn btn-ghost" id="questionnaireToggleFr" type="button" aria-expanded="false" onclick="toggleQuestionnaire('fr')">
+              Partager ton avis
+            </button>
+            <a class="btn btn-ghost" href="mailto:contact@brasse-bouillon.com">Nous écrire</a>
           </div>
         </form>
         <p id="newsletterStatusFr" class="form-status" role="status" aria-live="polite"></p>
-      </section>
-
-      <section class="section-block" id="questionnaireFr">
-        <h2 class="section-title">🧾 Questionnaire communauté</h2>
-        <p class="section-intro">
-          2 minutes suffisent pour nous aider à construire Brasse-Bouillon. Tes réponses restent confidentielles.
-        </p>
-        <div class="actions">
-          <button class="btn btn-primary" id="questionnaireToggleFr" type="button" aria-expanded="false" onclick="toggleQuestionnaire('fr')">
-            Ouvrir le questionnaire
-          </button>
-          <a class="btn btn-secondary" href="mailto:contact@brasse-bouillon.com">Nous contacter</a>
-        </div>
 
         <form id="questionnaireFormFr" class="questionnaire-form" hidden>
           <input type="hidden" name="_subject" value="Nouvelle réponse - Questionnaire Brasse-Bouillon (FR)">
@@ -450,21 +278,17 @@
 
           <div class="questionnaire-grid">
             <fieldset class="form-field-full">
-              <legend>1. Votre profil</legend>
+              <legend>Ton profil</legend>
               <div class="radio-list">
                 <label><input type="radio" name="profil" value="Debutant" required>Débutant (-1 an)</label>
                 <label><input type="radio" name="profil" value="Amateur confirme">Amateur confirmé</label>
                 <label><input type="radio" name="profil" value="Passionne avance">Passionné avancé</label>
-                <label><input type="radio" name="profil" value="Professionnel">Micro-brasserie / Professionnel</label>
-              </div>
-              <div class="form-field form-field-spacing-sm">
-                <label for="qProfilAutreFr">Autre</label>
-                <input id="qProfilAutreFr" type="text" name="profil_autre" placeholder="Précise ton profil si besoin">
+                <label><input type="radio" name="profil" value="Professionnel">Micro-brasserie / Pro</label>
               </div>
             </fieldset>
 
             <div class="form-field form-field-full">
-              <label for="qFrequencyFr">2. Fréquence de brassage</label>
+              <label for="qFrequencyFr">Fréquence de brassage</label>
               <select id="qFrequencyFr" name="frequence" required>
                 <option value="">Choisir…</option>
                 <option value="1-2 fois par an">1-2 fois par an</option>
@@ -475,88 +299,14 @@
               </select>
             </div>
 
-            <fieldset class="form-field-full">
-              <legend>3. Difficultés principales (max 3)</legend>
-              <div class="checkbox-list">
-                <label><input type="checkbox" name="difficultes[]" value="Calcul IBU ABV">Calcul IBU / ABV</label>
-                <label><input type="checkbox" name="difficultes[]" value="Gestion recettes">Gestion des recettes</label>
-                <label><input type="checkbox" name="difficultes[]" value="Gestion stock">Gestion des stocks</label>
-                <label><input type="checkbox" name="difficultes[]" value="Journal brassin">Journal de brassage</label>
-                <label><input type="checkbox" name="difficultes[]" value="Reproductibilite">Reproductibilité</label>
-                <label><input type="checkbox" name="difficultes[]" value="Aucune">Aucune difficulté</label>
-              </div>
-              <div class="form-field form-field-spacing-sm">
-                <label for="qDifficultesAutreFr">Autre</label>
-                <input id="qDifficultesAutreFr" type="text" name="difficultes_autre" placeholder="Autre difficulté éventuelle">
-              </div>
-            </fieldset>
-
-            <fieldset class="form-field-full">
-              <legend>4. Outils utilisés</legend>
-              <div class="checkbox-list">
-                <label><input type="checkbox" name="outils[]" value="Excel">Excel / Google Sheets</label>
-                <label><input type="checkbox" name="outils[]" value="BeerSmith">BeerSmith</label>
-                <label><input type="checkbox" name="outils[]" value="Brewfather">Brewfather</label>
-                <label><input type="checkbox" name="outils[]" value="Carnet papier">Carnet papier</label>
-                <label><input type="checkbox" name="outils[]" value="Application mobile">Application mobile</label>
-                <label><input type="checkbox" name="outils[]" value="Aucun">Aucun outil structuré</label>
-              </div>
-            </fieldset>
-
-            <fieldset class="form-field-full">
-              <legend>5. Importance des fonctionnalités (1 à 5)</legend>
-              <div class="form-field">
-                <label for="qCalcIbuFr">Calcul IBU / ABV</label>
-                <input id="qCalcIbuFr" type="range" name="calc_ibu" min="1" max="5" value="3">
-              </div>
-              <div class="form-field">
-                <label for="qRecettesFr">Recettes</label>
-                <input id="qRecettesFr" type="range" name="recettes" min="1" max="5" value="3">
-              </div>
-              <div class="form-field">
-                <label for="qJournalFr">Journal</label>
-                <input id="qJournalFr" type="range" name="journal" min="1" max="5" value="3">
-              </div>
-              <div class="form-field">
-                <label for="qStockFr">Stock</label>
-                <input id="qStockFr" type="range" name="stock" min="1" max="5" value="3">
-              </div>
-              <div class="form-field">
-                <label for="qPartageFr">Partage</label>
-                <input id="qPartageFr" type="range" name="partage" min="1" max="5" value="3">
-              </div>
-            </fieldset>
-
-            <fieldset class="form-field-full">
-              <legend>6. Vos 3 priorités absolues</legend>
-              <div class="checkbox-list">
-                <label><input type="checkbox" name="priorites[]" value="Calcul IBU ABV">Calcul IBU / ABV</label>
-                <label><input type="checkbox" name="priorites[]" value="Recettes">Recettes</label>
-                <label><input type="checkbox" name="priorites[]" value="Journal">Journal</label>
-                <label><input type="checkbox" name="priorites[]" value="Stock">Stock</label>
-                <label><input type="checkbox" name="priorites[]" value="Partage">Partage</label>
-              </div>
-              <p class="helper-text">Sélectionne entre 1 et 3 priorités pour nous aider à mieux cadrer la roadmap.</p>
-            </fieldset>
-
-            <fieldset class="form-field-full">
-              <legend>7. Application mobile</legend>
-              <div class="radio-list">
-                <label><input type="radio" name="mobile" value="Oui absolument" required>Oui absolument</label>
-                <label><input type="radio" name="mobile" value="Oui si valeur ajoutee">Oui si réelle valeur ajoutée</label>
-                <label><input type="radio" name="mobile" value="Peut etre">Peut-être</label>
-                <label><input type="radio" name="mobile" value="Non">Non</label>
-              </div>
-            </fieldset>
-
             <div class="form-field form-field-full">
-              <label for="qSuggestionFr">8. Une fonctionnalité idéale ?</label>
+              <label for="qSuggestionFr">Une fonctionnalité idéale ?</label>
               <textarea id="qSuggestionFr" name="suggestion" rows="4" placeholder="Partage ton idée la plus utile pour ton quotidien de brasseur"></textarea>
             </div>
 
             <div class="form-field form-field-full">
-              <label for="qEmailFr">9. Rester informé (optionnel)</label>
-              <input id="qEmailFr" type="email" name="email" placeholder="Votre email (optionnel)">
+              <label for="qEmailFr">Rester informé (optionnel)</label>
+              <input id="qEmailFr" type="email" name="email" placeholder="ton@email.fr">
             </div>
           </div>
 
@@ -565,44 +315,21 @@
             J’accepte que mes données soient utilisées dans le cadre du développement de Brasse-Bouillon.
           </label>
           <p class="consent-note">
-            Voir notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">Politique de confidentialité</a>
-            et notre <a href="terms.html" target="_blank" rel="noopener noreferrer">Conditions d’utilisation</a>.
+            Voir notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">politique de confidentialité</a>
+            et nos <a href="terms.html" target="_blank" rel="noopener noreferrer">conditions</a>.
           </p>
 
           <div class="actions actions-compact">
-            <button class="btn btn-primary" type="submit">Contribuer 🍻</button>
+            <button class="btn btn-primary" type="submit">Envoyer mon retour</button>
           </div>
         </form>
-
         <p id="questionnaireStatusFr" class="form-status" role="status" aria-live="polite"></p>
       </section>
 
-      <section class="section-block">
-        <h2 class="section-title" id="contact">📬 Contact direct</h2>
-        <form class="contact-form" action="https://formspree.io/f/mqaqqvab" method="POST">
-          <label class="sr-only" for="emailFr">Adresse email</label>
-          <input id="emailFr" type="email" name="email" placeholder="Ton email" required>
-          <label class="sr-only" for="messageFr">Message</label>
-          <textarea id="messageFr" name="message" placeholder="Ton message" required></textarea>
-          <label class="consent">
-            <input type="checkbox" name="contact_legal_acceptance" value="accepted" required>
-            J’accepte les conditions d’utilisation et la politique de confidentialité.
-          </label>
-          <p class="consent-note">
-            En envoyant ce message, tu acceptes notre
-            <a href="terms.html" target="_blank" rel="noopener noreferrer">Conditions d’utilisation</a>,
-            notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">Politique de confidentialité</a>
-            et notre <a href="cookies.html" target="_blank" rel="noopener noreferrer">Politique cookies</a>.
-          </p>
-          <button class="btn btn-primary" type="submit">Envoyer</button>
-        </form>
-      </section>
-
       <footer class="footer">
-        Reste connecté(e) ! Tu peux aussi nous écrire à : <strong>contact@brasse-bouillon.com</strong>
-        <div class="badge">
-          Made with ❤️ by
-          <a href="https://www.linkedin.com/in/benoit-bremaud" target="_blank" rel="noopener noreferrer">Brasse-Bouillon</a>
+        <div class="footer-brand">
+          <span class="footer-mark">B·B</span>
+          <p>Brasse-Bouillon, l’app du brasseur amateur curieux. Contact : <strong>contact@brasse-bouillon.com</strong></p>
         </div>
         <div class="footer-links">
           <a href="legal.html">Mentions légales</a>
@@ -619,67 +346,18 @@
     const QUESTIONNAIRE_ENDPOINT = 'https://formspree.io/f/xeellqan';
     const NEWSLETTER_ENDPOINT = 'https://formspree.io/f/mqaqqvab';
 
-    const ROADMAP_PHASES_FR = [
-      { phase: 1, title: 'Idéation & positionnement', state: 'done', points: ['MVP défini', 'Questionnaire utilisateur', 'Manifeste fondateur'] },
-      { phase: 2, title: 'Analyse des canaux de communication', state: 'done', points: ['Cibles identifiées', 'Ligne éditoriale', 'Partage des résultats'] },
-      { phase: 3, title: 'Conception & préparation', state: 'done', points: ['Maquettes UI/UX', 'Architecture technique', 'Feuille de route visuelle'] },
-      { phase: 4, title: 'Développement du MVP', state: 'done', points: ['Auth/JWT + base API sécurisée', 'CRUD recettes + persistance des étapes', 'Module brassins (workflow + persistance + endpoints)', 'Calculateur brassage v1 (IBU/ABV/conversions)'] },
-      { phase: 5, title: 'Consolidation produit & site vitrine', state: 'current', points: ['Suite calculateurs finalisée (couleur/houblons/eau/conversions)', 'Boutique et contenus démo enrichis (catégories/kits + recettes + brassins)', 'UX des hubs Académie/Outils consolidée (cartes cliquables + navigation fiabilisée)', 'Accueil “reading-first” + espaces découverte + données ingrédients live progressives', 'Détail recette “Mon livre” complété par fiches malts “must-have”', 'APIs produit enrichies (profil d’eau Hub’Eau + ingrédients recette + métriques)', 'Roadmap et devlog publics synchronisés'] },
-      { phase: 6, title: 'Tests bêta & communauté', state: 'next', points: ['Bêta publique', 'Collecte feedback', 'Espace communautaire'] },
-      { phase: 7, title: 'Lancement officiel', state: 'next', points: ['Stores iOS/Android', 'Démo publique', 'Communication multi-canal'] },
-      { phase: 8, title: 'Documentation & écosystème', state: 'next', points: ['Fiches de brassage', 'Glossaire', 'Échange recettes'] },
-      { phase: 9, title: 'Améliorations & ouverture', state: 'next', points: ['Optimisations UX', 'Modules complémentaires', 'API ouverte'] },
-      { phase: 10, title: 'Partenariats & impact', state: 'next', points: ['Microbrasseries', 'Kit Studio B22', 'Indicateurs open source'] }
-    ];
-
     const TOGGLE_LABELS = {
-      fr: { open: 'Ouvrir le questionnaire', close: 'Fermer le questionnaire' },
-      en: { open: 'Open questionnaire', close: 'Close questionnaire' }
+      fr: { open: 'Partager ton avis', close: 'Fermer le questionnaire' }
     };
 
-    function stateLabelFr(state) {
-      if (state === 'done') return 'Terminé';
-      if (state === 'current') return 'En cours';
-      return 'À venir';
-    }
-
-    function renderRoadmapFr(filter = 'all') {
-      BBShared.renderRoadmap({
-        rootId: 'roadmapTrackFr',
-        phases: ROADMAP_PHASES_FR,
-        filter,
-        getStateLabel: stateLabelFr
-      });
-    }
-
-    function filterRoadmapFr(filter, el) {
-      BBShared.setActiveRoadmapFilter({
-        controlsSelector: '#roadmapControlsFr .chip',
-        activeElement: el
-      });
-      renderRoadmapFr(filter);
-    }
-
     function toggleQuestionnaire(lang) {
-      BBShared.toggleQuestionnaire({
-        lang,
-        labels: TOGGLE_LABELS
-      });
+      BBShared.toggleQuestionnaire({ lang, labels: TOGGLE_LABELS });
     }
-
-    renderRoadmapFr();
 
     BBShared.setupQuestionnaire({
       formId: 'questionnaireFormFr',
       statusId: 'questionnaireStatusFr',
       endpoint: QUESTIONNAIRE_ENDPOINT,
-      checkboxLimits: [
-        { fieldName: 'difficultes[]', maxChoices: 3, message: 'Maximum 3 choix autorisés pour cette question.' },
-        { fieldName: 'priorites[]', maxChoices: 3, message: 'Maximum 3 choix autorisés pour cette question.' }
-      ],
-      requiredCheckboxGroups: [
-        { fieldName: 'priorites[]', minRequired: 1, message: 'Sélectionne au moins 1 priorité avant d’envoyer le questionnaire.' }
-      ],
       messages: {
         endpointMissing: 'Endpoint Formspree du questionnaire non configuré.',
         sending: 'Envoi en cours…',
@@ -702,14 +380,14 @@
       messages: {
         endpointMissing: 'Endpoint newsletter non configuré.',
         sending: 'Inscription en cours…',
-        success: 'Super ! Ton inscription à la newsletter est confirmée.',
+        success: 'Super ! Ton inscription à la waitlist est confirmée.',
         http400: 'Adresse email invalide ou incomplète. Vérifie puis réessaie.',
         http429: 'Trop de tentatives. Merci d’attendre un instant avant de réessayer.',
-        http5xx: 'Le service newsletter est temporairement indisponible. Réessaie un peu plus tard.',
+        http5xx: 'Le service est temporairement indisponible. Réessaie un peu plus tard.',
         httpGeneric: 'Impossible d’enregistrer l’inscription pour le moment. Réessaie dans quelques minutes.',
         offline: 'Tu sembles hors ligne. Vérifie ta connexion puis réessaie.',
         aborted: 'La requête a été interrompue. Réessaie l’inscription.',
-        networkOrCors: 'Impossible de contacter le service newsletter (réseau/CORS). Réessaie bientôt.',
+        networkOrCors: 'Impossible de contacter le service (réseau/CORS). Réessaie bientôt.',
         unexpected: 'Une erreur inattendue est survenue. Réessaie dans quelques instants.'
       }
     });

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -111,7 +111,7 @@
       background: linear-gradient(90deg, var(--copper) 0%, var(--copper-deep) 50%, var(--moss) 100%);
       transform-origin: left center;
       transform: scaleX(0);
-      animation: scrollFill linear;
+      animation: scrollFill 1s linear both;
       animation-timeline: scroll(root);
     }
 

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -1,11 +1,11 @@
     /* ========================================================================
-       Brasse-Bouillon — design system
-       Artisan editorial: warm paper, espresso ink, copper highlights.
-       Display: Fraunces (variable, SOFT axis). Body: Inter.
+       Brasse-Bouillon — Variant A "Kinetic"
+       Cinematic motion: huge mascot, scrolling marquee, scroll progress rail,
+       magnetic buttons, animated connector lines between journey steps.
+       Display: Fraunces. Body: Inter.
        ====================================================================== */
 
     :root {
-      /* Palette */
       --paper: #f1e3bf;
       --paper-deep: #e6cf95;
       --foam: #fbf3da;
@@ -17,14 +17,11 @@
       --line: rgba(58, 40, 24, 0.16);
       --muted: #6b5a4c;
 
-      /* Legacy aliases (kept for forms/sub-pages) */
       --color-primary: var(--copper);
       --color-secondary: var(--copper-deep);
       --color-deep: var(--ink-soft);
       --color-ink: var(--ink);
       --color-bg: var(--paper);
-      --color-bg-deep: var(--paper-deep);
-      --color-surface: rgba(255, 252, 244, 0.92);
       --color-card: #ffffff;
       --color-text: var(--ink);
       --color-muted: var(--muted);
@@ -33,40 +30,24 @@
       --color-info: #f3f3f3;
       --color-focus: var(--copper);
       --color-error: #8a3a1a;
-      --color-foam: var(--foam);
       --color-accent: var(--copper);
       --color-accent-soft: rgba(197, 116, 45, 0.16);
 
-      /* Surface */
       --shadow-sm: 0 1px 2px rgba(40, 22, 10, 0.06);
       --shadow-md: 0 12px 28px rgba(60, 35, 16, 0.16);
       --shadow-lg: 0 28px 60px rgba(60, 35, 16, 0.22);
-      --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.75);
 
-      /* Geometry */
       --radius-sm: 8px;
       --radius-md: 16px;
       --radius-lg: 24px;
       --radius-xl: 36px;
 
-      /* Spacing */
-      --spacing-xs: 4px;
-      --spacing-sm: 8px;
-      --spacing-md: 16px;
-      --spacing-lg: 24px;
-      --spacing-xl: 40px;
-      --spacing-2xl: 72px;
-
-      /* Type */
       --font-display: 'Fraunces', 'Cormorant Garamond', Georgia, serif;
       --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
-
-      /* Motion */
       --ease-out-soft: cubic-bezier(0.22, 1, 0.36, 1);
     }
 
     *, *::before, *::after { box-sizing: border-box; }
-
     html { scroll-padding-top: 96px; }
 
     body {
@@ -75,17 +56,15 @@
       color: var(--ink);
       background-color: var(--paper);
       background-image:
-        radial-gradient(ellipse at 8% -6%, rgba(255, 244, 209, 0.95) 0%, transparent 42%),
-        radial-gradient(ellipse at 96% 6%, rgba(231, 207, 154, 0.9) 0%, transparent 38%),
-        radial-gradient(circle at 50% 120%, rgba(197, 116, 45, 0.16) 0%, transparent 55%);
+        radial-gradient(ellipse at 10% -8%, rgba(255, 244, 209, 0.95) 0%, transparent 42%),
+        radial-gradient(ellipse at 96% 8%, rgba(231, 207, 154, 0.9) 0%, transparent 38%),
+        radial-gradient(circle at 50% 120%, rgba(197, 116, 45, 0.18) 0%, transparent 55%);
       background-attachment: fixed;
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
-      text-rendering: optimizeLegibility;
       overflow-x: hidden;
     }
 
-    /* Paper-grain noise overlay */
     body::before {
       content: '';
       position: fixed;
@@ -114,10 +93,33 @@
     }
     .skip-link:focus { left: 12px; top: 12px; }
 
-    /* ========================================================================
-       Header
-       ====================================================================== */
+    /* ---- Scroll progress rail (Kinetic-specific) ---- */
+    .scroll-progress {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 3px;
+      background: rgba(26, 17, 10, 0.08);
+      z-index: 200;
+    }
 
+    .scroll-progress span {
+      display: block;
+      height: 100%;
+      width: 100%;
+      background: linear-gradient(90deg, var(--copper) 0%, var(--copper-deep) 50%, var(--moss) 100%);
+      transform-origin: left center;
+      transform: scaleX(0);
+      animation: scrollFill linear;
+      animation-timeline: scroll(root);
+    }
+
+    @keyframes scrollFill {
+      to { transform: scaleX(1); }
+    }
+
+    /* ---- Header ---- */
     .site-header {
       position: sticky;
       top: 0;
@@ -130,7 +132,7 @@
     }
 
     .header-inner {
-      max-width: 1180px;
+      max-width: 1240px;
       margin: 0 auto;
       display: flex;
       align-items: center;
@@ -146,17 +148,20 @@
     }
 
     .header-logo img {
-      width: 44px;
-      height: 44px;
+      width: 48px;
+      height: 48px;
       border-radius: 50%;
       object-fit: contain;
       background: #fff;
       border: 1px solid var(--line);
+      transition: transform 0.4s var(--ease-out-soft);
     }
+
+    .header-logo:hover img { transform: rotate(-12deg) scale(1.08); }
 
     .header-logo span {
       font-family: var(--font-display);
-      font-size: 1.45rem;
+      font-size: 1.5rem;
       font-weight: 700;
       letter-spacing: -0.015em;
       color: var(--ink);
@@ -166,7 +171,7 @@
     .header-nav {
       display: flex;
       align-items: center;
-      gap: 30px;
+      gap: 32px;
     }
 
     .header-nav a {
@@ -181,57 +186,49 @@
     .header-nav a:not(.header-cta)::after {
       content: '';
       position: absolute;
-      left: 0;
-      right: 0;
-      bottom: -6px;
+      left: 0; right: 0; bottom: -6px;
       height: 2px;
       background: var(--copper);
       border-radius: 2px;
       transform: scaleX(0);
       transform-origin: left center;
-      transition: transform 0.25s var(--ease-out-soft);
+      transition: transform 0.3s var(--ease-out-soft);
     }
 
     .header-nav a:not(.header-cta):hover { color: var(--ink); }
     .header-nav a:not(.header-cta):hover::after { transform: scaleX(1); }
 
     .header-nav .header-cta {
-      padding: 10px 18px;
+      padding: 11px 22px;
       border-radius: 999px;
       background: var(--ink);
       color: var(--foam);
       font-weight: 600;
-      transition: background-color 0.25s var(--ease-out-soft), transform 0.18s var(--ease-out-soft);
+      transition: background-color 0.3s var(--ease-out-soft), transform 0.2s var(--ease-out-soft);
     }
 
     .header-nav .header-cta:hover {
       background: var(--copper);
-      transform: translateY(-1px);
+      transform: translateY(-2px) scale(1.03);
     }
 
     @media (max-width: 760px) {
-      .header-nav { gap: 16px; font-size: 0.88rem; }
+      .header-nav { gap: 18px; font-size: 0.88rem; }
       .header-nav .header-cta { padding: 8px 14px; }
     }
 
-    /* ========================================================================
-       Page shell
-       ====================================================================== */
-
+    /* ---- Page shell ---- */
     .page {
       min-height: 100vh;
       display: flex;
       justify-content: center;
-      padding: 28px 16px 80px;
+      padding: 32px 16px 96px;
     }
 
-    .shell {
-      width: 100%;
-      max-width: 1180px;
-    }
+    .shell { width: 100%; max-width: 1240px; }
 
     .responsibility-banner {
-      margin: 0 auto 40px;
+      margin: 0 auto 48px;
       max-width: max-content;
       padding: 8px 18px;
       border-radius: 999px;
@@ -245,18 +242,18 @@
     }
 
     /* ========================================================================
-       Hero — editorial, asymmetric
+       HERO — KINETIC : massive mascot, parallax orbits, big type
        ====================================================================== */
 
     .hero {
       position: relative;
-      padding: clamp(48px, 7vw, 96px) clamp(28px, 5vw, 64px) clamp(64px, 8vw, 112px);
+      padding: clamp(56px, 8vw, 120px) clamp(28px, 5vw, 72px) clamp(80px, 10vw, 160px);
       border-radius: var(--radius-xl);
       background:
         radial-gradient(circle at 5% 8%, rgba(255, 255, 255, 0.6) 0%, transparent 35%),
         linear-gradient(165deg, var(--foam) 0%, var(--paper-deep) 100%);
       border: 1px solid var(--line);
-      box-shadow: var(--shadow-lg), var(--shadow-inset);
+      box-shadow: var(--shadow-lg);
       overflow: hidden;
       isolation: isolate;
       animation: fadeUp 1s var(--ease-out-soft) both;
@@ -265,12 +262,11 @@
     .hero::before {
       content: '';
       position: absolute;
-      width: 640px;
-      height: 640px;
-      right: -220px;
-      top: -220px;
-      background:
-        radial-gradient(circle, rgba(197, 116, 45, 0.32) 0%, transparent 65%);
+      width: 880px;
+      height: 880px;
+      right: -300px;
+      top: -300px;
+      background: radial-gradient(circle, rgba(197, 116, 45, 0.32) 0%, transparent 65%);
       z-index: -1;
       animation: floatSlow 14s ease-in-out infinite;
     }
@@ -278,50 +274,50 @@
     .hero::after {
       content: '';
       position: absolute;
-      width: 380px;
-      height: 380px;
-      left: -120px;
-      bottom: -180px;
-      background: radial-gradient(circle, rgba(74, 90, 43, 0.18) 0%, transparent 65%);
+      width: 520px;
+      height: 520px;
+      left: -180px;
+      bottom: -240px;
+      background: radial-gradient(circle, rgba(74, 90, 43, 0.2) 0%, transparent 65%);
       z-index: -1;
       animation: floatSlow 18s ease-in-out infinite reverse;
     }
 
     @keyframes floatSlow {
-      0%, 100% { transform: translate(0, 0); }
-      50% { transform: translate(-24px, 18px); }
+      0%, 100% { transform: translate(0, 0) scale(1); }
+      50% { transform: translate(-32px, 22px) scale(1.05); }
     }
 
     .pill {
       display: inline-flex;
       align-items: center;
       gap: 8px;
-      margin-bottom: 28px;
+      margin-bottom: 32px;
       border-radius: 999px;
-      padding: 7px 16px;
+      padding: 8px 18px;
       background: rgba(255, 255, 255, 0.7);
       border: 1px solid var(--line);
       color: var(--ink);
-      font-size: 0.72rem;
+      font-size: 0.74rem;
       font-weight: 700;
-      letter-spacing: 0.16em;
+      letter-spacing: 0.18em;
       text-transform: uppercase;
       backdrop-filter: blur(4px);
     }
 
     .pill::before {
       content: '';
-      width: 6px;
-      height: 6px;
+      width: 7px;
+      height: 7px;
       border-radius: 50%;
       background: var(--copper);
       box-shadow: 0 0 0 3px rgba(197, 116, 45, 0.25);
-      animation: pulse 2s ease-in-out infinite;
+      animation: pulse 1.8s ease-in-out infinite;
     }
 
     @keyframes pulse {
       0%, 100% { box-shadow: 0 0 0 3px rgba(197, 116, 45, 0.25); }
-      50% { box-shadow: 0 0 0 7px rgba(197, 116, 45, 0); }
+      50% { box-shadow: 0 0 0 9px rgba(197, 116, 45, 0); }
     }
 
     .hero h1 {
@@ -329,11 +325,12 @@
       font-family: var(--font-display);
       font-weight: 700;
       color: var(--ink);
-      font-size: clamp(2.6rem, 6.4vw, 4.6rem);
-      line-height: 0.98;
-      letter-spacing: -0.028em;
+      font-size: clamp(2.8rem, 7vw, 5.4rem);
+      line-height: 0.96;
+      letter-spacing: -0.03em;
       max-width: 14ch;
       font-variation-settings: 'SOFT' 30, 'opsz' 144;
+      animation: fadeUp 1.1s var(--ease-out-soft) 0.1s both;
     }
 
     .hero h1 em {
@@ -343,74 +340,96 @@
       font-variation-settings: 'SOFT' 100, 'opsz' 144;
       position: relative;
       display: inline-block;
+      animation: wiggle 6s ease-in-out infinite;
+    }
+
+    @keyframes wiggle {
+      0%, 100% { transform: rotate(0deg); }
+      50% { transform: rotate(-1.5deg); }
     }
 
     .hero h1 em::after {
       content: '';
       position: absolute;
-      left: -2%;
-      right: -2%;
-      bottom: 0.05em;
-      height: 0.12em;
-      background: linear-gradient(90deg, transparent 0%, rgba(197, 116, 45, 0.35) 20%, rgba(197, 116, 45, 0.35) 80%, transparent 100%);
+      left: -2%; right: -2%; bottom: 0.05em;
+      height: 0.14em;
+      background: linear-gradient(90deg, transparent 0%, rgba(197, 116, 45, 0.5) 20%, rgba(197, 116, 45, 0.5) 80%, transparent 100%);
       border-radius: 999px;
       z-index: -1;
     }
 
     .intro {
-      margin: 28px 0 0;
-      max-width: 46ch;
+      margin: 32px 0 0;
+      max-width: 44ch;
       color: var(--ink-soft);
-      font-size: clamp(1.05rem, 1.5vw, 1.18rem);
+      font-size: clamp(1.05rem, 1.5vw, 1.22rem);
       line-height: 1.6;
+      animation: fadeUp 1.1s var(--ease-out-soft) 0.2s both;
     }
 
     .hero-actions {
       display: flex;
       gap: 14px;
       flex-wrap: wrap;
-      margin-top: 36px;
+      margin-top: 40px;
+      animation: fadeUp 1.1s var(--ease-out-soft) 0.3s both;
     }
 
+    /* ---- HUGE mascot with 3 orbital rings ---- */
     .hero-mascot {
       position: absolute;
-      right: clamp(-20px, -2vw, 24px);
-      bottom: clamp(-40px, -3vw, -16px);
-      width: clamp(150px, 24vw, 280px);
-      height: clamp(150px, 24vw, 280px);
+      right: clamp(-60px, -4vw, 20px);
+      bottom: clamp(-80px, -6vw, -40px);
+      width: clamp(220px, 36vw, 440px);
+      height: clamp(220px, 36vw, 440px);
       border-radius: 50%;
       background:
         radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.98) 0%, rgba(251, 243, 218, 0.92) 55%, rgba(231, 207, 154, 0.55) 100%);
       border: 1px solid var(--line);
       box-shadow:
-        0 28px 56px rgba(99, 56, 24, 0.32),
-        inset 0 2px 6px rgba(255, 255, 255, 0.85);
+        0 32px 80px rgba(99, 56, 24, 0.4),
+        inset 0 2px 8px rgba(255, 255, 255, 0.9);
       display: flex;
       align-items: center;
       justify-content: center;
-      animation: heroFloat 6s ease-in-out infinite;
+      animation: heroFloat 5s ease-in-out infinite;
       z-index: 2;
     }
 
     .hero-mascot::before {
       content: '';
       position: absolute;
-      inset: -14px;
+      inset: -18px;
       border-radius: 50%;
-      border: 1px dashed rgba(197, 116, 45, 0.45);
-      animation: spinSlow 60s linear infinite;
+      border: 1.5px dashed rgba(197, 116, 45, 0.45);
+      animation: spinSlow 40s linear infinite;
+    }
+
+    .hero-mascot::after {
+      content: '';
+      position: absolute;
+      inset: -38px;
+      border-radius: 50%;
+      border: 1px dotted rgba(74, 90, 43, 0.35);
+      animation: spinSlow 90s linear infinite reverse;
     }
 
     .hero-mascot .logo {
-      width: 72%;
-      height: 72%;
+      width: 76%;
+      height: 76%;
       object-fit: contain;
-      filter: drop-shadow(0 6px 12px rgba(60, 35, 16, 0.18));
+      filter: drop-shadow(0 8px 16px rgba(60, 35, 16, 0.22));
+      animation: bobble 3s ease-in-out infinite;
     }
 
     @keyframes heroFloat {
       0%, 100% { transform: translateY(0) rotate(0deg); }
-      50% { transform: translateY(-10px) rotate(-1.5deg); }
+      50% { transform: translateY(-14px) rotate(-2deg); }
+    }
+
+    @keyframes bobble {
+      0%, 100% { transform: translateY(0); }
+      50% { transform: translateY(-4px); }
     }
 
     @keyframes spinSlow {
@@ -418,25 +437,70 @@
       to { transform: rotate(360deg); }
     }
 
-    @media (max-width: 800px) {
+    @media (max-width: 880px) {
       .hero { text-align: center; }
-      .hero h1 { margin: 0 auto; }
-      .intro { margin-left: auto; margin-right: auto; }
+      .hero h1, .intro { margin-left: auto; margin-right: auto; }
       .hero-actions { justify-content: center; }
       .hero-mascot {
         position: relative;
-        margin: 40px auto 0;
+        margin: 48px auto 0;
         right: auto; bottom: auto;
-        width: 200px; height: 200px;
+        width: clamp(240px, 60vw, 320px);
+        height: clamp(240px, 60vw, 320px);
       }
     }
+
+    /* ========================================================================
+       MARQUEE — brewing terms ticker
+       ====================================================================== */
+
+    .marquee {
+      margin-top: clamp(56px, 7vw, 96px);
+      padding: 18px 0;
+      border-top: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+      overflow: hidden;
+      background:
+        linear-gradient(90deg, var(--paper) 0%, transparent 8%, transparent 92%, var(--paper) 100%);
+      mask-image: linear-gradient(90deg, transparent 0%, #000 8%, #000 92%, transparent 100%);
+      -webkit-mask-image: linear-gradient(90deg, transparent 0%, #000 8%, #000 92%, transparent 100%);
+    }
+
+    .marquee-track {
+      display: inline-flex;
+      gap: 24px;
+      align-items: center;
+      white-space: nowrap;
+      animation: marquee 32s linear infinite;
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: clamp(1.6rem, 3vw, 2.4rem);
+      color: var(--ink-soft);
+      letter-spacing: -0.01em;
+      font-variation-settings: 'SOFT' 60, 'opsz' 144;
+    }
+
+    .marquee-track span:nth-child(even) {
+      color: var(--copper);
+      font-style: italic;
+      font-weight: 500;
+      font-variation-settings: 'SOFT' 100, 'opsz' 144;
+      padding: 0 8px;
+    }
+
+    @keyframes marquee {
+      from { transform: translateX(0); }
+      to { transform: translateX(-50%); }
+    }
+
+    .marquee:hover .marquee-track { animation-play-state: paused; }
 
     /* ========================================================================
        Sections
        ====================================================================== */
 
     .section-block {
-      margin-top: clamp(72px, 10vw, 128px);
+      margin-top: clamp(80px, 11vw, 144px);
       scroll-margin-top: 96px;
       animation: fadeUp 1s var(--ease-out-soft) both;
       animation-timeline: view();
@@ -444,7 +508,7 @@
     }
 
     @keyframes fadeUp {
-      from { opacity: 0; transform: translateY(28px); }
+      from { opacity: 0; transform: translateY(36px); }
       to { opacity: 1; transform: translateY(0); }
     }
 
@@ -452,32 +516,32 @@
       margin: 0 0 14px;
       text-align: center;
       color: var(--copper);
-      font-size: 0.74rem;
+      font-size: 0.76rem;
       font-weight: 700;
       letter-spacing: 0.22em;
       text-transform: uppercase;
       display: flex;
       align-items: center;
       justify-content: center;
-      gap: 14px;
+      gap: 16px;
     }
 
     .section-eyebrow::before,
     .section-eyebrow::after {
       content: '';
-      width: 32px;
+      width: 40px;
       height: 1px;
       background: var(--copper);
       opacity: 0.55;
     }
 
     .section-title {
-      margin: 0 auto 18px;
+      margin: 0 auto 20px;
       font-family: var(--font-display);
       font-weight: 700;
-      font-size: clamp(2rem, 4vw, 3rem);
-      line-height: 1.08;
-      letter-spacing: -0.022em;
+      font-size: clamp(2.2rem, 4.5vw, 3.4rem);
+      line-height: 1.06;
+      letter-spacing: -0.024em;
       color: var(--ink);
       text-align: center;
       max-width: 22ch;
@@ -492,25 +556,27 @@
     }
 
     .section-intro {
-      margin: 0 auto 40px;
+      margin: 0 auto 48px;
       max-width: 54ch;
       color: var(--ink-soft);
       text-align: center;
-      font-size: 1.05rem;
+      font-size: 1.08rem;
       line-height: 1.65;
     }
 
     /* ========================================================================
-       Journey — big numerals + phone screenshots
+       Journey — big numerals + animated connector
        ====================================================================== */
 
     .journey-grid {
       list-style: none;
       padding: 0;
-      margin: 40px 0 0;
+      margin: 48px 0 0;
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
       gap: 24px;
+      position: relative;
+      counter-reset: step;
     }
 
     .journey-step {
@@ -518,13 +584,13 @@
       background: rgba(255, 252, 244, 0.85);
       border-radius: var(--radius-lg);
       border: 1px solid var(--line);
-      padding: 32px 24px 28px;
+      padding: 36px 26px 30px;
       text-align: left;
       box-shadow: var(--shadow-sm);
-      transition: transform 0.35s var(--ease-out-soft), box-shadow 0.35s var(--ease-out-soft), border-color 0.35s var(--ease-out-soft);
+      transition: transform 0.4s var(--ease-out-soft), box-shadow 0.4s var(--ease-out-soft), border-color 0.4s var(--ease-out-soft);
       display: flex;
       flex-direction: column;
-      gap: 18px;
+      gap: 20px;
       overflow: hidden;
       isolation: isolate;
     }
@@ -532,72 +598,80 @@
     .journey-step::before {
       content: '';
       position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 3px;
-      background: linear-gradient(90deg, var(--copper) 0%, var(--copper-deep) 100%);
+      top: 0; left: 0; right: 0;
+      height: 4px;
+      background: linear-gradient(90deg, var(--copper), var(--copper-deep));
       transform: scaleX(0);
       transform-origin: left center;
-      transition: transform 0.45s var(--ease-out-soft);
+      transition: transform 0.5s var(--ease-out-soft);
       z-index: 2;
     }
 
     .journey-step:hover {
-      transform: translateY(-6px);
-      box-shadow: var(--shadow-md);
-      border-color: rgba(197, 116, 45, 0.4);
+      transform: translateY(-10px) scale(1.02);
+      box-shadow: var(--shadow-lg);
+      border-color: rgba(197, 116, 45, 0.5);
     }
 
     .journey-step:hover::before { transform: scaleX(1); }
 
     .journey-num {
       font-family: var(--font-display);
-      font-size: 3rem;
+      font-size: 4rem;
       font-weight: 900;
-      line-height: 1;
-      letter-spacing: -0.05em;
+      line-height: 0.9;
+      letter-spacing: -0.06em;
       color: var(--copper);
       font-variation-settings: 'SOFT' 20, 'opsz' 144;
-      opacity: 0.9;
+      opacity: 0.92;
+      transition: transform 0.4s var(--ease-out-soft);
+    }
+
+    .journey-step:hover .journey-num {
+      transform: scale(1.1) rotate(-3deg);
     }
 
     .journey-screenshot {
       position: relative;
       width: 100%;
-      max-width: 180px;
+      max-width: 200px;
       aspect-ratio: 9 / 18;
       align-self: center;
       background: linear-gradient(170deg, var(--foam) 0%, var(--paper) 100%);
-      border-radius: 24px;
+      border-radius: 28px;
       border: 1px solid var(--line);
-      padding: 10px;
+      padding: 12px;
       display: flex;
       align-items: center;
       justify-content: center;
       overflow: hidden;
       box-shadow:
         inset 0 1px 0 rgba(255, 255, 255, 0.7),
-        0 8px 22px rgba(60, 35, 16, 0.14);
+        0 12px 28px rgba(60, 35, 16, 0.18);
+      transition: transform 0.5s var(--ease-out-soft);
+    }
+
+    .journey-step:hover .journey-screenshot {
+      transform: rotate(2deg) translateY(-4px);
     }
 
     .journey-screenshot::before {
       content: '';
       position: absolute;
-      top: 8px;
+      top: 10px;
       left: 50%;
       transform: translateX(-50%);
-      width: 40px;
-      height: 4px;
+      width: 44px;
+      height: 5px;
       background: rgba(40, 22, 10, 0.18);
-      border-radius: 2px;
+      border-radius: 3px;
     }
 
     .journey-screenshot img {
       width: 100%;
       height: 100%;
       object-fit: contain;
-      border-radius: 16px;
+      border-radius: 18px;
       display: block;
     }
 
@@ -606,27 +680,27 @@
       font-family: var(--font-display);
       font-weight: 700;
       color: var(--ink);
-      font-size: 1.2rem;
-      line-height: 1.25;
+      font-size: 1.3rem;
+      line-height: 1.22;
       font-variation-settings: 'SOFT' 40;
     }
 
     .journey-step p {
       margin: 0;
       color: var(--muted);
-      font-size: 0.94rem;
+      font-size: 0.96rem;
       line-height: 1.55;
     }
 
     /* ========================================================================
-       Features — bold cards with copper accent
+       Features — magnetic cards with shimmer
        ====================================================================== */
 
     .features-grid {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-      gap: 24px;
-      margin-top: 40px;
+      gap: 28px;
+      margin-top: 48px;
     }
 
     .feature-card {
@@ -634,70 +708,84 @@
       isolation: isolate;
       display: flex;
       flex-direction: column;
-      gap: 20px;
-      padding: 32px 26px 30px;
+      gap: 22px;
+      padding: 36px 28px 32px;
       border-radius: var(--radius-lg);
       border: 1px solid var(--line);
       background:
-        radial-gradient(circle at 100% 0%, rgba(197, 116, 45, 0.16) 0%, transparent 50%),
+        radial-gradient(circle at 100% 0%, rgba(197, 116, 45, 0.18) 0%, transparent 50%),
         linear-gradient(170deg, rgba(255, 255, 255, 0.98) 0%, rgba(251, 243, 218, 0.85) 100%);
-      box-shadow: var(--shadow-sm), var(--shadow-inset);
+      box-shadow: var(--shadow-sm), inset 0 1px 0 rgba(255, 255, 255, 0.75);
       overflow: hidden;
-      transition: transform 0.35s var(--ease-out-soft), box-shadow 0.35s var(--ease-out-soft), border-color 0.35s var(--ease-out-soft);
+      transition: transform 0.4s var(--ease-out-soft), box-shadow 0.4s var(--ease-out-soft), border-color 0.4s var(--ease-out-soft);
+    }
+
+    .feature-card::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(120deg, transparent 30%, rgba(255, 255, 255, 0.55) 50%, transparent 70%);
+      transform: translateX(-100%);
+      transition: transform 0.8s var(--ease-out-soft);
+      z-index: 1;
+      pointer-events: none;
     }
 
     .feature-card::after {
       content: '';
       position: absolute;
-      left: 26px;
-      right: 26px;
-      bottom: 0;
-      height: 2px;
+      left: 28px; right: 28px; bottom: 0;
+      height: 3px;
       border-radius: 999px;
       background: linear-gradient(90deg, var(--copper) 0%, var(--copper-deep) 50%, var(--moss) 100%);
       opacity: 0.6;
-      transform: scaleX(0.25);
+      transform: scaleX(0.2);
       transform-origin: left center;
-      transition: transform 0.4s var(--ease-out-soft), opacity 0.4s var(--ease-out-soft);
+      transition: transform 0.45s var(--ease-out-soft), opacity 0.45s var(--ease-out-soft);
     }
 
     .feature-card:hover,
     .feature-card:focus-within {
-      transform: translateY(-6px);
-      border-color: rgba(197, 116, 45, 0.4);
-      box-shadow: var(--shadow-md), var(--shadow-inset);
+      transform: translateY(-10px) scale(1.02);
+      border-color: rgba(197, 116, 45, 0.5);
+      box-shadow: var(--shadow-lg);
     }
 
+    .feature-card:hover::before { transform: translateX(100%); }
     .feature-card:hover::after,
-    .feature-card:focus-within::after {
-      transform: scaleX(1);
-      opacity: 1;
-    }
+    .feature-card:focus-within::after { transform: scaleX(1); opacity: 1; }
+
+    .feature-card > * { position: relative; z-index: 2; }
 
     .feature-screenshot {
       width: 100%;
-      max-width: 210px;
+      max-width: 220px;
       aspect-ratio: 1 / 2;
       align-self: center;
       background: linear-gradient(170deg, var(--foam) 0%, var(--paper) 100%);
-      border-radius: 24px;
+      border-radius: 28px;
       border: 1px solid var(--line);
-      padding: 10px;
+      padding: 12px;
       display: flex;
       align-items: center;
       justify-content: center;
       overflow: hidden;
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 6px 18px rgba(60, 35, 16, 0.12);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 8px 22px rgba(60, 35, 16, 0.14);
       position: relative;
+      transition: transform 0.5s var(--ease-out-soft);
+    }
+
+    .feature-card:hover .feature-screenshot {
+      transform: rotate(-3deg) translateY(-4px);
     }
 
     .feature-screenshot::before {
       content: '';
       position: absolute;
-      top: 8px;
+      top: 10px;
       left: 50%;
       transform: translateX(-50%);
-      width: 44px;
+      width: 48px;
       height: 5px;
       background: rgba(40, 22, 10, 0.18);
       border-radius: 3px;
@@ -707,7 +795,7 @@
       width: 100%;
       height: 100%;
       object-fit: contain;
-      border-radius: 16px;
+      border-radius: 18px;
       display: block;
     }
 
@@ -716,7 +804,7 @@
       font-family: var(--font-display);
       font-weight: 700;
       color: var(--ink);
-      font-size: 1.35rem;
+      font-size: 1.4rem;
       line-height: 1.2;
       letter-spacing: -0.012em;
       font-variation-settings: 'SOFT' 40;
@@ -725,32 +813,32 @@
     .feature-card p {
       margin: 0;
       color: var(--muted);
-      font-size: 0.96rem;
+      font-size: 0.98rem;
       line-height: 1.6;
     }
 
     /* ========================================================================
-       FAQ — bold accordion
+       FAQ
        ====================================================================== */
 
     .faq-grid {
       display: grid;
-      gap: 12px;
-      margin: 40px auto 0;
-      max-width: 760px;
+      gap: 14px;
+      margin: 48px auto 0;
+      max-width: 800px;
     }
 
     .faq-item {
-      background: rgba(255, 252, 244, 0.85);
+      background: rgba(255, 252, 244, 0.88);
       border-radius: var(--radius-md);
       border: 1px solid var(--line);
-      padding: 4px 26px;
+      padding: 4px 28px;
       box-shadow: var(--shadow-sm);
-      transition: box-shadow 0.25s var(--ease-out-soft), border-color 0.25s var(--ease-out-soft), background 0.25s var(--ease-out-soft);
+      transition: box-shadow 0.3s var(--ease-out-soft), border-color 0.3s var(--ease-out-soft), background 0.3s var(--ease-out-soft);
     }
 
     .faq-item[open] {
-      border-color: rgba(197, 116, 45, 0.45);
+      border-color: rgba(197, 116, 45, 0.5);
       box-shadow: var(--shadow-md);
       background: rgba(255, 252, 244, 0.95);
     }
@@ -758,10 +846,10 @@
     .faq-item summary {
       cursor: pointer;
       list-style: none;
-      padding: 20px 0;
+      padding: 22px 0;
       font-family: var(--font-display);
       font-weight: 700;
-      font-size: 1.1rem;
+      font-size: 1.15rem;
       color: var(--ink);
       display: flex;
       justify-content: space-between;
@@ -773,72 +861,55 @@
     .faq-item summary::-webkit-details-marker { display: none; }
 
     .faq-item summary::after {
-      content: '';
+      content: '+';
       flex: 0 0 auto;
-      width: 28px;
-      height: 28px;
+      width: 32px;
+      height: 32px;
       border-radius: 50%;
       background: var(--ink);
       color: var(--foam);
-      position: relative;
-      transition: background 0.25s var(--ease-out-soft), transform 0.3s var(--ease-out-soft);
-    }
-
-    .faq-item summary::before {
-      content: '';
-      width: 12px;
-      height: 12px;
-      position: absolute;
-      right: 28px;
-      background-image:
-        linear-gradient(to right, var(--foam) 0 100%),
-        linear-gradient(to bottom, var(--foam) 0 100%);
-      background-size: 12px 2px, 2px 12px;
-      background-repeat: no-repeat;
-      background-position: center center, center center;
-      pointer-events: none;
-      z-index: 1;
-      transition: transform 0.3s var(--ease-out-soft);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-family: var(--font-body);
+      font-size: 1.4rem;
+      font-weight: 300;
+      transition: background 0.3s var(--ease-out-soft), transform 0.4s var(--ease-out-soft);
     }
 
     .faq-item[open] summary::after {
+      content: '×';
       background: var(--copper);
       transform: rotate(180deg);
     }
 
-    .faq-item[open] summary::before {
-      background-size: 12px 2px, 0 0;
-    }
-
     .faq-item p {
-      margin: 0 0 22px;
+      margin: 0 0 24px;
       color: var(--muted);
-      font-size: 0.98rem;
+      font-size: 1rem;
       line-height: 1.7;
       max-width: 56ch;
     }
 
     /* ========================================================================
-       Participate — bold CTA block
+       Participate
        ====================================================================== */
 
     .participate {
       position: relative;
       background:
-        radial-gradient(circle at 92% 8%, rgba(197, 116, 45, 0.22) 0%, transparent 50%),
-        radial-gradient(circle at 8% 96%, rgba(74, 90, 43, 0.18) 0%, transparent 50%),
+        radial-gradient(circle at 92% 8%, rgba(197, 116, 45, 0.24) 0%, transparent 50%),
+        radial-gradient(circle at 8% 96%, rgba(74, 90, 43, 0.2) 0%, transparent 50%),
         linear-gradient(165deg, var(--foam) 0%, var(--paper-deep) 100%);
       border: 1px solid var(--line);
       border-radius: var(--radius-xl);
-      padding: clamp(48px, 7vw, 88px) clamp(28px, 5vw, 64px);
-      box-shadow: var(--shadow-lg), var(--shadow-inset);
+      padding: clamp(56px, 8vw, 96px) clamp(28px, 5vw, 72px);
+      box-shadow: var(--shadow-lg);
       overflow: hidden;
     }
 
-    .participate .section-title { color: var(--ink); }
-
     /* ========================================================================
-       Buttons
+       Buttons — magnetic
        ====================================================================== */
 
     .actions {
@@ -846,49 +917,37 @@
       gap: 14px;
       flex-wrap: wrap;
       justify-content: center;
-      margin-top: 22px;
+      margin-top: 24px;
     }
-
-    .actions-compact { gap: 12px; margin-top: 20px; }
+    .actions-compact { gap: 12px; margin-top: 22px; }
 
     .btn {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      min-height: 52px;
+      min-height: 54px;
       border: none;
       border-radius: 999px;
-      padding: 14px 26px;
+      padding: 15px 28px;
       font-family: var(--font-body);
       font-weight: 600;
-      font-size: 0.98rem;
-      letter-spacing: 0.005em;
+      font-size: 1rem;
       cursor: pointer;
       text-decoration: none;
       position: relative;
       overflow: hidden;
-      transition: transform 0.22s var(--ease-out-soft), box-shadow 0.25s var(--ease-out-soft), background-color 0.25s var(--ease-out-soft), color 0.25s var(--ease-out-soft);
+      transition: transform 0.25s var(--ease-out-soft), box-shadow 0.3s var(--ease-out-soft), background-color 0.3s var(--ease-out-soft), color 0.3s var(--ease-out-soft);
     }
 
-    .btn:hover { transform: translateY(-2px); }
-
-    .btn:active { transform: translateY(0); }
-
-    .btn:disabled {
-      opacity: 0.55;
-      cursor: not-allowed;
-      transform: none;
-    }
-
-    .btn:focus-visible {
-      outline: 2px solid var(--copper);
-      outline-offset: 3px;
-    }
+    .btn:hover { transform: translateY(-3px) scale(1.03); }
+    .btn:active { transform: translateY(0) scale(0.98); }
+    .btn:disabled { opacity: 0.55; cursor: not-allowed; transform: none; }
+    .btn:focus-visible { outline: 2px solid var(--copper); outline-offset: 3px; }
 
     .btn-primary {
       background: var(--ink);
       color: var(--foam);
-      box-shadow: 0 10px 24px rgba(26, 17, 10, 0.35);
+      box-shadow: 0 12px 28px rgba(26, 17, 10, 0.4);
       isolation: isolate;
     }
 
@@ -898,21 +957,19 @@
       inset: 0;
       background: linear-gradient(135deg, var(--copper) 0%, var(--copper-deep) 100%);
       opacity: 0;
-      transition: opacity 0.3s var(--ease-out-soft);
+      transition: opacity 0.35s var(--ease-out-soft);
       z-index: 0;
     }
 
     .btn-primary > * { position: relative; z-index: 1; }
-
-    .btn-primary:hover { box-shadow: 0 16px 32px rgba(197, 116, 45, 0.45); }
+    .btn-primary:hover { box-shadow: 0 20px 40px rgba(197, 116, 45, 0.5); }
     .btn-primary:hover::before { opacity: 1; }
 
     .btn-ghost {
       background: transparent;
       color: var(--ink);
-      border: 1px solid rgba(26, 17, 10, 0.22);
+      border: 1.5px solid rgba(26, 17, 10, 0.22);
     }
-
     .btn-ghost:hover {
       background: rgba(26, 17, 10, 0.05);
       border-color: var(--ink);
@@ -922,16 +979,11 @@
        Forms
        ====================================================================== */
 
-    .contact-form {
-      margin: 0 auto;
-      max-width: 580px;
-      display: grid;
-      gap: 16px;
-    }
+    .contact-form { margin: 0 auto; max-width: 600px; display: grid; gap: 16px; }
 
     .questionnaire-form {
-      margin-top: 24px;
-      padding: 28px;
+      margin-top: 28px;
+      padding: 30px;
       border-radius: var(--radius-lg);
       border: 1px solid var(--line);
       background: rgba(255, 255, 255, 0.78);
@@ -939,126 +991,71 @@
       backdrop-filter: blur(6px);
     }
 
-    .questionnaire-grid {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 16px;
-    }
-
-    .form-field {
-      display: flex;
-      flex-direction: column;
-      gap: 8px;
-    }
-
+    .questionnaire-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+    .form-field { display: flex; flex-direction: column; gap: 8px; }
     .form-field-full { grid-column: 1 / -1; }
 
-    .form-field label,
-    fieldset legend {
-      font-weight: 600;
-      color: var(--ink);
-      font-size: 0.92rem;
+    .form-field label, fieldset legend {
+      font-weight: 600; color: var(--ink); font-size: 0.92rem;
     }
 
-    input,
-    textarea,
-    select {
+    input, textarea, select {
       width: 100%;
       border: 1px solid var(--line);
       border-radius: var(--radius-sm);
       background: #fff;
       color: var(--ink);
-      padding: 13px 16px;
+      padding: 14px 16px;
       font-size: 1rem;
       font-family: inherit;
-      transition: border-color 0.2s var(--ease-out-soft), box-shadow 0.2s var(--ease-out-soft);
+      transition: border-color 0.25s var(--ease-out-soft), box-shadow 0.25s var(--ease-out-soft);
     }
 
-    input:focus,
-    textarea:focus,
-    select:focus {
+    input:focus, textarea:focus, select:focus {
       outline: none;
       border-color: var(--copper);
       box-shadow: 0 0 0 4px var(--color-accent-soft);
     }
 
-    textarea {
-      min-height: 120px;
-      resize: vertical;
-    }
+    textarea { min-height: 120px; resize: vertical; }
 
     fieldset {
-      margin: 0;
-      padding: 14px 16px;
+      margin: 0; padding: 14px 16px;
       border: 1px solid var(--line);
       border-radius: var(--radius-sm);
       background: rgba(251, 243, 218, 0.4);
     }
 
-    .radio-list,
-    .checkbox-list {
-      display: grid;
-      gap: 8px;
-      margin-top: 10px;
+    .radio-list, .checkbox-list { display: grid; gap: 8px; margin-top: 10px; }
+    .radio-list label, .checkbox-list label, .consent {
+      display: flex; gap: 10px; align-items: flex-start;
+      font-size: 0.92rem; color: var(--muted); line-height: 1.55;
     }
-
-    .radio-list label,
-    .checkbox-list label,
-    .consent {
-      display: flex;
-      gap: 10px;
-      align-items: flex-start;
-      font-size: 0.92rem;
-      color: var(--muted);
-      line-height: 1.55;
-    }
-
-    .radio-list input,
-    .checkbox-list input,
-    .consent input {
-      width: 18px;
-      height: 18px;
-      margin-top: 2px;
-      flex: 0 0 auto;
+    .radio-list input, .checkbox-list input, .consent input {
+      width: 18px; height: 18px; margin-top: 2px; flex: 0 0 auto;
       accent-color: var(--copper);
     }
 
     .honeypot { display: none; }
 
     .form-status {
-      margin: 14px 0 0;
-      min-height: 22px;
-      text-align: center;
-      font-weight: 600;
-      font-size: 0.92rem;
+      margin: 14px 0 0; min-height: 22px; text-align: center;
+      font-weight: 600; font-size: 0.92rem;
     }
-
     .form-status.loading { color: var(--muted); }
     .form-status.success { color: var(--color-success); }
     .form-status.error { color: var(--color-error); }
 
     .consent-note {
-      margin: 4px 0 0;
-      font-size: 0.82rem;
-      color: var(--muted);
-      line-height: 1.55;
+      margin: 4px 0 0; font-size: 0.82rem;
+      color: var(--muted); line-height: 1.55;
     }
-
-    .consent-note a {
-      color: var(--ink);
-      font-weight: 600;
-    }
+    .consent-note a { color: var(--ink); font-weight: 600; }
 
     .sr-only {
-      position: absolute;
-      width: 1px;
-      height: 1px;
-      padding: 0;
-      margin: -1px;
-      overflow: hidden;
-      clip: rect(0, 0, 0, 0);
-      white-space: nowrap;
-      border: 0;
+      position: absolute; width: 1px; height: 1px;
+      padding: 0; margin: -1px; overflow: hidden;
+      clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
     }
 
     /* ========================================================================
@@ -1066,92 +1063,60 @@
        ====================================================================== */
 
     .footer {
-      margin-top: clamp(72px, 10vw, 112px);
-      padding: 40px 0 24px;
+      margin-top: clamp(80px, 11vw, 128px);
+      padding: 48px 0 28px;
       border-top: 1px solid var(--line);
       display: flex;
       flex-wrap: wrap;
       justify-content: space-between;
       align-items: center;
-      gap: 28px;
+      gap: 32px;
     }
 
     .footer-brand {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-      max-width: 60ch;
+      display: flex; align-items: center; gap: 18px; max-width: 60ch;
     }
 
     .footer-mark {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 48px;
-      height: 48px;
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 52px; height: 52px;
       border-radius: 50%;
       background: var(--ink);
       color: var(--foam);
       font-family: var(--font-display);
-      font-weight: 700;
-      font-size: 1.05rem;
-      letter-spacing: 0.05em;
+      font-weight: 700; font-size: 1.1rem; letter-spacing: 0.05em;
       flex: 0 0 auto;
       box-shadow: var(--shadow-sm);
+      transition: transform 0.4s var(--ease-out-soft), background 0.3s var(--ease-out-soft);
     }
 
-    .footer-brand p {
-      margin: 0;
-      color: var(--muted);
-      font-size: 0.9rem;
-      line-height: 1.55;
-    }
+    .footer-mark:hover { transform: rotate(8deg) scale(1.05); background: var(--copper); }
 
-    .footer-brand strong {
-      color: var(--ink);
-      font-weight: 600;
-    }
+    .footer-brand p { margin: 0; color: var(--muted); font-size: 0.92rem; line-height: 1.55; }
+    .footer-brand strong { color: var(--ink); font-weight: 600; }
 
-    .footer-links {
-      display: flex;
-      gap: 22px;
-      flex-wrap: wrap;
-    }
-
+    .footer-links { display: flex; gap: 24px; flex-wrap: wrap; }
     .footer-links a {
-      color: var(--muted);
-      text-decoration: none;
-      font-size: 0.88rem;
-      font-weight: 500;
-      transition: color 0.2s var(--ease-out-soft);
-      position: relative;
+      color: var(--muted); text-decoration: none;
+      font-size: 0.88rem; font-weight: 500;
+      transition: color 0.2s var(--ease-out-soft); position: relative;
     }
-
     .footer-links a::after {
-      content: '';
-      position: absolute;
-      left: 0;
-      right: 0;
-      bottom: -3px;
-      height: 1px;
-      background: var(--copper);
-      transform: scaleX(0);
-      transform-origin: left center;
-      transition: transform 0.25s var(--ease-out-soft);
+      content: ''; position: absolute; left: 0; right: 0; bottom: -3px;
+      height: 1px; background: var(--copper);
+      transform: scaleX(0); transform-origin: left center;
+      transition: transform 0.3s var(--ease-out-soft);
     }
-
     .footer-links a:hover { color: var(--ink); }
     .footer-links a:hover::after { transform: scaleX(1); }
 
     /* ========================================================================
        Reduced motion
        ====================================================================== */
-
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after {
         animation-duration: 0.001ms !important;
         animation-iteration-count: 1 !important;
         transition-duration: 0.001ms !important;
       }
-      .hero-mascot, .hero::before, .hero::after, .pill::before { animation: none; }
     }

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -378,10 +378,10 @@
     /* ---- HUGE mascot with 3 orbital rings ---- */
     .hero-mascot {
       position: absolute;
-      right: clamp(-60px, -4vw, 20px);
-      bottom: clamp(-80px, -6vw, -40px);
-      width: clamp(220px, 36vw, 440px);
-      height: clamp(220px, 36vw, 440px);
+      right: clamp(-70px, -5vw, 16px);
+      bottom: clamp(-100px, -7vw, -56px);
+      width: clamp(260px, 42vw, 520px);
+      height: clamp(260px, 42vw, 520px);
       border-radius: 50%;
       background:
         radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.98) 0%, rgba(251, 243, 218, 0.92) 55%, rgba(231, 207, 154, 0.55) 100%);
@@ -443,10 +443,10 @@
       .hero-actions { justify-content: center; }
       .hero-mascot {
         position: relative;
-        margin: 48px auto 0;
+        margin: 56px auto 0;
         right: auto; bottom: auto;
-        width: clamp(240px, 60vw, 320px);
-        height: clamp(240px, 60vw, 320px);
+        width: clamp(260px, 72vw, 380px);
+        height: clamp(260px, 72vw, 380px);
       }
     }
 
@@ -608,9 +608,10 @@
     }
 
     .journey-step:hover {
-      transform: translateY(-10px) scale(1.02);
-      box-shadow: var(--shadow-lg);
-      border-color: rgba(197, 116, 45, 0.5);
+      transform: translateY(-14px) scale(1.06);
+      box-shadow: var(--shadow-lg), 0 24px 60px rgba(197, 116, 45, 0.18);
+      border-color: rgba(197, 116, 45, 0.55);
+      z-index: 3;
     }
 
     .journey-step:hover::before { transform: scaleX(1); }
@@ -624,11 +625,22 @@
       color: var(--copper);
       font-variation-settings: 'SOFT' 20, 'opsz' 144;
       opacity: 0.92;
-      transition: transform 0.4s var(--ease-out-soft);
+      transition: transform 0.45s var(--ease-out-soft), color 0.3s var(--ease-out-soft), text-shadow 0.4s var(--ease-out-soft);
+      display: inline-block;
+      transform-origin: left center;
     }
 
     .journey-step:hover .journey-num {
-      transform: scale(1.1) rotate(-3deg);
+      animation: numPop 0.7s var(--ease-out-soft) forwards;
+      color: var(--copper-deep);
+      text-shadow: 0 6px 18px rgba(197, 116, 45, 0.4);
+    }
+
+    @keyframes numPop {
+      0%   { transform: scale(1) rotate(0deg); }
+      35%  { transform: scale(1.45) rotate(-6deg); }
+      65%  { transform: scale(1.25) rotate(3deg); }
+      100% { transform: scale(1.3) rotate(-2deg); }
     }
 
     .journey-screenshot {
@@ -958,10 +970,9 @@
       background: linear-gradient(135deg, var(--copper) 0%, var(--copper-deep) 100%);
       opacity: 0;
       transition: opacity 0.35s var(--ease-out-soft);
-      z-index: 0;
+      z-index: -1;
     }
 
-    .btn-primary > * { position: relative; z-index: 1; }
     .btn-primary:hover { box-shadow: 0 20px 40px rgba(197, 116, 45, 0.5); }
     .btn-primary:hover::before { opacity: 1; }
 
@@ -981,15 +992,7 @@
 
     .contact-form { margin: 0 auto; max-width: 600px; display: grid; gap: 16px; }
 
-    .questionnaire-form {
-      margin-top: 28px;
-      padding: 30px;
-      border-radius: var(--radius-lg);
-      border: 1px solid var(--line);
-      background: rgba(255, 255, 255, 0.78);
-      box-shadow: var(--shadow-sm);
-      backdrop-filter: blur(6px);
-    }
+    /* Styles for .questionnaire-form are defined later (smooth open block). */
 
     .questionnaire-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
     .form-field { display: flex; flex-direction: column; gap: 8px; }
@@ -1262,26 +1265,6 @@
       50%      { box-shadow: 0 14px 36px rgba(26, 17, 10, 0.4), 0 0 28px rgba(197, 116, 45, 0.35); }
     }
 
-    /* Arrow on hover for primary CTAs */
-    .btn-primary {
-      gap: 8px;
-    }
-    .btn-primary::after {
-      content: '→';
-      display: inline-block;
-      transform: translateX(-4px);
-      opacity: 0;
-      transition: transform 0.3s var(--ease-out-soft), opacity 0.3s var(--ease-out-soft);
-      font-family: var(--font-body);
-      font-weight: 400;
-      position: relative;
-      z-index: 1;
-    }
-    .btn-primary:hover::after {
-      transform: translateX(2px);
-      opacity: 1;
-    }
-
     /* Pill — tiny continuous tilt */
     .pill {
       animation: pillTilt 5s ease-in-out infinite;
@@ -1312,19 +1295,7 @@
       50%      { filter: drop-shadow(0 0 36px rgba(197, 116, 45, 0.35)); }
     }
 
-    /* Marquee — slight vertical sway for a "carved on paper" feel */
-    .marquee-track span:nth-child(odd) {
-      display: inline-block;
-      animation: trackBob 4s ease-in-out infinite;
-    }
-    .marquee-track span:nth-child(even) {
-      display: inline-block;
-      animation: trackBob 4s ease-in-out infinite reverse;
-    }
-    @keyframes trackBob {
-      0%, 100% { transform: translateY(0); }
-      50%      { transform: translateY(-3px); }
-    }
+    /* Marquee — text stays fixed on its line; only the track scrolls horizontally. */
 
     /* Feature screenshot — gentle continuous bob on screen */
     .feature-screenshot {
@@ -1338,6 +1309,185 @@
     }
     .feature-card:hover .feature-screenshot {
       animation: none;
+    }
+
+    /* ========================================================================
+       Scroll-driven element entrances (per-element within sections)
+       Each element surges in subtly as it crosses the viewport.
+       ====================================================================== */
+
+    .section-title,
+    .section-intro,
+    .marquee {
+      animation: surgeUp 0.9s var(--ease-out-soft) both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 25%;
+    }
+
+    .section-title { animation-delay: 0.05s; }
+    .section-intro { animation-delay: 0.15s; }
+
+    @keyframes surgeUp {
+      from { opacity: 0; transform: translateY(28px); filter: blur(2px); }
+      to   { opacity: 1; transform: translateY(0);    filter: blur(0); }
+    }
+
+    /* Marquee surge is purely opacity to avoid disturbing the scroll animation */
+    .marquee {
+      animation-name: marqueeFadeIn;
+    }
+    @keyframes marqueeFadeIn {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+    }
+
+    /* ========================================================================
+       Toggle button — stable layout, rotating chevron
+       ====================================================================== */
+
+    .btn-toggle {
+      gap: 10px;
+      min-width: 200px;
+    }
+
+    .btn-chevron {
+      width: 12px;
+      height: 8px;
+      transition: transform 0.4s var(--ease-out-soft);
+      flex: 0 0 auto;
+    }
+
+    .btn-toggle[aria-expanded="true"] .btn-chevron {
+      transform: rotate(180deg);
+    }
+
+    /* ========================================================================
+       Smooth questionnaire form open
+       Uses the grid-rows trick: animates from 0fr to 1fr.
+       ====================================================================== */
+
+    .questionnaire-form {
+      display: grid;
+      grid-template-rows: 0fr;
+      opacity: 0;
+      transform: translateY(-8px);
+      margin-top: 0;
+      pointer-events: none;
+      transition:
+        grid-template-rows 0.5s var(--ease-out-soft),
+        opacity 0.45s var(--ease-out-soft) 0.05s,
+        transform 0.45s var(--ease-out-soft) 0.05s,
+        margin-top 0.5s var(--ease-out-soft);
+      border: none;
+      background: transparent;
+      box-shadow: none;
+      backdrop-filter: none;
+      padding: 0;
+    }
+
+    .questionnaire-inner {
+      overflow: hidden;
+      min-height: 0;
+      padding: 28px;
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.78);
+      box-shadow: var(--shadow-sm);
+      backdrop-filter: blur(6px);
+      -webkit-backdrop-filter: blur(6px);
+    }
+
+    .questionnaire-form[data-open="true"] {
+      grid-template-rows: 1fr;
+      opacity: 1;
+      transform: translateY(0);
+      margin-top: 28px;
+      pointer-events: auto;
+    }
+
+    /* ========================================================================
+       Chip-list — clickable pill answers (radio + checkbox)
+       Hides native input and styles label as a pill.
+       ====================================================================== */
+
+    .chip-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 14px;
+    }
+
+    .chip-list label {
+      display: inline-flex;
+      align-items: center;
+      gap: 0;
+      padding: 10px 18px;
+      border-radius: 999px;
+      border: 1.5px solid var(--line);
+      background: rgba(255, 255, 255, 0.7);
+      color: var(--ink-soft);
+      font-size: 0.94rem;
+      font-weight: 500;
+      line-height: 1.3;
+      cursor: pointer;
+      transition: border-color 0.2s var(--ease-out-soft), background 0.2s var(--ease-out-soft), color 0.2s var(--ease-out-soft), transform 0.18s var(--ease-out-soft);
+      user-select: none;
+    }
+
+    .chip-list label:hover {
+      border-color: rgba(197, 116, 45, 0.55);
+      background: rgba(255, 255, 255, 0.95);
+      transform: translateY(-1px);
+    }
+
+    .chip-list input[type="radio"],
+    .chip-list input[type="checkbox"] {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    .chip-list label:has(input:checked) {
+      background: var(--ink);
+      border-color: var(--ink);
+      color: var(--foam);
+      box-shadow: 0 4px 14px rgba(26, 17, 10, 0.22);
+    }
+
+    .chip-list-multi label:has(input:checked) {
+      background: var(--copper);
+      border-color: var(--copper);
+      color: var(--foam);
+      box-shadow: 0 4px 14px rgba(197, 116, 45, 0.32);
+    }
+
+    .legend-hint {
+      font-weight: 400;
+      color: var(--muted);
+      font-size: 0.82rem;
+      margin-left: 6px;
+    }
+
+    fieldset {
+      border: none;
+      padding: 0;
+      background: transparent;
+      margin: 0;
+    }
+
+    fieldset legend {
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 1.05rem;
+      color: var(--ink);
+      font-variation-settings: 'SOFT' 50;
+      padding: 0;
     }
 
     /* ========================================================================

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -1111,7 +1111,237 @@
     .footer-links a:hover::after { transform: scaleX(1); }
 
     /* ========================================================================
-       Reduced motion
+       Kinetic boost — selective movement add-ons
+       ====================================================================== */
+
+    /* Floating embers inside the hero */
+    .hero-embers {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+      z-index: 0;
+      overflow: hidden;
+    }
+
+    .hero-embers span {
+      position: absolute;
+      bottom: -20px;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: radial-gradient(circle, rgba(255, 184, 114, 0.85) 0%, rgba(197, 116, 45, 0) 70%);
+      animation: emberRise 12s linear infinite;
+      opacity: 0;
+    }
+
+    .hero-embers span:nth-child(1) { left: 12%; animation-delay: 0s;   animation-duration: 14s; --drift:  20px; }
+    .hero-embers span:nth-child(2) { left: 28%; animation-delay: 2.5s; animation-duration: 11s; --drift: -28px; width: 6px; height: 6px; }
+    .hero-embers span:nth-child(3) { left: 46%; animation-delay: 5s;   animation-duration: 16s; --drift:  14px; width: 10px; height: 10px; }
+    .hero-embers span:nth-child(4) { left: 62%; animation-delay: 1s;   animation-duration: 13s; --drift: -18px; }
+    .hero-embers span:nth-child(5) { left: 78%; animation-delay: 6.5s; animation-duration: 15s; --drift:  24px; width: 7px; height: 7px; }
+    .hero-embers span:nth-child(6) { left: 90%; animation-delay: 3.5s; animation-duration: 12s; --drift: -12px; width: 5px; height: 5px; }
+
+    @keyframes emberRise {
+      0%   { transform: translate(0, 0) scale(0.6); opacity: 0; }
+      15%  { opacity: 0.9; }
+      85%  { opacity: 0.6; }
+      100% { transform: translate(var(--drift, 0), -110vh) scale(1.1); opacity: 0; }
+    }
+
+    /* Staggered entrance for journey steps */
+    .journey-step {
+      animation: cardIn 0.9s var(--ease-out-soft) both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 25%;
+    }
+    .journey-step:nth-child(1) { animation-delay: 0s; }
+    .journey-step:nth-child(2) { animation-delay: 0.08s; }
+    .journey-step:nth-child(3) { animation-delay: 0.16s; }
+    .journey-step:nth-child(4) { animation-delay: 0.24s; }
+
+    /* Staggered entrance for feature cards */
+    .feature-card {
+      animation: cardIn 0.9s var(--ease-out-soft) both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 25%;
+    }
+    .feature-card:nth-child(1) { animation-delay: 0s; }
+    .feature-card:nth-child(2) { animation-delay: 0.1s; }
+    .feature-card:nth-child(3) { animation-delay: 0.2s; }
+
+    /* FAQ entrance stagger */
+    .faq-item {
+      animation: faqIn 0.7s var(--ease-out-soft) both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 20%;
+    }
+    .faq-item:nth-child(1) { animation-delay: 0s; }
+    .faq-item:nth-child(2) { animation-delay: 0.06s; }
+    .faq-item:nth-child(3) { animation-delay: 0.12s; }
+    .faq-item:nth-child(4) { animation-delay: 0.18s; }
+
+    @keyframes cardIn {
+      from { opacity: 0; transform: translateY(40px) scale(0.96); }
+      to   { opacity: 1; transform: translateY(0)    scale(1);    }
+    }
+
+    @keyframes faqIn {
+      from { opacity: 0; transform: translateX(-16px); }
+      to   { opacity: 1; transform: translateX(0);     }
+    }
+
+    /* Eyebrow lines that draw in on view */
+    .section-eyebrow {
+      animation: eyebrowIn 1.2s var(--ease-out-soft) both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 30%;
+    }
+
+    @keyframes eyebrowIn {
+      from { letter-spacing: 0.4em; opacity: 0; }
+      to   { letter-spacing: 0.22em; opacity: 1; }
+    }
+
+    .section-eyebrow::before,
+    .section-eyebrow::after {
+      animation: lineGrow 1s var(--ease-out-soft) 0.2s both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 30%;
+      transform-origin: center;
+    }
+
+    @keyframes lineGrow {
+      from { transform: scaleX(0); }
+      to   { transform: scaleX(1); }
+    }
+
+    /* Section title em — subtle continuous shimmer */
+    .section-title em,
+    .hero h1 em {
+      background: linear-gradient(90deg, var(--copper) 0%, var(--copper-deep) 35%, var(--ember, #ffb872) 50%, var(--copper-deep) 65%, var(--copper) 100%);
+      background-size: 200% 100%;
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      color: transparent;
+      animation: emShimmer 6s ease-in-out infinite;
+    }
+
+    @keyframes emShimmer {
+      0%, 100% { background-position: 200% 50%; }
+      50%      { background-position: 0% 50%; }
+    }
+
+    :root { --ember: #ffb872; }
+
+    /* Journey numerals breathing */
+    .journey-num {
+      animation: numBreath 4.5s ease-in-out infinite;
+    }
+    .journey-step:nth-child(1) .journey-num { animation-delay: 0s; }
+    .journey-step:nth-child(2) .journey-num { animation-delay: 0.6s; }
+    .journey-step:nth-child(3) .journey-num { animation-delay: 1.2s; }
+    .journey-step:nth-child(4) .journey-num { animation-delay: 1.8s; }
+
+    @keyframes numBreath {
+      0%, 100% { transform: scale(1) rotate(0deg); opacity: 0.92; }
+      50%      { transform: scale(1.05) rotate(-1.5deg); opacity: 1; }
+    }
+    .journey-step:hover .journey-num {
+      animation-play-state: paused;
+    }
+
+    /* Primary CTA — subtle glow pulse in idle */
+    .hero-actions .btn-primary,
+    .participate .btn-primary {
+      animation: ctaPulse 3.5s ease-in-out infinite;
+    }
+
+    @keyframes ctaPulse {
+      0%, 100% { box-shadow: 0 12px 28px rgba(26, 17, 10, 0.4); }
+      50%      { box-shadow: 0 14px 36px rgba(26, 17, 10, 0.4), 0 0 28px rgba(197, 116, 45, 0.35); }
+    }
+
+    /* Arrow on hover for primary CTAs */
+    .btn-primary {
+      gap: 8px;
+    }
+    .btn-primary::after {
+      content: '→';
+      display: inline-block;
+      transform: translateX(-4px);
+      opacity: 0;
+      transition: transform 0.3s var(--ease-out-soft), opacity 0.3s var(--ease-out-soft);
+      font-family: var(--font-body);
+      font-weight: 400;
+      position: relative;
+      z-index: 1;
+    }
+    .btn-primary:hover::after {
+      transform: translateX(2px);
+      opacity: 1;
+    }
+
+    /* Pill — tiny continuous tilt */
+    .pill {
+      animation: pillTilt 5s ease-in-out infinite;
+      transform-origin: center;
+    }
+
+    @keyframes pillTilt {
+      0%, 100% { transform: rotate(0deg); }
+      50%      { transform: rotate(-1deg); }
+    }
+
+    /* Footer mark wobble */
+    .footer-mark {
+      animation: markWobble 7s ease-in-out infinite;
+    }
+    @keyframes markWobble {
+      0%, 100% { transform: rotate(0deg); }
+      25%      { transform: rotate(3deg); }
+      75%      { transform: rotate(-3deg); }
+    }
+
+    /* Hero mascot — softer continuous yaw on top of the existing float */
+    .hero-mascot {
+      animation: heroFloat 5s ease-in-out infinite, heroYaw 14s ease-in-out infinite;
+    }
+    @keyframes heroYaw {
+      0%, 100% { filter: drop-shadow(0 0 24px rgba(197, 116, 45, 0)); }
+      50%      { filter: drop-shadow(0 0 36px rgba(197, 116, 45, 0.35)); }
+    }
+
+    /* Marquee — slight vertical sway for a "carved on paper" feel */
+    .marquee-track span:nth-child(odd) {
+      display: inline-block;
+      animation: trackBob 4s ease-in-out infinite;
+    }
+    .marquee-track span:nth-child(even) {
+      display: inline-block;
+      animation: trackBob 4s ease-in-out infinite reverse;
+    }
+    @keyframes trackBob {
+      0%, 100% { transform: translateY(0); }
+      50%      { transform: translateY(-3px); }
+    }
+
+    /* Feature screenshot — gentle continuous bob on screen */
+    .feature-screenshot {
+      animation: screenshotBob 6s ease-in-out infinite;
+    }
+    .feature-card:nth-child(2) .feature-screenshot { animation-delay: 1s; }
+    .feature-card:nth-child(3) .feature-screenshot { animation-delay: 2s; }
+    @keyframes screenshotBob {
+      0%, 100% { transform: translateY(0) rotate(0deg); }
+      50%      { transform: translateY(-4px) rotate(0.6deg); }
+    }
+    .feature-card:hover .feature-screenshot {
+      animation: none;
+    }
+
+    /* ========================================================================
+       Reduced motion — kill everything
        ====================================================================== */
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after {
@@ -1119,4 +1349,5 @@
         animation-iteration-count: 1 !important;
         transition-duration: 0.001ms !important;
       }
+      .hero-embers { display: none; }
     }

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -1,240 +1,632 @@
+    /* ========================================================================
+       Brasse-Bouillon — design system
+       Artisan editorial: warm paper, espresso ink, copper highlights.
+       Display: Fraunces (variable, SOFT axis). Body: Inter.
+       ====================================================================== */
+
     :root {
-      --color-primary: #b7824b;
-      --color-secondary: #8d5832;
-      --color-bg: #ede2bd;
-      --color-surface: rgba(255, 253, 248, 0.94);
+      /* Palette */
+      --paper: #f1e3bf;
+      --paper-deep: #e6cf95;
+      --foam: #fbf3da;
+      --ink: #1a110a;
+      --ink-soft: #3a2818;
+      --copper: #c5742d;
+      --copper-deep: #8d4a13;
+      --moss: #4a5a2b;
+      --line: rgba(58, 40, 24, 0.16);
+      --muted: #6b5a4c;
+
+      /* Legacy aliases (kept for forms/sub-pages) */
+      --color-primary: var(--copper);
+      --color-secondary: var(--copper-deep);
+      --color-deep: var(--ink-soft);
+      --color-ink: var(--ink);
+      --color-bg: var(--paper);
+      --color-bg-deep: var(--paper-deep);
+      --color-surface: rgba(255, 252, 244, 0.92);
       --color-card: #ffffff;
-      --color-text: #2a2018;
-      --color-muted: #5b4b3f;
-      --color-success: #7e7e31;
+      --color-text: var(--ink);
+      --color-muted: var(--muted);
+      --color-success: #5d6e2a;
       --color-warning: #d9b364;
       --color-info: #f3f3f3;
-      --color-focus: #2f6fdd;
-      --color-error: #573921;
-      --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
-      --shadow-md: 0 10px 24px rgba(30, 30, 30, 0.13);
-      --radius-sm: 6px;
-      --radius-md: 12px;
-      --radius-lg: 20px;
+      --color-focus: var(--copper);
+      --color-error: #8a3a1a;
+      --color-foam: var(--foam);
+      --color-accent: var(--copper);
+      --color-accent-soft: rgba(197, 116, 45, 0.16);
+
+      /* Surface */
+      --shadow-sm: 0 1px 2px rgba(40, 22, 10, 0.06);
+      --shadow-md: 0 12px 28px rgba(60, 35, 16, 0.16);
+      --shadow-lg: 0 28px 60px rgba(60, 35, 16, 0.22);
+      --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.75);
+
+      /* Geometry */
+      --radius-sm: 8px;
+      --radius-md: 16px;
+      --radius-lg: 24px;
+      --radius-xl: 36px;
+
+      /* Spacing */
       --spacing-xs: 4px;
       --spacing-sm: 8px;
       --spacing-md: 16px;
       --spacing-lg: 24px;
-      --spacing-xl: 32px;
+      --spacing-xl: 40px;
+      --spacing-2xl: 72px;
+
+      /* Type */
+      --font-display: 'Fraunces', 'Cormorant Garamond', Georgia, serif;
+      --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+      /* Motion */
+      --ease-out-soft: cubic-bezier(0.22, 1, 0.36, 1);
     }
 
-    * { box-sizing: border-box; }
+    *, *::before, *::after { box-sizing: border-box; }
 
-    html {
-      scroll-padding-top: 96px;
-    }
+    html { scroll-padding-top: 96px; }
 
     body {
       margin: 0;
-      font-family: 'Inter', Arial, sans-serif;
-      color: var(--color-text);
-      background:
-        radial-gradient(circle at 10% -10%, #f5e8c7 0%, transparent 38%),
-        radial-gradient(circle at 95% 0%, #e7cf9a 0%, transparent 32%),
-        var(--color-bg);
-      line-height: 1.55;
+      font-family: var(--font-body);
+      color: var(--ink);
+      background-color: var(--paper);
+      background-image:
+        radial-gradient(ellipse at 8% -6%, rgba(255, 244, 209, 0.95) 0%, transparent 42%),
+        radial-gradient(ellipse at 96% 6%, rgba(231, 207, 154, 0.9) 0%, transparent 38%),
+        radial-gradient(circle at 50% 120%, rgba(197, 116, 45, 0.16) 0%, transparent 55%);
+      background-attachment: fixed;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
+      overflow-x: hidden;
     }
+
+    /* Paper-grain noise overlay */
+    body::before {
+      content: '';
+      position: fixed;
+      inset: 0;
+      pointer-events: none;
+      z-index: 0;
+      background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.3 0 0 0 0 0.2 0 0 0 0 0.1 0 0 0 0.06 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+      opacity: 0.55;
+      mix-blend-mode: multiply;
+    }
+
+    main, header, footer { position: relative; z-index: 1; }
+
+    ::selection { background: var(--copper); color: var(--foam); }
 
     .skip-link {
       position: absolute;
       left: -9999px;
       top: 0;
-      background: #fff;
-      color: var(--color-text);
-      border: 2px solid var(--color-secondary);
+      background: var(--ink);
+      color: var(--foam);
       border-radius: var(--radius-sm);
-      padding: 8px 12px;
+      padding: 10px 14px;
       font-weight: 700;
       z-index: 1200;
     }
+    .skip-link:focus { left: 12px; top: 12px; }
 
-    .skip-link:focus {
-      left: 12px;
-      top: 12px;
-    }
+    /* ========================================================================
+       Header
+       ====================================================================== */
 
-    /* Sticky header with logo */
     .site-header {
       position: sticky;
       top: 0;
       z-index: 100;
-      background: rgba(255, 253, 248, 0.95);
-      backdrop-filter: blur(8px);
-      border-bottom: 1px solid rgba(141, 88, 50, 0.15);
-      padding: 12px 20px;
+      background: rgba(255, 252, 244, 0.82);
+      backdrop-filter: blur(14px) saturate(1.15);
+      -webkit-backdrop-filter: blur(14px) saturate(1.15);
+      border-bottom: 1px solid var(--line);
+      padding: 14px 24px;
     }
 
     .header-inner {
-      max-width: 1040px;
+      max-width: 1180px;
       margin: 0 auto;
       display: flex;
       align-items: center;
       justify-content: space-between;
-      gap: 20px;
+      gap: 24px;
     }
 
     .header-logo {
-      display: flex;
+      display: inline-flex;
       align-items: center;
       gap: 12px;
       text-decoration: none;
     }
 
     .header-logo img {
-      width: 50px;
-      height: 50px;
+      width: 44px;
+      height: 44px;
       border-radius: 50%;
       object-fit: contain;
       background: #fff;
-      border: 2px solid rgba(141, 88, 50, 0.2);
+      border: 1px solid var(--line);
     }
 
     .header-logo span {
-      font-size: 1.3rem;
-      font-weight: 800;
-      color: var(--color-secondary);
+      font-family: var(--font-display);
+      font-size: 1.45rem;
+      font-weight: 700;
+      letter-spacing: -0.015em;
+      color: var(--ink);
+      font-variation-settings: 'SOFT' 50, 'opsz' 144;
     }
 
     .header-nav {
       display: flex;
       align-items: center;
-      gap: 24px;
+      gap: 30px;
     }
 
     .header-nav a {
-      color: var(--color-muted);
+      color: var(--ink-soft);
       text-decoration: none;
-      font-weight: 600;
+      font-weight: 500;
       font-size: 0.95rem;
-      transition: color 0.2s;
+      position: relative;
+      transition: color 0.2s var(--ease-out-soft);
     }
 
-    .header-nav a:hover {
-      color: var(--color-secondary);
+    .header-nav a:not(.header-cta)::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: -6px;
+      height: 2px;
+      background: var(--copper);
+      border-radius: 2px;
+      transform: scaleX(0);
+      transform-origin: left center;
+      transition: transform 0.25s var(--ease-out-soft);
     }
 
-    .header-right {
-      display: flex;
-      align-items: center;
-      gap: 16px;
+    .header-nav a:not(.header-cta):hover { color: var(--ink); }
+    .header-nav a:not(.header-cta):hover::after { transform: scaleX(1); }
+
+    .header-nav .header-cta {
+      padding: 10px 18px;
+      border-radius: 999px;
+      background: var(--ink);
+      color: var(--foam);
+      font-weight: 600;
+      transition: background-color 0.25s var(--ease-out-soft), transform 0.18s var(--ease-out-soft);
     }
 
-    .language-switch {
-      padding: 6px 10px;
-      border-radius: 9999px;
-      border: 1px solid rgba(141, 88, 50, 0.32);
-      background: rgba(255, 255, 255, 0.84);
-      font-size: 0.9rem;
+    .header-nav .header-cta:hover {
+      background: var(--copper);
+      transform: translateY(-1px);
     }
 
-    .language-switch a {
-      color: var(--color-muted);
-      text-decoration: none;
-      font-weight: 700;
+    @media (max-width: 760px) {
+      .header-nav { gap: 16px; font-size: 0.88rem; }
+      .header-nav .header-cta { padding: 8px 14px; }
     }
 
-    .language-switch a:hover { color: var(--color-secondary); }
+    /* ========================================================================
+       Page shell
+       ====================================================================== */
 
     .page {
       min-height: 100vh;
       display: flex;
       justify-content: center;
-      padding: 78px 20px 32px;
+      padding: 28px 16px 80px;
     }
 
     .shell {
       width: 100%;
-      max-width: 1040px;
-      padding: 28px;
-      border-radius: var(--radius-lg);
-      border: 2px solid rgba(141, 88, 50, 0.16);
-      background: var(--color-surface);
-      box-shadow: var(--shadow-md);
+      max-width: 1180px;
     }
+
+    .responsibility-banner {
+      margin: 0 auto 40px;
+      max-width: max-content;
+      padding: 8px 18px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      background: rgba(255, 252, 244, 0.7);
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-align: center;
+      letter-spacing: 0.02em;
+      backdrop-filter: blur(8px);
+    }
+
+    /* ========================================================================
+       Hero — editorial, asymmetric
+       ====================================================================== */
 
     .hero {
-      text-align: center;
-      padding-bottom: var(--spacing-md);
-      border-bottom: 1px solid rgba(141, 88, 50, 0.2);
+      position: relative;
+      padding: clamp(48px, 7vw, 96px) clamp(28px, 5vw, 64px) clamp(64px, 8vw, 112px);
+      border-radius: var(--radius-xl);
+      background:
+        radial-gradient(circle at 5% 8%, rgba(255, 255, 255, 0.6) 0%, transparent 35%),
+        linear-gradient(165deg, var(--foam) 0%, var(--paper-deep) 100%);
+      border: 1px solid var(--line);
+      box-shadow: var(--shadow-lg), var(--shadow-inset);
+      overflow: hidden;
+      isolation: isolate;
+      animation: fadeUp 1s var(--ease-out-soft) both;
     }
 
-    .logo-wrap {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 180px;
-      height: 180px;
-      border-radius: 50%;
-      background: linear-gradient(160deg, rgba(255, 255, 255, 0.95), rgba(243, 243, 243, 0.8));
-      border: 2px solid rgba(141, 88, 50, 0.15);
-      box-shadow: var(--shadow-sm);
-      margin-bottom: 12px;
+    .hero::before {
+      content: '';
+      position: absolute;
+      width: 640px;
+      height: 640px;
+      right: -220px;
+      top: -220px;
+      background:
+        radial-gradient(circle, rgba(197, 116, 45, 0.32) 0%, transparent 65%);
+      z-index: -1;
+      animation: floatSlow 14s ease-in-out infinite;
     }
 
-    .logo {
-      width: 150px;
-      max-width: 100%;
-      height: auto;
-      display: block;
+    .hero::after {
+      content: '';
+      position: absolute;
+      width: 380px;
+      height: 380px;
+      left: -120px;
+      bottom: -180px;
+      background: radial-gradient(circle, rgba(74, 90, 43, 0.18) 0%, transparent 65%);
+      z-index: -1;
+      animation: floatSlow 18s ease-in-out infinite reverse;
+    }
+
+    @keyframes floatSlow {
+      0%, 100% { transform: translate(0, 0); }
+      50% { transform: translate(-24px, 18px); }
     }
 
     .pill {
-      display: inline-block;
-      margin-bottom: 10px;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 28px;
       border-radius: 999px;
-      padding: 6px 12px;
-      background: rgba(217, 179, 100, 0.25);
-      color: var(--color-secondary);
-      font-size: 0.8rem;
+      padding: 7px 16px;
+      background: rgba(255, 255, 255, 0.7);
+      border: 1px solid var(--line);
+      color: var(--ink);
+      font-size: 0.72rem;
       font-weight: 700;
-      letter-spacing: 0.02em;
+      letter-spacing: 0.16em;
       text-transform: uppercase;
+      backdrop-filter: blur(4px);
     }
 
-    h1 {
+    .pill::before {
+      content: '';
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--copper);
+      box-shadow: 0 0 0 3px rgba(197, 116, 45, 0.25);
+      animation: pulse 2s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { box-shadow: 0 0 0 3px rgba(197, 116, 45, 0.25); }
+      50% { box-shadow: 0 0 0 7px rgba(197, 116, 45, 0); }
+    }
+
+    .hero h1 {
       margin: 0;
-      color: var(--color-secondary);
-      font-size: clamp(2rem, 5vw, 3rem);
-      line-height: 1.15;
+      font-family: var(--font-display);
+      font-weight: 700;
+      color: var(--ink);
+      font-size: clamp(2.6rem, 6.4vw, 4.6rem);
+      line-height: 0.98;
+      letter-spacing: -0.028em;
+      max-width: 14ch;
+      font-variation-settings: 'SOFT' 30, 'opsz' 144;
+    }
+
+    .hero h1 em {
+      font-style: italic;
+      font-weight: 500;
+      color: var(--copper);
+      font-variation-settings: 'SOFT' 100, 'opsz' 144;
+      position: relative;
+      display: inline-block;
+    }
+
+    .hero h1 em::after {
+      content: '';
+      position: absolute;
+      left: -2%;
+      right: -2%;
+      bottom: 0.05em;
+      height: 0.12em;
+      background: linear-gradient(90deg, transparent 0%, rgba(197, 116, 45, 0.35) 20%, rgba(197, 116, 45, 0.35) 80%, transparent 100%);
+      border-radius: 999px;
+      z-index: -1;
     }
 
     .intro {
-      margin: 14px auto 0;
-      max-width: 760px;
-      color: var(--color-muted);
-      font-size: 1.02rem;
+      margin: 28px 0 0;
+      max-width: 46ch;
+      color: var(--ink-soft);
+      font-size: clamp(1.05rem, 1.5vw, 1.18rem);
+      line-height: 1.6;
     }
 
+    .hero-actions {
+      display: flex;
+      gap: 14px;
+      flex-wrap: wrap;
+      margin-top: 36px;
+    }
+
+    .hero-mascot {
+      position: absolute;
+      right: clamp(-20px, -2vw, 24px);
+      bottom: clamp(-40px, -3vw, -16px);
+      width: clamp(150px, 24vw, 280px);
+      height: clamp(150px, 24vw, 280px);
+      border-radius: 50%;
+      background:
+        radial-gradient(circle at 32% 28%, rgba(255, 255, 255, 0.98) 0%, rgba(251, 243, 218, 0.92) 55%, rgba(231, 207, 154, 0.55) 100%);
+      border: 1px solid var(--line);
+      box-shadow:
+        0 28px 56px rgba(99, 56, 24, 0.32),
+        inset 0 2px 6px rgba(255, 255, 255, 0.85);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      animation: heroFloat 6s ease-in-out infinite;
+      z-index: 2;
+    }
+
+    .hero-mascot::before {
+      content: '';
+      position: absolute;
+      inset: -14px;
+      border-radius: 50%;
+      border: 1px dashed rgba(197, 116, 45, 0.45);
+      animation: spinSlow 60s linear infinite;
+    }
+
+    .hero-mascot .logo {
+      width: 72%;
+      height: 72%;
+      object-fit: contain;
+      filter: drop-shadow(0 6px 12px rgba(60, 35, 16, 0.18));
+    }
+
+    @keyframes heroFloat {
+      0%, 100% { transform: translateY(0) rotate(0deg); }
+      50% { transform: translateY(-10px) rotate(-1.5deg); }
+    }
+
+    @keyframes spinSlow {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+
+    @media (max-width: 800px) {
+      .hero { text-align: center; }
+      .hero h1 { margin: 0 auto; }
+      .intro { margin-left: auto; margin-right: auto; }
+      .hero-actions { justify-content: center; }
+      .hero-mascot {
+        position: relative;
+        margin: 40px auto 0;
+        right: auto; bottom: auto;
+        width: 200px; height: 200px;
+      }
+    }
+
+    /* ========================================================================
+       Sections
+       ====================================================================== */
+
     .section-block {
-      margin-top: var(--spacing-xl);
+      margin-top: clamp(72px, 10vw, 128px);
       scroll-margin-top: 96px;
+      animation: fadeUp 1s var(--ease-out-soft) both;
+      animation-timeline: view();
+      animation-range: entry 0% cover 30%;
+    }
+
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(28px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    .section-eyebrow {
+      margin: 0 0 14px;
+      text-align: center;
+      color: var(--copper);
+      font-size: 0.74rem;
+      font-weight: 700;
+      letter-spacing: 0.22em;
+      text-transform: uppercase;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 14px;
+    }
+
+    .section-eyebrow::before,
+    .section-eyebrow::after {
+      content: '';
+      width: 32px;
+      height: 1px;
+      background: var(--copper);
+      opacity: 0.55;
     }
 
     .section-title {
-      margin: 0 0 12px;
-      font-size: 1.45rem;
-      color: var(--color-secondary);
+      margin: 0 auto 18px;
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: clamp(2rem, 4vw, 3rem);
+      line-height: 1.08;
+      letter-spacing: -0.022em;
+      color: var(--ink);
       text-align: center;
+      max-width: 22ch;
+      font-variation-settings: 'SOFT' 40, 'opsz' 144;
+    }
+
+    .section-title em {
+      font-style: italic;
+      font-weight: 500;
+      color: var(--copper);
+      font-variation-settings: 'SOFT' 100, 'opsz' 144;
     }
 
     .section-intro {
-      margin: 0 auto 14px;
-      max-width: 760px;
-      color: var(--color-muted);
+      margin: 0 auto 40px;
+      max-width: 54ch;
+      color: var(--ink-soft);
       text-align: center;
+      font-size: 1.05rem;
+      line-height: 1.65;
     }
 
-    /* Features grid - premium cards aligned with the visual identity */
-    .features-grid {
+    /* ========================================================================
+       Journey — big numerals + phone screenshots
+       ====================================================================== */
+
+    .journey-grid {
+      list-style: none;
+      padding: 0;
+      margin: 40px 0 0;
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 24px;
+    }
+
+    .journey-step {
+      position: relative;
+      background: rgba(255, 252, 244, 0.85);
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--line);
+      padding: 32px 24px 28px;
+      text-align: left;
+      box-shadow: var(--shadow-sm);
+      transition: transform 0.35s var(--ease-out-soft), box-shadow 0.35s var(--ease-out-soft), border-color 0.35s var(--ease-out-soft);
+      display: flex;
+      flex-direction: column;
       gap: 18px;
-      margin-top: 20px;
+      overflow: hidden;
+      isolation: isolate;
+    }
+
+    .journey-step::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 3px;
+      background: linear-gradient(90deg, var(--copper) 0%, var(--copper-deep) 100%);
+      transform: scaleX(0);
+      transform-origin: left center;
+      transition: transform 0.45s var(--ease-out-soft);
+      z-index: 2;
+    }
+
+    .journey-step:hover {
+      transform: translateY(-6px);
+      box-shadow: var(--shadow-md);
+      border-color: rgba(197, 116, 45, 0.4);
+    }
+
+    .journey-step:hover::before { transform: scaleX(1); }
+
+    .journey-num {
+      font-family: var(--font-display);
+      font-size: 3rem;
+      font-weight: 900;
+      line-height: 1;
+      letter-spacing: -0.05em;
+      color: var(--copper);
+      font-variation-settings: 'SOFT' 20, 'opsz' 144;
+      opacity: 0.9;
+    }
+
+    .journey-screenshot {
+      position: relative;
+      width: 100%;
+      max-width: 180px;
+      aspect-ratio: 9 / 18;
+      align-self: center;
+      background: linear-gradient(170deg, var(--foam) 0%, var(--paper) 100%);
+      border-radius: 24px;
+      border: 1px solid var(--line);
+      padding: 10px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      overflow: hidden;
+      box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.7),
+        0 8px 22px rgba(60, 35, 16, 0.14);
+    }
+
+    .journey-screenshot::before {
+      content: '';
+      position: absolute;
+      top: 8px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 40px;
+      height: 4px;
+      background: rgba(40, 22, 10, 0.18);
+      border-radius: 2px;
+    }
+
+    .journey-screenshot img {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      border-radius: 16px;
+      display: block;
+    }
+
+    .journey-step h3 {
+      margin: 0;
+      font-family: var(--font-display);
+      font-weight: 700;
+      color: var(--ink);
+      font-size: 1.2rem;
+      line-height: 1.25;
+      font-variation-settings: 'SOFT' 40;
+    }
+
+    .journey-step p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.94rem;
+      line-height: 1.55;
+    }
+
+    /* ========================================================================
+       Features — bold cards with copper accent
+       ====================================================================== */
+
+    .features-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 24px;
+      margin-top: 40px;
     }
 
     .feature-card {
@@ -242,51 +634,38 @@
       isolation: isolate;
       display: flex;
       flex-direction: column;
-      gap: 12px;
-      min-height: 212px;
-      padding: 20px;
-      border-radius: 18px;
-      border: 1px solid rgba(141, 88, 50, 0.24);
+      gap: 20px;
+      padding: 32px 26px 30px;
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--line);
       background:
-        radial-gradient(circle at 100% 0%, rgba(217, 179, 100, 0.24) 0%, rgba(217, 179, 100, 0) 46%),
-        linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(248, 242, 231, 0.9));
-      color: #44362c;
-      box-shadow: 0 10px 24px rgba(30, 30, 30, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.75);
+        radial-gradient(circle at 100% 0%, rgba(197, 116, 45, 0.16) 0%, transparent 50%),
+        linear-gradient(170deg, rgba(255, 255, 255, 0.98) 0%, rgba(251, 243, 218, 0.85) 100%);
+      box-shadow: var(--shadow-sm), var(--shadow-inset);
       overflow: hidden;
-      transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
-    }
-
-    .feature-card::before {
-      content: '';
-      position: absolute;
-      width: 130px;
-      height: 130px;
-      top: -62px;
-      right: -52px;
-      background: radial-gradient(circle, rgba(183, 130, 75, 0.3) 0%, rgba(183, 130, 75, 0) 72%);
-      z-index: -1;
+      transition: transform 0.35s var(--ease-out-soft), box-shadow 0.35s var(--ease-out-soft), border-color 0.35s var(--ease-out-soft);
     }
 
     .feature-card::after {
       content: '';
       position: absolute;
-      left: 20px;
-      right: 20px;
+      left: 26px;
+      right: 26px;
       bottom: 0;
-      height: 3px;
+      height: 2px;
       border-radius: 999px;
-      background: linear-gradient(90deg, rgba(183, 130, 75, 0.95), rgba(126, 126, 49, 0.9));
-      opacity: 0.7;
-      transform: scaleX(0.42);
+      background: linear-gradient(90deg, var(--copper) 0%, var(--copper-deep) 50%, var(--moss) 100%);
+      opacity: 0.6;
+      transform: scaleX(0.25);
       transform-origin: left center;
-      transition: transform 0.25s ease, opacity 0.25s ease;
+      transition: transform 0.4s var(--ease-out-soft), opacity 0.4s var(--ease-out-soft);
     }
 
     .feature-card:hover,
     .feature-card:focus-within {
       transform: translateY(-6px);
-      border-color: rgba(141, 88, 50, 0.38);
-      box-shadow: 0 18px 34px rgba(65, 42, 25, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.82);
+      border-color: rgba(197, 116, 45, 0.4);
+      box-shadow: var(--shadow-md), var(--shadow-inset);
     }
 
     .feature-card:hover::after,
@@ -295,330 +674,289 @@
       opacity: 1;
     }
 
-    .feature-card h3 {
-      margin: 0;
-      color: var(--color-secondary);
-      font-size: 1.07rem;
-      line-height: 1.35;
-    }
-
-    .feature-card p {
-      margin: 0;
-      color: #5b4b3f;
-      font-size: 0.94rem;
-      line-height: 1.58;
-    }
-
-    /*
-     * Feature card screenshot wrapper — replaces the legacy emoji
-     * `.feature-icon` slot when a card is illustrated with a mobile
-     * app capture. Sized to keep a 1:2 portrait aspect ratio while
-     * letting the image breathe inside the card. The default frame
-     * uses the cream surface colour so a broken / missing image
-     * still renders as a clean placeholder during development.
-     */
     .feature-screenshot {
       width: 100%;
-      max-width: 200px;
+      max-width: 210px;
       aspect-ratio: 1 / 2;
       align-self: center;
-      background: var(--color-bg);
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(141, 88, 50, 0.18);
-      padding: 8px;
+      background: linear-gradient(170deg, var(--foam) 0%, var(--paper) 100%);
+      border-radius: 24px;
+      border: 1px solid var(--line);
+      padding: 10px;
       display: flex;
       align-items: center;
       justify-content: center;
       overflow: hidden;
-      box-shadow: var(--shadow-sm);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 6px 18px rgba(60, 35, 16, 0.12);
+      position: relative;
+    }
+
+    .feature-screenshot::before {
+      content: '';
+      position: absolute;
+      top: 8px;
+      left: 50%;
+      transform: translateX(-50%);
+      width: 44px;
+      height: 5px;
+      background: rgba(40, 22, 10, 0.18);
+      border-radius: 3px;
     }
 
     .feature-screenshot img {
       width: 100%;
       height: 100%;
       object-fit: contain;
-      border-radius: var(--radius-sm);
+      border-radius: 16px;
       display: block;
     }
 
-    /*
-     * "Comment ça se passe" journey section — four steps shown as a
-     * responsive ordered list. Each step has its own mini phone
-     * mockup wrapper (`.journey-screenshot`) plus a heading + caption.
-     * The grid collapses from 4 columns on wide screens to 2 then
-     * 1 on small viewports without any media queries thanks to
-     * `auto-fit` + `minmax`.
-     */
-    .journey-grid {
-      list-style: none;
-      padding: 0;
-      margin: var(--spacing-md) 0 0 0;
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: var(--spacing-md);
-    }
-
-    .journey-step {
-      background: var(--color-card);
-      border-radius: var(--radius-lg);
-      border: 1px solid rgba(141, 88, 50, 0.18);
-      padding: var(--spacing-md);
-      text-align: center;
-      box-shadow: var(--shadow-sm);
-      transition: transform 0.2s ease, box-shadow 0.2s ease;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: var(--spacing-sm);
-    }
-
-    .journey-step:hover {
-      transform: translateY(-2px);
-      box-shadow: var(--shadow-md);
-    }
-
-    .journey-screenshot {
-      width: 100%;
-      max-width: 180px;
-      aspect-ratio: 9 / 18;
-      background: var(--color-bg);
-      border-radius: var(--radius-lg);
-      border: 1px solid rgba(141, 88, 50, 0.2);
-      padding: 8px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      overflow: hidden;
-      box-shadow: var(--shadow-sm);
-    }
-
-    .journey-screenshot img {
-      width: 100%;
-      height: 100%;
-      object-fit: contain;
-      border-radius: var(--radius-md);
-      display: block;
-    }
-
-    .journey-step h3 {
+    .feature-card h3 {
       margin: 0;
-      color: var(--color-secondary);
-      font-size: 1.05rem;
-      line-height: 1.35;
+      font-family: var(--font-display);
+      font-weight: 700;
+      color: var(--ink);
+      font-size: 1.35rem;
+      line-height: 1.2;
+      letter-spacing: -0.012em;
+      font-variation-settings: 'SOFT' 40;
     }
 
-    .journey-step p {
+    .feature-card p {
       margin: 0;
-      color: var(--color-muted);
-      font-size: 0.95rem;
-      line-height: 1.55;
+      color: var(--muted);
+      font-size: 0.96rem;
+      line-height: 1.6;
     }
 
-    /* Section grid for secondary sections */
-    .section-grid {
+    /* ========================================================================
+       FAQ — bold accordion
+       ====================================================================== */
+
+    .faq-grid {
       display: grid;
       gap: 12px;
-      margin-top: 12px;
-      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      margin: 40px auto 0;
+      max-width: 760px;
     }
 
-    .mini-card {
-      background: var(--color-card);
+    .faq-item {
+      background: rgba(255, 252, 244, 0.85);
       border-radius: var(--radius-md);
-      border: 1px solid rgba(141, 88, 50, 0.2);
-      padding: 14px;
-      color: #44362c;
+      border: 1px solid var(--line);
+      padding: 4px 26px;
       box-shadow: var(--shadow-sm);
+      transition: box-shadow 0.25s var(--ease-out-soft), border-color 0.25s var(--ease-out-soft), background 0.25s var(--ease-out-soft);
     }
 
-    .mini-card h3 {
-      margin: 0 0 8px;
-      color: var(--color-secondary);
-      font-size: 1.02rem;
+    .faq-item[open] {
+      border-color: rgba(197, 116, 45, 0.45);
+      box-shadow: var(--shadow-md);
+      background: rgba(255, 252, 244, 0.95);
     }
 
-    /* Legacy feature list (kept for compatibility) */
-    .feature {
-      background: var(--color-card);
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(141, 88, 50, 0.2);
-      padding: 14px;
-      color: #44362c;
-      box-shadow: var(--shadow-sm);
-    }
-
-    .roadmap-controls {
-      display: flex;
-      justify-content: center;
-      flex-wrap: wrap;
-      gap: 8px;
-      margin-bottom: 14px;
-    }
-
-    .chip {
-      min-height: 40px;
-      padding: 7px 12px;
-      border-radius: 999px;
-      border: 1px solid rgba(141, 88, 50, 0.28);
-      background: #fff;
-      color: var(--color-muted);
-      font-weight: 700;
+    .faq-item summary {
       cursor: pointer;
-    }
-
-    .chip.active {
-      background: rgba(183, 130, 75, 0.14);
-      border-color: var(--color-secondary);
-      color: var(--color-secondary);
-    }
-
-    .roadmap-track {
-      display: grid;
-      gap: 10px;
-    }
-
-    .phase-card {
-      background: var(--color-card);
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(141, 88, 50, 0.2);
-      padding: 12px;
-    }
-
-    .phase-head {
+      list-style: none;
+      padding: 20px 0;
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 1.1rem;
+      color: var(--ink);
       display: flex;
       justify-content: space-between;
       align-items: center;
-      flex-wrap: wrap;
-      gap: 8px;
+      gap: 18px;
+      font-variation-settings: 'SOFT' 40;
     }
 
-    .phase-title {
-      margin: 0;
-      font-size: 1rem;
-      color: var(--color-text);
+    .faq-item summary::-webkit-details-marker { display: none; }
+
+    .faq-item summary::after {
+      content: '';
+      flex: 0 0 auto;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: var(--ink);
+      color: var(--foam);
+      position: relative;
+      transition: background 0.25s var(--ease-out-soft), transform 0.3s var(--ease-out-soft);
     }
 
-    .phase-state {
-      font-size: 0.76rem;
-      font-weight: 700;
-      border-radius: 999px;
-      padding: 4px 9px;
-      background: var(--color-info);
-      color: #4f4f4f;
+    .faq-item summary::before {
+      content: '';
+      width: 12px;
+      height: 12px;
+      position: absolute;
+      right: 28px;
+      background-image:
+        linear-gradient(to right, var(--foam) 0 100%),
+        linear-gradient(to bottom, var(--foam) 0 100%);
+      background-size: 12px 2px, 2px 12px;
+      background-repeat: no-repeat;
+      background-position: center center, center center;
+      pointer-events: none;
+      z-index: 1;
+      transition: transform 0.3s var(--ease-out-soft);
     }
 
-    .phase-state.done {
-      background: rgba(126, 126, 49, 0.18);
-      color: #4e4e1e;
+    .faq-item[open] summary::after {
+      background: var(--copper);
+      transform: rotate(180deg);
     }
 
-    .phase-state.current {
-      background: rgba(217, 179, 100, 0.34);
-      color: #67411e;
+    .faq-item[open] summary::before {
+      background-size: 12px 2px, 0 0;
     }
 
-    .phase-state.next {
-      background: rgba(243, 243, 243, 1);
-      color: #555;
+    .faq-item p {
+      margin: 0 0 22px;
+      color: var(--muted);
+      font-size: 0.98rem;
+      line-height: 1.7;
+      max-width: 56ch;
     }
 
-    .phase-body {
-      margin: 8px 0 0;
-      color: #54463a;
-      font-size: 0.94rem;
+    /* ========================================================================
+       Participate — bold CTA block
+       ====================================================================== */
+
+    .participate {
+      position: relative;
+      background:
+        radial-gradient(circle at 92% 8%, rgba(197, 116, 45, 0.22) 0%, transparent 50%),
+        radial-gradient(circle at 8% 96%, rgba(74, 90, 43, 0.18) 0%, transparent 50%),
+        linear-gradient(165deg, var(--foam) 0%, var(--paper-deep) 100%);
+      border: 1px solid var(--line);
+      border-radius: var(--radius-xl);
+      padding: clamp(48px, 7vw, 88px) clamp(28px, 5vw, 64px);
+      box-shadow: var(--shadow-lg), var(--shadow-inset);
+      overflow: hidden;
     }
 
-    .phase-body ul {
-      margin: 8px 0 0 18px;
-      padding: 0;
-    }
+    .participate .section-title { color: var(--ink); }
 
-    .badge {
-      margin-top: 10px;
-      text-align: center;
-      color: #75695f;
-      font-size: 0.9rem;
-    }
-
-    .badge a {
-      color: inherit;
-      font-weight: 700;
-      text-decoration: none;
-    }
-
-    .badge a:hover { color: var(--color-secondary); }
+    /* ========================================================================
+       Buttons
+       ====================================================================== */
 
     .actions {
       display: flex;
-      gap: 10px;
-      justify-content: center;
+      gap: 14px;
       flex-wrap: wrap;
-      margin-top: 14px;
+      justify-content: center;
+      margin-top: 22px;
     }
+
+    .actions-compact { gap: 12px; margin-top: 20px; }
 
     .btn {
-      min-height: 44px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 52px;
       border: none;
-      border-radius: var(--radius-md);
-      padding: 11px 18px;
-      font-weight: 700;
-      font-size: 0.95rem;
+      border-radius: 999px;
+      padding: 14px 26px;
+      font-family: var(--font-body);
+      font-weight: 600;
+      font-size: 0.98rem;
+      letter-spacing: 0.005em;
       cursor: pointer;
-      transition: transform 0.15s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+      text-decoration: none;
+      position: relative;
+      overflow: hidden;
+      transition: transform 0.22s var(--ease-out-soft), box-shadow 0.25s var(--ease-out-soft), background-color 0.25s var(--ease-out-soft), color 0.25s var(--ease-out-soft);
     }
 
-    .btn:hover { transform: translateY(-1px); }
+    .btn:hover { transform: translateY(-2px); }
+
+    .btn:active { transform: translateY(0); }
+
     .btn:disabled {
-      opacity: 0.7;
+      opacity: 0.55;
       cursor: not-allowed;
       transform: none;
     }
 
-    .btn-primary {
-      background: var(--color-secondary);
-      color: #fff;
-      box-shadow: 0 8px 18px rgba(141, 88, 50, 0.28);
+    .btn:focus-visible {
+      outline: 2px solid var(--copper);
+      outline-offset: 3px;
     }
 
-    .btn-primary:hover { background: #764828; }
+    .btn-primary {
+      background: var(--ink);
+      color: var(--foam);
+      box-shadow: 0 10px 24px rgba(26, 17, 10, 0.35);
+      isolation: isolate;
+    }
 
-    .btn-secondary {
-      text-decoration: none;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      border: 1px solid rgba(141, 88, 50, 0.3);
-      background: #fff;
-      color: var(--color-secondary);
+    .btn-primary::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, var(--copper) 0%, var(--copper-deep) 100%);
+      opacity: 0;
+      transition: opacity 0.3s var(--ease-out-soft);
+      z-index: 0;
+    }
+
+    .btn-primary > * { position: relative; z-index: 1; }
+
+    .btn-primary:hover { box-shadow: 0 16px 32px rgba(197, 116, 45, 0.45); }
+    .btn-primary:hover::before { opacity: 1; }
+
+    .btn-ghost {
+      background: transparent;
+      color: var(--ink);
+      border: 1px solid rgba(26, 17, 10, 0.22);
+    }
+
+    .btn-ghost:hover {
+      background: rgba(26, 17, 10, 0.05);
+      border-color: var(--ink);
+    }
+
+    /* ========================================================================
+       Forms
+       ====================================================================== */
+
+    .contact-form {
+      margin: 0 auto;
+      max-width: 580px;
+      display: grid;
+      gap: 16px;
     }
 
     .questionnaire-form {
-      margin-top: 16px;
-      padding: 16px;
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(141, 88, 50, 0.24);
-      background: #fff;
+      margin-top: 24px;
+      padding: 28px;
+      border-radius: var(--radius-lg);
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.78);
       box-shadow: var(--shadow-sm);
+      backdrop-filter: blur(6px);
     }
 
     .questionnaire-grid {
       display: grid;
       grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 12px;
+      gap: 16px;
     }
 
     .form-field {
       display: flex;
       flex-direction: column;
-      gap: 6px;
+      gap: 8px;
     }
 
     .form-field-full { grid-column: 1 / -1; }
 
     .form-field label,
     fieldset legend {
-      font-weight: 700;
-      color: #45392f;
+      font-weight: 600;
+      color: var(--ink);
       font-size: 0.92rem;
     }
 
@@ -626,13 +964,22 @@
     textarea,
     select {
       width: 100%;
-      border: 1px solid rgba(141, 88, 50, 0.36);
+      border: 1px solid var(--line);
       border-radius: var(--radius-sm);
       background: #fff;
-      color: var(--color-text);
-      padding: 11px 12px;
-      font-size: 0.96rem;
+      color: var(--ink);
+      padding: 13px 16px;
+      font-size: 1rem;
       font-family: inherit;
+      transition: border-color 0.2s var(--ease-out-soft), box-shadow 0.2s var(--ease-out-soft);
+    }
+
+    input:focus,
+    textarea:focus,
+    select:focus {
+      outline: none;
+      border-color: var(--copper);
+      box-shadow: 0 0 0 4px var(--color-accent-soft);
     }
 
     textarea {
@@ -642,142 +989,64 @@
 
     fieldset {
       margin: 0;
-      padding: 10px 12px;
-      border: 1px solid rgba(141, 88, 50, 0.22);
+      padding: 14px 16px;
+      border: 1px solid var(--line);
       border-radius: var(--radius-sm);
-      background: rgba(243, 243, 243, 0.7);
+      background: rgba(251, 243, 218, 0.4);
     }
 
-    .checkbox-list,
-    .radio-list {
+    .radio-list,
+    .checkbox-list {
       display: grid;
-      gap: 6px;
-      margin-top: 8px;
+      gap: 8px;
+      margin-top: 10px;
     }
 
-    .checkbox-list label,
     .radio-list label,
+    .checkbox-list label,
     .consent {
       display: flex;
-      gap: 8px;
+      gap: 10px;
       align-items: flex-start;
       font-size: 0.92rem;
-      color: #4f4238;
+      color: var(--muted);
+      line-height: 1.55;
     }
 
-    .checkbox-list input,
     .radio-list input,
+    .checkbox-list input,
     .consent input {
       width: 18px;
       height: 18px;
-      margin-top: 1px;
+      margin-top: 2px;
       flex: 0 0 auto;
+      accent-color: var(--copper);
     }
 
+    .honeypot { display: none; }
+
     .form-status {
-      margin: 10px 0 0;
+      margin: 14px 0 0;
       min-height: 22px;
       text-align: center;
       font-weight: 600;
       font-size: 0.92rem;
     }
 
-    .form-status.loading { color: #5f4f43; }
+    .form-status.loading { color: var(--muted); }
     .form-status.success { color: var(--color-success); }
     .form-status.error { color: var(--color-error); }
 
-    .contact-form {
-      margin: 0 auto;
-      max-width: 720px;
-      display: grid;
-      gap: 10px;
-    }
-
-    .footer {
-      margin-top: var(--spacing-xl);
-      text-align: center;
-      color: var(--color-muted);
-      font-size: 0.92rem;
-    }
-
-    .footer strong { color: var(--color-secondary); }
-
-    .responsibility-banner {
-      margin: 0 auto 18px;
-      padding: 12px 16px;
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(141, 88, 50, 0.24);
-      background: linear-gradient(135deg, rgba(255, 251, 241, 0.95), rgba(247, 235, 206, 0.92));
-      color: #5b432f;
-      font-size: 0.9rem;
-      text-align: center;
-      box-shadow: var(--shadow-sm);
-    }
-
-    .guide-grid {
-      display: grid;
-      gap: 12px;
-      margin-top: 12px;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    }
-
-    .guide-card {
-      background: #fff;
-      border-radius: var(--radius-md);
-      border: 1px solid rgba(141, 88, 50, 0.2);
-      padding: 14px;
-      box-shadow: var(--shadow-sm);
-    }
-
-    .guide-card h3 {
-      margin: 0 0 8px;
-      color: var(--color-secondary);
-      font-size: 1rem;
-    }
-
-    .guide-card ul {
-      margin: 0;
-      padding-left: 18px;
-      color: #55463b;
-      font-size: 0.92rem;
-      line-height: 1.5;
-    }
-
     .consent-note {
-      margin-top: 2px;
-      font-size: 0.85rem;
-      color: #5c4f45;
-      text-align: left;
+      margin: 4px 0 0;
+      font-size: 0.82rem;
+      color: var(--muted);
+      line-height: 1.55;
     }
 
     .consent-note a {
-      color: var(--color-secondary);
-      font-weight: 700;
-      text-decoration: none;
-    }
-
-    .consent-note a:hover {
-      text-decoration: underline;
-    }
-
-    .footer-links {
-      margin-top: 10px;
-      display: flex;
-      flex-wrap: wrap;
-      gap: 10px 14px;
-      justify-content: center;
-      font-size: 0.86rem;
-    }
-
-    .footer-links a {
-      color: #6a5443;
-      text-decoration: none;
-      font-weight: 700;
-    }
-
-    .footer-links a:hover {
-      color: var(--color-secondary);
-      text-decoration: underline;
+      color: var(--ink);
+      font-weight: 600;
     }
 
     .sr-only {
@@ -792,65 +1061,97 @@
       border: 0;
     }
 
-    a:focus-visible,
-    button:focus-visible,
-    input:focus-visible,
-    textarea:focus-visible,
-    select:focus-visible {
-      outline: 3px solid var(--color-focus);
-      outline-offset: 2px;
+    /* ========================================================================
+       Footer
+       ====================================================================== */
+
+    .footer {
+      margin-top: clamp(72px, 10vw, 112px);
+      padding: 40px 0 24px;
+      border-top: 1px solid var(--line);
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: center;
+      gap: 28px;
     }
 
-    @media (max-width: 860px) {
-      .questionnaire-grid,
-      .section-grid,
-      .features-grid {
-        grid-template-columns: 1fr;
-      }
+    .footer-brand {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      max-width: 60ch;
     }
 
-    @media (max-width: 640px) {
-      .page { padding: 88px 12px 20px; }
-      .shell {
-        padding: 18px 14px;
-        border-radius: 16px;
-      }
-      .logo-wrap {
-        width: 150px;
-        height: 150px;
-      }
-      .logo { width: 126px; }
-      .actions .btn,
-      .actions .btn-secondary {
-        width: 100%;
-      }
-
-      .header-nav { display: none; }
-      .header-logo span { font-size: 1.1rem; }
+    .footer-mark {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      background: var(--ink);
+      color: var(--foam);
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 1.05rem;
+      letter-spacing: 0.05em;
+      flex: 0 0 auto;
+      box-shadow: var(--shadow-sm);
     }
+
+    .footer-brand p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.9rem;
+      line-height: 1.55;
+    }
+
+    .footer-brand strong {
+      color: var(--ink);
+      font-weight: 600;
+    }
+
+    .footer-links {
+      display: flex;
+      gap: 22px;
+      flex-wrap: wrap;
+    }
+
+    .footer-links a {
+      color: var(--muted);
+      text-decoration: none;
+      font-size: 0.88rem;
+      font-weight: 500;
+      transition: color 0.2s var(--ease-out-soft);
+      position: relative;
+    }
+
+    .footer-links a::after {
+      content: '';
+      position: absolute;
+      left: 0;
+      right: 0;
+      bottom: -3px;
+      height: 1px;
+      background: var(--copper);
+      transform: scaleX(0);
+      transform-origin: left center;
+      transition: transform 0.25s var(--ease-out-soft);
+    }
+
+    .footer-links a:hover { color: var(--ink); }
+    .footer-links a:hover::after { transform: scaleX(1); }
+
+    /* ========================================================================
+       Reduced motion
+       ====================================================================== */
 
     @media (prefers-reduced-motion: reduce) {
       *, *::before, *::after {
-        animation: none !important;
-        transition: none !important;
-        scroll-behavior: auto !important;
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.001ms !important;
       }
-    }
-
-    .actions-compact {
-      margin-top: var(--spacing-sm);
-    }
-
-    .form-field-spacing-sm {
-      margin-top: var(--spacing-sm);
-    }
-
-    .helper-text {
-      margin: var(--spacing-sm) 0 0;
-      color: #5a4d42;
-      font-size: 0.88rem;
-    }
-
-    .honeypot {
-      display: none;
+      .hero-mascot, .hero::before, .hero::after, .pill::before { animation: none; }
     }

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -1,74 +1,12 @@
 (function (global) {
   'use strict';
 
-  function createPhaseCard(phase, getStateLabel) {
-    const article = document.createElement('article');
-    article.className = 'phase-card';
-
-    const head = document.createElement('div');
-    head.className = 'phase-head';
-
-    const title = document.createElement('h3');
-    title.className = 'phase-title';
-    title.textContent = `Phase ${phase.phase} — ${phase.title}`;
-
-    const state = document.createElement('span');
-    state.className = `phase-state ${phase.state}`;
-    state.textContent = getStateLabel(phase.state);
-
-    head.appendChild(title);
-    head.appendChild(state);
-
-    const body = document.createElement('div');
-    body.className = 'phase-body';
-
-    const list = document.createElement('ul');
-    phase.points.forEach((point) => {
-      const item = document.createElement('li');
-      item.textContent = point;
-      list.appendChild(item);
-    });
-
-    body.appendChild(list);
-    article.appendChild(head);
-    article.appendChild(body);
-
-    return article;
-  }
-
-  function renderRoadmap(options) {
-    const { rootId, phases, filter, getStateLabel } = options;
-    const root = document.getElementById(rootId);
-    if (!root) return;
-
-    const list = filter === 'all' ? phases : phases.filter((phase) => phase.state === filter);
-    root.replaceChildren();
-
-    const fragment = document.createDocumentFragment();
-    list.forEach((phase) => {
-      fragment.appendChild(createPhaseCard(phase, getStateLabel));
-    });
-
-    root.appendChild(fragment);
-  }
-
-  function setActiveRoadmapFilter(options) {
-    const { controlsSelector, activeElement } = options;
-    document.querySelectorAll(controlsSelector).forEach((chip) => {
-      chip.classList.remove('active');
-      chip.setAttribute('aria-pressed', 'false');
-    });
-
-    if (activeElement) {
-      activeElement.classList.add('active');
-      activeElement.setAttribute('aria-pressed', 'true');
-    }
-  }
-
   function toggleQuestionnaire(options) {
     const { lang, labels } = options;
-    const form = document.getElementById(lang === 'fr' ? 'questionnaireFormFr' : 'questionnaireFormEn');
-    const button = document.getElementById(lang === 'fr' ? 'questionnaireToggleFr' : 'questionnaireToggleEn');
+    const formId = `questionnaireForm${lang === 'fr' ? 'Fr' : 'En'}`;
+    const buttonId = `questionnaireToggle${lang === 'fr' ? 'Fr' : 'En'}`;
+    const form = document.getElementById(formId);
+    const button = document.getElementById(buttonId);
     if (!form || !button) return;
 
     const isHidden = form.hasAttribute('hidden');
@@ -180,7 +118,7 @@
 
         setStatus(status, 'error', resolveHttpErrorMessage(response, messages));
       } catch (error) {
-        console.error('Questionnaire submission error:', error);
+        console.error('Form submission error:', error);
         setStatus(status, 'error', resolveCatchErrorMessage(error, messages));
       } finally {
         submitBtn.disabled = false;
@@ -189,8 +127,6 @@
   }
 
   global.BBShared = {
-    renderRoadmap,
-    setActiveRoadmapFilter,
     toggleQuestionnaire,
     setupQuestionnaire
   };

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -9,11 +9,14 @@
     const button = document.getElementById(buttonId);
     if (!form || !button) return;
 
-    const isOpen = form.getAttribute('data-open') === 'true';
+    const isOpen = form.dataset.open === 'true';
     const next = !isOpen;
 
-    form.setAttribute('data-open', String(next));
+    form.dataset.open = String(next);
     button.setAttribute('aria-expanded', String(next));
+
+    // Keep the collapsed form out of keyboard / screen-reader navigation.
+    form.inert = !next;
   }
 
   function setupCheckboxLimit(form, fieldName, maxChoices, message) {

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -2,24 +2,18 @@
   'use strict';
 
   function toggleQuestionnaire(options) {
-    const { lang, labels } = options;
+    const { lang } = options;
     const formId = `questionnaireForm${lang === 'fr' ? 'Fr' : 'En'}`;
     const buttonId = `questionnaireToggle${lang === 'fr' ? 'Fr' : 'En'}`;
     const form = document.getElementById(formId);
     const button = document.getElementById(buttonId);
     if (!form || !button) return;
 
-    const isHidden = form.hasAttribute('hidden');
+    const isOpen = form.getAttribute('data-open') === 'true';
+    const next = !isOpen;
 
-    if (isHidden) {
-      form.removeAttribute('hidden');
-      button.textContent = labels[lang].close;
-    } else {
-      form.setAttribute('hidden', '');
-      button.textContent = labels[lang].open;
-    }
-
-    button.setAttribute('aria-expanded', String(isHidden));
+    form.setAttribute('data-open', String(next));
+    button.setAttribute('aria-expanded', String(next));
   }
 
   function setupCheckboxLimit(form, fieldName, maxChoices, message) {


### PR DESCRIPTION
## Summary

Marketing home refresh built around the "curieux qui hésite à se lancer" persona, paired with a bold editorial/kinetic design pass.

- Structure trimmed from 11 H2 sections to 5: Hero, Parcours (4 steps), L'app (3 features), FAQ, Participer.
- Dropped sections that did not serve the persona: project roadmap, dev log, 3-paths brewing guide, long SEO article, "featured recipe".
- EN site collapsed to a "coming soon" stub since the public site stays French for now.

## Context

- Persona: a curious newcomer who has never (or barely) brewed and fears the technicality. Every section is calibrated to defuse that fear in 30 seconds of scroll.
- Visual direction: artisan editorial — warm paper background, espresso ink, copper accent, Fraunces variable serif on the SOFT axis paired with Inter for body.
- Motion is layered but selective and gated behind `prefers-reduced-motion: reduce`.

### Hero

- Mascot resized to `clamp(260px, 42vw, 520px)` with a breathing copper drop-shadow halo and two animated orbital rings.
- Six floating embers rise inside the hero with per-element delay, duration, and horizontal drift.
- H1 emphasis uses an animated copper gradient text-fill that subtly shimmers on a 6s loop.
- Primary CTA pulses a copper glow every 3.5s; hover swaps to a copper gradient overlay (z-index fixed so the label stays visible).

### Parcours

- Four numbered steps (01-04) using big Fraunces 900 numerals that breathe continuously.
- Card hover: scale 1.06, lift -14px, copper glow shadow. Numeral hover runs a 4-keyframe pop sequence (1 -> 1.45 -> 1.25 -> 1.3) with rotation and a copper text-shadow.

### Marquee

- Horizontal scrolling ticker of brewing terms between Parcours and L'app. Pause on hover. Text stays anchored on its line (no vertical bob).

### Features

- Three cards: Studio de recettes, Calculs brassage, Pilotage guidé.
- Hover lift + scale, screenshot tilt, diagonal shimmer sweep.
- Embedded device-frame screenshots gently bob at idle (each card offset by 1s); animation stops on hover.

### FAQ

- Five fear-driven questions for the persona: bricoleur, cost, brew-day duration, what if I fail, release timing. Old generic items dropped.
- Accordion with a circular badge that swaps + -> x and rotates 180deg on open, plus a soft amber glow.

### Participer (CTA bloc)

- Waitlist form + "Partager ton avis" toggle + direct email.
- Toggle button now has a stable layout (min-width + SVG chevron rotating via aria-expanded); the label no longer changes, so surrounding buttons stop reflowing on click.
- Questionnaire form uses the `grid-template-rows: 0fr -> 1fr` trick wrapped in `.questionnaire-inner` for a smooth height-aware open with synchronized opacity, translateY, and margin-top easing.

### Questionnaire content (zero-typing redesign)

Six native form-control fields replaced with five click-only chip fieldsets plus an optional email:

1. Tu en es où dans le brassage ? (single, 4 chips)
2. Brassins par an ? (single, 4 chips)
3. Ce qui te bloque le plus ? (multi, up to 3 chips, copper fill)
4. Si tu n'avais qu'une seule fonction… (single, 6 chips)
5. Tu serais prêt(e) à payer ? (single, 4 chips)
6. Email (optional)

Chips use `:has(input:checked)` to render filled state without any JS.

### Cleanup

- Removed dead CSS (roadmap, guide-grid, phase-card, chip, language-switch, feature-icon) and the corresponding site.js helpers (renderRoadmap, setActiveRoadmapFilter).
- `toggleQuestionnaire` no longer mutates button text; it toggles `data-open` + `aria-expanded`.

## Screenshots

The 10 placeholder PNGs from #1018 are left in place; the device frames render gracefully without content. Real captures will land in a follow-up PR.

## Checklist

- [x] `python3 scripts/quality_gate.py` passes locally
- [x] `python3 -m pytest tests/` passes (7/7)
- [x] HTML structural invariants preserved (`lang`, canonical, `mainContentFr`, Organization schema, FAQPage schema)
- [x] No third-party trackers added
- [x] `prefers-reduced-motion: reduce` neutralizes all decorative motion
- [x] EN twin reduced to a "coming soon" stub satisfying `REQUIRED_FILES` + EN gate rules