### PR TITLE
feat(website): premium bottom band for the 18+ notice + ambient rising bubbles

### DIFF
--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -23,6 +23,7 @@
 <body>
   <a class="skip-link" href="#mainContentEn">Skip to main content</a>
   <div class="bubbles" aria-hidden="true"></div>
+  <div class="beer-foam" aria-hidden="true"></div>
 
   <header class="site-header">
     <div class="header-inner">

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -76,5 +76,7 @@
       </p>
     </div>
   </aside>
+
+  <script src="site.js"></script>
 </body>
 </html>

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -22,6 +22,7 @@
 </head>
 <body>
   <a class="skip-link" href="#mainContentEn">Skip to main content</a>
+  <div class="bubbles" aria-hidden="true"></div>
 
   <header class="site-header">
     <div class="header-inner">
@@ -64,5 +65,15 @@
       </footer>
     </div>
   </main>
+
+  <aside class="responsibility-band" aria-label="Legal notice">
+    <div class="responsibility-band__inner">
+      <span class="responsibility-band__badge" aria-hidden="true">18+</span>
+      <p>
+        Excessive alcohol consumption is harmful to health. Please drink responsibly.
+        Brasse-Bouillon is intended for adults and promotes responsible consumption.
+      </p>
+    </div>
+  </aside>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -108,6 +108,7 @@
 <body>
   <a class="skip-link" href="#mainContentFr">Aller au contenu principal</a>
   <div class="scroll-progress" aria-hidden="true"><span></span></div>
+  <div class="bubbles" aria-hidden="true"></div>
 
   <header class="site-header">
     <div class="header-inner">
@@ -126,10 +127,6 @@
 
   <main class="page" id="mainContentFr">
     <div class="shell">
-      <p class="responsibility-banner">
-        Brasse-Bouillon s’adresse aux adultes (18+) et promeut une consommation responsable. L’abus d’alcool est dangereux pour la santé.
-      </p>
-
       <section class="hero">
         <div class="hero-embers" aria-hidden="true">
           <span></span><span></span><span></span><span></span><span></span><span></span>
@@ -408,6 +405,16 @@
       </footer>
     </div>
   </main>
+
+  <aside class="responsibility-band" aria-label="Avertissement légal">
+    <div class="responsibility-band__inner">
+      <span class="responsibility-band__badge" aria-hidden="true">18+</span>
+      <p>
+        L’abus d’alcool est dangereux pour la santé. À consommer avec modération.
+        Brasse-Bouillon s’adresse aux adultes et promeut une consommation responsable.
+      </p>
+    </div>
+  </aside>
 
   <script src="site.js"></script>
   <script>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -109,6 +109,7 @@
   <a class="skip-link" href="#mainContentFr">Aller au contenu principal</a>
   <div class="scroll-progress" aria-hidden="true"><span></span></div>
   <div class="bubbles" aria-hidden="true"></div>
+  <div class="beer-foam" aria-hidden="true"></div>
 
   <header class="site-header">
     <div class="header-inner">

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -373,6 +373,139 @@
     }
 
     /* ========================================================================
+       DEW / CONDENSATION — real water droplets (transparent, lens effect)
+       clinging to the cards; a few bead and trickle down. Foreground layer.
+       Injected per card by site.js (setupDew).
+       ====================================================================== */
+
+    /* doubled class raises specificity so card rules like
+       `.feature-card > * { position: relative; z-index: 2 }` can't
+       override the layer's absolute positioning / stacking. */
+    .dew-layer.dew-layer {
+      position: absolute;
+      top: 0;
+      left: 0;
+      /* width/height set in JS from the measured card (some cards, e.g.
+         <details> FAQ items, give a 0-height box with inset:0). */
+      z-index: 30;
+      border-radius: inherit;
+      overflow: hidden;
+      pointer-events: none;
+    }
+
+    .dew {
+      position: absolute;
+      left: var(--dx);
+      top: var(--dy);
+      width: var(--ds);
+      height: var(--ds);
+      border-radius: 50%;
+      pointer-events: none;
+      /* a light grey glassy cast (rather than pure white) */
+      background: rgba(116, 120, 132, 0.2);
+      /* lens / magnify: brighten + sharpen the card seen through the drop */
+      backdrop-filter: brightness(1.16) contrast(1.14) saturate(1.06);
+      -webkit-backdrop-filter: brightness(1.16) contrast(1.14) saturate(1.06);
+      box-shadow:
+        inset 0 1px 1px rgba(255, 255, 255, 0.36),
+        inset 0 -3px 4px rgba(255, 255, 255, 0.42),
+        inset 0 0 0 0.8px rgba(78, 58, 32, 0.42),
+        0 2px 6px rgba(52, 34, 15, 0.4);
+    }
+
+    .dew::after {
+      content: '';
+      position: absolute;
+      top: 16%;
+      left: 24%;
+      width: 30%;
+      height: 30%;
+      border-radius: 50%;
+      background: radial-gradient(
+        circle,
+        rgba(255, 255, 255, 0.95) 0 40%,
+        rgba(255, 255, 255, 0) 72%
+      );
+    }
+
+    /* Trickling drop = a falling wrapper (carries the faint vertical trail)
+       containing the pear-shaped bead. Splitting them keeps the trail
+       upright while the bead is rotated into a teardrop. */
+    .dew-run {
+      position: absolute;
+      left: var(--dx);
+      top: var(--dy);
+      width: var(--ds);
+      height: var(--ds);
+      pointer-events: none;
+      /* accelerating fall (gravity): slow start, speeding up. */
+      animation: dew-run var(--dr-dur) cubic-bezier(0.6, 0.04, 0.98, 0.34)
+        var(--dr-delay) infinite;
+    }
+
+    .dew-run__bead {
+      position: absolute;
+      inset: 0;
+      /* pear / teardrop: sharp point at the top, round heavy bottom. */
+      border-radius: 0 50% 50% 50%;
+      transform: scale(0.9, 1.26) rotate(45deg);
+      /* a touch lighter than the fixed beads to offset the trail behind it */
+      background: rgba(116, 120, 132, 0.16);
+      backdrop-filter: brightness(1.16) contrast(1.14) saturate(1.06);
+      -webkit-backdrop-filter: brightness(1.16) contrast(1.14) saturate(1.06);
+      box-shadow:
+        inset 0 1px 1px rgba(255, 255, 255, 0.36),
+        inset 0 -3px 4px rgba(255, 255, 255, 0.42),
+        inset 0 0 0 0.8px rgba(78, 58, 32, 0.42),
+        0 2px 6px rgba(52, 34, 15, 0.4);
+    }
+
+    /* same specular highlight as the fixed beads, so both read identically */
+    .dew-run__bead::after {
+      content: '';
+      position: absolute;
+      top: 18%;
+      left: 22%;
+      width: 30%;
+      height: 30%;
+      border-radius: 50%;
+      background: radial-gradient(
+        circle,
+        rgba(255, 255, 255, 0.95) 0 40%,
+        rgba(255, 255, 255, 0) 72%
+      );
+    }
+
+    /* faint wet trail left behind, fading upward */
+    .dew-run::before {
+      content: '';
+      position: absolute;
+      left: 50%;
+      bottom: 42%;
+      transform: translateX(-50%);
+      width: max(3px, calc(var(--ds) * 0.62));
+      height: var(--dr-trail);
+      /* tapering trail: wide at the drop, narrowing to a fine point */
+      clip-path: polygon(49% 0%, 51% 0%, 100% 100%, 0% 100%);
+      background: linear-gradient(
+        to top,
+        rgba(212, 218, 228, 0.3),
+        rgba(212, 218, 228, 0)
+      );
+    }
+
+    @keyframes dew-run {
+      0% { transform: translateY(0); opacity: 0; }
+      10% { opacity: 1; }
+      88% { opacity: 1; }
+      100% { transform: translateY(var(--dr-dist)); opacity: 0; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .dew--run { animation: none; }
+    }
+
+    /* ========================================================================
        HERO — KINETIC : massive mascot, parallax orbits, big type
        ====================================================================== */
 

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -227,18 +227,109 @@
 
     .shell { width: 100%; max-width: 1240px; }
 
-    .responsibility-banner {
-      margin: 0 auto 48px;
-      max-width: max-content;
-      padding: 8px 18px;
-      border-radius: 999px;
-      border: 1px solid var(--line);
-      background: rgba(255, 252, 244, 0.7);
-      color: var(--muted);
-      font-size: 0.78rem;
-      text-align: center;
-      letter-spacing: 0.02em;
-      backdrop-filter: blur(8px);
+    /* ========================================================================
+       RESPONSIBILITY BAND — Loi Évin notice, full-bleed at the page foot
+       ====================================================================== */
+
+    .responsibility-band {
+      position: relative;
+      z-index: 1;
+      margin-top: clamp(56px, 8vw, 96px);
+      background: var(--ink);
+      color: var(--foam);
+      padding: clamp(22px, 3.2vw, 32px) 24px;
+    }
+
+    .responsibility-band__inner {
+      width: 100%;
+      max-width: 1240px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      gap: 20px;
+    }
+
+    .responsibility-band__badge {
+      flex: 0 0 auto;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 54px;
+      height: 54px;
+      border-radius: 50%;
+      background: var(--copper);
+      color: var(--foam);
+      font-family: var(--font-display);
+      font-weight: 700;
+      font-size: 1.02rem;
+      letter-spacing: 0.04em;
+      box-shadow: 0 0 0 4px rgba(197, 116, 45, 0.22), var(--shadow-md);
+    }
+
+    .responsibility-band p {
+      margin: 0;
+      max-width: 70ch;
+      font-size: 0.9rem;
+      line-height: 1.55;
+      color: rgba(251, 243, 218, 0.82);
+    }
+
+    @media (max-width: 600px) {
+      .responsibility-band__inner {
+        flex-direction: column;
+        text-align: center;
+        gap: 14px;
+      }
+    }
+
+    /* ========================================================================
+       RISING CO₂ BUBBLES — ambient background, like gas in a glass of beer
+       Bubbles are injected by site.js (setupBubbles) with randomized
+       per-bubble custom properties. Fixed layer behind all content.
+       ====================================================================== */
+
+    .bubbles {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      overflow: hidden;
+      pointer-events: none;
+    }
+
+    .bubble {
+      position: absolute;
+      bottom: -6vh;
+      left: var(--x);
+      width: var(--size);
+      height: var(--size);
+      border-radius: 50%;
+      background: radial-gradient(
+        circle at 32% 28%,
+        rgba(255, 255, 255, 0.95) 0%,
+        rgba(255, 255, 255, 0.45) 28%,
+        rgba(255, 252, 244, 0.12) 60%,
+        rgba(255, 252, 244, 0.02) 100%
+      );
+      box-shadow:
+        inset 0 0 2px rgba(255, 255, 255, 0.7),
+        0 0 6px rgba(255, 255, 255, 0.18);
+      opacity: 0;
+      will-change: transform, opacity;
+      animation: bubble-rise var(--dur) linear var(--delay) infinite;
+    }
+
+    @keyframes bubble-rise {
+      0%   { transform: translate(0, 0) scale(0.85); opacity: 0; }
+      6%   { opacity: var(--op); }
+      25%  { transform: translate(var(--sway), -25vh) scale(1); }
+      50%  { transform: translate(calc(var(--sway) * -1), -50vh) scale(1.06); }
+      75%  { transform: translate(var(--sway), -75vh) scale(1.12); }
+      94%  { opacity: var(--op); }
+      100% { transform: translate(0, -104vh) scale(1.18); opacity: 0; }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .bubbles { display: none; }
     }
 
     /* ========================================================================

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -333,6 +333,46 @@
     }
 
     /* ========================================================================
+       BEER FOAM — creamy head crowning the very top of the page
+       ====================================================================== */
+
+    .beer-foam {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 0;
+      height: clamp(172px, 19vw, 264px);
+      pointer-events: none;
+      background: linear-gradient(
+        to bottom,
+        rgba(255, 253, 248, 0.98) 0%,
+        rgba(254, 248, 233, 0.88) 55%,
+        rgba(251, 243, 218, 0.4) 84%,
+        rgba(251, 243, 218, 0) 100%
+      );
+      /* Organic foam bubbles are injected by site.js (setupFoam). */
+    }
+
+    .foam-bubble {
+      position: absolute;
+      left: var(--fx);
+      bottom: var(--fy);
+      width: var(--fs);
+      height: var(--fs);
+      border-radius: 50%;
+      transform: translate(-50%, 50%);
+      opacity: var(--fo);
+      background: radial-gradient(
+        circle at 36% 30%,
+        #ffffff 0 36%,
+        #fbf3da 74%,
+        #efe0b8 100%
+      );
+      box-shadow: 0 1px 2px rgba(150, 120, 70, 0.18);
+    }
+
+    /* ========================================================================
        HERO — KINETIC : massive mascot, parallax orbits, big type
        ====================================================================== */
 

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -54,11 +54,14 @@
       margin: 0;
       font-family: var(--font-body);
       color: var(--ink);
-      background-color: var(--paper);
+      /* Warm, golden "glass of beer" backdrop: pale near the top (foam),
+         deepening to amber/gold lower down. */
+      background-color: #e1bf72;
       background-image:
-        radial-gradient(ellipse at 10% -8%, rgba(255, 244, 209, 0.95) 0%, transparent 42%),
-        radial-gradient(ellipse at 96% 8%, rgba(231, 207, 154, 0.9) 0%, transparent 38%),
-        radial-gradient(circle at 50% 120%, rgba(197, 116, 45, 0.18) 0%, transparent 55%);
+        radial-gradient(ellipse at 10% -8%, rgba(255, 246, 214, 0.92) 0%, transparent 42%),
+        radial-gradient(ellipse at 96% 8%, rgba(228, 190, 110, 0.95) 0%, transparent 40%),
+        radial-gradient(circle at 50% 122%, rgba(186, 110, 40, 0.4) 0%, transparent 62%),
+        linear-gradient(to bottom, rgba(244, 232, 194, 0.66) 0%, rgba(226, 187, 104, 0.42) 52%, rgba(208, 160, 72, 0.62) 100%);
       background-attachment: fixed;
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
@@ -303,29 +306,50 @@
       width: var(--size);
       height: var(--size);
       border-radius: 50%;
-      background: radial-gradient(
-        circle at 32% 28%,
-        rgba(255, 255, 255, 0.95) 0%,
-        rgba(255, 255, 255, 0.45) 28%,
-        rgba(255, 252, 244, 0.12) 60%,
-        rgba(255, 252, 244, 0.02) 100%
-      );
+      /* a real gas bubble: mostly transparent (the beer shows through),
+         with a bright thin rim and a small specular highlight. */
+      background:
+        radial-gradient(
+          circle at 35% 30%,
+          rgba(255, 255, 255, 0.85) 0 10%,
+          rgba(255, 255, 255, 0.25) 30%,
+          transparent 54%
+        ),
+        radial-gradient(
+          circle at 50% 50%,
+          transparent 54%,
+          rgba(255, 255, 255, 0.62) 72%,
+          rgba(255, 255, 255, 0.2) 84%,
+          transparent 93%
+        );
       box-shadow:
-        inset 0 0 2px rgba(255, 255, 255, 0.7),
-        0 0 6px rgba(255, 255, 255, 0.18);
+        /* faint dark contour gives the bubble a visible edge on light bg */
+        inset 0 0 0 0.6px rgba(108, 80, 46, 0.3),
+        inset 1px 1px 2px rgba(255, 255, 255, 0.45),
+        0 0 3px rgba(120, 90, 50, 0.18);
       opacity: 0;
-      will-change: transform, opacity;
-      animation: bubble-rise var(--dur) linear var(--delay) infinite;
+      will-change: translate, transform, opacity;
+      /* Rise (Y) and sway (X) are split across the `translate` and
+         `transform` properties so the acceleration isn't linearised by
+         sway waypoints. The bubble rises continuously to the top (foam),
+         fading only at the very top — never stopping mid-screen. */
+      animation:
+        bubble-rise var(--dur) cubic-bezier(0.45, 0, 0.85, 0.4) var(--delay)
+          infinite,
+        bubble-sway calc(var(--dur) / 3.5) ease-in-out var(--delay) infinite
+          alternate;
     }
 
     @keyframes bubble-rise {
-      0%   { transform: translate(0, 0) scale(0.85); opacity: 0; }
-      6%   { opacity: var(--op); }
-      25%  { transform: translate(var(--sway), -25vh) scale(1); }
-      50%  { transform: translate(calc(var(--sway) * -1), -50vh) scale(1.06); }
-      75%  { transform: translate(var(--sway), -75vh) scale(1.12); }
-      94%  { opacity: var(--op); }
-      100% { transform: translate(0, -104vh) scale(1.18); opacity: 0; }
+      0% { translate: 0 0; opacity: 0; }
+      5% { opacity: var(--op); }
+      92% { opacity: var(--op); }
+      100% { translate: 0 -112vh; opacity: 0; }
+    }
+
+    @keyframes bubble-sway {
+      from { transform: translateX(calc(var(--sway) * -1)) scale(0.92); }
+      to { transform: translateX(var(--sway)) scale(1.12); }
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -123,8 +123,51 @@
     });
   }
 
+  /**
+   * Populates a `.bubbles` layer with rising CO₂ bubbles, like gas in a
+   * glass of beer. Each bubble gets randomized custom properties (size,
+   * horizontal position, duration, start delay, sway amplitude, opacity)
+   * consumed by the CSS `bubble-rise` animation. No-ops when the user
+   * prefers reduced motion or when no `.bubbles` layer is present.
+   */
+  function setupBubbles(options) {
+    const layer = document.querySelector('.bubbles');
+    if (!layer) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    const count = (options && options.count) || 48;
+    const fragment = document.createDocumentFragment();
+
+    for (let i = 0; i < count; i += 1) {
+      const bubble = document.createElement('span');
+      bubble.className = 'bubble';
+      bubble.style.setProperty('--size', `${(3 + Math.random() * 9).toFixed(1)}px`);
+      bubble.style.setProperty('--x', `${(Math.random() * 100).toFixed(2)}vw`);
+      bubble.style.setProperty('--dur', `${(9 + Math.random() * 13).toFixed(1)}s`);
+      bubble.style.setProperty('--delay', `${(-Math.random() * 22).toFixed(1)}s`);
+      bubble.style.setProperty('--sway', `${(6 + Math.random() * 22).toFixed(0)}px`);
+      bubble.style.setProperty('--op', (0.18 + Math.random() * 0.4).toFixed(2));
+      fragment.appendChild(bubble);
+    }
+
+    layer.appendChild(fragment);
+  }
+
+  function onReady(fn) {
+    if (document.readyState !== 'loading') {
+      fn();
+    } else {
+      document.addEventListener('DOMContentLoaded', fn);
+    }
+  }
+
+  onReady(function () {
+    setupBubbles();
+  });
+
   global.BBShared = {
     toggleQuestionnaire,
-    setupQuestionnaire
+    setupQuestionnaire,
+    setupBubbles
   };
 }(window));

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -135,18 +135,27 @@
     if (!layer) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
-    const count = (options && options.count) || 48;
+    const count = (options && options.count) || 110;
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < count; i += 1) {
       const bubble = document.createElement('span');
       bubble.className = 'bubble';
-      bubble.style.setProperty('--size', `${(3 + Math.random() * 9).toFixed(1)}px`);
+
+      // Skew towards small bubbles with a few big ones (like real CO2):
+      // most are 2–8px, some medium, the rare large reaching ~22px.
+      const sizeFactor = Math.pow(Math.random(), 1.7);
+      const size = 2 + sizeFactor * 20;
+      // Larger bubbles tend to be a touch more opaque and rise faster.
+      const opacity = 0.25 + sizeFactor * 0.35 + Math.random() * 0.25;
+      const duration = 7 + (1 - sizeFactor) * 12 + Math.random() * 3;
+
+      bubble.style.setProperty('--size', `${size.toFixed(1)}px`);
       bubble.style.setProperty('--x', `${(Math.random() * 100).toFixed(2)}vw`);
-      bubble.style.setProperty('--dur', `${(9 + Math.random() * 13).toFixed(1)}s`);
-      bubble.style.setProperty('--delay', `${(-Math.random() * 22).toFixed(1)}s`);
-      bubble.style.setProperty('--sway', `${(6 + Math.random() * 22).toFixed(0)}px`);
-      bubble.style.setProperty('--op', (0.18 + Math.random() * 0.4).toFixed(2));
+      bubble.style.setProperty('--dur', `${duration.toFixed(1)}s`);
+      bubble.style.setProperty('--delay', `${(-Math.random() * 20).toFixed(1)}s`);
+      bubble.style.setProperty('--sway', `${(6 + Math.random() * 26).toFixed(0)}px`);
+      bubble.style.setProperty('--op', Math.min(opacity, 0.9).toFixed(2));
       fragment.appendChild(bubble);
     }
 

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -163,6 +163,42 @@
     layer.appendChild(fragment);
   }
 
+  /**
+   * Fills a `.beer-foam` background layer with irregular foam bubbles —
+   * varied size / position / opacity, denser and larger near the bottom
+   * so the underside reads as an organic, lumpy head spilling into the
+   * beer (rather than a regular tiled pattern). No-ops when the layer is
+   * absent.
+   */
+  function setupFoam(options) {
+    const foam = document.querySelector('.beer-foam');
+    if (!foam) return;
+
+    // Dense overlapping placement: many bubbles piled on top of one
+    // another so the head reads as a solid foam mass with no visible gaps
+    // between droplets. Larger bubbles sit lower (gravity), fine froth on
+    // top; high opacity so overlaps stay creamy and continuous.
+    const count = (options && options.count) || 4200;
+    const fragment = document.createDocumentFragment();
+
+    for (let i = 0; i < count; i += 1) {
+      const bubble = document.createElement('span');
+      bubble.className = 'foam-bubble';
+
+      const vy = Math.pow(Math.random(), 1.35);
+      const size = 9 + (1 - vy) * 44 + Math.random() * 12;
+      const bottomPx = vy * 232 - 26;
+
+      bubble.style.setProperty('--fx', `${(Math.random() * 100).toFixed(2)}%`);
+      bubble.style.setProperty('--fy', `${bottomPx.toFixed(0)}px`);
+      bubble.style.setProperty('--fs', `${size.toFixed(0)}px`);
+      bubble.style.setProperty('--fo', (0.85 + Math.random() * 0.15).toFixed(2));
+      fragment.appendChild(bubble);
+    }
+
+    foam.appendChild(fragment);
+  }
+
   function onReady(fn) {
     if (document.readyState !== 'loading') {
       fn();
@@ -173,11 +209,13 @@
 
   onReady(function () {
     setupBubbles();
+    setupFoam();
   });
 
   global.BBShared = {
     toggleQuestionnaire,
     setupQuestionnaire,
-    setupBubbles
+    setupBubbles,
+    setupFoam
   };
 }(window));

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -199,6 +199,85 @@
     foam.appendChild(fragment);
   }
 
+  /**
+   * Adds condensation (dew) droplets clinging to the front of each card,
+   * like beads on a cold glass. A measured few static beads per card, plus
+   * one or two that trickle down with a faint wet trail. Foreground layer,
+   * pointer-events disabled so it never blocks interaction. Trickling is
+   * skipped under prefers-reduced-motion.
+   */
+  function setupDew(options) {
+    const selector =
+      (options && options.selector) ||
+      '.hero, .journey-step, .feature-card, .faq-item, .participate';
+    const cards = document.querySelectorAll(selector);
+    if (!cards.length) return;
+
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    cards.forEach((card) => {
+      // A closed <details> hides every child except its <summary>, so for
+      // those cards attach the dew to the always-visible <summary>.
+      const host =
+        card.tagName === 'DETAILS'
+          ? card.querySelector(':scope > summary') || card
+          : card;
+
+      if (host.querySelector(':scope > .dew-layer')) return;
+      if (window.getComputedStyle(host).position === 'static') {
+        host.style.position = 'relative';
+      }
+
+      const layer = document.createElement('span');
+      layer.className = 'dew-layer';
+
+      // Density proportional to card area so small and large cards keep a
+      // consistent look (one bead per ~10000 px²), clamped to sane bounds.
+      const cardW = host.offsetWidth || 300;
+      const cardH = host.offsetHeight || 240;
+      // Size the layer explicitly — `inset:0` yields a 0-height box on some
+      // cards (e.g. <details> FAQ items), hiding the drops.
+      layer.style.width = `${cardW}px`;
+      layer.style.height = `${cardH}px`;
+      const area = cardW * cardH;
+      const beads = Math.min(150, Math.max(13, Math.round(area / 10000)));
+      for (let i = 0; i < beads; i += 1) {
+        const drop = document.createElement('span');
+        drop.className = 'dew';
+        drop.style.setProperty('--dx', `${(5 + Math.random() * 90).toFixed(1)}%`);
+        drop.style.setProperty('--dy', `${(5 + Math.random() * 88).toFixed(1)}%`);
+        // skew small: lots of fine beads, a few larger ones
+        const beadSize = 3 + Math.pow(Math.random(), 1.8) * 11;
+        drop.style.setProperty('--ds', `${beadSize.toFixed(1)}px`);
+        layer.appendChild(drop);
+      }
+
+      if (!reduce) {
+        // fewer, more scattered trickling drops (1 per ~230000 px²), 1–5.
+        const runners = Math.min(5, Math.max(1, Math.round(area / 230000)));
+        const cardHeight = cardH;
+        for (let i = 0; i < runners; i += 1) {
+          const run = document.createElement('span');
+          run.className = 'dew-run';
+          run.style.setProperty('--dx', `${(10 + Math.random() * 80).toFixed(1)}%`);
+          run.style.setProperty('--dy', `${(5 + Math.random() * 20).toFixed(1)}%`);
+          run.style.setProperty('--ds', `${(8 + Math.random() * 5).toFixed(1)}px`);
+          run.style.setProperty('--dr-dist', `${Math.round(cardHeight * 0.72)}px`);
+          run.style.setProperty('--dr-trail', `${(135 + Math.random() * 105).toFixed(0)}px`);
+          run.style.setProperty('--dr-dur', `${(4 + Math.random() * 5).toFixed(1)}s`);
+          run.style.setProperty('--dr-delay', `${(Math.random() * 9).toFixed(1)}s`);
+
+          const bead = document.createElement('span');
+          bead.className = 'dew-run__bead';
+          run.appendChild(bead);
+          layer.appendChild(run);
+        }
+      }
+
+      host.appendChild(layer);
+    });
+  }
+
   function onReady(fn) {
     if (document.readyState !== 'loading') {
       fn();
@@ -212,10 +291,18 @@
     setupFoam();
   });
 
+  // Dew density depends on final card sizes — run once layout is settled.
+  if (document.readyState === 'complete') {
+    setupDew();
+  } else {
+    window.addEventListener('load', setupDew);
+  }
+
   global.BBShared = {
     toggleQuestionnaire,
     setupQuestionnaire,
     setupBubbles,
-    setupFoam
+    setupFoam,
+    setupDew
   };
 }(window));

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -135,16 +135,17 @@
     if (!layer) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
-    const count = (options && options.count) || 110;
+    const count = (options && options.count) || 135;
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < count; i += 1) {
       const bubble = document.createElement('span');
       bubble.className = 'bubble';
 
-      // Skew towards small bubbles with a few big ones (like real CO2):
-      // most are 2–8px, some medium, the rare large reaching ~22px.
-      const sizeFactor = Math.pow(Math.random(), 1.7);
+      // Strong skew towards small bubbles with a few big ones (like real
+      // CO2): the bulk are tiny 2–6px fizz, some medium, the rare large
+      // reaching ~22px.
+      const sizeFactor = Math.pow(Math.random(), 2.4);
       const size = 2 + sizeFactor * 20;
       // Larger bubbles tend to be a touch more opaque and rise faster.
       const opacity = 0.25 + sizeFactor * 0.35 + Math.random() * 0.25;

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -135,21 +135,20 @@
     if (!layer) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
-    const count = (options && options.count) || 135;
+    const count = (options && options.count) || 520;
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < count; i += 1) {
       const bubble = document.createElement('span');
       bubble.className = 'bubble';
 
-      // Strong skew towards small bubbles with a few big ones (like real
-      // CO2): the bulk are tiny 2–6px fizz, some medium, the rare large
-      // reaching ~22px.
+      // Strong skew towards small bubbles with a few bigger ones (like real
+      // CO2): the bulk are tiny 2–6px fizz, some medium, the largest ~15px.
       const sizeFactor = Math.pow(Math.random(), 2.4);
-      const size = 2 + sizeFactor * 20;
+      const size = 2 + sizeFactor * 13;
       // Larger bubbles tend to be a touch more opaque and rise faster.
-      const opacity = 0.25 + sizeFactor * 0.35 + Math.random() * 0.25;
-      const duration = 7 + (1 - sizeFactor) * 12 + Math.random() * 3;
+      const opacity = 0.45 + sizeFactor * 0.3 + Math.random() * 0.25;
+      const duration = 5 + (1 - sizeFactor) * 8 + Math.random() * 2;
 
       bubble.style.setProperty('--size', `${size.toFixed(1)}px`);
       bubble.style.setProperty('--x', `${(Math.random() * 100).toFixed(2)}vw`);


### PR DESCRIPTION
## Summary

Two visual changes to the marketing site.

**1. Relocate the Loi Évin responsible-drinking notice.** It was the first thing visible (top of `<main>`, before the hero) and felt intrusive. Moved to a full-bleed dark band at the foot of the page — `--ink` background, copper `18+` badge, foam text — the pattern used by premium spirits sites. Still present, legible and not hidden, so it stays compliant. Also **added the notice to `index-en.html`**, which had none before (compliance gap).

**2. Ambient rising bubbles.** A background layer of CO2 bubbles rising like gas in a glass of beer: randomized size / speed / horizontal sway / opacity, injected by `setupBubbles` in `site.js`, animated in pure CSS, fixed behind all content (`z-index: 0`), and disabled under `prefers-reduced-motion`.

Removed the now-unused `.responsibility-banner` rule.

## Checklist

- [x] Quality gate passes (`python scripts/quality_gate.py`)
- [x] FR + EN twins kept in sync
- [x] No inline styles in HTML; design tokens used; no framework added
- [x] `aria-hidden` on decorative layers; reduced-motion respected
- [x] Responsibility band kept `z-index:1` so it stays above the bubble layer