### PR TITLE
fix(website): stop dew layer from overflowing cards on mobile

### DIFF
--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -421,8 +421,13 @@
       position: absolute;
       top: 0;
       left: 0;
-      /* width/height set in JS from the measured card (some cards, e.g.
-         <details> FAQ items, give a 0-height box with inset:0). */
+      /* Match the host via percentages, not baked-in pixels: a px width
+         measured at one viewport stays stale after a resize/orientation
+         change and overflows the card, causing horizontal page scroll on
+         mobile. 100%/100% resolves against the (position:relative) host —
+         including the <details> summary the FAQ dew is attached to. */
+      width: 100%;
+      height: 100%;
       z-index: 30;
       border-radius: inherit;
       overflow: hidden;

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -232,12 +232,11 @@
 
       // Density proportional to card area so small and large cards keep a
       // consistent look (one bead per ~10000 px²), clamped to sane bounds.
+      // offsetWidth/Height are read only to size bead counts — the layer
+      // itself is stretched to the host in CSS (100%/100%), so it stays in
+      // sync after a resize instead of overflowing with a stale px width.
       const cardW = host.offsetWidth || 300;
       const cardH = host.offsetHeight || 240;
-      // Size the layer explicitly — `inset:0` yields a 0-height box on some
-      // cards (e.g. <details> FAQ items), hiding the drops.
-      layer.style.width = `${cardW}px`;
-      layer.style.height = `${cardH}px`;
       const area = cardW * cardH;
       const beads = Math.min(110, Math.max(9, Math.round(area / 13000)));
       for (let i = 0; i < beads; i += 1) {


### PR DESCRIPTION
## Problem
On mobile, cards rendered slightly left of centre with a horizontal scroll. The condensation (`.dew-layer`) overlay was sized by `setupDew` with a baked-in pixel width/height measured at load. That value goes stale on any viewport-width change and, since cards do not clip the absolutely-positioned layer, the oversized layer pushed the document `scrollWidth` past the viewport.

Measured on the live site at 390px width: `scrollWidth` 771px vs viewport ~485px; `.dew-layer` baked at 742px.

## Fix
Size the layer to its host in CSS (`width:100%; height:100%`) instead of baking pixels. It now tracks the card on every resize and can never overflow. `offsetWidth/Height` are still read in JS but only to scale bead counts; percentage-based bead positions follow the layer automatically. The `<details>` FAQ host (which originally forced the px sizing) keeps a non-zero box under percentages — verified.

## Verification
- Live-DOM repro of the fix: `scrollWidth` 771 → 485 (overflow eliminated), FAQ dew-layer box 395×103 (drops still visible).
- Local render at 390px: page centred, no horizontal scroll, dew/foam/bubbles intact.

## Scope
FR + EN share `site.css`/`site.js` — both pages covered. No token, copy, or markup changes.