### PR TITLE
feat(website): accessible mobile burger menu for the header nav

### DIFF
--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -1,8 +1,12 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="fr" class="no-js">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Progressive enhancement: flip to `js` so the mobile nav only
+       collapses behind the burger when scripting is available. Without
+       JS the header nav stays visible (no-js fallback). -->
+  <script>document.documentElement.classList.replace('no-js', 'js');</script>
   <title>Brasse-Bouillon — Application de brassage amateur (recettes bière, IBU/ABV, fermentation)</title>
 
   <!-- SEO Meta Tags -->

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -117,7 +117,17 @@
         <img src="logo-hero.png" alt="Brasse-Bouillon" width="50" height="50">
         <span>Brasse-Bouillon</span>
       </a>
-      <nav class="header-nav">
+      <button
+        class="nav-toggle"
+        id="navToggle"
+        type="button"
+        aria-expanded="false"
+        aria-controls="headerNav"
+        aria-label="Ouvrir le menu"
+      >
+        <span class="nav-toggle__bars" aria-hidden="true"></span>
+      </button>
+      <nav class="header-nav" id="headerNav">
         <a href="#journeyFr">Parcours</a>
         <a href="#features">L’app</a>
         <a href="#faq">FAQ</a>
@@ -429,6 +439,10 @@
     function toggleQuestionnaire(lang) {
       BBShared.toggleQuestionnaire({ lang, labels: TOGGLE_LABELS });
     }
+
+    BBShared.setupMenu({
+      labels: { open: 'Ouvrir le menu', close: 'Fermer le menu' }
+    });
 
     BBShared.setupQuestionnaire({
       formId: 'questionnaireFormFr',

--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -36,23 +36,34 @@ REQUIRED_FILES = [
 HTML_RULES = {
     "index.html": [
         (r"<!DOCTYPE html>", "doctype HTML5 manquant"),
-        (r"<html\s+lang=\"fr\"", "balise <html lang=\"fr\"> manquante"),
+        (r"<html\s+lang=\"fr\"", 'balise <html lang="fr"> manquante'),
         (r"<title>.+</title>", "balise <title> manquante"),
         (r"id=\"mainContentFr\"", "ancre principale #mainContentFr manquante"),
         (
             r"<link\s+rel=\"canonical\"\s+href=\""
             r"https://brasse-bouillon\.com/\"",
-            "canonical FR vers "
-            "https://brasse-bouillon.com/ manquante",
+            "canonical FR vers https://brasse-bouillon.com/ manquante",
         ),
         (
             r'"@type"\s*:\s*"Organization"',
             "schema Organization manquant dans index.html",
         ),
+        (
+            r'<nav[^>]*\bid="headerNav"',
+            "id #headerNav manquant sur la nav (cible du menu burger)",
+        ),
+        (
+            r'class="nav-toggle"',
+            "bouton burger .nav-toggle manquant dans le header",
+        ),
+        (
+            r'aria-controls="headerNav"',
+            'attribut aria-controls="headerNav" manquant sur le bouton burger',
+        ),
     ],
     "index-en.html": [
         (r"<!DOCTYPE html>", "doctype HTML5 manquant"),
-        (r"<html\s+lang=\"en\"", "balise <html lang=\"en\"> manquante"),
+        (r"<html\s+lang=\"en\"", 'balise <html lang="en"> manquante'),
         (r"<title>.+</title>", "balise <title> manquante"),
         (r"id=\"mainContentEn\"", "ancre principale #mainContentEn manquante"),
         (
@@ -62,8 +73,7 @@ HTML_RULES = {
         (
             r"<link\s+rel=\"canonical\"\s+href=\""
             r"https://brasse-bouillon\.com/\"",
-            "canonical EN vers "
-            "https://brasse-bouillon.com/ manquante",
+            "canonical EN vers https://brasse-bouillon.com/ manquante",
         ),
     ],
 }
@@ -187,8 +197,7 @@ def check_sitemap_policy(root: Path = ROOT) -> list[str]:
     if loc_values != [HOMEPAGE_URL]:
         found = ", ".join(loc_values) if loc_values else "aucune URL"
         errors.append(
-            "sitemap.xml: doit contenir uniquement "
-            f"{HOMEPAGE_URL} (trouvé: {found})"
+            f"sitemap.xml: doit contenir uniquement {HOMEPAGE_URL} (trouvé: {found})"
         )
 
     return errors
@@ -213,9 +222,7 @@ def check_robots_policy(root: Path = ROOT) -> list[str]:
 
     for directive in ROBOTS_REQUIRED_DIRECTIVES:
         if directive.lower() not in known_directives:
-            errors.append(
-                f"robots.txt: directive requise manquante: {directive}"
-            )
+            errors.append(f"robots.txt: directive requise manquante: {directive}")
 
     return errors
 

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -220,9 +220,90 @@
       transform: translateY(-2px) scale(1.03);
     }
 
+    /* Burger toggle — hidden on desktop, revealed at the mobile breakpoint. */
+    .nav-toggle {
+      display: none;
+      width: 44px;
+      height: 44px;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+      color: var(--ink);
+      transition: background-color 0.2s var(--ease-out-soft);
+    }
+
+    .nav-toggle:hover { background: rgba(58, 40, 24, 0.06); }
+
+    .nav-toggle__bars,
+    .nav-toggle__bars::before,
+    .nav-toggle__bars::after {
+      content: '';
+      display: block;
+      width: 20px;
+      height: 2px;
+      border-radius: 2px;
+      background: var(--ink);
+      transition: transform 0.22s var(--ease-out-soft), opacity 0.22s var(--ease-out-soft);
+    }
+
+    .nav-toggle__bars { position: relative; }
+    .nav-toggle__bars::before { position: absolute; top: -6px; left: 0; }
+    .nav-toggle__bars::after { position: absolute; top: 6px; left: 0; }
+
+    .nav-toggle[aria-expanded='true'] .nav-toggle__bars { background: transparent; }
+    .nav-toggle[aria-expanded='true'] .nav-toggle__bars::before { transform: translateY(6px) rotate(45deg); }
+    .nav-toggle[aria-expanded='true'] .nav-toggle__bars::after { transform: translateY(-6px) rotate(-45deg); }
+
     @media (max-width: 760px) {
-      .header-nav { gap: 18px; font-size: 0.88rem; }
-      .header-nav .header-cta { padding: 8px 14px; }
+      .nav-toggle { display: inline-flex; }
+
+      /* Nav collapses into a dropdown panel under the sticky header. */
+      .header-nav {
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        flex-direction: column;
+        align-items: stretch;
+        gap: 4px;
+        padding: 10px 24px 18px;
+        background: rgba(255, 252, 244, 0.97);
+        backdrop-filter: blur(14px) saturate(1.15);
+        -webkit-backdrop-filter: blur(14px) saturate(1.15);
+        border-bottom: 1px solid var(--line);
+        box-shadow: var(--shadow-md);
+        /* Closed state — removed from layout and tab order. */
+        visibility: hidden;
+        opacity: 0;
+        transform: translateY(-8px);
+        pointer-events: none;
+        transition: opacity 0.22s var(--ease-out-soft),
+          transform 0.22s var(--ease-out-soft), visibility 0.22s;
+      }
+
+      .header-nav[data-open='true'] {
+        visibility: visible;
+        opacity: 1;
+        transform: translateY(0);
+        pointer-events: auto;
+      }
+
+      /* Comfortable touch targets (>= 44px) for each link. */
+      .header-nav a {
+        padding: 12px 4px;
+        font-size: 1rem;
+      }
+
+      .header-nav a:not(.header-cta)::after { display: none; }
+
+      .header-nav .header-cta {
+        margin-top: 6px;
+        text-align: center;
+        padding: 13px 14px;
+      }
     }
 
     /* ---- Page shell ---- */

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -258,10 +258,12 @@
     .nav-toggle[aria-expanded='true'] .nav-toggle__bars::after { transform: translateY(-6px) rotate(-45deg); }
 
     @media (max-width: 760px) {
-      .nav-toggle { display: inline-flex; }
+      /* Burger + collapse are gated on `.js`: without scripting the toggle
+         can't work, so the nav must stay visible (no-js fallback). */
+      .js .nav-toggle { display: inline-flex; }
 
       /* Nav collapses into a dropdown panel under the sticky header. */
-      .header-nav {
+      .js .header-nav {
         position: absolute;
         top: 100%;
         left: 0;

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -124,6 +124,49 @@
   }
 
   /**
+   * Wires the mobile header burger button to the collapsible nav. The nav's
+   * open state is held on `data-open`; CSS reveals it only at the mobile
+   * breakpoint. Closes after following an in-page link and on Escape (then
+   * returns focus to the toggle). No-ops when either element is absent.
+   */
+  function setupMenu(options = {}) {
+    const navId = options.navId || 'headerNav';
+    const toggleId = options.toggleId || 'navToggle';
+    const labels = options.labels || { open: 'Ouvrir le menu', close: 'Fermer le menu' };
+
+    const nav = document.getElementById(navId);
+    const toggle = document.getElementById(toggleId);
+    if (!nav || !toggle) return;
+
+    function setOpen(next) {
+      nav.dataset.open = String(next);
+      toggle.setAttribute('aria-expanded', String(next));
+      toggle.setAttribute('aria-label', next ? labels.close : labels.open);
+    }
+
+    setOpen(false);
+
+    toggle.addEventListener('click', () => {
+      setOpen(nav.dataset.open !== 'true');
+    });
+
+    // Close after following an in-page link.
+    nav.querySelectorAll('a').forEach((link) => {
+      link.addEventListener('click', () => {
+        if (nav.dataset.open === 'true') setOpen(false);
+      });
+    });
+
+    // Close on Escape and return focus to the toggle.
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && nav.dataset.open === 'true') {
+        setOpen(false);
+        toggle.focus();
+      }
+    });
+  }
+
+  /**
    * Populates a `.bubbles` layer with rising CO₂ bubbles, like gas in a
    * glass of beer. Each bubble gets randomized custom properties (size,
    * horizontal position, duration, start delay, sway amplitude, opacity)
@@ -299,6 +342,7 @@
   global.BBShared = {
     toggleQuestionnaire,
     setupQuestionnaire,
+    setupMenu,
     setupBubbles,
     setupFoam,
     setupDew

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -150,10 +150,23 @@
       setOpen(nav.dataset.open !== 'true');
     });
 
-    // Close after following an in-page link.
+    // Close after following an in-page link. Focus would otherwise stay on
+    // the link CSS is about to hide, so move it to the destination section
+    // (same-page hash) — falling back to the toggle — to keep keyboard /
+    // assistive-tech focus on a visible element.
     nav.querySelectorAll('a').forEach((link) => {
       link.addEventListener('click', () => {
-        if (nav.dataset.open === 'true') setOpen(false);
+        if (nav.dataset.open !== 'true') return;
+        setOpen(false);
+
+        const hash = link.getAttribute('href') || '';
+        const target = hash.startsWith('#') ? document.getElementById(hash.slice(1)) : null;
+        if (target) {
+          if (!target.hasAttribute('tabindex')) target.setAttribute('tabindex', '-1');
+          target.focus({ preventScroll: true });
+        } else {
+          toggle.focus();
+        }
       });
     });
 

--- a/packages/website/tests/test_quality_gate.py
+++ b/packages/website/tests/test_quality_gate.py
@@ -18,7 +18,7 @@ def _create_valid_fixture(base: Path) -> None:
     _write_file(base, "CONTRIBUTING.md", "# contributing\n")
     _write_file(base, "favicon.ico", "ico")
     legal_html_template = (
-        "<!DOCTYPE html><html lang=\"{lang}\"><head>"
+        '<!DOCTYPE html><html lang="{lang}"><head>'
         "<title>{title}</title></head><body></body></html>"
     )
     legal_pages = [
@@ -49,6 +49,13 @@ def _create_valid_fixture(base: Path) -> None:
   <script type="application/ld+json">{"@type":"Organization"}</script>
 </head>
 <body>
+  <header class="site-header"><div class="header-inner">
+    <button class="nav-toggle" id="navToggle" type="button"
+      aria-expanded="false" aria-controls="headerNav" aria-label="Ouvrir le menu">
+      <span class="nav-toggle__bars"></span>
+    </button>
+    <nav class="header-nav" id="headerNav"><a href="#features">L'app</a></nav>
+  </div></header>
   <main id="mainContentFr"></main>
 </body>
 </html>
@@ -126,9 +133,7 @@ class QualityGateTests(unittest.TestCase):
             )
 
             errors = quality_gate.collect_errors(root)
-            self.assertTrue(
-                any("meta robots noindex,follow" in err for err in errors)
-            )
+            self.assertTrue(any("meta robots noindex,follow" in err for err in errors))
 
     def test_detects_disallowed_software_application_schema(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -146,8 +151,23 @@ class QualityGateTests(unittest.TestCase):
 
             errors = quality_gate.collect_errors(root)
             expected = "SoftwareApplication non autorisé"
+            self.assertTrue(any(expected in err for err in errors))
+
+    def test_detects_missing_burger_toggle(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            fr_path = root / "index.html"
+            fr_content = fr_path.read_text(encoding="utf-8")
+            # Drop the burger button — header nav becomes inaccessible on mobile.
+            fr_path.write_text(
+                fr_content.replace('class="nav-toggle"', 'class="removed"'),
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.collect_errors(root)
             self.assertTrue(
-                any(expected in err for err in errors)
+                any("bouton burger .nav-toggle manquant" in err for err in errors)
             )
 
     def test_detects_sitemap_not_fr_only(self) -> None:
@@ -167,9 +187,7 @@ class QualityGateTests(unittest.TestCase):
 
             errors = quality_gate.collect_errors(root)
             expected = "sitemap.xml: doit contenir uniquement"
-            self.assertTrue(
-                any(expected in err for err in errors)
-            )
+            self.assertTrue(any(expected in err for err in errors))
 
     def test_detects_missing_robots_directive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -185,10 +203,7 @@ Sitemap: https://brasse-bouillon.com/sitemap.xml
 
             errors = quality_gate.collect_errors(root)
             self.assertTrue(
-                any(
-                    "directive requise manquante: Allow: /" in err
-                    for err in errors
-                )
+                any("directive requise manquante: Allow: /" in err for err in errors)
             )
 
     def test_detects_disallowed_aggregate_rating_fields(self) -> None:
@@ -210,12 +225,8 @@ Sitemap: https://brasse-bouillon.com/sitemap.xml
             self.assertTrue(
                 any("aggregateRating non autorisé" in err for err in errors)
             )
-            self.assertTrue(
-                any("ratingValue non autorisé" in err for err in errors)
-            )
-            self.assertTrue(
-                any("ratingCount non autorisé" in err for err in errors)
-            )
+            self.assertTrue(any("ratingValue non autorisé" in err for err in errors))
+            self.assertTrue(any("ratingCount non autorisé" in err for err in errors))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Adds a mobile burger menu to the marketing site header. Below 760px the nav links collapse behind a toggle that opens a dropdown panel under the sticky header; the desktop layout is unchanged above the breakpoint.

This work was started on a stale base (pre-dating the beer-glass ambiance) and is **re-applied here on top of current `main`**, so the bubbles / foam / dew ambiance and the recent fixes (#1057, #1059, #1060, #1062) are fully preserved — verified locally (menu closed + open, ambiance intact, no horizontal overflow).

## Changes
- **index.html** — `.nav-toggle` button with `aria-expanded` / `aria-controls="headerNav"` / dynamic `aria-label`; `id="headerNav"` on the nav; `BBShared.setupMenu()` call.
- **site.js** — `setupMenu()`: toggles `data-open`, closes after following an in-page link and on Escape (returning focus to the toggle). No-ops when elements are absent.
- **site.css** — `.nav-toggle` (44×44 touch target, bars animate to an X) and the mobile dropdown nav. Desktop nav untouched.
- **quality_gate.py + test** — three structural rules asserting the burger markup is present, plus a regression test.

## Accessibility
- Toggle is a real `<button>` with `aria-expanded`, `aria-controls`, and a state-aware `aria-label`.
- Closed nav is removed from layout and tab order (`visibility:hidden` + `pointer-events:none`).
- Escape closes and restores focus; 44px+ touch targets.

## Verification
- `python scripts/quality_gate.py` ✓ and `pytest tests/` ✓ (8 passed, incl. new burger test).
- Local mobile render at 390px: toggle reveals/hides the dropdown, ambiance intact.

## Note
`index-en.html` is the coming-soon stub with no multi-link nav, so it needs no burger; the gate rules are scoped to `index.html`.