### PR TITLE
fix(mobile/batches): pin demo fermentation tracker to J+5 / J+14

### DIFF
--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -68,9 +68,8 @@ function useFermentationTrackerInfo(batch: Batch | null) {
     // always shows J+5 / J+14; `startedAt` is still required above as the
     // signal that fermentation has actually begun.
     const daysElapsed = DEMO_FERMENTATION_DAYS_ELAPSED;
-    const progressPct = Math.round(
-      (daysElapsed / DEMO_FERMENTATION_TARGET_DAYS) * 100,
-    );
+    const ratio = daysElapsed / DEMO_FERMENTATION_TARGET_DAYS;
+    const progressPct = Math.round(ratio * 100);
 
     // Estimate the current gravity as a linear interpolation between
     // the recipe's OG and FG using the fermentation progress. Real
@@ -79,7 +78,6 @@ function useFermentationTrackerInfo(batch: Batch | null) {
     const recipe = demoRecipes.find((r) => r.id === batch.recipeId);
     const og = recipe?.stats?.og ?? 1.048;
     const fg = recipe?.stats?.fg ?? 1.012;
-    const ratio = daysElapsed / DEMO_FERMENTATION_TARGET_DAYS;
     const currentSg = og - (og - fg) * ratio;
 
     return {

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -22,8 +22,12 @@ import { demoRecipes } from "@/mocks/demo-data";
 import { getErrorMessage } from "@/core/http/http-error";
 import { useRouter } from "expo-router";
 
-const DAY_MS = 24 * 60 * 60 * 1000;
 const DEMO_FERMENTATION_TARGET_DAYS = 14;
+// Pinned so the demo fermentation always reads exactly "J+5 / J+14" — the
+// state the marketing site showcases. Deriving the day count from a fixed
+// past `startedAt` would drift with the calendar (and disagree with the
+// step's own "jour 5 sur 14" copy).
+const DEMO_FERMENTATION_DAYS_ELAPSED = 5;
 const DEMO_FERMENTATION_TEMPERATURE_C = 19;
 
 // Dynamic widths cannot live in `StyleSheet.create()` because they
@@ -60,15 +64,10 @@ function useFermentationTrackerInfo(batch: Batch | null) {
       return null;
     }
 
-    const startedAt = new Date(currentStep.startedAt);
-    if (Number.isNaN(startedAt.getTime())) {
-      return null;
-    }
-    const elapsedMs = Math.max(0, Date.now() - startedAt.getTime());
-    const daysElapsed = Math.min(
-      DEMO_FERMENTATION_TARGET_DAYS,
-      Math.floor(elapsedMs / DAY_MS),
-    );
+    // The day count is pinned (not derived from `startedAt`) so the demo
+    // always shows J+5 / J+14; `startedAt` is still required above as the
+    // signal that fermentation has actually begun.
+    const daysElapsed = DEMO_FERMENTATION_DAYS_ELAPSED;
     const progressPct = Math.round(
       (daysElapsed / DEMO_FERMENTATION_TARGET_DAYS) * 100,
     );

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -173,6 +173,25 @@ describe("BatchDetailsScreen — demo-mode fermentation tracker", () => {
     expect(screen.getByText("idéal 18–20 °C")).toBeTruthy();
   });
 
+  it("pins the headline to J+5 even when fermentation started long ago (regression)", async () => {
+    const longAgo = new Date(
+      Date.now() - 40 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const longAgoBatch = {
+      ...fermentationInProgressBatch,
+      steps: fermentationInProgressBatch.steps.map((step) =>
+        step.stepOrder === 2 ? { ...step, startedAt: longAgo } : step,
+      ),
+    };
+    (getBatchDetails as jest.Mock).mockResolvedValue(longAgoBatch);
+
+    renderBatchDetailsScreen("b-demo-pdd-ferm");
+
+    // A date-derived count would cap at J+14 here; the demo pin keeps J+5.
+    expect(await screen.findByText("Fermentation")).toBeTruthy();
+    expect(screen.getByText("J+5 / J+14")).toBeTruthy();
+  });
+
   it("hides the fermentation card in live mode (sad path)", async () => {
     dataSource.useDemoData = false;
 


### PR DESCRIPTION
## Problem
The demo-mode fermentation tracker on `BatchDetailsScreen` derived its day count from a fixed past `startedAt` (`2026-05-14`). So the headline drifted with the calendar — today it would read **J+7 / J+14** — while the step's own copy says "jour 5 sur 14". This is the exact screen the marketing site showcases for journey step 3 ("Suis la fermentation"), so the capture must be deterministic.

## Fix
Pin `daysElapsed` to a demo constant (`DEMO_FERMENTATION_DAYS_ELAPSED = 5`) instead of computing it from `startedAt`. The card now always reads **J+5 / J+14** with a consistent ~1.035 gravity, independent of the capture date. `startedAt` is still required as the signal that fermentation has begun. Demo-mode only — no backend/live-mode impact.

## Tests
- Existing demo-fermentation suite still green (J+5 headline, gravity 1.035, hidden in live mode / wrong step / not-yet-started).
- **New regression test**: a fermentation started 40 days ago still renders J+5 (a date-derived count would have capped at J+14).
- `npm run ci:check` (lint + typecheck + format) green; 8/8 tests pass.

## Context
Wave 1 prep for refreshing the website's placeholder screenshots with real app captures (journey step 3). Part of the app→site capture initiative.