### PR TITLE
chore(website): cache-bust site.css/site.js with a version query

### DIFF
--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="site.css">
+  <link rel="stylesheet" href="site.css?v=20260521">
 </head>
 <body>
   <a class="skip-link" href="#mainContentEn">Skip to main content</a>
@@ -77,6 +77,6 @@
     </div>
   </aside>
 
-  <script src="site.js"></script>
+  <script src="site.js?v=20260521"></script>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -42,7 +42,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="site.css">
+  <link rel="stylesheet" href="site.css?v=20260521">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -431,7 +431,7 @@
     </div>
   </aside>
 
-  <script src="site.js"></script>
+  <script src="site.js?v=20260521"></script>
   <script>
     const QUESTIONNAIRE_ENDPOINT = 'https://formspree.io/f/xeellqan';
     const NEWSLETTER_ENDPOINT = 'https://formspree.io/f/mqaqqvab';


### PR DESCRIPTION
## Why
`site.css` and `site.js` have stable, unversioned filenames, so browsers keep serving the cached copy after a deploy. Users miss shipped fixes (e.g. the mobile burger menu and the dew-overflow fix) until they manually clear their cache — exactly the symptom reported.

## What
Append `?v=20260521` to the stylesheet and script URLs on both homepages (`index.html`, `index-en.html`). The browser treats a new query string as a new URL and re-fetches; the file on disk is unchanged. Bump the value whenever `site.css`/`site.js` changes.

## Cost
None functionally: no extra request, no extra payload, no DOM/JS change — only the asset URL label differs.

## Verification
- Quality gate ✓, `pytest tests/` ✓ (8 passed). No gate rule depends on the bare asset string.
- Live site already serves the correct (post-#1062/#1063) assets; this prevents future stale-cache misses.