### PR TITLE
docs(log): record epic #1026 creation (beta distribution + feedback loop)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -5,6 +5,14 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ---
 
+## 2026-05-20
+
+### Backlog — epic #1026 created: beta distribution Android + in-product feedback loop
+
+- New epic `epic(feedback)` #1026 (label `epic:feedback`, Project 11). Reframes "APK link on the website?" into a full beta funnel: download + feedback loop on website and mobile app. Channel decided: APK now (EAS build -> GitHub Release asset), Play Store later; Android first.
+- Children: #1007 (C1 download page, adopted) · #1027 (C2 API feedback endpoint, foundation) · #1028 (C3 website widget) · #1029 (C4 in-app RN feedback) · #1030 (C5 UML conception). Reuses the `feedback-widget` project (hexagonal core + web adapter; RN adapter = feedback-widget#15).
+- Dependencies referenced not duplicated: EAS #975/#748/#967. Distinguished from #571 (Ydays site widget) and #896 (tasting feedback).
+
 ## 2026-05-19
 
 ### PR #1020 merged (`99f2208`) — ci(website): GitHub Pages deploy workflow + reclaim brasse-bouillon.com from archived repo

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -9,7 +9,7 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ### Backlog — epic #1026 created: beta distribution Android + in-product feedback loop
 
-- New epic `epic(feedback)` #1026 (label `epic:feedback`, Project 11). Reframes "APK link on the website?" into a full beta funnel: download + feedback loop on website and mobile app. Channel decided: APK now (EAS build -> GitHub Release asset), Play Store later; Android first.
+- New epic `epic(feedback)` #1026 (label `epic:feedback`, added to the brasse-bouillon GitHub Project `PVT_kwHOB8rwIc4AuVew`). Reframes "APK link on the website?" into a full beta funnel: download + feedback loop on website and mobile app. Channel decided: APK now (EAS build -> GitHub Release asset), Play Store later; Android first.
 - Children: #1007 (C1 download page, adopted) · #1027 (C2 API feedback endpoint, foundation) · #1028 (C3 website widget) · #1029 (C4 in-app RN feedback) · #1030 (C5 UML conception). Reuses the `feedback-widget` project (hexagonal core + web adapter; RN adapter = feedback-widget#15).
 - Dependencies referenced not duplicated: EAS #975/#748/#967. Distinguished from #571 (Ydays site widget) and #896 (tasting feedback).
 


### PR DESCRIPTION
## Summary

Append a PROJECT_LOG entry (2026-05-20) recording the creation of epic #1026 (beta distribution Android + in-product feedback loop) and its children #1007/#1027/#1028/#1029/#1030.

## Context

Operational audit trail per the project-log discipline — terse references, most-recent-first. Documents the channel decision (APK now via EAS -> GitHub Release, Play Store later) and the reuse of the `feedback-widget` project, plus the distinctions vs #571 (Ydays site) and #896 (tasting feedback).

## Checklist

- [x] Add-only, most-recent-first
- [x] Terse references (issue numbers + decisions), no narrative bloat
- [x] No AI attribution, English only
