### PR TITLE
perf(website): lighten bubble/dew rendering (remove backdrop-filter)

### DIFF
--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -428,8 +428,6 @@
       /* a light grey glassy cast (rather than pure white) */
       background: rgba(116, 120, 132, 0.2);
       /* lens / magnify: brighten + sharpen the card seen through the drop */
-      backdrop-filter: brightness(1.16) contrast(1.14) saturate(1.06);
-      -webkit-backdrop-filter: brightness(1.16) contrast(1.14) saturate(1.06);
       box-shadow:
         inset 0 1px 1px rgba(255, 255, 255, 0.36),
         inset 0 -3px 4px rgba(255, 255, 255, 0.42),
@@ -475,8 +473,6 @@
       transform: scale(0.9, 1.26) rotate(45deg);
       /* a touch lighter than the fixed beads to offset the trail behind it */
       background: rgba(116, 120, 132, 0.16);
-      backdrop-filter: brightness(1.16) contrast(1.14) saturate(1.06);
-      -webkit-backdrop-filter: brightness(1.16) contrast(1.14) saturate(1.06);
       box-shadow:
         inset 0 1px 1px rgba(255, 255, 255, 0.36),
         inset 0 -3px 4px rgba(255, 255, 255, 0.42),

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -135,7 +135,7 @@
     if (!layer) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
-    const count = (options && options.count) || 520;
+    const count = (options && options.count) || 110;
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < count; i += 1) {
@@ -177,7 +177,7 @@
     // another so the head reads as a solid foam mass with no visible gaps
     // between droplets. Larger bubbles sit lower (gravity), fine froth on
     // top; high opacity so overlaps stay creamy and continuous.
-    const count = (options && options.count) || 4200;
+    const count = (options && options.count) || 1500;
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < count; i += 1) {
@@ -239,7 +239,7 @@
       layer.style.width = `${cardW}px`;
       layer.style.height = `${cardH}px`;
       const area = cardW * cardH;
-      const beads = Math.min(150, Math.max(13, Math.round(area / 10000)));
+      const beads = Math.min(80, Math.max(7, Math.round(area / 17000)));
       for (let i = 0; i < beads; i += 1) {
         const drop = document.createElement('span');
         drop.className = 'dew';


### PR DESCRIPTION
Fixes display artifacts (stray dark pixels) and janky animation reported after #1057. Root cause: backdrop-filter on ~440 droplet elements + ~5500 DOM nodes. Removes backdrop-filter (visual preserved via highlight/rim/shadow) and reduces counts (foam 4200->1500, bubbles 520->110, dew ~halved). ~2200 nodes, 0 backdrop-filter. Docs-only behaviour change, quality gate green.