### PR TITLE
perf(website): drop the foam layer, trim bubbles and trickle drops

### DIFF
--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -18,12 +18,11 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="site.css?v=20260521">
+  <link rel="stylesheet" href="site.css?v=20260521-2">
 </head>
 <body>
   <a class="skip-link" href="#mainContentEn">Skip to main content</a>
   <div class="bubbles" aria-hidden="true"></div>
-  <div class="beer-foam" aria-hidden="true"></div>
 
   <header class="site-header">
     <div class="header-inner">
@@ -77,6 +76,6 @@
     </div>
   </aside>
 
-  <script src="site.js?v=20260521"></script>
+  <script src="site.js?v=20260521-2"></script>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -42,7 +42,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="site.css?v=20260521">
+  <link rel="stylesheet" href="site.css?v=20260521-2">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -113,7 +113,6 @@
   <a class="skip-link" href="#mainContentFr">Aller au contenu principal</a>
   <div class="scroll-progress" aria-hidden="true"><span></span></div>
   <div class="bubbles" aria-hidden="true"></div>
-  <div class="beer-foam" aria-hidden="true"></div>
 
   <header class="site-header">
     <div class="header-inner">
@@ -431,7 +430,7 @@
     </div>
   </aside>
 
-  <script src="site.js?v=20260521"></script>
+  <script src="site.js?v=20260521-2"></script>
   <script>
     const QUESTIONNAIRE_ENDPOINT = 'https://formspree.io/f/xeellqan';
     const NEWSLETTER_ENDPOINT = 'https://formspree.io/f/mqaqqvab';

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -420,11 +420,12 @@
         inset 1px 1px 2px rgba(255, 255, 255, 0.45),
         0 0 3px rgba(120, 90, 50, 0.18);
       opacity: 0;
-      will-change: translate, transform, opacity;
       /* Rise (Y) and sway (X) are split across the `translate` and
          `transform` properties so the acceleration isn't linearised by
-         sway waypoints. The bubble rises continuously to the top (foam),
-         fading only at the very top — never stopping mid-screen. */
+         sway waypoints. The bubble rises continuously to the top, fading
+         only at the very top — never stopping mid-screen. No `will-change`:
+         it would pin a permanent GPU layer per bubble (memory churn on
+         mobile); the compositor still promotes the animating transform. */
       animation:
         bubble-rise var(--dur) cubic-bezier(0.45, 0, 0.85, 0.4) var(--delay)
           infinite,
@@ -446,49 +447,6 @@
 
     @media (prefers-reduced-motion: reduce) {
       .bubbles { display: none; }
-    }
-
-    /* ========================================================================
-       BEER FOAM — creamy head crowning the very top of the page
-       ====================================================================== */
-
-    .beer-foam {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      z-index: 0;
-      height: clamp(172px, 19vw, 264px);
-      pointer-events: none;
-      /* own GPU layer (Firefox ghosting fix) */
-      transform: translateZ(0);
-      backface-visibility: hidden;
-      background: linear-gradient(
-        to bottom,
-        rgba(255, 253, 248, 0.98) 0%,
-        rgba(254, 248, 233, 0.88) 55%,
-        rgba(251, 243, 218, 0.4) 84%,
-        rgba(251, 243, 218, 0) 100%
-      );
-      /* Organic foam bubbles are injected by site.js (setupFoam). */
-    }
-
-    .foam-bubble {
-      position: absolute;
-      left: var(--fx);
-      bottom: var(--fy);
-      width: var(--fs);
-      height: var(--fs);
-      border-radius: 50%;
-      transform: translate(-50%, 50%);
-      opacity: var(--fo);
-      background: radial-gradient(
-        circle at 36% 30%,
-        #ffffff 0 36%,
-        #fbf3da 74%,
-        #efe0b8 100%
-      );
-      box-shadow: 0 1px 2px rgba(150, 120, 70, 0.18);
     }
 
     /* ========================================================================

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -518,7 +518,10 @@
       width: var(--ds);
       height: var(--ds);
       pointer-events: none;
-      /* accelerating fall (gravity): slow start, speeding up. */
+      /* accelerating fall (gravity): slow start, speeding up. `--dr-dur` is
+         the whole cycle, mostly idle — the fall occupies only its first
+         ~22%, so a drip appears occasionally rather than looping nonstop
+         (animation-delay alone only delays the first iteration). */
       animation: dew-run var(--dr-dur) cubic-bezier(0.6, 0.04, 0.98, 0.34)
         var(--dr-delay) infinite;
     }
@@ -573,14 +576,17 @@
     }
 
     @keyframes dew-run {
+      /* The fall happens in the first ~22% of the cycle; the rest is idle
+         (invisible, parked at the bottom) so a drip is occasional. */
       0% { transform: translateY(0); opacity: 0; }
-      10% { opacity: 1; }
-      88% { opacity: 1; }
+      2% { opacity: 1; }
+      22% { transform: translateY(var(--dr-dist)); opacity: 1; }
+      26% { transform: translateY(var(--dr-dist)); opacity: 0; }
       100% { transform: translateY(var(--dr-dist)); opacity: 0; }
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .dew--run { animation: none; }
+      .dew-run { animation: none; }
     }
 
     /* ========================================================================

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -283,8 +283,11 @@
           run.style.setProperty('--ds', `${(8 + Math.random() * 5).toFixed(1)}px`);
           run.style.setProperty('--dr-dist', `${Math.round(cardH * 0.72)}px`);
           run.style.setProperty('--dr-trail', `${(135 + Math.random() * 105).toFixed(0)}px`);
-          run.style.setProperty('--dr-dur', `${(5 + Math.random() * 4).toFixed(1)}s`);
-          run.style.setProperty('--dr-delay', `${(2 + Math.random() * 16).toFixed(1)}s`);
+          // Full cycle is mostly idle (the fall is ~22% of it), so a 12–20s
+          // duration yields a drip roughly every 12–20s, plus a staggered
+          // first-appearance delay so they don't all fall in unison.
+          run.style.setProperty('--dr-dur', `${(12 + Math.random() * 8).toFixed(1)}s`);
+          run.style.setProperty('--dr-delay', `${(Math.random() * 14).toFixed(1)}s`);
 
           const bead = document.createElement('span');
           bead.className = 'dew-run__bead';

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -191,7 +191,7 @@
     if (!layer) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
-    const count = (options && options.count) || 170;
+    const count = (options && options.count) || 120;
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < count; i += 1) {
@@ -216,42 +216,6 @@
     }
 
     layer.appendChild(fragment);
-  }
-
-  /**
-   * Fills a `.beer-foam` background layer with irregular foam bubbles —
-   * varied size / position / opacity, denser and larger near the bottom
-   * so the underside reads as an organic, lumpy head spilling into the
-   * beer (rather than a regular tiled pattern). No-ops when the layer is
-   * absent.
-   */
-  function setupFoam(options) {
-    const foam = document.querySelector('.beer-foam');
-    if (!foam) return;
-
-    // Dense overlapping placement: many bubbles piled on top of one
-    // another so the head reads as a solid foam mass with no visible gaps
-    // between droplets. Larger bubbles sit lower (gravity), fine froth on
-    // top; high opacity so overlaps stay creamy and continuous.
-    const count = (options && options.count) || 2600;
-    const fragment = document.createDocumentFragment();
-
-    for (let i = 0; i < count; i += 1) {
-      const bubble = document.createElement('span');
-      bubble.className = 'foam-bubble';
-
-      const vy = Math.pow(Math.random(), 1.35);
-      const size = 9 + (1 - vy) * 44 + Math.random() * 12;
-      const bottomPx = vy * 232 - 26;
-
-      bubble.style.setProperty('--fx', `${(Math.random() * 100).toFixed(2)}%`);
-      bubble.style.setProperty('--fy', `${bottomPx.toFixed(0)}px`);
-      bubble.style.setProperty('--fs', `${size.toFixed(0)}px`);
-      bubble.style.setProperty('--fo', (0.85 + Math.random() * 0.15).toFixed(2));
-      fragment.appendChild(bubble);
-    }
-
-    foam.appendChild(fragment);
   }
 
   /**
@@ -307,19 +271,20 @@
       }
 
       if (!reduce) {
-        // fewer, more scattered trickling drops (1 per ~230000 px²), 1–5.
-        const runners = Math.min(5, Math.max(1, Math.round(area / 230000)));
-        const cardHeight = cardH;
-        for (let i = 0; i < runners; i += 1) {
+        // A trickling drop is rare and expensive: at most one per card, and
+        // only on roughly half the cards, with a long random delay so a drip
+        // appears only "every so often" rather than continuously.
+        const hasRunner = Math.random() < 0.5;
+        if (hasRunner) {
           const run = document.createElement('span');
           run.className = 'dew-run';
           run.style.setProperty('--dx', `${(10 + Math.random() * 80).toFixed(1)}%`);
           run.style.setProperty('--dy', `${(5 + Math.random() * 20).toFixed(1)}%`);
           run.style.setProperty('--ds', `${(8 + Math.random() * 5).toFixed(1)}px`);
-          run.style.setProperty('--dr-dist', `${Math.round(cardHeight * 0.72)}px`);
+          run.style.setProperty('--dr-dist', `${Math.round(cardH * 0.72)}px`);
           run.style.setProperty('--dr-trail', `${(135 + Math.random() * 105).toFixed(0)}px`);
-          run.style.setProperty('--dr-dur', `${(4 + Math.random() * 5).toFixed(1)}s`);
-          run.style.setProperty('--dr-delay', `${(Math.random() * 9).toFixed(1)}s`);
+          run.style.setProperty('--dr-dur', `${(5 + Math.random() * 4).toFixed(1)}s`);
+          run.style.setProperty('--dr-delay', `${(2 + Math.random() * 16).toFixed(1)}s`);
 
           const bead = document.createElement('span');
           bead.className = 'dew-run__bead';
@@ -342,7 +307,6 @@
 
   onReady(function () {
     setupBubbles();
-    setupFoam();
   });
 
   // Dew density depends on final card sizes — run once layout is settled.
@@ -357,7 +321,6 @@
     setupQuestionnaire,
     setupMenu,
     setupBubbles,
-    setupFoam,
     setupDew
   };
 }(window));


### PR DESCRIPTION
## Why
Mobile felt janky. Profiling (mobile, 4× CPU throttle) pinned the cause: the page had **3315 DOM elements, 2600 of them the `.beer-foam` head** (78% of the page), driving style recalc over 5887 elements (54ms) and layout over 3344 nodes (50ms). The foam is also **mostly hidden behind the cards**, so it costs a lot for little visible benefit.

## What
- **Remove the foam layer entirely** — `.beer-foam` div (both homepages), `setupFoam` (JS), and the `.beer-foam`/`.foam-bubble` CSS. A foam rendered as a single **image** is planned as a later, much cheaper pass.
- **Bubbles:** 170 → 120 and drop the per-bubble `will-change` (it pinned a permanent GPU layer per bubble; the compositor still promotes the animating transform).
- **Dew:** keep the cheap static perled beads; make the expensive *trickling* drop **rare** — at most one per card, only ~half the cards, with a long random delay so a drip appears only occasionally.
- **Cache-bust** bumped to `?v=20260521-2` so visitors fetch the new build.

## Impact
DOM ~3300 → ~700 nodes. Golden backdrop, rising bubbles and fixed beads preserved.

## Verification
- Quality gate ✓, `pytest tests/` ✓ (8 passed), `node --check site.js` ✓.
- Local mobile render (390px): foam gone, golden background + bubbles + beads intact, burger menu working.