### PR TITLE
feat(api): feedback ingestion endpoint

### DIFF
--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -12,6 +12,7 @@ import { CatalogModule } from './catalog/catalog.module';
 import { ConfigModule } from '@nestjs/config';
 import { DatabaseModule } from './database/database.module';
 import { EquipmentModule } from './equipment/equipment.module';
+import { FeedbackModule } from './feedback/feedback.module';
 import { LabelModule } from './label/label.module';
 import { Module } from '@nestjs/common';
 import { RecipeModule } from './recipe/recipe.module';
@@ -84,6 +85,9 @@ const bootstrapEnvironment = buildBootstrapEnvironmentConfig();
     WaterModule,
     LabelModule,
     ScanModule,
+
+    // Feedback module - public POST /feedback endpoint (epic #1026, #1027)
+    FeedbackModule,
 
     // Beer contribution module - 501 stubs anticipating the v0.2+
     // community contribution flow (Epic #693 part 4/5, ADR-0001 clause 3).

--- a/packages/api/src/database/migrations/1795000000000-AddFeedbackTable.ts
+++ b/packages/api/src/database/migrations/1795000000000-AddFeedbackTable.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `feedback` table (epic #1026, C2 / #1027).
+ *
+ * One row per submitted piece of feedback from the website widget or
+ * the mobile app, mirroring the `feedback-widget` `FeedbackPayload`
+ * wire contract plus a server-side `created_at`. No backend consent
+ * column at v0.1 — consent is client-side per ADR-0003.
+ *
+ * Indexes on `project_id` (filter by source surface) and `created_at`
+ * (chronological triage) anticipate the future maintainer review
+ * screen; both are low-cardinality-safe at v0.1 volumes.
+ */
+export class AddFeedbackTable1795000000000 implements MigrationInterface {
+  name = 'AddFeedbackTable1795000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "feedback" (
+        "id" varchar PRIMARY KEY NOT NULL,
+        "project_id" varchar(100) NOT NULL,
+        "category" varchar(20) NOT NULL,
+        "sub_category" varchar(40),
+        "message" text NOT NULL,
+        "url" varchar(2048) NOT NULL,
+        "referrer" varchar(2048),
+        "user_agent" varchar(512) NOT NULL,
+        "viewport_w" integer NOT NULL,
+        "viewport_h" integer NOT NULL,
+        "locale" varchar(20) NOT NULL,
+        "client_timestamp" datetime NOT NULL,
+        "widget_version" varchar(40) NOT NULL,
+        "scroll_depth" float NOT NULL,
+        "session_id" varchar(128) NOT NULL,
+        "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_feedback_project_id" ON "feedback" ("project_id")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_feedback_created_at" ON "feedback" ("created_at")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_feedback_created_at"`);
+    await queryRunner.query(`DROP INDEX "IDX_feedback_project_id"`);
+    await queryRunner.query(`DROP TABLE "feedback"`);
+  }
+}

--- a/packages/api/src/database/migrations/1795000000000-AddFeedbackTable.ts
+++ b/packages/api/src/database/migrations/1795000000000-AddFeedbackTable.ts
@@ -31,9 +31,11 @@ export class AddFeedbackTable1795000000000 implements MigrationInterface {
         "locale" varchar(20) NOT NULL,
         "client_timestamp" datetime NOT NULL,
         "widget_version" varchar(40) NOT NULL,
-        "scroll_depth" float NOT NULL,
+        "scroll_depth" real NOT NULL,
         "session_id" varchar(128) NOT NULL,
-        "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+        "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        CONSTRAINT "CHK_feedback_category" CHECK ("category" IN ('bug', 'typo', 'error', 'ambiguous', 'suggestion', 'other')),
+        CONSTRAINT "CHK_feedback_scroll_depth" CHECK ("scroll_depth" >= 0 AND "scroll_depth" <= 1)
       )
     `);
     await queryRunner.query(

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -8,6 +8,7 @@ import { DistributorOrmEntity } from '../catalog/distributor/entities/distributo
 import { EquipmentProfileOrmEntity } from '../equipment/entities/equipment-profile.orm.entity';
 import { EquipmentTemplateDistributorOrmEntity } from '../catalog/equipment/entities/equipment-template-distributor.orm.entity';
 import { EquipmentTemplateOrmEntity } from '../catalog/equipment/entities/equipment-template.orm.entity';
+import { Feedback } from '../feedback/entities/feedback.entity';
 import { FermentableDistributorOrmEntity } from '../catalog/fermentable/entities/fermentable-distributor.orm.entity';
 import { FermentableOrmEntity } from '../catalog/fermentable/entities/fermentable.orm.entity';
 import { HopDistributorOrmEntity } from '../catalog/hop/entities/hop-distributor.orm.entity';
@@ -73,6 +74,7 @@ export const ormEntities = [
   YeastDistributorOrmEntity,
   MiscTemplateDistributorOrmEntity,
   EquipmentTemplateDistributorOrmEntity,
+  Feedback,
 ];
 
 const parseBooleanEnv = (name: string, defaultValue: boolean): boolean => {

--- a/packages/api/src/feedback/controllers/feedback.controller.spec.ts
+++ b/packages/api/src/feedback/controllers/feedback.controller.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+import { CreateFeedbackDto } from '../dtos/create-feedback.dto';
+import { FeedbackResponseDto } from '../dtos/feedback-response.dto';
+import { FeedbackService } from '../services/feedback.service';
+import { FeedbackController } from './feedback.controller';
+
+describe('FeedbackController', () => {
+  let controller: FeedbackController;
+  let service: FeedbackService;
+
+  const mockService = {
+    create: jest.fn(),
+  };
+
+  const dto: CreateFeedbackDto = {
+    projectId: 'brasse-bouillon-website',
+    category: 'suggestion',
+    subCategory: 'improvement',
+    message: 'It would help to show the file size before download.',
+    url: 'https://brasse-bouillon.com/download',
+    referrer: null,
+    userAgent: 'Mozilla/5.0',
+    viewport: { w: 390, h: 844 },
+    locale: 'fr-FR',
+    timestamp: '2026-05-21T10:15:00.000Z',
+    widgetVersion: '0.2.0',
+    scrollDepth: 1,
+    sessionId: 'sess_abc',
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FeedbackController],
+      providers: [{ provide: FeedbackService, useValue: mockService }],
+    })
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: jest.fn().mockReturnValue(true) })
+      .compile();
+
+    controller = module.get<FeedbackController>(FeedbackController);
+    service = module.get<FeedbackService>(FeedbackService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  // Happy path — delegates to the service and returns its result
+  it('delegates the submission to the service', async () => {
+    const response: FeedbackResponseDto = {
+      id: 'fb-1',
+      category: 'suggestion',
+      subCategory: 'improvement',
+      createdAt: new Date('2026-05-21T10:15:01.000Z'),
+    };
+    const createSpy = jest.spyOn(service, 'create').mockResolvedValue(response);
+
+    const result = await controller.submit(dto);
+
+    expect(createSpy).toHaveBeenCalledWith(dto);
+    expect(result).toBe(response);
+  });
+
+  // Sad path — service errors bubble up to the global filter
+  it('propagates a service error', async () => {
+    jest.spyOn(service, 'create').mockRejectedValue(new Error('boom'));
+
+    await expect(controller.submit(dto)).rejects.toThrow('boom');
+  });
+});

--- a/packages/api/src/feedback/controllers/feedback.controller.ts
+++ b/packages/api/src/feedback/controllers/feedback.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiOperation,
+  ApiTags,
+  ApiTooManyRequestsResponse,
+} from '@nestjs/swagger';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+
+import { CreateFeedbackDto } from '../dtos/create-feedback.dto';
+import { FeedbackResponseDto } from '../dtos/feedback-response.dto';
+import { FeedbackService } from '../services/feedback.service';
+
+/**
+ * Feedback Controller
+ *
+ * Public, anonymous endpoint — any curious visitor (website or app)
+ * can submit feedback without authentication. Intentionally NOT guarded
+ * by `JwtAuthGuard`. Rate-limited via `@Throttle` to deter spam.
+ */
+@ApiTags('Feedback')
+@Controller('feedback')
+export class FeedbackController {
+  constructor(private readonly feedbackService: FeedbackService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UseGuards(ThrottlerGuard)
+  @Throttle({ default: { limit: 5, ttl: 60_000 } })
+  @ApiOperation({
+    summary: 'Submit a piece of feedback (public, anonymous)',
+  })
+  @ApiCreatedResponse({ type: FeedbackResponseDto })
+  @ApiBadRequestResponse({ description: 'Invalid feedback payload' })
+  @ApiTooManyRequestsResponse({ description: 'Rate limit exceeded' })
+  async submit(@Body() dto: CreateFeedbackDto): Promise<FeedbackResponseDto> {
+    return this.feedbackService.create(dto);
+  }
+}

--- a/packages/api/src/feedback/dtos/create-feedback.dto.ts
+++ b/packages/api/src/feedback/dtos/create-feedback.dto.ts
@@ -1,11 +1,13 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
   IsEnum,
   IsInt,
   IsISO8601,
   IsNotEmpty,
+  IsNotEmptyObject,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   Max,
@@ -68,14 +70,14 @@ export class CreateFeedbackDto {
   @IsEnum(TOP_LEVEL_CATEGORIES)
   category: TopLevelCategory;
 
-  @ApiProperty({
+  @ApiPropertyOptional({
     nullable: true,
     example: 'broken-feature',
     description:
       'Sub-category; must match the chosen category, or null for "other"',
   })
   @IsValidSubCategory()
-  subCategory: string | null;
+  subCategory?: string | null;
 
   @ApiProperty({
     example: 'The download button does nothing on Android 13.',
@@ -92,11 +94,14 @@ export class CreateFeedbackDto {
   @MaxLength(2048)
   url: string;
 
-  @ApiProperty({ nullable: true, example: 'https://brasse-bouillon.com/' })
+  @ApiPropertyOptional({
+    nullable: true,
+    example: 'https://brasse-bouillon.com/',
+  })
   @IsOptional()
   @IsString()
   @MaxLength(2048)
-  referrer: string | null;
+  referrer?: string | null;
 
   @ApiProperty({ example: 'Mozilla/5.0 (...)' })
   @IsString()
@@ -104,6 +109,8 @@ export class CreateFeedbackDto {
   userAgent: string;
 
   @ApiProperty({ type: FeedbackViewportDto })
+  @IsObject()
+  @IsNotEmptyObject()
   @ValidateNested()
   @Type(() => FeedbackViewportDto)
   viewport: FeedbackViewportDto;

--- a/packages/api/src/feedback/dtos/create-feedback.dto.ts
+++ b/packages/api/src/feedback/dtos/create-feedback.dto.ts
@@ -1,0 +1,143 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import {
+  IsEnum,
+  IsInt,
+  IsISO8601,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+
+import {
+  FEEDBACK_MESSAGE_MAX_LENGTH,
+  FEEDBACK_MESSAGE_MIN_LENGTH,
+  TOP_LEVEL_CATEGORIES,
+  type TopLevelCategory,
+} from '../feedback.constants';
+import { IsValidSubCategory } from '../validators/is-valid-sub-category.validator';
+
+/**
+ * Viewport dimensions, mirrors the widget's `ViewportSize`.
+ */
+export class FeedbackViewportDto {
+  @ApiProperty({ example: 1280, description: 'Viewport width in CSS pixels' })
+  @IsInt()
+  @Min(0)
+  @Max(100_000)
+  w: number;
+
+  @ApiProperty({ example: 800, description: 'Viewport height in CSS pixels' })
+  @IsInt()
+  @Min(0)
+  @Max(100_000)
+  h: number;
+}
+
+/**
+ * Create Feedback DTO — mirrors the `feedback-widget` `FeedbackPayload`
+ * wire contract (`BrowserContext & CategorizedFeedback & { message }`).
+ *
+ * The global `ValidationPipe` runs with `forbidNonWhitelisted: true`,
+ * so this DTO must match the widget payload field-for-field: any extra
+ * property in the body is rejected with a 400. `reporterName` is
+ * deliberately absent — it is collected in the widget UI but not part
+ * of the transmitted payload at v0.1.
+ */
+export class CreateFeedbackDto {
+  @ApiProperty({
+    example: 'brasse-bouillon-website',
+    description: 'Source project identifier set by the widget',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  projectId: string;
+
+  @ApiProperty({
+    enum: TOP_LEVEL_CATEGORIES,
+    example: 'bug',
+    description: 'Top-level feedback category',
+  })
+  @IsEnum(TOP_LEVEL_CATEGORIES)
+  category: TopLevelCategory;
+
+  @ApiProperty({
+    nullable: true,
+    example: 'broken-feature',
+    description:
+      'Sub-category; must match the chosen category, or null for "other"',
+  })
+  @IsValidSubCategory()
+  subCategory: string | null;
+
+  @ApiProperty({
+    example: 'The download button does nothing on Android 13.',
+    minLength: FEEDBACK_MESSAGE_MIN_LENGTH,
+    maxLength: FEEDBACK_MESSAGE_MAX_LENGTH,
+  })
+  @IsString()
+  @MinLength(FEEDBACK_MESSAGE_MIN_LENGTH)
+  @MaxLength(FEEDBACK_MESSAGE_MAX_LENGTH)
+  message: string;
+
+  @ApiProperty({ example: 'https://brasse-bouillon.com/download' })
+  @IsString()
+  @MaxLength(2048)
+  url: string;
+
+  @ApiProperty({ nullable: true, example: 'https://brasse-bouillon.com/' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2048)
+  referrer: string | null;
+
+  @ApiProperty({ example: 'Mozilla/5.0 (...)' })
+  @IsString()
+  @MaxLength(512)
+  userAgent: string;
+
+  @ApiProperty({ type: FeedbackViewportDto })
+  @ValidateNested()
+  @Type(() => FeedbackViewportDto)
+  viewport: FeedbackViewportDto;
+
+  @ApiProperty({ example: 'fr-FR' })
+  @IsString()
+  @MaxLength(20)
+  locale: string;
+
+  @ApiProperty({
+    example: '2026-05-21T10:15:00.000Z',
+    description: 'ISO-8601 timestamp set client-side at submission',
+  })
+  @IsISO8601()
+  timestamp: string;
+
+  @ApiProperty({ example: '0.2.0' })
+  @IsString()
+  @MaxLength(40)
+  widgetVersion: string;
+
+  @ApiProperty({
+    example: 0.42,
+    minimum: 0,
+    maximum: 1,
+    description: 'Scroll depth ratio (0 = top, 1 = fully scrolled)',
+  })
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  scrollDepth: number;
+
+  @ApiProperty({ example: 'sess_8f3a1c…' })
+  @IsString()
+  @MaxLength(128)
+  sessionId: string;
+}

--- a/packages/api/src/feedback/dtos/feedback-response.dto.ts
+++ b/packages/api/src/feedback/dtos/feedback-response.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import type { TopLevelCategory } from '../feedback.constants';
+
+/**
+ * Feedback Response DTO — the minimal acknowledgement returned after a
+ * successful submission. Deliberately does not echo the stored context
+ * (url, userAgent, sessionId, …) back to the caller.
+ */
+export class FeedbackResponseDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  id: string;
+
+  @ApiProperty({ example: 'bug' })
+  category: TopLevelCategory;
+
+  @ApiProperty({ nullable: true, example: 'broken-feature' })
+  subCategory: string | null;
+
+  @ApiProperty({ example: '2026-05-21T10:15:00.000Z' })
+  createdAt: Date;
+}

--- a/packages/api/src/feedback/entities/feedback.entity.ts
+++ b/packages/api/src/feedback/entities/feedback.entity.ts
@@ -78,7 +78,7 @@ export class Feedback {
   widget_version: string;
 
   /** Scroll depth ratio in [0, 1] at submission time. */
-  @Column({ type: 'float' })
+  @Column({ type: 'real' })
   scroll_depth: number;
 
   /** Opaque client session identifier. */

--- a/packages/api/src/feedback/entities/feedback.entity.ts
+++ b/packages/api/src/feedback/entities/feedback.entity.ts
@@ -1,0 +1,91 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import type { TopLevelCategory } from '../feedback.constants';
+
+/**
+ * Feedback Entity
+ *
+ * One row per submitted piece of feedback, from the website widget or
+ * the mobile app. Mirrors the `feedback-widget` `FeedbackPayload` wire
+ * contract plus a server-side `created_at`.
+ *
+ * Database: SQLite (`feedback` table). Persisted from day one (no
+ * demo-only path). No backend consent gate at v0.1 — consent is
+ * client-side per ADR-0003 (backend sync is the v0.2 roadmap).
+ *
+ * @class Feedback
+ */
+@Entity('feedback')
+@Index(['project_id'])
+@Index(['created_at'])
+export class Feedback {
+  /** Auto-generated UUID primary key. */
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  /** Source project identifier (e.g. `brasse-bouillon-website`). */
+  @Column({ type: 'varchar', length: 100 })
+  project_id: string;
+
+  /** Top-level feedback category. */
+  @Column({ type: 'varchar', length: 20 })
+  category: TopLevelCategory;
+
+  /** Sub-category; null for the `other` category. */
+  @Column({ type: 'varchar', length: 40, nullable: true })
+  sub_category: string | null;
+
+  /** Free-text user message. Treated as potentially-PII content. */
+  @Column({ type: 'text' })
+  message: string;
+
+  /** URL the feedback was sent from. */
+  @Column({ type: 'varchar', length: 2048 })
+  url: string;
+
+  /** Referrer URL, when available. */
+  @Column({ type: 'varchar', length: 2048, nullable: true })
+  referrer: string | null;
+
+  /** Browser/device user agent string. */
+  @Column({ type: 'varchar', length: 512 })
+  user_agent: string;
+
+  /** Viewport width in CSS pixels. */
+  @Column({ type: 'integer' })
+  viewport_w: number;
+
+  /** Viewport height in CSS pixels. */
+  @Column({ type: 'integer' })
+  viewport_h: number;
+
+  /** Reporter locale (e.g. `fr-FR`). */
+  @Column({ type: 'varchar', length: 20 })
+  locale: string;
+
+  /** Client-set submission timestamp (distinct from `created_at`). */
+  @Column({ type: 'datetime' })
+  client_timestamp: Date;
+
+  /** Widget version that produced the payload. */
+  @Column({ type: 'varchar', length: 40 })
+  widget_version: string;
+
+  /** Scroll depth ratio in [0, 1] at submission time. */
+  @Column({ type: 'float' })
+  scroll_depth: number;
+
+  /** Opaque client session identifier. */
+  @Column({ type: 'varchar', length: 128 })
+  session_id: string;
+
+  /** Server-side creation timestamp. */
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+}

--- a/packages/api/src/feedback/feedback.constants.ts
+++ b/packages/api/src/feedback/feedback.constants.ts
@@ -1,0 +1,57 @@
+/**
+ * Feedback taxonomy — mirrored from the `feedback-widget` core package
+ * (`@feedback-widget/core`, `domain/Feedback.ts`).
+ *
+ * The widget is the source of truth for the wire contract. This file
+ * re-declares the allowed category / sub-category pairings server-side
+ * so the API can reject malformed payloads independently of the client
+ * (a client check is advisory only — never trusted).
+ *
+ * Keep in sync with the widget when its taxonomy evolves.
+ */
+
+export const TOP_LEVEL_CATEGORIES = [
+  'bug',
+  'typo',
+  'error',
+  'ambiguous',
+  'suggestion',
+  'other',
+] as const;
+
+export type TopLevelCategory = (typeof TOP_LEVEL_CATEGORIES)[number];
+
+/**
+ * Allowed sub-categories per top-level category. `other` carries no
+ * sub-category (the wire value must be `null`).
+ */
+export const SUB_CATEGORIES_BY_CATEGORY = {
+  bug: [
+    'crash',
+    'broken-feature',
+    'visual-glitch',
+    'wrong-output',
+    'regression',
+  ],
+  typo: ['prose', 'code-sample', 'heading', 'link-text', 'alt-text'],
+  error: ['js-console', 'http-404', 'http-5xx', 'broken-link', 'missing-asset'],
+  ambiguous: [
+    'wording',
+    'navigation',
+    'terminology',
+    'example-unclear',
+    'missing-context',
+  ],
+  suggestion: [
+    'new-feature',
+    'improvement',
+    'new-example',
+    'content-refactor',
+    'accessibility',
+  ],
+  other: [],
+} as const satisfies Record<TopLevelCategory, readonly string[]>;
+
+/** User message length bounds — match the widget's view-layer validation. */
+export const FEEDBACK_MESSAGE_MIN_LENGTH = 10;
+export const FEEDBACK_MESSAGE_MAX_LENGTH = 2000;

--- a/packages/api/src/feedback/feedback.module.ts
+++ b/packages/api/src/feedback/feedback.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { FeedbackController } from './controllers/feedback.controller';
+import { Feedback } from './entities/feedback.entity';
+import { FeedbackService } from './services/feedback.service';
+import { IsValidSubCategoryConstraint } from './validators/is-valid-sub-category.validator';
+
+/**
+ * Feedback Module (epic #1026, C2 / #1027)
+ *
+ * Registers the public `POST /feedback` endpoint, its persistence, and
+ * the sub-category pairing validator. No backend consent dependency at
+ * v0.1 (ADR-0003 keeps consent client-side; backend sync is v0.2).
+ */
+@Module({
+  imports: [TypeOrmModule.forFeature([Feedback])],
+  controllers: [FeedbackController],
+  providers: [FeedbackService, IsValidSubCategoryConstraint],
+})
+export class FeedbackModule {}

--- a/packages/api/src/feedback/services/feedback.service.spec.ts
+++ b/packages/api/src/feedback/services/feedback.service.spec.ts
@@ -1,0 +1,152 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { CreateFeedbackDto } from '../dtos/create-feedback.dto';
+import { Feedback } from '../entities/feedback.entity';
+import { FeedbackService } from './feedback.service';
+
+/**
+ * Builds a valid feedback DTO; override any field per test.
+ */
+function buildDto(
+  overrides: Partial<CreateFeedbackDto> = {},
+): CreateFeedbackDto {
+  return {
+    projectId: 'brasse-bouillon-website',
+    category: 'bug',
+    subCategory: 'broken-feature',
+    message: 'The download button does nothing on Android 13.',
+    url: 'https://brasse-bouillon.com/download',
+    referrer: 'https://brasse-bouillon.com/',
+    userAgent: 'Mozilla/5.0',
+    viewport: { w: 1280, h: 800 },
+    locale: 'fr-FR',
+    timestamp: '2026-05-21T10:15:00.000Z',
+    widgetVersion: '0.2.0',
+    scrollDepth: 0.42,
+    sessionId: 'sess_8f3a1c',
+    ...overrides,
+  };
+}
+
+describe('FeedbackService', () => {
+  let service: FeedbackService;
+  let repository: Repository<Feedback>;
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeedbackService,
+        { provide: getRepositoryToken(Feedback), useValue: mockRepository },
+      ],
+    }).compile();
+
+    service = module.get<FeedbackService>(FeedbackService);
+    repository = module.get<Repository<Feedback>>(getRepositoryToken(Feedback));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('create', () => {
+    // Happy path
+    it('persists the feedback and returns its acknowledgement', async () => {
+      const dto = buildDto();
+      const created = { ...dto } as unknown as Feedback;
+      const saved: Feedback = {
+        id: 'fb-1',
+        project_id: dto.projectId,
+        category: 'bug',
+        sub_category: 'broken-feature',
+        message: dto.message,
+        url: dto.url,
+        referrer: dto.referrer,
+        user_agent: dto.userAgent,
+        viewport_w: 1280,
+        viewport_h: 800,
+        locale: 'fr-FR',
+        client_timestamp: new Date(dto.timestamp),
+        widget_version: '0.2.0',
+        scroll_depth: 0.42,
+        session_id: 'sess_8f3a1c',
+        created_at: new Date('2026-05-21T10:15:01.000Z'),
+      };
+      const createSpy = jest
+        .spyOn(repository, 'create')
+        .mockReturnValue(created);
+      const saveSpy = jest.spyOn(repository, 'save').mockResolvedValue(saved);
+
+      const result = await service.create(dto);
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          project_id: 'brasse-bouillon-website',
+          category: 'bug',
+          sub_category: 'broken-feature',
+          viewport_w: 1280,
+          viewport_h: 800,
+          scroll_depth: 0.42,
+        }),
+      );
+      expect(saveSpy).toHaveBeenCalledWith(created);
+      expect(result).toEqual({
+        id: 'fb-1',
+        category: 'bug',
+        subCategory: 'broken-feature',
+        createdAt: saved.created_at,
+      });
+    });
+
+    // Edge case — 'other' carries a null sub-category and null referrer
+    it('maps null sub-category and null referrer for the "other" category', async () => {
+      const dto = buildDto({
+        category: 'other',
+        subCategory: null,
+        referrer: null,
+        scrollDepth: 0,
+      });
+      const created = {} as Feedback;
+      const createSpy = jest
+        .spyOn(repository, 'create')
+        .mockReturnValue(created);
+      jest.spyOn(repository, 'save').mockResolvedValue({
+        id: 'fb-2',
+        category: 'other',
+        sub_category: null,
+        created_at: new Date('2026-05-21T11:00:00.000Z'),
+      } as Feedback);
+
+      const result = await service.create(dto);
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: 'other',
+          sub_category: null,
+          referrer: null,
+          scroll_depth: 0,
+        }),
+      );
+      expect(result.subCategory).toBeNull();
+    });
+
+    // Sad path — repository failure propagates
+    it('propagates a repository error', async () => {
+      const dto = buildDto();
+      jest.spyOn(repository, 'create').mockReturnValue({} as Feedback);
+      jest
+        .spyOn(repository, 'save')
+        .mockRejectedValue(new Error('DB write failed'));
+
+      await expect(service.create(dto)).rejects.toThrow('DB write failed');
+    });
+  });
+});

--- a/packages/api/src/feedback/services/feedback.service.ts
+++ b/packages/api/src/feedback/services/feedback.service.ts
@@ -1,0 +1,63 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { CreateFeedbackDto } from '../dtos/create-feedback.dto';
+import { FeedbackResponseDto } from '../dtos/feedback-response.dto';
+import { Feedback } from '../entities/feedback.entity';
+
+/**
+ * Feedback Service
+ *
+ * Persists feedback submissions from the website widget and the mobile
+ * app. No backend consent gate at v0.1 (consent is client-side per
+ * ADR-0003); the service stores what it receives and returns a minimal
+ * acknowledgement.
+ */
+@Injectable()
+export class FeedbackService {
+  private readonly logger = new Logger(FeedbackService.name);
+
+  constructor(
+    @InjectRepository(Feedback)
+    private readonly feedbackRepository: Repository<Feedback>,
+  ) {}
+
+  /**
+   * Persists one feedback submission and returns its acknowledgement.
+   *
+   * @param dto validated feedback payload mirroring the widget contract
+   * @returns the new feedback id, category, sub-category and timestamp
+   */
+  async create(dto: CreateFeedbackDto): Promise<FeedbackResponseDto> {
+    const feedback = this.feedbackRepository.create({
+      project_id: dto.projectId,
+      category: dto.category,
+      sub_category: dto.subCategory ?? null,
+      message: dto.message,
+      url: dto.url,
+      referrer: dto.referrer ?? null,
+      user_agent: dto.userAgent,
+      viewport_w: dto.viewport.w,
+      viewport_h: dto.viewport.h,
+      locale: dto.locale,
+      client_timestamp: new Date(dto.timestamp),
+      widget_version: dto.widgetVersion,
+      scroll_depth: dto.scrollDepth,
+      session_id: dto.sessionId,
+    });
+
+    const saved = await this.feedbackRepository.save(feedback);
+
+    this.logger.log(
+      `Feedback ${saved.id} stored (${saved.category}/${saved.sub_category ?? 'none'}) from ${saved.project_id}`,
+    );
+
+    return {
+      id: saved.id,
+      category: saved.category,
+      subCategory: saved.sub_category,
+      createdAt: saved.created_at,
+    };
+  }
+}

--- a/packages/api/src/feedback/validators/is-valid-sub-category.validator.spec.ts
+++ b/packages/api/src/feedback/validators/is-valid-sub-category.validator.spec.ts
@@ -1,0 +1,58 @@
+import { ValidationArguments } from 'class-validator';
+
+import { IsValidSubCategoryConstraint } from './is-valid-sub-category.validator';
+
+/**
+ * Builds the ValidationArguments shape the constraint reads, with the
+ * sibling `category` set on `object`.
+ */
+function argsFor(category: unknown): ValidationArguments {
+  return {
+    object: { category },
+    value: undefined,
+    targetName: 'CreateFeedbackDto',
+    property: 'subCategory',
+    constraints: [],
+  };
+}
+
+describe('IsValidSubCategoryConstraint', () => {
+  const constraint = new IsValidSubCategoryConstraint();
+
+  // Happy path — a valid pairing
+  it('accepts a sub-category that belongs to its category', () => {
+    expect(constraint.validate('crash', argsFor('bug'))).toBe(true);
+    expect(constraint.validate('improvement', argsFor('suggestion'))).toBe(
+      true,
+    );
+  });
+
+  // Happy path — 'other' requires a null sub-category
+  it('accepts null for the "other" category', () => {
+    expect(constraint.validate(null, argsFor('other'))).toBe(true);
+    expect(constraint.validate(undefined, argsFor('other'))).toBe(true);
+  });
+
+  // Sad path — mismatched pairing
+  it('rejects a sub-category that does not belong to its category', () => {
+    expect(constraint.validate('wrong-output', argsFor('typo'))).toBe(false);
+    expect(constraint.validate('crash', argsFor('suggestion'))).toBe(false);
+  });
+
+  // Sad path — 'other' must not carry a sub-category
+  it('rejects a non-null sub-category for "other"', () => {
+    expect(constraint.validate('crash', argsFor('other'))).toBe(false);
+  });
+
+  // Edge case — non-string sub-category for a category that needs one
+  it('rejects a missing sub-category for a category that requires one', () => {
+    expect(constraint.validate(undefined, argsFor('bug'))).toBe(false);
+    expect(constraint.validate(null, argsFor('bug'))).toBe(false);
+  });
+
+  // Edge case — unknown category defers to @IsEnum (passes here)
+  it('passes when the category itself is invalid (avoids double-reporting)', () => {
+    expect(constraint.validate('crash', argsFor('nonsense'))).toBe(true);
+    expect(constraint.validate('crash', argsFor(undefined))).toBe(true);
+  });
+});

--- a/packages/api/src/feedback/validators/is-valid-sub-category.validator.ts
+++ b/packages/api/src/feedback/validators/is-valid-sub-category.validator.ts
@@ -1,0 +1,61 @@
+import {
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+import {
+  SUB_CATEGORIES_BY_CATEGORY,
+  TopLevelCategory,
+} from '../feedback.constants';
+
+/**
+ * Validates that `subCategory` is consistent with the sibling
+ * `category` field, per the `feedback-widget` taxonomy:
+ *
+ * - `other` → `subCategory` must be `null` / absent.
+ * - any other category → `subCategory` must be one of that category's
+ *   allowed values.
+ *
+ * Synchronous, no dependency injection. When `category` itself is
+ * invalid, this constraint passes (the `@IsEnum` on `category` reports
+ * that error — we avoid double-reporting).
+ */
+@ValidatorConstraint({ name: 'isValidSubCategory', async: false })
+export class IsValidSubCategoryConstraint implements ValidatorConstraintInterface {
+  validate(value: unknown, args: ValidationArguments): boolean {
+    const category = (args.object as { category?: unknown }).category as
+      | TopLevelCategory
+      | undefined;
+
+    if (category === undefined || !(category in SUB_CATEGORIES_BY_CATEGORY)) {
+      return true;
+    }
+
+    if (category === 'other') {
+      return value === null || value === undefined;
+    }
+
+    const allowed = SUB_CATEGORIES_BY_CATEGORY[category] as readonly string[];
+    return typeof value === 'string' && allowed.includes(value);
+  }
+
+  defaultMessage(args: ValidationArguments): string {
+    const category = (args.object as { category?: unknown }).category;
+    return `subCategory is not valid for category "${String(category)}"`;
+  }
+}
+
+export function IsValidSubCategory(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string): void {
+    registerDecorator({
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      constraints: [],
+      validator: IsValidSubCategoryConstraint,
+    });
+  };
+}

--- a/packages/api/test/feedback.e2e-spec.ts
+++ b/packages/api/test/feedback.e2e-spec.ts
@@ -1,0 +1,116 @@
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+import request from 'supertest';
+import { useContainer } from 'class-validator';
+
+/**
+ * Issue #1027 — feedback ingestion endpoint, e2e regression guards on
+ * `POST /feedback`.
+ *
+ * Two contracts pinned here:
+ *
+ *   1. Wiring — a valid payload persists and returns 201. This exercises
+ *      the real TypeORM DataSource and would fail with
+ *      `EntityMetadataNotFoundError` if the `Feedback` entity were not
+ *      registered in `ormEntities` (the bug Codex/Copilot flagged on the
+ *      first revision). Unit tests mock the repository and cannot catch it.
+ *   2. Validation — `forbidNonWhitelisted` + field rules reject malformed
+ *      bodies with 400 (short message, unknown extra field, bad pairing).
+ *
+ * The ThrottlerGuard is overridden so the rate limit never interferes.
+ */
+function validPayload(): Record<string, unknown> {
+  return {
+    projectId: 'brasse-bouillon-website',
+    category: 'bug',
+    subCategory: 'broken-feature',
+    message: 'The download button does nothing on Android 13.',
+    url: 'https://brasse-bouillon.com/download',
+    referrer: null,
+    userAgent: 'Mozilla/5.0',
+    viewport: { w: 1280, h: 800 },
+    locale: 'fr-FR',
+    timestamp: '2026-05-21T10:15:00.000Z',
+    widgetVersion: '0.2.0',
+    scrollDepth: 0.42,
+    sessionId: 'sess_e2e',
+  };
+}
+
+describe('POST /feedback (e2e — Issue #1027)', () => {
+  let app: INestApplication<App>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    useContainer(app.select(AppModule), { fallbackOnErrors: true });
+    // Apply the same input validation as main.ts so the 400 contracts hold.
+    app.useGlobalPipes(
+      new ValidationPipe({
+        transform: true,
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        stopAtFirstError: true,
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // Happy path — valid payload persists (exercises the real DataSource)
+  it('accepts a valid submission and returns 201 with an acknowledgement', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/feedback')
+      .send(validPayload())
+      .expect(201);
+
+    const body = res.body as { id?: unknown; category?: unknown };
+    expect(typeof body.id).toBe('string');
+    expect(body.category).toBe('bug');
+  });
+
+  // Edge — 'other' category with a null sub-category is accepted
+  it('accepts the "other" category with a null sub-category', async () => {
+    await request(app.getHttpServer())
+      .post('/feedback')
+      .send({ ...validPayload(), category: 'other', subCategory: null })
+      .expect(201);
+  });
+
+  // Sad — message shorter than the minimum length → 400
+  it('rejects a message shorter than the minimum length', async () => {
+    await request(app.getHttpServer())
+      .post('/feedback')
+      .send({ ...validPayload(), message: 'too short' })
+      .expect(400);
+  });
+
+  // Sad — unknown extra field → 400 (forbidNonWhitelisted)
+  it('rejects an unknown extra field', async () => {
+    await request(app.getHttpServer())
+      .post('/feedback')
+      .send({ ...validPayload(), reporterName: 'Anon' })
+      .expect(400);
+  });
+
+  // Sad — sub-category that does not match the category → 400
+  it('rejects a sub-category that does not match the category', async () => {
+    await request(app.getHttpServer())
+      .post('/feedback')
+      .send({ ...validPayload(), category: 'typo', subCategory: 'crash' })
+      .expect(400);
+  });
+});


### PR DESCRIPTION
C2 of epic #1026. Public POST /feedback endpoint (anonymous, rate-limited) persisting feedback to a new table. Mirrors the feedback-widget FeedbackPayload contract; server-side pairing validation. No backend consent gate at v0.1 (ADR-0003, client-side). Closes #1027