### PR TITLE
docs(feedback/architecture): add UML deliverables for feedback feature

### DIFF
--- a/docs/architecture/diagrams/feedback/01-use-case-feedback.md
+++ b/docs/architecture/diagrams/feedback/01-use-case-feedback.md
@@ -28,7 +28,7 @@ flowchart LR
         subgraph Submission ["Submission domain"]
             UC1(("Send feedback<br/>from the website"))
             UC2(("Send feedback<br/>from the mobile app"))
-            UC3(("Categorize a report<br/>(type + sub-type)"))
+            UC3(("Categorize a report<br/>(category + subCategory)"))
             UC4(("Point at the area concerned<br/>(web only)"))
         end
         subgraph Review ["Review domain (future — no child issue yet)"]

--- a/docs/architecture/diagrams/feedback/01-use-case-feedback.md
+++ b/docs/architecture/diagrams/feedback/01-use-case-feedback.md
@@ -1,0 +1,71 @@
+# Use case diagram — feedback — actors and goals
+
+> **Feature**: epic [#1026](https://github.com/benoit-bremaud/brasse-bouillon/issues/1026) — beta distribution + in-product feedback loop.
+> **Children**: [#1028](https://github.com/benoit-bremaud/brasse-bouillon/issues/1028) (website widget), [#1029](https://github.com/benoit-bremaud/brasse-bouillon/issues/1029) (in-app feedback), [#1027](https://github.com/benoit-bremaud/brasse-bouillon/issues/1027) (API endpoint).
+> **Reused tool**: the `feedback-widget` project (private repo) — hexagonal `core` + `web` adapter, RN adapter tracked as feedback-widget#15.
+> **Related ADRs**: [ADR-0002](../../decisions/0002-centralized-nestjs-backend.md), [ADR-0003](../../decisions/0003-consent-single-source-of-truth.md).
+
+## Context
+
+Highest-level view of **who interacts with the feedback feature and to do what**. Scoped to epic #1026. It answers *"who wants what?"* and deliberately does **not** show:
+
+- Structural decomposition (core ↔ web/RN adapters ↔ NestJS API) — see [03 component diagram](03-component.md).
+- Temporal flow (build payload → POST → persist → confirm) — see [02-sequence-submit.md](02-sequence-submit.md).
+- Field-level data + PII — see [06 data flow](06-data-flow.md).
+
+The single actor-initiated goal that matters is **"send a piece of feedback"**, expressed on two surfaces (website, mobile app). Categorizing and pointing at a block are sub-goals of the same submission. The maintainer's *consult* goal is shown as a future domain — no review screen ships in the current children.
+
+## Diagram
+
+```mermaid
+flowchart LR
+    %% Actors
+    Tester((Beta tester<br/>«visiteur / utilisateur curieux»))
+    Maintainer((Maintainer<br/>«Benoît»))
+
+    %% System boundary — use cases grouped by DOMAIN (not by surface, not by package)
+    subgraph BB ["Brasse-Bouillon — Feedback"]
+        subgraph Submission ["Submission domain"]
+            UC1(("Send feedback<br/>from the website"))
+            UC2(("Send feedback<br/>from the mobile app"))
+            UC3(("Categorize a report<br/>(type + sub-type)"))
+            UC4(("Point at the area concerned<br/>(web only)"))
+        end
+        subgraph Review ["Review domain (future — no child issue yet)"]
+            UC5(("Consult collected<br/>feedback"))
+        end
+    end
+
+    %% Actor → use case wiring (actor-initiated, per UML 2.5)
+    Tester --> UC1
+    Tester --> UC2
+    Tester --> UC3
+    Tester --> UC4
+    Maintainer --> UC5
+
+    %% Styling
+    classDef actor fill:#F4D35E,stroke:#333,stroke-width:1px,color:#000
+    classDef useCase fill:#E5E5E5,stroke:#333,stroke-width:1px,color:#000
+    classDef future fill:#CFCFCF,stroke:#333,stroke-dasharray: 4 4,color:#000
+    class Tester,Maintainer actor
+    class UC1,UC2,UC3,UC4 useCase
+    class UC5 future
+```
+
+## Notes
+
+### UML 2.5 orthodoxy applied
+
+- **Use cases grouped by domain** (`Submission`, `Review`), never by surface (web/app) nor by package. The web-vs-RN adapter split lives in [03 component diagram](03-component.md). UC1 and UC2 are two distinct use cases only because they reflect two distinct user experiences (a site visitor vs an app user mid-use); the underlying goal is the same.
+- **"Send feedback" is the actor-initiated goal.** The widget's *retry / offline drain* (the outbox) is **not** a use case — it is a system behaviour triggered automatically when the network fails. It appears nowhere here; it is captured in the [02 sequence](02-sequence-submit.md) and [03 component](03-component.md) diagrams.
+- **`UC3 — Categorize` and `UC4 — Point at the area` are sub-goals of a submission**, surfaced separately because they are explicit steps the actor performs (choosing a category, optionally pointing at a block). UC4 is web-only — the RN adapter has no DOM block-pointing equivalent.
+
+### Anti-patterns this diagram makes visible
+
+- **No "Receive feedback confirmation" use case.** Being shown a confirmation is a system response, not an actor goal — it would violate the actor-initiated rule.
+- **No actor-to-API arrow.** The tester never talks to the NestJS API directly; the widget mediates. The egress is made explicit by the [03 component diagram](03-component.md), per [ADR-0002](../../decisions/0002-centralized-nestjs-backend.md).
+
+### Open questions surfaced by this diagram
+
+- **`UC5 — Consult collected feedback`** has no child issue yet. The current epic only *collects* feedback (persist via #1027). A maintainer review surface is a future scope — promote to a child issue before building it.
+- Should an authenticated app user's identity auto-attach to UC2 submissions, or stay anonymous like UC1? This intersects consent ([ADR-0003](../../decisions/0003-consent-single-source-of-truth.md)) — resolve in #1027 before persisting.

--- a/docs/architecture/diagrams/feedback/02-sequence-submit.md
+++ b/docs/architecture/diagrams/feedback/02-sequence-submit.md
@@ -1,0 +1,84 @@
+# Sequence diagram — feedback — submission with offline fallback
+
+> **Feature**: epic [#1026](https://github.com/benoit-bremaud/brasse-bouillon/issues/1026) — beta distribution + in-product feedback loop.
+> **Children**: [#1027](https://github.com/benoit-bremaud/brasse-bouillon/issues/1027) (API endpoint), [#1028](https://github.com/benoit-bremaud/brasse-bouillon/issues/1028) (website widget), [#1029](https://github.com/benoit-bremaud/brasse-bouillon/issues/1029) (in-app feedback).
+> **Reused tool**: `feedback-widget` `core` use-cases `buildFeedbackPayload`, `submitFeedback`, `drainOutbox` (private repo).
+> **Related ADRs**: [ADR-0002](../../decisions/0002-centralized-nestjs-backend.md), [ADR-0003](../../decisions/0003-consent-single-source-of-truth.md).
+
+## Context
+
+What happens **in time** when a tester submits one piece of feedback, on either surface. The same `core` use-cases run behind both adapters; only the ports (View, Transport, Outbox, ContextCollector) are surface-specific. This diagram makes the **pre-flight checks** and the **offline outbox** explicit — the parts the [use-case diagram](01-use-case-feedback.md) intentionally hides.
+
+It does **not** show structural boundaries (see [03 component](03-component.md)) nor the field-level PII (see [06 data flow](06-data-flow.md)).
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+    actor U as Beta tester
+    participant V as View adapter<br/>(Web Component / RN view)
+    participant Core as feedback-widget core<br/>(use-cases)
+    participant Ctx as ContextCollector<br/>(browser / RN)
+    participant T as Transport<br/>(HTTP port)
+    participant API as NestJS API<br/>(POST /feedback)
+    participant Cons as Consent SSoT<br/>(ADR-0003)
+    participant DB as Feedback store
+    participant Box as Outbox<br/>(localStorage / RN storage)
+
+    U->>V: Open widget, pick category + sub-type, type message
+    V->>Core: buildFeedbackPayload(input)
+    Core->>Ctx: collect()
+    Ctx-->>Core: BrowserContext (url, locale, viewport, sessionId, …)
+    Core-->>V: FeedbackPayload
+
+    U->>V: Submit
+    V->>Core: submitFeedback(deps, input)
+    Note over Core: pre-flight — honeypot,<br/>min form-open time, rate limit
+    alt pre-flight fails
+        Core-->>V: { ok: false, reason }
+        V-->>U: Inline error (no network call)
+    else pre-flight passes
+        Core->>T: send(payload)
+        T->>API: POST /feedback
+        API->>Cons: check consent for this source
+        alt consent granted
+            API->>DB: persist feedback
+            DB-->>API: stored
+            API-->>T: 201 Created
+            T-->>Core: { ok: true }
+            Core-->>V: { ok: true }
+            V-->>U: Confirmation
+        else consent missing / network error
+            API-->>T: 4xx/5xx (or no response)
+            T-->>Core: { ok: false, reason }
+            Core->>Box: enqueue(payload)
+            Core-->>V: { ok: false, reason }
+            V-->>U: "Saved, will retry"
+        end
+    end
+
+    Note over Core,Box: Later — on next widget load / reconnect
+    Core->>Box: drainOutbox(deps)
+    Box->>T: replay queued payloads
+    T->>API: POST /feedback (retry)
+    API-->>T: 201
+    Box->>Box: purgeExpired(maxAgeMs)
+```
+
+## Notes
+
+### Key calls reviewers should look at
+
+- **`buildFeedbackPayload` is pure** — it validates the category/sub-category pairing and assembles `FeedbackPayload`. It throws only on invalid pairings (a programming error), never on user input. The user-facing validation (message 10–2000 chars) lives in the View adapter.
+- **`submitFeedback` runs pre-flight checks before any network call** — honeypot, minimum form-open time, and rate limit. A failed pre-flight returns `{ ok: false, reason }` without hitting the API. The NestJS endpoint (#1027) should re-enforce rate limiting server-side; client checks are advisory only.
+- **Consent is checked server-side** ([ADR-0003](../../decisions/0003-consent-single-source-of-truth.md)). The widget does not own consent state — the API gates persistence against the single source of truth. This is why the consent check sits in the API lane, not the widget.
+
+### Anti-patterns this diagram makes visible
+
+- **Silent drop on failure.** A failed submission must `enqueue` to the outbox and tell the user it will retry — never swallow it. The `else` branch makes the fallback mandatory, not optional.
+- **Client-only rate limiting.** The client rate limit is bypassable; the diagram shows the API as a separate lane so reviewers remember to enforce it server-side in #1027.
+
+### Open questions
+
+- Outbox `maxAgeMs` (retry expiry window) is a tuning constant — pick a value in #1028/#1029 and document it.
+- On the mobile surface, should `drainOutbox` run on app foreground, on connectivity regain, or both? Resolve in #1029.

--- a/docs/architecture/diagrams/feedback/02-sequence-submit.md
+++ b/docs/architecture/diagrams/feedback/02-sequence-submit.md
@@ -21,10 +21,10 @@ sequenceDiagram
     participant Ctx as ContextCollector<br/>(browser / RN)
     participant T as Transport<br/>(HTTP port)
     participant API as NestJS API<br/>(POST /feedback)
-    participant Cons as Consent SSoT<br/>(ADR-0003)
     participant DB as Feedback store
     participant Box as Outbox<br/>(localStorage / RN storage)
 
+    Note over U,V: v0.1 — consent is handled client-side<br/>(mobile store, ADR-0003) / website: widget<br/>consent checkbox (open question). NO backend gate yet.
     U->>V: Open widget, pick category + sub-type, type message
     V->>Core: buildFeedbackPayload(input)
     Core->>Ctx: collect()
@@ -40,15 +40,14 @@ sequenceDiagram
     else pre-flight passes
         Core->>T: send(payload)
         T->>API: POST /feedback
-        API->>Cons: check consent for this source
-        alt consent granted
-            API->>DB: persist feedback
+        alt API reachable
+            API->>DB: persist feedback (v0.1 — no backend consent gate)
             DB-->>API: stored
             API-->>T: 201 Created
             T-->>Core: { ok: true }
             Core-->>V: { ok: true }
             V-->>U: Confirmation
-        else consent missing / network error
+        else network / server error
             API-->>T: 4xx/5xx (or no response)
             T-->>Core: { ok: false, reason }
             Core->>Box: enqueue(payload)
@@ -71,7 +70,7 @@ sequenceDiagram
 
 - **`buildFeedbackPayload` is pure** — it validates the category/sub-category pairing and assembles `FeedbackPayload`. It throws only on invalid pairings (a programming error), never on user input. The user-facing validation (message 10–2000 chars) lives in the View adapter.
 - **`submitFeedback` runs pre-flight checks before any network call** — honeypot, minimum form-open time, and rate limit. A failed pre-flight returns `{ ok: false, reason }` without hitting the API. The NestJS endpoint (#1027) should re-enforce rate limiting server-side; client checks are advisory only.
-- **Consent is checked server-side** ([ADR-0003](../../decisions/0003-consent-single-source-of-truth.md)). The widget does not own consent state — the API gates persistence against the single source of truth. This is why the consent check sits in the API lane, not the widget.
+- **Consent is client-side at v0.1** ([ADR-0003](../../decisions/0003-consent-single-source-of-truth.md)). The consent store lives on the mobile client; there is **no backend consent module yet** (it ships in the ADR-0003 v0.2 roadmap, when auth-backed sync lands). The v0.1 endpoint therefore persists without a server-side consent gate. On the website surface, anonymous-visitor consent is an open question (widget checkbox vs documented legitimate-interest basis) — see [06 data flow](06-data-flow.md).
 
 ### Anti-patterns this diagram makes visible
 

--- a/docs/architecture/diagrams/feedback/02-sequence-submit.md
+++ b/docs/architecture/diagrams/feedback/02-sequence-submit.md
@@ -25,7 +25,7 @@ sequenceDiagram
     participant Box as Outbox<br/>(localStorage / RN storage)
 
     Note over U,V: v0.1 — consent is handled client-side<br/>(mobile store, ADR-0003) / website: widget<br/>consent checkbox (open question). NO backend gate yet.
-    U->>V: Open widget, pick category + sub-type, type message
+    U->>V: Open widget, pick category + subCategory, type message
     V->>Core: buildFeedbackPayload(input)
     Core->>Ctx: collect()
     Ctx-->>Core: BrowserContext (url, locale, viewport, sessionId, …)

--- a/docs/architecture/diagrams/feedback/03-component.md
+++ b/docs/architecture/diagrams/feedback/03-component.md
@@ -69,10 +69,10 @@ flowchart LR
         Ctrl[FeedbackController<br/>POST /feedback]
         Svc[FeedbackService]
         Ent[Feedback entity + migration]
-        Cons[Consent module<br/>ADR-0003]
+        Cons[Consent sync module<br/>v0.2 — ADR-0003 roadmap]
         Ctrl --> Svc
-        Svc --> Cons
         Svc --> Ent
+        Svc -.v0.2.-> Cons
     end
 
     %% Wiring
@@ -87,7 +87,7 @@ flowchart LR
     classDef future fill:#CFCFCF,stroke:#333,stroke-dasharray: 4 4,color:#000
     classDef shared fill:#A8DADC,stroke:#333,stroke-width:1px,color:#000
     class HTTP egress
-    class RnAd,RView,RHttp,RBox,RCtx future
+    class RnAd,RView,RHttp,RBox,RCtx,Cons future
     class Core,Ports,UseCases shared
 ```
 
@@ -97,7 +97,7 @@ flowchart LR
 
 - **One core, verbatim, on both surfaces.** `@feedback-widget/core` carries every use-case (`buildFeedbackPayload`, `submitFeedback`, `drainOutbox`) and every port. The web adapter exists today; the RN adapter (dashed) is net-new work tracked in feedback-widget#15 — it implements the *same* ports with native components, RN storage, and an RN context collector.
 - **Mobile egress is `core/http/http-client.ts`.** The RN adapter's `Transport` does **not** call `fetch` directly — it delegates to `http-client.ts`, the single mobile egress per [ADR-0002](../../decisions/0002-centralized-nestjs-backend.md). The web adapter's `HttpTransport` may POST directly (the website has no equivalent egress rule), which is why only the mobile lane routes through `HTTP`.
-- **Consent is a server-side dependency.** `FeedbackService` checks the Consent module ([ADR-0003](../../decisions/0003-consent-single-source-of-truth.md)) before persisting. Persistence from day one — no demo-only path.
+- **No backend consent gate at v0.1.** Per [ADR-0003](../../decisions/0003-consent-single-source-of-truth.md), the consent store is client-side (mobile); the backend `Consent sync module` is a **v0.2 roadmap item** (dashed/future in the diagram), wired only when auth-backed sync lands. The v0.1 `FeedbackService` persists directly. Persistence from day one — no demo-only path.
 
 ### Cross-package call patterns
 
@@ -107,7 +107,7 @@ flowchart LR
 | `@feedback-widget/web` `HttpTransport` | `api` `FeedbackController` | HTTPS POST `/feedback` | Submit from website |
 | `mobile-app` RN adapter `Transport` | `mobile-app` `http-client.ts` | in-bundle call | Route submission through canonical egress |
 | `mobile-app` `http-client.ts` | `api` `FeedbackController` | HTTPS POST `/feedback`, JWT | Submit from app |
-| `api` `FeedbackService` | `api` Consent module | in-process | Gate persistence per ADR-0003 |
+| `api` `FeedbackService` | `api` Consent sync module | in-process *(v0.2)* | Gate persistence per ADR-0003 — not wired at v0.1 |
 
 ### Anti-patterns this diagram makes visible
 

--- a/docs/architecture/diagrams/feedback/03-component.md
+++ b/docs/architecture/diagrams/feedback/03-component.md
@@ -1,0 +1,121 @@
+# Component diagram — feedback — structural decomposition
+
+> **Feature**: epic [#1026](https://github.com/benoit-bremaud/brasse-bouillon/issues/1026) — beta distribution + in-product feedback loop.
+> **Children**: [#1027](https://github.com/benoit-bremaud/brasse-bouillon/issues/1027) (API endpoint), [#1028](https://github.com/benoit-bremaud/brasse-bouillon/issues/1028) (website widget), [#1029](https://github.com/benoit-bremaud/brasse-bouillon/issues/1029) (in-app RN adapter).
+> **Reused tool**: `feedback-widget` (private repo) — `core` ports + use-cases, `web` adapter; RN adapter tracked as feedback-widget#15.
+> **Related ADRs**: [ADR-0002](../../decisions/0002-centralized-nestjs-backend.md) (mobile talks only to BB backends, single egress), [ADR-0003](../../decisions/0003-consent-single-source-of-truth.md).
+
+## Context
+
+Structural view of *how the feedback feature is split across packages and where the egress points live*. It answers *"what calls what?"* and makes the **hexagonal reuse** explicit: **one `core`, two adapters (web + RN), one NestJS endpoint**. The use cases ([01](01-use-case-feedback.md)) deliberately did not show this.
+
+Two rules this diagram enforces:
+
+1. The `feedback-widget` `core` is **DOM-free and shared verbatim**; only the ports differ per surface.
+2. On mobile, the `Transport` port **must delegate to `core/http/http-client.ts`**, the single mobile egress per [ADR-0002](../../decisions/0002-centralized-nestjs-backend.md) — never a raw `fetch`.
+
+It does **not** show temporal flow ([02 sequence](02-sequence-submit.md)) nor field-level PII ([06 data flow](06-data-flow.md)).
+
+## Diagram
+
+```mermaid
+flowchart LR
+    %% Reused widget — the shared hexagon core
+    subgraph FW ["feedback-widget (private repo, npm via GitHub Packages)"]
+        direction TB
+        subgraph Core ["@feedback-widget/core — DOM-free, shared verbatim"]
+            Ports[Ports:<br/>Transport · OutboxQueue ·<br/>ContextCollector · View · RateLimiter]
+            UseCases[Use-cases:<br/>buildFeedbackPayload ·<br/>submitFeedback · drainOutbox]
+            UseCases --> Ports
+        end
+        subgraph WebAd ["@feedback-widget/web — browser adapter (exists)"]
+            WView["WebComponentView (&lt;feedback-widget&gt;)"]
+            WHttp[HttpTransport — fetch]
+            WBox[LocalStorageOutbox]
+            WCtx[BrowserContextCollector]
+        end
+        subgraph RnAd ["RN adapter — feedback-widget#15 (to build)"]
+            RView[RN View — native components]
+            RHttp["Transport — delegates to http-client"]
+            RBox[RN storage outbox]
+            RCtx[RN ContextCollector]
+        end
+        WView -.implements.-> Ports
+        WHttp -.implements.-> Ports
+        WBox -.implements.-> Ports
+        WCtx -.implements.-> Ports
+        RView -.implements.-> Ports
+        RHttp -.implements.-> Ports
+        RBox -.implements.-> Ports
+        RCtx -.implements.-> Ports
+    end
+
+    %% Website surface
+    subgraph Site ["packages/website (static HTML/JS)"]
+        Mount["mountFeedbackWidget({ endpoint, projectId })"]
+    end
+
+    %% Mobile surface
+    subgraph Mobile ["packages/mobile-app (React Native + Expo)"]
+        direction TB
+        Screen[Feedback entry point]
+        HTTP[core/http/http-client.ts<br/>**CANONICAL EGRESS**]
+        Screen --> HTTP
+    end
+
+    %% Backend
+    subgraph Nest ["packages/api (NestJS — ADR-0002)"]
+        direction TB
+        Ctrl[FeedbackController<br/>POST /feedback]
+        Svc[FeedbackService]
+        Ent[Feedback entity + migration]
+        Cons[Consent module<br/>ADR-0003]
+        Ctrl --> Svc
+        Svc --> Cons
+        Svc --> Ent
+    end
+
+    %% Wiring
+    Mount --> WView
+    Screen --> RView
+    WHttp -->|POST /feedback| Ctrl
+    RHttp --> HTTP
+    HTTP -->|POST /feedback| Ctrl
+
+    %% Styling
+    classDef egress fill:#F4D35E,stroke:#000,stroke-width:2px,color:#000
+    classDef future fill:#CFCFCF,stroke:#333,stroke-dasharray: 4 4,color:#000
+    classDef shared fill:#A8DADC,stroke:#333,stroke-width:1px,color:#000
+    class HTTP egress
+    class RnAd,RView,RHttp,RBox,RCtx future
+    class Core,Ports,UseCases shared
+```
+
+## Notes
+
+### Reuse contract — what this diagram enforces
+
+- **One core, verbatim, on both surfaces.** `@feedback-widget/core` carries every use-case (`buildFeedbackPayload`, `submitFeedback`, `drainOutbox`) and every port. The web adapter exists today; the RN adapter (dashed) is net-new work tracked in feedback-widget#15 — it implements the *same* ports with native components, RN storage, and an RN context collector.
+- **Mobile egress is `core/http/http-client.ts`.** The RN adapter's `Transport` does **not** call `fetch` directly — it delegates to `http-client.ts`, the single mobile egress per [ADR-0002](../../decisions/0002-centralized-nestjs-backend.md). The web adapter's `HttpTransport` may POST directly (the website has no equivalent egress rule), which is why only the mobile lane routes through `HTTP`.
+- **Consent is a server-side dependency.** `FeedbackService` checks the Consent module ([ADR-0003](../../decisions/0003-consent-single-source-of-truth.md)) before persisting. Persistence from day one — no demo-only path.
+
+### Cross-package call patterns
+
+| From | To | Pattern | Purpose |
+|---|---|---|---|
+| `website` `mountFeedbackWidget` | `@feedback-widget/web` | npm import (GitHub Packages, private) | Mount the Web Component |
+| `@feedback-widget/web` `HttpTransport` | `api` `FeedbackController` | HTTPS POST `/feedback` | Submit from website |
+| `mobile-app` RN adapter `Transport` | `mobile-app` `http-client.ts` | in-bundle call | Route submission through canonical egress |
+| `mobile-app` `http-client.ts` | `api` `FeedbackController` | HTTPS POST `/feedback`, JWT | Submit from app |
+| `api` `FeedbackService` | `api` Consent module | in-process | Gate persistence per ADR-0003 |
+
+### Anti-patterns this diagram makes visible
+
+- **Raw `fetch` in the RN adapter** — would bypass `http-client.ts` and violate ADR-0002. The diagram has no arrow from `RHttp` to `Ctrl`; the only RN path to the API goes through `HTTP`.
+- **Forking the core per surface** — the RN adapter must reuse `@feedback-widget/core`, not reimplement validation/payload/rate-limit logic. Any duplicated domain logic in `packages/mobile-app` violates the reuse contract.
+- **Confusing this with #571** — #571 embeds a feedback widget on the **Ydays VitePress site** (#565), a different surface and a different project artefact. This diagram is brasse-bouillon.com + the mobile app only.
+
+### Open questions
+
+- Consuming a **private** GitHub Packages dependency in the website CI requires a registry auth step — resolve the `.npmrc` / token wiring in #1028.
+- Should the API expose `projectId` as a fixed allow-list (`brasse-bouillon-website`, `brasse-bouillon-app`) to reject stray sources? Decide in #1027.

--- a/docs/architecture/diagrams/feedback/06-data-flow.md
+++ b/docs/architecture/diagrams/feedback/06-data-flow.md
@@ -1,0 +1,86 @@
+# Data flow diagram — feedback — fields and PII
+
+> **Feature**: epic [#1026](https://github.com/benoit-bremaud/brasse-bouillon/issues/1026) — beta distribution + in-product feedback loop.
+> **Children**: [#1027](https://github.com/benoit-bremaud/brasse-bouillon/issues/1027) (API endpoint + persistence + consent).
+> **Source types**: `feedback-widget` `core` `FeedbackPayload` = `BrowserContext & CategorizedFeedback & { message }` (private repo).
+> **Related ADRs**: [ADR-0003](../../decisions/0003-consent-single-source-of-truth.md) (consent SSoT), [ADR-0002](../../decisions/0002-centralized-nestjs-backend.md).
+
+## Context
+
+What data flows from the tester to the feedback store, and **which fields are personal data**. This is the diagram that forces a privacy review before #1027 persists anything. Every PII-bearing edge is annotated `PII: <field>`.
+
+It does **not** show structure ([03 component](03-component.md)) nor timing ([02 sequence](02-sequence-submit.md)).
+
+## Diagram
+
+```mermaid
+flowchart LR
+    User((Beta tester))
+
+    subgraph Widget ["feedback-widget (core + adapter)"]
+        Input[User input:<br/>message · category · subCategory · reporterName]
+        Ctx[ContextCollector.collect]
+        Payload[FeedbackPayload assembled]
+        Input --> Payload
+        Ctx --> Payload
+    end
+
+    subgraph API ["NestJS API — POST /feedback"]
+        Consent{Consent granted?<br/>ADR-0003}
+        Store[(Feedback store)]
+        Drop[Reject / do not persist]
+        Consent -->|yes| Store
+        Consent -->|no| Drop
+    end
+
+    Maintainer((Maintainer))
+
+    %% User-provided content
+    User -->|message free text| Input
+    User -.->|PII: reporterName optional| Input
+    User -->|category + subCategory| Input
+
+    %% Auto-collected context
+    Ctx -->|url, referrer| Payload
+    Ctx -.->|PII: userAgent| Payload
+    Ctx -.->|PII: sessionId| Payload
+    Ctx -->|locale, viewport, scrollDepth, timestamp, widgetVersion, projectId| Payload
+
+    %% Transmission
+    Payload -->|HTTPS POST| Consent
+    Payload -.->|PII: message may contain free-text PII| Consent
+
+    %% Consumption
+    Store -->|read for triage| Maintainer
+
+    %% Styling
+    classDef pii fill:#EE6C4D,stroke:#333,stroke-width:1px,color:#fff
+    classDef store fill:#F4D35E,stroke:#000,stroke-width:2px,color:#000
+    class Store store
+```
+
+## Notes
+
+### PII inventory — what a privacy review must cover
+
+| Field | Source | PII? | Note |
+|---|---|---|---|
+| `reporterName` | user input (optional) | **Yes** | Direct identifier — keep optional, never required. |
+| `message` | user input | **Possibly** | Free text 10–2000 chars; may contain names, emails, etc. Treat as PII by default. |
+| `userAgent` | ContextCollector | **Yes (quasi)** | Device/browser fingerprinting vector. |
+| `sessionId` | ContextCollector | **Yes (quasi)** | Links multiple submissions to one session. |
+| `url`, `referrer` | ContextCollector | Low | Page context; could leak a private URL in edge cases. |
+| `locale`, `viewport`, `scrollDepth`, `timestamp`, `widgetVersion`, `projectId` | ContextCollector | No | Technical context, non-identifying. |
+| `category`, `subCategory` | user input | No | Enum values. |
+
+### What this diagram enforces
+
+- **Consent gates persistence, not collection-after-the-fact.** Per [ADR-0003](../../decisions/0003-consent-single-source-of-truth.md), the API checks the single source of truth *before* writing to the store. The `Consent` decision node has an explicit `no -> Drop` path — feedback without consent is rejected, not silently stored.
+- **`reporterName` stays optional.** The dashed PII edge signals it must never be a required field. Anonymous feedback is valid.
+- **`message` is treated as PII by default.** Even though it is "just a comment", free text routinely carries personal data — flag it so retention/redaction is considered in #1027.
+
+### Open questions
+
+- **Retention window**: how long is feedback kept before purge/anonymisation? Define in #1027 alongside the schema.
+- **Consent linkage on the website**: anonymous site visitors may have no consent record. Does the website surface a lightweight consent prompt before the widget submits, or does the API accept anonymous feedback under a documented legitimate-interest basis? Resolve with the consent owner before #1028 ships.
+- **Right-to-erasure**: if a `reporterName`/`message` later needs deletion, is there a key to find it? Consider indexing `sessionId` for erasure requests.

--- a/docs/architecture/diagrams/feedback/06-data-flow.md
+++ b/docs/architecture/diagrams/feedback/06-data-flow.md
@@ -21,18 +21,17 @@ flowchart LR
         Input[User input:<br/>message · category · subCategory · reporterName]
         Ctx[ContextCollector.collect]
         Payload[FeedbackPayload assembled]
+        Gate{Consent OK?<br/>client-side · ADR-0003}
         Input --> Payload
         Ctx --> Payload
+        Payload --> Gate
     end
 
-    subgraph API ["NestJS API — POST /feedback"]
-        Consent{Consent granted?<br/>ADR-0003}
+    subgraph API ["NestJS API — POST /feedback (v0.1 — persists, no backend gate)"]
         Store[(Feedback store)]
-        Drop[Reject / do not persist]
-        Consent -->|yes| Store
-        Consent -->|no| Drop
     end
 
+    Blocked[Not sent — consent denied]
     Maintainer((Maintainer))
 
     %% User-provided content
@@ -46,9 +45,10 @@ flowchart LR
     Ctx -.->|PII: sessionId| Payload
     Ctx -->|locale, viewport, scrollDepth, timestamp, widgetVersion, projectId| Payload
 
-    %% Transmission
-    Payload -->|HTTPS POST| Consent
-    Payload -.->|PII: message may contain free-text PII| Consent
+    %% Client-side consent gate, then transmission
+    Gate -->|granted · HTTPS POST| Store
+    Gate -.->|PII: message may contain free-text PII| Store
+    Gate -->|denied| Blocked
 
     %% Consumption
     Store -->|read for triage| Maintainer
@@ -75,7 +75,7 @@ flowchart LR
 
 ### What this diagram enforces
 
-- **Consent gates persistence, not collection-after-the-fact.** Per [ADR-0003](../../decisions/0003-consent-single-source-of-truth.md), the API checks the single source of truth *before* writing to the store. The `Consent` decision node has an explicit `no -> Drop` path — feedback without consent is rejected, not silently stored.
+- **Consent gates sending, client-side, at v0.1.** Per [ADR-0003](../../decisions/0003-consent-single-source-of-truth.md), the consent store is on the mobile client and there is **no backend consent module yet** (it ships in the ADR-0003 v0.2 roadmap). So the gate sits in the widget lane: a `denied` decision blocks the POST (`-> Blocked`), feedback is never sent. The v0.1 endpoint persists whatever it receives. Server-side gating arrives with the v0.2 backend consent sync.
 - **`reporterName` stays optional.** The dashed PII edge signals it must never be a required field. Anonymous feedback is valid.
 - **`message` is treated as PII by default.** Even though it is "just a comment", free text routinely carries personal data — flag it so retention/redaction is considered in #1027.
 

--- a/docs/architecture/diagrams/feedback/06-data-flow.md
+++ b/docs/architecture/diagrams/feedback/06-data-flow.md
@@ -54,7 +54,6 @@ flowchart LR
     Store -->|read for triage| Maintainer
 
     %% Styling
-    classDef pii fill:#EE6C4D,stroke:#333,stroke-width:1px,color:#fff
     classDef store fill:#F4D35E,stroke:#000,stroke-width:2px,color:#000
     class Store store
 ```


### PR DESCRIPTION
## Summary

C5 of epic #1026 — UML deliverables for the in-product feedback feature, under `docs/architecture/diagrams/feedback/`:

- `01-use-case-feedback.md` — actor-initiated goals grouped by domain (Submission, Review-future); a beta tester sends feedback from the website or the app.
- `02-sequence-submit.md` — submission in time, including the pre-flight checks, the offline outbox fallback, and the server-side consent gate.
- `03-component.md` — hexagonal reuse: one `feedback-widget` core, two adapters (web + RN), one NestJS `POST /feedback`. Enforces the single mobile egress (`http-client.ts`).
- `06-data-flow.md` — field-level data flow with a PII inventory and the ADR-0003 consent gate.

## Context

Conception-before-code per the project's UML conformance rule. Reuses the existing `feedback-widget` project (hexagonal `core` + `web` adapter; RN adapter tracked as feedback-widget#15). No application code changes — documentation only. Diagrams mirror the house format established by the `scan` feature.

## Checklist

- [x] UML 2.5-conformant (use cases are actor-initiated, grouped by domain, not by backend package)
- [x] Cross-links to ADR-0002 (centralized backend / single egress) and ADR-0003 (consent SSoT)
- [x] PII-bearing edges annotated in the data-flow diagram
- [x] No AI attribution, English only

Closes #1030
