### PR TITLE
fix(website): Firefox mascot-ghost compositing artifact + density rebalance

### DIFF
--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -75,11 +75,16 @@
       pointer-events: none;
       z-index: 0;
       background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.3 0 0 0 0 0.2 0 0 0 0 0.1 0 0 0 0.06 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
-      opacity: 0.55;
-      mix-blend-mode: multiply;
+      opacity: 0.4;
     }
 
     main, header, footer { position: relative; z-index: 1; }
+
+    /* Isolate the hero so its high-contrast mascot can't ghost into the
+       fixed background layers on some GPUs (compositing artifact). */
+    .hero {
+      isolation: isolate;
+    }
 
     ::selection { background: var(--copper); color: var(--foam); }
 
@@ -297,6 +302,10 @@
       z-index: 0;
       overflow: hidden;
       pointer-events: none;
+      /* own GPU layer — avoids Firefox ghosting of scrolling content
+         (e.g. the mascot) into this fixed layer. */
+      transform: translateZ(0);
+      backface-visibility: hidden;
     }
 
     .bubble {
@@ -368,6 +377,9 @@
       z-index: 0;
       height: clamp(172px, 19vw, 264px);
       pointer-events: none;
+      /* own GPU layer (Firefox ghosting fix) */
+      transform: translateZ(0);
+      backface-visibility: hidden;
       background: linear-gradient(
         to bottom,
         rgba(255, 253, 248, 0.98) 0%,
@@ -704,6 +716,8 @@
       object-fit: contain;
       filter: drop-shadow(0 8px 16px rgba(60, 35, 16, 0.22));
       animation: bobble 3s ease-in-out infinite;
+      /* keep the high-contrast mascot on its own layer (Firefox ghosting fix) */
+      backface-visibility: hidden;
     }
 
     @keyframes heroFloat {

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -135,7 +135,7 @@
     if (!layer) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
-    const count = (options && options.count) || 110;
+    const count = (options && options.count) || 170;
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < count; i += 1) {
@@ -177,7 +177,7 @@
     // another so the head reads as a solid foam mass with no visible gaps
     // between droplets. Larger bubbles sit lower (gravity), fine froth on
     // top; high opacity so overlaps stay creamy and continuous.
-    const count = (options && options.count) || 1500;
+    const count = (options && options.count) || 2600;
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < count; i += 1) {
@@ -239,7 +239,7 @@
       layer.style.width = `${cardW}px`;
       layer.style.height = `${cardH}px`;
       const area = cardW * cardH;
-      const beads = Math.min(80, Math.max(7, Math.round(area / 17000)));
+      const beads = Math.min(110, Math.max(9, Math.round(area / 13000)));
       for (let i = 0; i < beads; i += 1) {
         const drop = document.createElement('span');
         drop.className = 'dew';


### PR DESCRIPTION
Follow-up to #1057/#1059. On Firefox the mascot ghosted into the fixed bubble/foam layers (GPU compositing artifact); Chrome was fine. Fix: promote .bubbles, .beer-foam and the mascot to their own GPU layers (translateZ(0)/backface-visibility), drop mix-blend-mode:multiply on the grain overlay (kept via opacity), isolate the hero. backdrop-filter stays removed. Density rebalanced (foam 2600, bubbles 170, dew a bit denser) — ~3400 nodes vs ~5500 original. Quality gate green.