### PR TITLE
docs(log): record website perf (#1059) + Firefox compositing fix (#1060)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,11 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-05-21
 
+### PRs #1062 + #1063 merged — mobile responsive fix + accessible burger menu
+
+- PR #1062 (`fix(website)`): cards rendered left-shifted with horizontal scroll on mobile. Cause: `setupDew` baked an absolute px width/height into each `.dew-layer`, which went stale on viewport change and overflowed the (unclipped) cards, pushing `scrollWidth` past the viewport (measured 771 vs ~485 at 390px). Fix: size the layer to its host in CSS (`100%/100%`); `offsetWidth/Height` kept only for bead-count scaling. Deployed.
+- PR #1063 (`feat(website)`): accessible mobile burger menu (≤760px) — header links collapse behind a toggle into a dropdown panel; desktop unchanged. Re-applied on top of current `main` (the original work sat on a stale pre-ambiance base) so bubbles/foam/dew are fully preserved (verified open + closed locally). `setupMenu()` handles `data-open`, link-close, Escape. Review follow-ups: focus moves to the destination section on link-close (Copilot), and a `js`/`no-js` `<html>` flip keeps the nav visible without JavaScript (Codex P2). Quality-gate rules + regression test added. Deployed.
+
 ### PRs #1059 + #1060 merged — website ambiance perf + Firefox compositing fix (follow-ups to #1057)
 
 - PR #1059 (`aa5faa9`) `perf(website)`: the dew "lens" used `backdrop-filter` on ~440 elements (~5500 DOM nodes total) → compositing artifacts + jank. Removed `backdrop-filter` (look kept via highlight/rim/shadow) and cut counts.

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,11 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-05-21
 
+### PRs #1059 + #1060 merged — website ambiance perf + Firefox compositing fix (follow-ups to #1057)
+
+- PR #1059 (`aa5faa9`) `perf(website)`: the dew "lens" used `backdrop-filter` on ~440 elements (~5500 DOM nodes total) → compositing artifacts + jank. Removed `backdrop-filter` (look kept via highlight/rim/shadow) and cut counts.
+- PR #1060 (`12a7d4b`) `fix(website)`: on Firefox the high-contrast mascot ghosted into the fixed bubble/foam layers (GPU artifact; Chrome unaffected). Promoted `.bubbles`/`.beer-foam`/mascot to their own GPU layers (`translateZ(0)`/`backface-visibility`), dropped `mix-blend-mode:multiply` on the grain overlay (kept via opacity), isolated the hero. Density rebalanced (foam 2600, bubbles 170, dew denser) — ~3400 nodes vs ~5500, 0 `backdrop-filter`. Deployed.
+
 ### PR #1057 merged (`bd56bb2`) — feat(website): "glass of beer" ambiance + 18+ band relocation
 
 - Branch `feat/website-responsibility-band`. Moves the Loi Évin 18+ notice from the top of the page to a full-bleed dark bottom band (FR + EN — the EN page previously had no notice, gap closed). Adds the "page = glass of beer" ambiance: rising CO2 bubbles accelerating up to the foam, a compact foam head crowning the top, condensation droplets on every card (perled beads + pear-shaped trickles with tapering fading trails), and an amber/gold backdrop deepening downward. Pure CSS/JS, no framework, `prefers-reduced-motion` respected.

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -15,7 +15,7 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 ### PRs #1059 + #1060 merged — website ambiance perf + Firefox compositing fix (follow-ups to #1057)
 
 - PR #1059 (`aa5faa9`) `perf(website)`: the dew "lens" used `backdrop-filter` on ~440 elements (~5500 DOM nodes total) → compositing artifacts + jank. Removed `backdrop-filter` (look kept via highlight/rim/shadow) and cut counts.
-- PR #1060 (`12a7d4b`) `fix(website)`: on Firefox the high-contrast mascot ghosted into the fixed bubble/foam layers (GPU artifact; Chrome unaffected). Promoted `.bubbles`/`.beer-foam`/mascot to their own GPU layers (`translateZ(0)`/`backface-visibility`), dropped `mix-blend-mode:multiply` on the grain overlay (kept via opacity), isolated the hero. Density rebalanced (foam 2600, bubbles 170, dew denser) — ~3400 nodes vs ~5500, 0 `backdrop-filter`. Deployed.
+- PR #1060 (`12a7d4b`) `fix(website)`: on Firefox the high-contrast mascot ghosted into the fixed bubble/foam layers (GPU artifact; Chrome unaffected). Promoted `.bubbles`/`.beer-foam` to their own GPU layers (`translateZ(0)` + `backface-visibility`) and gave the mascot `.logo` `backface-visibility:hidden`, dropped `mix-blend-mode:multiply` on the grain overlay (kept via opacity), isolated the hero. Density rebalanced (foam 2600, bubbles 170, dew denser) — ~3400 nodes vs ~5500, and no `backdrop-filter` on the droplet/foam ambiance layers (the `.site-header`/`.pill`/questionnaire chrome keep theirs by design). Deployed.
 
 ### PR #1057 merged (`bd56bb2`) — feat(website): "glass of beer" ambiance + 18+ band relocation
 


### PR DESCRIPTION
## Summary
Records two operational entries in PROJECT_LOG.md:
- **#1059** — removed `backdrop-filter` on dew/foam droplets and cut element counts to fix animation jank.
- **#1060** — eliminated the Firefox-only compositing ghost (mascot bleed in fixed layers) via GPU layer promotion, and rebalanced droplet/bubble density.

Documentation only. No code or website asset changes; does not trigger a deploy.

## Verification
- Both PRs merged to `main` and Website Deploy succeeded for each.
- Live site current at HEAD 12a7d4b.