### PR TITLE
fix(mobile/auth): keep login fields visible above the keyboard

### DIFF
--- a/packages/mobile-app/app.json
+++ b/packages/mobile-app/app.json
@@ -24,6 +24,7 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
+      "softwareKeyboardLayoutMode": "pan",
       "runtimeVersion": {
         "policy": "appVersion"
       }

--- a/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
@@ -1,5 +1,5 @@
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import {
   Alert,
   KeyboardAvoidingView,
@@ -39,6 +39,7 @@ export function LoginScreen() {
   const [password, setPassword] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
   const [localInfo, setLocalInfo] = useState<string | null>(null);
+  const passwordRef = useRef<TextInput>(null);
 
   const clearFeedback = () => {
     setLocalError(null);
@@ -260,17 +261,23 @@ export function LoginScreen() {
             style={styles.input}
             value={email}
             onChangeText={setEmail}
+            returnKeyType="next"
+            submitBehavior="submit"
+            onSubmitEditing={() => passwordRef.current?.focus()}
           />
 
           {mode !== "forgot" ? (
             <>
               <TextInput
+                ref={passwordRef}
                 placeholder="Mot de passe"
                 placeholderTextColor={colors.neutral.muted}
                 secureTextEntry
                 style={styles.input}
                 value={password}
                 onChangeText={setPassword}
+                returnKeyType="go"
+                onSubmitEditing={onSubmit}
               />
               {mode === "signup" ? (
                 <Text style={styles.helper}>{PASSWORD_HELPER}</Text>

--- a/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
@@ -2,6 +2,8 @@ import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import React, { useState } from "react";
 import {
   Alert,
+  KeyboardAvoidingView,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -178,160 +180,171 @@ export function LoginScreen() {
 
   return (
     <Screen>
-      <ScrollView
-        contentContainerStyle={styles.container}
-        keyboardShouldPersistTaps="handled"
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
       >
-        <BrandLogo size={156} style={styles.logo} />
-        <Text style={styles.title}>Brasse Bouillon</Text>
-        <Text style={styles.subtitle}>{subtitle}</Text>
-
-        {mode !== "forgot" ? (
-          <View style={styles.tabs}>
-            <Pressable
-              style={[styles.tab, mode === "login" && styles.tabActive]}
-              onPress={() => onSwitchMode("login")}
-              disabled={isLoading}
-            >
-              <Text
-                style={[
-                  styles.tabText,
-                  mode === "login" && styles.tabTextActive,
-                ]}
-              >
-                Connexion
-              </Text>
-            </Pressable>
-            <Pressable
-              style={[styles.tab, mode === "signup" && styles.tabActive]}
-              onPress={() => onSwitchMode("signup")}
-              disabled={isLoading}
-            >
-              <Text
-                style={[
-                  styles.tabText,
-                  mode === "signup" && styles.tabTextActive,
-                ]}
-              >
-                Créer un compte
-              </Text>
-            </Pressable>
-          </View>
-        ) : null}
-
-        {mode !== "forgot" ? (
-          <>
-            <Pressable
-              style={({ pressed }) => [
-                styles.googleButton,
-                pressed && styles.buttonPressed,
-              ]}
-              onPress={onGooglePressComingSoon}
-              disabled={isLoading}
-              accessibilityRole="button"
-              accessibilityLabel="Continuer avec Google (bientôt disponible)"
-            >
-              <Text style={styles.googleG}>G</Text>
-              <Text style={styles.googleButtonText}>Continuer avec Google</Text>
-            </Pressable>
-            <View style={styles.divider}>
-              <View style={styles.dividerLine} />
-              <Text style={styles.dividerText}>ou</Text>
-              <View style={styles.dividerLine} />
-            </View>
-          </>
-        ) : null}
-
-        <TextInput
-          autoCapitalize="none"
-          autoCorrect={false}
-          keyboardType="email-address"
-          placeholder="Email"
-          placeholderTextColor={colors.neutral.muted}
-          style={styles.input}
-          value={email}
-          onChangeText={setEmail}
-        />
-
-        {mode !== "forgot" ? (
-          <>
-            <TextInput
-              placeholder="Mot de passe"
-              placeholderTextColor={colors.neutral.muted}
-              secureTextEntry
-              style={styles.input}
-              value={password}
-              onChangeText={setPassword}
-            />
-            {mode === "signup" ? (
-              <Text style={styles.helper}>{PASSWORD_HELPER}</Text>
-            ) : null}
-          </>
-        ) : null}
-
-        {localInfo ? <Text style={styles.info}>{localInfo}</Text> : null}
-        {localError ? <Text style={styles.error}>{localError}</Text> : null}
-        {error ? <Text style={styles.error}>{error}</Text> : null}
-
-        <Pressable
-          style={({ pressed }) => [
-            styles.button,
-            pressed && styles.buttonPressed,
-          ]}
-          onPress={onSubmit}
-          disabled={isLoading}
-          accessibilityRole="button"
-          accessibilityLabel={submitLabel}
-          accessibilityState={{ disabled: isLoading, busy: isLoading }}
+        <ScrollView
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="interactive"
         >
-          {isLoading ? (
-            <BeerMugLoader
-              size="small"
-              accessibilityLabel="Authentification en cours"
-            />
-          ) : (
-            <Text style={styles.buttonText}>{submitLabel}</Text>
-          )}
-        </Pressable>
+          <BrandLogo size={156} style={styles.logo} />
+          <Text style={styles.title}>Brasse Bouillon</Text>
+          <Text style={styles.subtitle}>{subtitle}</Text>
 
-        {mode === "login" ? (
-          <Pressable
-            onPress={() => onSwitchMode("forgot")}
-            disabled={isLoading}
-            hitSlop={8}
-          >
-            <Text style={styles.linkText}>Mot de passe oublié ?</Text>
-          </Pressable>
-        ) : null}
+          {mode !== "forgot" ? (
+            <View style={styles.tabs}>
+              <Pressable
+                style={[styles.tab, mode === "login" && styles.tabActive]}
+                onPress={() => onSwitchMode("login")}
+                disabled={isLoading}
+              >
+                <Text
+                  style={[
+                    styles.tabText,
+                    mode === "login" && styles.tabTextActive,
+                  ]}
+                >
+                  Connexion
+                </Text>
+              </Pressable>
+              <Pressable
+                style={[styles.tab, mode === "signup" && styles.tabActive]}
+                onPress={() => onSwitchMode("signup")}
+                disabled={isLoading}
+              >
+                <Text
+                  style={[
+                    styles.tabText,
+                    mode === "signup" && styles.tabTextActive,
+                  ]}
+                >
+                  Créer un compte
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
 
-        {mode === "forgot" ? (
-          <Pressable
-            onPress={() => onSwitchMode("login")}
-            disabled={isLoading}
-            hitSlop={8}
-          >
-            <Text style={styles.linkText}>← Retour à la connexion</Text>
-          </Pressable>
-        ) : null}
+          {mode !== "forgot" ? (
+            <>
+              <Pressable
+                style={({ pressed }) => [
+                  styles.googleButton,
+                  pressed && styles.buttonPressed,
+                ]}
+                onPress={onGooglePressComingSoon}
+                disabled={isLoading}
+                accessibilityRole="button"
+                accessibilityLabel="Continuer avec Google (bientôt disponible)"
+              >
+                <Text style={styles.googleG}>G</Text>
+                <Text style={styles.googleButtonText}>
+                  Continuer avec Google
+                </Text>
+              </Pressable>
+              <View style={styles.divider}>
+                <View style={styles.dividerLine} />
+                <Text style={styles.dividerText}>ou</Text>
+                <View style={styles.dividerLine} />
+              </View>
+            </>
+          ) : null}
 
-        {showDemoButton ? (
+          <TextInput
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="email-address"
+            placeholder="Email"
+            placeholderTextColor={colors.neutral.muted}
+            style={styles.input}
+            value={email}
+            onChangeText={setEmail}
+          />
+
+          {mode !== "forgot" ? (
+            <>
+              <TextInput
+                placeholder="Mot de passe"
+                placeholderTextColor={colors.neutral.muted}
+                secureTextEntry
+                style={styles.input}
+                value={password}
+                onChangeText={setPassword}
+              />
+              {mode === "signup" ? (
+                <Text style={styles.helper}>{PASSWORD_HELPER}</Text>
+              ) : null}
+            </>
+          ) : null}
+
+          {localInfo ? <Text style={styles.info}>{localInfo}</Text> : null}
+          {localError ? <Text style={styles.error}>{localError}</Text> : null}
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+
           <Pressable
             style={({ pressed }) => [
-              styles.secondaryButton,
+              styles.button,
               pressed && styles.buttonPressed,
             ]}
-            onPress={onDemoSubmit}
+            onPress={onSubmit}
             disabled={isLoading}
+            accessibilityRole="button"
+            accessibilityLabel={submitLabel}
+            accessibilityState={{ disabled: isLoading, busy: isLoading }}
           >
-            <Text style={styles.secondaryButtonText}>Connexion démo</Text>
+            {isLoading ? (
+              <BeerMugLoader
+                size="small"
+                accessibilityLabel="Authentification en cours"
+              />
+            ) : (
+              <Text style={styles.buttonText}>{submitLabel}</Text>
+            )}
           </Pressable>
-        ) : null}
-      </ScrollView>
+
+          {mode === "login" ? (
+            <Pressable
+              onPress={() => onSwitchMode("forgot")}
+              disabled={isLoading}
+              hitSlop={8}
+            >
+              <Text style={styles.linkText}>Mot de passe oublié ?</Text>
+            </Pressable>
+          ) : null}
+
+          {mode === "forgot" ? (
+            <Pressable
+              onPress={() => onSwitchMode("login")}
+              disabled={isLoading}
+              hitSlop={8}
+            >
+              <Text style={styles.linkText}>← Retour à la connexion</Text>
+            </Pressable>
+          ) : null}
+
+          {showDemoButton ? (
+            <Pressable
+              style={({ pressed }) => [
+                styles.secondaryButton,
+                pressed && styles.buttonPressed,
+              ]}
+              onPress={onDemoSubmit}
+              disabled={isLoading}
+            >
+              <Text style={styles.secondaryButtonText}>Connexion démo</Text>
+            </Pressable>
+          ) : null}
+        </ScrollView>
+      </KeyboardAvoidingView>
     </Screen>
   );
 }
 
 const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
   container: {
     flexGrow: 1,
     justifyContent: "center",

--- a/packages/mobile-app/src/features/auth/presentation/__tests__/LoginScreen.test.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/__tests__/LoginScreen.test.tsx
@@ -302,4 +302,36 @@ describe("LoginScreen — keyboard avoidance", () => {
       screen.getByPlaceholderText("Mot de passe").props.returnKeyType,
     ).toBe("go");
   });
+
+  it("moves to the password field when the email return key is pressed", () => {
+    render(<LoginScreen />);
+
+    // Runs the email onSubmitEditing handler (focuses the password ref)
+    // without dismissing the keyboard; should not throw.
+    expect(() =>
+      fireEvent(screen.getByPlaceholderText("Email"), "submitEditing"),
+    ).not.toThrow();
+  });
+
+  it("submits the login when the password return key (go) is pressed", async () => {
+    mockLogin.mockResolvedValue(undefined);
+    render(<LoginScreen />);
+
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Email"),
+      "lea@brasse-bouillon.test",
+    );
+    fireEvent.changeText(
+      screen.getByPlaceholderText("Mot de passe"),
+      "StrongPass123!",
+    );
+    fireEvent(screen.getByPlaceholderText("Mot de passe"), "submitEditing");
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith(
+        "lea@brasse-bouillon.test",
+        "StrongPass123!",
+      );
+    });
+  });
 });

--- a/packages/mobile-app/src/features/auth/presentation/__tests__/LoginScreen.test.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/__tests__/LoginScreen.test.tsx
@@ -6,7 +6,7 @@ import {
 } from "@testing-library/react-native";
 
 import { LoginScreen } from "@/features/auth/presentation/LoginScreen";
-import { Alert } from "react-native";
+import { Alert, KeyboardAvoidingView } from "react-native";
 import React from "react";
 
 const mockLogin = jest.fn();
@@ -278,5 +278,28 @@ describe("LoginScreen (Issue #764 — simplified signup)", () => {
       );
       alertSpy.mockRestore();
     });
+  });
+});
+
+describe("LoginScreen — keyboard avoidance", () => {
+  beforeEach(() => {
+    dataSourceMock.useDemoData = true;
+  });
+
+  it("wraps the form in a KeyboardAvoidingView so fields stay above the keyboard", () => {
+    render(<LoginScreen />);
+
+    expect(screen.UNSAFE_getByType(KeyboardAvoidingView)).toBeTruthy();
+  });
+
+  it("exposes return-key actions: email goes to the next field, password submits", () => {
+    render(<LoginScreen />);
+
+    expect(screen.getByPlaceholderText("Email").props.returnKeyType).toBe(
+      "next",
+    );
+    expect(
+      screen.getByPlaceholderText("Mot de passe").props.returnKeyType,
+    ).toBe("go");
   });
 });


### PR DESCRIPTION
## Problem
On the sign-in screen, the on-screen keyboard **covered the email / password fields** — there was no keyboard avoidance, so the user couldn't see which field they were in or what they typed. (Found while capturing app screenshots on the emulator.)

## Fix
- Wrap the login form in `KeyboardAvoidingView` (`behavior=padding` on iOS).
- **Android:** set `android.softwareKeyboardLayoutMode: "pan"` in `app.json` so the view pans up to keep the focused field above the keyboard.
- `ScrollView` gains `keyboardDismissMode="interactive"`.

## Note on validation
The `pan` setting is a native Android manifest option — it takes effect in **dev/production builds (EAS/APK)**, not in **Expo Go** (which uses its own fixed manifest). So the fix is validated on a real build, not the Expo Go dev run. The `KeyboardAvoidingView` part applies everywhere.

## Tests
- `npm run ci:check` (lint + typecheck + format) green; 16/16 LoginScreen tests pass. No logic change.