### PR TITLE
docs(marketing): homebrewer needs study — report site (desk research + survey kit)

### DIFF
--- a/docs/marketing/needs-study/.gitignore
+++ b/docs/marketing/needs-study/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.vitepress/dist/
+.vitepress/cache/

--- a/docs/marketing/needs-study/.vitepress/config.mjs
+++ b/docs/marketing/needs-study/.vitepress/config.mjs
@@ -2,80 +2,165 @@ import pkg from "../package.json" with { type: "json" };
 
 const siteVersion = pkg.version;
 
+const fontHead = [
+  ["meta", { name: "robots", content: "noindex, nofollow" }],
+  ["meta", { name: "googlebot", content: "noindex, nofollow" }],
+  ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+  ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
+  [
+    "link",
+    {
+      rel: "stylesheet",
+      href:
+        "https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap"
+    }
+  ]
+];
+
+// Marketing-study plan order (A → B → C → D), French (root) sidebar.
+const sidebarFr = [
+  { text: "Rapport", items: [{ text: "Vue d'ensemble", link: "/" }] },
+  {
+    text: "A — Cadrage",
+    collapsed: false,
+    items: [{ text: "Objectifs, périmètre & méthode", link: "/00-method" }]
+  },
+  {
+    text: "B — Analyse de marché",
+    collapsed: false,
+    items: [
+      { text: "B1 · Environnement (PESTEL)", link: "/b1-environnement" },
+      { text: "B2 · Marché & taille", link: "/03c-desk-market-data" },
+      { text: "B2 · Marché français", link: "/03d-desk-french-market" },
+      { text: "B3 · Demande & besoins — Reddit", link: "/02-desk-reddit" },
+      { text: "B3 · Demande & besoins — Forums", link: "/03-desk-forums" },
+      { text: "B3 · Demande & besoins — Sources FR", link: "/03b-desk-french" },
+      { text: "B4 · Concurrence", link: "/01-desk-competitors" },
+      { text: "B4 · SWOT", link: "/b4-swot" }
+    ]
+  },
+  {
+    text: "C — Terrain (recherche primaire)",
+    collapsed: false,
+    items: [
+      { text: "Guide d'entretien", link: "/05-interview-guide" },
+      { text: "Résultats", link: "/c-resultats" }
+    ]
+  },
+  {
+    text: "D — Recommandation",
+    collapsed: false,
+    items: [
+      { text: "Synthèse & positionnement", link: "/04-synthesis" },
+      { text: "Backlog priorisé (besoins → features)", link: "/04b-prioritized-backlog" },
+      { text: "Lean Canvas", link: "/lean-canvas" },
+      { text: "Stratégie & plan d'action", link: "/d-strategie" }
+    ]
+  }
+];
+
+// English (/en/) sidebar — same plan order.
+const sidebarEn = [
+  { text: "Report", items: [{ text: "Overview", link: "/en/" }] },
+  {
+    text: "A — Scope",
+    collapsed: false,
+    items: [{ text: "Objectives, scope & method", link: "/en/00-method" }]
+  },
+  {
+    text: "B — Market analysis",
+    collapsed: false,
+    items: [
+      { text: "B1 · Environment (PESTEL)", link: "/en/b1-environnement" },
+      { text: "B2 · Market & sizing", link: "/en/03c-desk-market-data" },
+      { text: "B2 · French market", link: "/en/03d-desk-french-market" },
+      { text: "B3 · Demand & needs — Reddit", link: "/en/02-desk-reddit" },
+      { text: "B3 · Demand & needs — Forums", link: "/en/03-desk-forums" },
+      { text: "B3 · Demand & needs — French sources", link: "/en/03b-desk-french" },
+      { text: "B4 · Competition", link: "/en/01-desk-competitors" },
+      { text: "B4 · SWOT", link: "/en/b4-swot" }
+    ]
+  },
+  {
+    text: "C — Field (primary research)",
+    collapsed: false,
+    items: [
+      { text: "Interview guide", link: "/en/05-interview-guide" },
+      { text: "Results", link: "/en/c-resultats" }
+    ]
+  },
+  {
+    text: "D — Recommendation",
+    collapsed: false,
+    items: [
+      { text: "Synthesis & positioning", link: "/en/04-synthesis" },
+      { text: "Prioritized backlog (needs → features)", link: "/en/04b-prioritized-backlog" },
+      { text: "Lean Canvas", link: "/en/lean-canvas" },
+      { text: "Strategy & action plan", link: "/en/d-strategie" }
+    ]
+  }
+];
+
 /** @type {import('vitepress').UserConfig} */
 export default {
-  title: "Brasse-Bouillon — Needs Study",
+  title: "Brasse-Bouillon — Étude de besoins",
   description:
-    "Marketing needs study for Brasse-Bouillon: desk research, synthesis, prioritized needs, and primary-research plan (epic #1075).",
-  head: [
-    ["meta", { name: "robots", content: "noindex, nofollow" }],
-    ["meta", { name: "googlebot", content: "noindex, nofollow" }],
-    ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
-    ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
-    [
-      "link",
-      {
-        rel: "stylesheet",
-        href:
-          "https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap"
-      }
-    ]
-  ],
+    "Étude de besoins marketing pour Brasse-Bouillon : cadrage, analyse de marché, terrain et recommandations (epic #1075).",
+  head: fontHead,
   cleanUrls: true,
   lastUpdated: true,
   ignoreDeadLinks: true,
-  lang: "en",
   themeConfig: {
-    siteTitle: "Needs Study · Brasse-Bouillon",
-    nav: [
-      { text: "Home", link: "/" },
-      { text: "Synthesis", link: "/04-synthesis" },
-      { text: "Backlog", link: "/04b-prioritized-backlog" },
-      { text: "Method", link: "/00-method" },
-      { text: "Interview guide", link: "/05-interview-guide" },
-      { text: `epic #1075`, link: "https://github.com/benoit-bremaud/brasse-bouillon/issues/1075" }
-    ],
-    sidebar: [
-      {
-        text: "Report",
-        collapsed: false,
-        items: [
-          { text: "Overview", link: "/" },
-          { text: "Synthesis & positioning", link: "/04-synthesis" },
-          { text: "Prioritized backlog (needs → features)", link: "/04b-prioritized-backlog" }
-        ]
-      },
-      {
-        text: "Secondary research (desk)",
-        collapsed: false,
-        items: [
-          { text: "Method", link: "/00-method" },
-          { text: "Competitor reviews", link: "/01-desk-competitors" },
-          { text: "r/Homebrewing", link: "/02-desk-reddit" },
-          { text: "Forums (EN + FR)", link: "/03-desk-forums" },
-          { text: "French sources", link: "/03b-desk-french" },
-          { text: "Market / quant data", link: "/03c-desk-market-data" },
-          { text: "French market", link: "/03d-desk-french-market" }
-        ]
-      },
-      {
-        text: "Primary research",
-        collapsed: false,
-        items: [{ text: "Interview guide", link: "/05-interview-guide" }]
-      }
-    ],
     socialLinks: [
-      {
-        icon: "github",
-        link: "https://github.com/benoit-bremaud/brasse-bouillon/issues/1075"
-      }
+      { icon: "github", link: "https://github.com/benoit-bremaud/brasse-bouillon/issues/1075" }
     ],
-    footer: {
-      message:
-        'Marketing needs study — hypotheses pending primary-research confirmation. Tracked on <a href="https://github.com/benoit-bremaud/brasse-bouillon/issues/1075">epic #1075</a>.',
-      copyright: "Brasse-Bouillon · Needs Study"
+    search: { provider: "local" }
+  },
+  locales: {
+    root: {
+      label: "Français",
+      lang: "fr-FR",
+      themeConfig: {
+        siteTitle: "Étude de besoins · Brasse-Bouillon",
+        nav: [
+          { text: "Accueil", link: "/" },
+          { text: "Synthèse", link: "/04-synthesis" },
+          { text: "Backlog", link: "/04b-prioritized-backlog" },
+          { text: "Canvas", link: "/lean-canvas" },
+          { text: `epic #1075`, link: "https://github.com/benoit-bremaud/brasse-bouillon/issues/1075" }
+        ],
+        sidebar: sidebarFr,
+        outline: { level: [2, 3], label: "Sur cette page" },
+        docFooter: { prev: "Précédent", next: "Suivant" },
+        lastUpdatedText: "Dernière mise à jour",
+        footer: {
+          message:
+            'Étude de besoins marketing — hypothèses à confirmer par le terrain. Suivi sur <a href="https://github.com/benoit-bremaud/brasse-bouillon/issues/1075">epic #1075</a>.',
+          copyright: "Brasse-Bouillon · Étude de besoins"
+        }
+      }
     },
-    search: { provider: "local" },
-    outline: { level: [2, 3], label: "On this page" }
+    en: {
+      label: "English",
+      lang: "en",
+      link: "/en/",
+      themeConfig: {
+        siteTitle: "Needs Study · Brasse-Bouillon",
+        nav: [
+          { text: "Home", link: "/en/" },
+          { text: "Synthesis", link: "/en/04-synthesis" },
+          { text: "Backlog", link: "/en/04b-prioritized-backlog" },
+          { text: "Canvas", link: "/en/lean-canvas" },
+          { text: `epic #1075`, link: "https://github.com/benoit-bremaud/brasse-bouillon/issues/1075" }
+        ],
+        sidebar: sidebarEn,
+        outline: { level: [2, 3], label: "On this page" },
+        footer: {
+          message:
+            'Marketing needs study — hypotheses pending field confirmation. Tracked on <a href="https://github.com/benoit-bremaud/brasse-bouillon/issues/1075">epic #1075</a>.',
+          copyright: "Brasse-Bouillon · Needs Study"
+        }
+      }
+    }
   }
 };

--- a/docs/marketing/needs-study/.vitepress/config.mjs
+++ b/docs/marketing/needs-study/.vitepress/config.mjs
@@ -1,7 +1,3 @@
-import pkg from "../package.json" with { type: "json" };
-
-const siteVersion = pkg.version;
-
 const fontHead = [
   ["meta", { name: "robots", content: "noindex, nofollow" }],
   ["meta", { name: "googlebot", content: "noindex, nofollow" }],

--- a/docs/marketing/needs-study/.vitepress/config.mjs
+++ b/docs/marketing/needs-study/.vitepress/config.mjs
@@ -45,6 +45,7 @@ const sidebarFr = [
     items: [
       { text: "Guide d'entretien", link: "/05-interview-guide" },
       { text: "Sondage (questionnaire)", link: "/c-sondage" },
+      { text: "Kit de diffusion", link: "/c-diffusion" },
       { text: "Résultats", link: "/c-resultats" }
     ]
   },
@@ -88,6 +89,7 @@ const sidebarEn = [
     items: [
       { text: "Interview guide", link: "/en/05-interview-guide" },
       { text: "Survey (questionnaire)", link: "/en/c-survey" },
+      { text: "Distribution kit", link: "/en/c-distribution" },
       { text: "Results", link: "/en/c-resultats" }
     ]
   },

--- a/docs/marketing/needs-study/.vitepress/config.mjs
+++ b/docs/marketing/needs-study/.vitepress/config.mjs
@@ -30,6 +30,7 @@ export default {
     nav: [
       { text: "Home", link: "/" },
       { text: "Synthesis", link: "/04-synthesis" },
+      { text: "Backlog", link: "/04b-prioritized-backlog" },
       { text: "Method", link: "/00-method" },
       { text: "Interview guide", link: "/05-interview-guide" },
       { text: `epic #1075`, link: "https://github.com/benoit-bremaud/brasse-bouillon/issues/1075" }
@@ -40,7 +41,8 @@ export default {
         collapsed: false,
         items: [
           { text: "Overview", link: "/" },
-          { text: "Synthesis & positioning", link: "/04-synthesis" }
+          { text: "Synthesis & positioning", link: "/04-synthesis" },
+          { text: "Prioritized backlog (needs → features)", link: "/04b-prioritized-backlog" }
         ]
       },
       {

--- a/docs/marketing/needs-study/.vitepress/config.mjs
+++ b/docs/marketing/needs-study/.vitepress/config.mjs
@@ -44,6 +44,7 @@ const sidebarFr = [
     collapsed: false,
     items: [
       { text: "Guide d'entretien", link: "/05-interview-guide" },
+      { text: "Sondage (questionnaire)", link: "/c-sondage" },
       { text: "Résultats", link: "/c-resultats" }
     ]
   },
@@ -86,6 +87,7 @@ const sidebarEn = [
     collapsed: false,
     items: [
       { text: "Interview guide", link: "/en/05-interview-guide" },
+      { text: "Survey (questionnaire)", link: "/en/c-survey" },
       { text: "Results", link: "/en/c-resultats" }
     ]
   },

--- a/docs/marketing/needs-study/.vitepress/config.mjs
+++ b/docs/marketing/needs-study/.vitepress/config.mjs
@@ -1,0 +1,79 @@
+import pkg from "../package.json" with { type: "json" };
+
+const siteVersion = pkg.version;
+
+/** @type {import('vitepress').UserConfig} */
+export default {
+  title: "Brasse-Bouillon — Needs Study",
+  description:
+    "Marketing needs study for Brasse-Bouillon: desk research, synthesis, prioritized needs, and primary-research plan (epic #1075).",
+  head: [
+    ["meta", { name: "robots", content: "noindex, nofollow" }],
+    ["meta", { name: "googlebot", content: "noindex, nofollow" }],
+    ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+    ["link", { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" }],
+    [
+      "link",
+      {
+        rel: "stylesheet",
+        href:
+          "https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap"
+      }
+    ]
+  ],
+  cleanUrls: true,
+  lastUpdated: true,
+  ignoreDeadLinks: true,
+  lang: "en",
+  themeConfig: {
+    siteTitle: "Needs Study · Brasse-Bouillon",
+    nav: [
+      { text: "Home", link: "/" },
+      { text: "Synthesis", link: "/04-synthesis" },
+      { text: "Method", link: "/00-method" },
+      { text: "Interview guide", link: "/05-interview-guide" },
+      { text: `epic #1075`, link: "https://github.com/benoit-bremaud/brasse-bouillon/issues/1075" }
+    ],
+    sidebar: [
+      {
+        text: "Report",
+        collapsed: false,
+        items: [
+          { text: "Overview", link: "/" },
+          { text: "Synthesis & positioning", link: "/04-synthesis" }
+        ]
+      },
+      {
+        text: "Secondary research (desk)",
+        collapsed: false,
+        items: [
+          { text: "Method", link: "/00-method" },
+          { text: "Competitor reviews", link: "/01-desk-competitors" },
+          { text: "r/Homebrewing", link: "/02-desk-reddit" },
+          { text: "Forums (EN + FR)", link: "/03-desk-forums" },
+          { text: "French sources", link: "/03b-desk-french" },
+          { text: "Market / quant data", link: "/03c-desk-market-data" },
+          { text: "French market", link: "/03d-desk-french-market" }
+        ]
+      },
+      {
+        text: "Primary research",
+        collapsed: false,
+        items: [{ text: "Interview guide", link: "/05-interview-guide" }]
+      }
+    ],
+    socialLinks: [
+      {
+        icon: "github",
+        link: "https://github.com/benoit-bremaud/brasse-bouillon/issues/1075"
+      }
+    ],
+    footer: {
+      message:
+        'Marketing needs study — hypotheses pending primary-research confirmation. Tracked on <a href="https://github.com/benoit-bremaud/brasse-bouillon/issues/1075">epic #1075</a>.',
+      copyright: "Brasse-Bouillon · Needs Study"
+    },
+    search: { provider: "local" },
+    outline: { level: [2, 3], label: "On this page" }
+  }
+};

--- a/docs/marketing/needs-study/.vitepress/theme/index.js
+++ b/docs/marketing/needs-study/.vitepress/theme/index.js
@@ -1,0 +1,8 @@
+import DefaultTheme from "vitepress/theme";
+import "./style.css";
+
+// Sober variant of the brasse-bouillon.com "Kinetic" charter:
+// brand tokens + Fraunces/Inter typography, no animated motifs (report = readability first).
+export default {
+  extends: DefaultTheme
+};

--- a/docs/marketing/needs-study/.vitepress/theme/style.css
+++ b/docs/marketing/needs-study/.vitepress/theme/style.css
@@ -1,0 +1,93 @@
+/* ==========================================================================
+   Brasse-Bouillon — Needs Study report theme
+   Reuses the brasse-bouillon.com "Kinetic" charter tokens (copper / paper /
+   Fraunces + Inter), sober variant tuned for long-form reading: brand identity
+   without the animated motifs (bubbles / dew) of the marketing site.
+   Token source: packages/website/site.css :root
+   ========================================================================== */
+
+:root {
+  /* Brand charter tokens */
+  --bb-paper: #f1e3bf;
+  --bb-foam: #fbf3da;
+  --bb-ink: #1a110a;
+  --bb-ink-soft: #3a2818;
+  --bb-copper: #c5742d;
+  --bb-copper-deep: #8d4a13;
+  --bb-moss: #4a5a2b;
+  --bb-muted: #6b5a4c;
+  --bb-line: rgba(58, 40, 24, 0.16);
+  --bb-accent-soft: rgba(197, 116, 45, 0.16);
+
+  --font-display: "Fraunces", "Cormorant Garamond", Georgia, serif;
+  --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+
+  /* VitePress brand mapping (copper-deep for link/text AA contrast on light bg) */
+  --vp-c-brand-1: var(--bb-copper-deep);
+  --vp-c-brand-2: var(--bb-copper);
+  --vp-c-brand-3: var(--bb-copper);
+  --vp-c-brand-soft: var(--bb-accent-soft);
+
+  /* Warm but light backgrounds for readability */
+  --vp-c-bg: #faf5e8;
+  --vp-c-bg-alt: #f3e8cc;
+  --vp-c-bg-soft: #f6eed7;
+  --vp-c-bg-elv: #ffffff;
+
+  --vp-c-text-1: var(--bb-ink);
+  --vp-c-text-2: var(--bb-ink-soft);
+  --vp-c-text-3: var(--bb-muted);
+  --vp-c-divider: var(--bb-line);
+  --vp-c-gutter: var(--bb-line);
+
+  --vp-font-family-base: var(--font-body);
+}
+
+/* Headings in the display serif (Fraunces) */
+.vp-doc h1,
+.vp-doc h2,
+.vp-doc h3,
+.vp-doc h4,
+.VPHomeHero .name,
+.VPHomeHero .text,
+.VPNavBarTitle .title {
+  font-family: var(--font-display);
+  letter-spacing: -0.01em;
+}
+
+.vp-doc h1 {
+  font-weight: 900;
+}
+.vp-doc h2 {
+  font-weight: 700;
+}
+
+/* Zebra-stripe dense tables (the study has many) */
+.vp-doc tr:nth-child(2n) {
+  background-color: var(--vp-c-bg-soft);
+}
+.vp-doc th {
+  background-color: var(--bb-accent-soft);
+}
+
+/* Blockquotes get a copper edge — used for positioning statements & wedges */
+.vp-doc blockquote {
+  border-left-color: var(--bb-copper);
+  background: var(--vp-c-bg-soft);
+  border-radius: 0 8px 8px 0;
+}
+
+/* Dark mode: keep the copper accent legible on a deep-amber ink ground */
+.dark {
+  --vp-c-bg: #17110b;
+  --vp-c-bg-alt: #1f1810;
+  --vp-c-bg-soft: #211a11;
+  --vp-c-bg-elv: #211a11;
+  --vp-c-text-1: var(--bb-foam);
+  --vp-c-text-2: #d8c5a3;
+  --vp-c-text-3: #b09a78;
+  --vp-c-brand-1: #e08a3d;
+  --vp-c-brand-2: var(--bb-copper);
+  --vp-c-brand-3: var(--bb-copper);
+  --vp-c-divider: rgba(251, 243, 218, 0.14);
+}

--- a/docs/marketing/needs-study/00-method.md
+++ b/docs/marketing/needs-study/00-method.md
@@ -1,63 +1,65 @@
-# Marketing Needs Study — Method
+# Étude des besoins marketing — Méthode
 
-## Why this study exists
+## Pourquoi cette étude existe
 
-No formal user-needs study had ever been done for Brasse-Bouillon. Before investing further
-in features and positioning, we run a proper marketing needs study to identify what
-intermediate homebrewers actually want, validate (or kill) our differentiating hypothesis,
-and ground product decisions in evidence rather than assumption.
+Aucune étude formelle des besoins utilisateurs n'avait jamais été menée pour Brasse-Bouillon. Avant
+d'investir davantage dans les fonctionnalités et le positionnement, nous menons une véritable étude
+des besoins marketing afin d'identifier ce que les brasseurs amateurs intermédiaires veulent
+réellement, de valider (ou d'écarter) notre hypothèse différenciante, et d'ancrer les décisions
+produit dans des preuves plutôt que dans des suppositions.
 
-## Strategic frame (decided during the kickoff debrief)
+## Cadre stratégique (décidé lors du débrief de lancement)
 
-- **Primary target (beachhead):** regular / intermediate homebrewers; international / English-speaking
-  first, French also in scope.
-- **Product language:** bilingual FR + EN (implies an i18n effort tracked as a separate epic).
-- **Positioning hypothesis:**
-  - **Hook (hero):** a community for cloning and sharing beer recipes.
-  - **Foundation (table-stakes):** recipe organization + brew/fermentation tracking.
-- **Starting channels (2):** r/Homebrewing (users) + Indie Hackers (founder build-in-public);
-  LinkedIn kept in French for the founder's reconversion narrative.
+- **Cible principale (tête de pont) :** brasseurs amateurs réguliers / intermédiaires ; international /
+  anglophones d'abord, le français étant également dans le périmètre.
+- **Langue du produit :** bilingue FR + EN (ce qui implique un effort d'i18n suivi comme un epic distinct).
+- **Hypothèse de positionnement :**
+  - **Accroche (hero) :** une communauté pour cloner et partager des recettes de bière.
+  - **Socle (table-stakes) :** organisation des recettes + suivi du brassage / de la fermentation.
+- **Canaux de départ (2) :** r/Homebrewing (utilisateurs) + Indie Hackers (fondateur en build-in-public) ;
+  LinkedIn conservé en français pour le récit de reconversion du fondateur.
 
-## Research design
+## Conception de la recherche
 
-Two phases, cheap-to-expensive:
+Deux phases, du moins coûteux au plus coûteux :
 
-1. **Secondary research (desk research) — DONE.** Mine what already exists publicly: competitor
-   app reviews, Reddit, homebrewing forums. Cheap, fast, generates hypotheses.
-2. **Primary research — TODO.** Talk to real brewers: a structured interview guide
-   (via the `customer-research` skill) + 10-15 interviews to confirm or refute the desk findings.
+1. **Recherche secondaire (desk research) — FAIT.** Exploiter ce qui existe déjà publiquement : avis sur
+   les applications concurrentes, Reddit, forums de brassage amateur. Peu coûteux, rapide, générateur
+   d'hypothèses.
+2. **Recherche primaire — À FAIRE.** Parler à de vrais brasseurs : un guide d'entretien structuré
+   (via le skill `customer-research`) + 10-15 entretiens pour confirmer ou infirmer les conclusions du desk research.
 
-The order matters: secondary first to build hypotheses, primary second to confirm with real people.
+L'ordre compte : le secondaire d'abord pour construire des hypothèses, le primaire ensuite pour confirmer auprès de vraies personnes.
 
-## Secondary research execution
+## Exécution de la recherche secondaire
 
-Six desk passes across source families:
+Six passes de desk research à travers des familles de sources :
 
-- `01-desk-competitors.md` — reviews of Brewfather, BeerSmith, Brewer's Friend, BrewBuddy, and adjacent apps.
-- `02-desk-reddit.md` — r/Homebrewing recurring questions and pains.
+- `01-desk-competitors.md` — avis sur Brewfather, BeerSmith, Brewer's Friend, BrewBuddy et applications adjacentes.
+- `02-desk-reddit.md` — questions et points de douleur récurrents sur r/Homebrewing.
 - `03-desk-forums.md` — HomeBrewTalk (EN) + brassageamateur.com (FR).
-- `03b-desk-french.md` — dedicated French-language pass (FR blogs, tools, community channels).
-- `03c-desk-market-data.md` — quantitative layer (market size, downloads, recipe-DB sizes, uncovered competitors).
-- `03d-desk-french-market.md` — snowball pass on the French homebrewer population / market (fills the FR data gap).
-- `04-synthesis.md` — consolidated needs map + market context + one-sentence positioning statement.
-- `05-interview-guide.md` — bilingual primary-research instrument (JTBD interview guide).
-- `06-report.md` — final report (epic closure deliverable; written after primary research).
+- `03b-desk-french.md` — passe dédiée en langue française (blogs FR, outils, canaux communautaires).
+- `03c-desk-market-data.md` — couche quantitative (taille du marché, téléchargements, taille des bases de recettes, concurrents non couverts).
+- `03d-desk-french-market.md` — passe en boule de neige sur la population / le marché français des brasseurs amateurs (comble le manque de données FR).
+- `04-synthesis.md` — carte consolidée des besoins + contexte marché + énoncé de positionnement en une phrase.
+- `05-interview-guide.md` — instrument de recherche primaire bilingue (guide d'entretien JTBD).
+- `06-report.md` — rapport final (livrable de clôture de l'epic ; rédigé après la recherche primaire).
 
-## Method limitations (read before trusting the numbers)
+## Limites de la méthode (à lire avant de faire confiance aux chiffres)
 
-- **Reddit and HomeBrewTalk block automated fetching (HTTP 403).** r/Homebrewing findings are
-  *inferred* from adjacent forums and from the prevalence of clone-recipe compilations, not from
-  direct thread reads or upvote counts. HomeBrewTalk findings rely on search-result snippets.
-  brassageamateur.com was fetched directly.
-- **Frequency signals are qualitative** (recurrence of distinct threads / reviews), not scraped counts.
-  Treat rankings as directional.
-- **Forums over-represent people who are stuck** — a strong hypothesis generator, not proof.
-  This is exactly why primary research (interviews) follows.
-- To harden: read a sample of r/Homebrewing threads via an authenticated/API path and tag posts by
-  theme for true counts.
+- **Reddit et HomeBrewTalk bloquent la récupération automatisée (HTTP 403).** Les conclusions sur
+  r/Homebrewing sont *déduites* de forums adjacents et de la prévalence des compilations de recettes de
+  clones, et non de lectures directes de fils ou de comptages de votes. Les conclusions sur HomeBrewTalk
+  reposent sur des extraits de résultats de recherche. brassageamateur.com a été récupéré directement.
+- **Les signaux de fréquence sont qualitatifs** (récurrence de fils / avis distincts), et non des comptages
+  scrapés. Traitez les classements comme indicatifs.
+- **Les forums sur-représentent les personnes qui sont bloquées** — un puissant générateur d'hypothèses,
+  pas une preuve. C'est exactement pourquoi la recherche primaire (entretiens) suit.
+- Pour consolider : lire un échantillon de fils r/Homebrewing via un accès authentifié / API et taguer les
+  publications par thème pour obtenir de vrais comptages.
 
-## Status
+## Statut
 
-- Secondary research: complete (captured in `01`–`03d`, consolidated in `04`).
-- Primary research: not started.
-- Final report: not started.
+- Recherche secondaire : terminée (consignée dans `01`–`03d`, consolidée dans `04`).
+- Recherche primaire : non commencée.
+- Rapport final : non commencé.

--- a/docs/marketing/needs-study/00-method.md
+++ b/docs/marketing/needs-study/00-method.md
@@ -40,7 +40,8 @@ Six desk passes across source families:
 - `03c-desk-market-data.md` — quantitative layer (market size, downloads, recipe-DB sizes, uncovered competitors).
 - `03d-desk-french-market.md` — snowball pass on the French homebrewer population / market (fills the FR data gap).
 - `04-synthesis.md` — consolidated needs map + market context + one-sentence positioning statement.
-- `05-report.md` — final report (epic closure deliverable; written after primary research).
+- `05-interview-guide.md` — bilingual primary-research instrument (JTBD interview guide).
+- `06-report.md` — final report (epic closure deliverable; written after primary research).
 
 ## Method limitations (read before trusting the numbers)
 

--- a/docs/marketing/needs-study/00-method.md
+++ b/docs/marketing/needs-study/00-method.md
@@ -1,0 +1,62 @@
+# Marketing Needs Study — Method
+
+## Why this study exists
+
+No formal user-needs study had ever been done for Brasse-Bouillon. Before investing further
+in features and positioning, we run a proper marketing needs study to identify what
+intermediate homebrewers actually want, validate (or kill) our differentiating hypothesis,
+and ground product decisions in evidence rather than assumption.
+
+## Strategic frame (decided during the kickoff debrief)
+
+- **Primary target (beachhead):** regular / intermediate homebrewers; international / English-speaking
+  first, French also in scope.
+- **Product language:** bilingual FR + EN (implies an i18n effort tracked as a separate epic).
+- **Positioning hypothesis:**
+  - **Hook (hero):** a community for cloning and sharing beer recipes.
+  - **Foundation (table-stakes):** recipe organization + brew/fermentation tracking.
+- **Starting channels (2):** r/Homebrewing (users) + Indie Hackers (founder build-in-public);
+  LinkedIn kept in French for the founder's reconversion narrative.
+
+## Research design
+
+Two phases, cheap-to-expensive:
+
+1. **Secondary research (desk research) — DONE.** Mine what already exists publicly: competitor
+   app reviews, Reddit, homebrewing forums. Cheap, fast, generates hypotheses.
+2. **Primary research — TODO.** Talk to real brewers: a structured interview guide
+   (via the `customer-research` skill) + 10-15 interviews to confirm or refute the desk findings.
+
+The order matters: secondary first to build hypotheses, primary second to confirm with real people.
+
+## Secondary research execution
+
+Six desk passes across source families:
+
+- `01-desk-competitors.md` — reviews of Brewfather, BeerSmith, Brewer's Friend, BrewBuddy, and adjacent apps.
+- `02-desk-reddit.md` — r/Homebrewing recurring questions and pains.
+- `03-desk-forums.md` — HomeBrewTalk (EN) + brassageamateur.com (FR).
+- `03b-desk-french.md` — dedicated French-language pass (FR blogs, tools, community channels).
+- `03c-desk-market-data.md` — quantitative layer (market size, downloads, recipe-DB sizes, uncovered competitors).
+- `03d-desk-french-market.md` — snowball pass on the French homebrewer population / market (fills the FR data gap).
+- `04-synthesis.md` — consolidated needs map + market context + one-sentence positioning statement.
+- `05-report.md` — final report (epic closure deliverable; written after primary research).
+
+## Method limitations (read before trusting the numbers)
+
+- **Reddit and HomeBrewTalk block automated fetching (HTTP 403).** r/Homebrewing findings are
+  *inferred* from adjacent forums and from the prevalence of clone-recipe compilations, not from
+  direct thread reads or upvote counts. HomeBrewTalk findings rely on search-result snippets.
+  brassageamateur.com was fetched directly.
+- **Frequency signals are qualitative** (recurrence of distinct threads / reviews), not scraped counts.
+  Treat rankings as directional.
+- **Forums over-represent people who are stuck** — a strong hypothesis generator, not proof.
+  This is exactly why primary research (interviews) follows.
+- To harden: read a sample of r/Homebrewing threads via an authenticated/API path and tag posts by
+  theme for true counts.
+
+## Status
+
+- Secondary research: complete (captured in `01`–`03`, consolidated in `04`).
+- Primary research: not started.
+- Final report: not started.

--- a/docs/marketing/needs-study/00-method.md
+++ b/docs/marketing/needs-study/00-method.md
@@ -58,6 +58,6 @@ Six desk passes across source families:
 
 ## Status
 
-- Secondary research: complete (captured in `01`–`03`, consolidated in `04`).
+- Secondary research: complete (captured in `01`–`03d`, consolidated in `04`).
 - Primary research: not started.
 - Final report: not started.

--- a/docs/marketing/needs-study/01-desk-competitors.md
+++ b/docs/marketing/needs-study/01-desk-competitors.md
@@ -1,75 +1,76 @@
-# Desk Research — Competitor App Reviews
+# Recherche documentaire — Analyse des avis sur les apps concurrentes
 
-Source families: App Store / Google Play review summaries, Reddit/forum comparisons, comparison
-blogs, official docs. **Caveat:** HomeBrewTalk and some review pages returned 403; Reddit thread
-bodies were not retrievable, so a few claims lean on search snippets and are flagged. Star ratings
-are listing summaries at time of search (May 2026).
+Familles de sources : synthèses d'avis App Store / Google Play, comparaisons Reddit/forums, blogs
+comparatifs, documentation officielle. **Mise en garde :** HomeBrewTalk et certaines pages d'avis ont
+renvoyé une erreur 403 ; le corps des fils Reddit n'a pas pu être récupéré, si bien que quelques
+affirmations s'appuient sur des extraits de recherche et sont signalées comme telles. Les notes en
+étoiles correspondent aux synthèses de fiches au moment de la recherche (mai 2026).
 
-## Per-competitor findings
+## Constats par concurrent
 
-### Brewfather (cloud-based; the sentiment leader)
+### Brewfather (basé sur le cloud ; le leader en matière de satisfaction)
 
-**Praise**
-- Best-in-class cross-device cloud sync (design on laptop, log gravity on phone) — the most-cited reason to switch.
-- Clean, modern, non-overwhelming UI; fast onboarding.
-- Strong batch system (each brew = a variation of a master recipe) + fermentation tracking; Tilt/Grainfather integrations (the in-app Tilt chart is a named purchase driver).
-- Ad-free, responsive dev support, cheap (~$20/yr).
+**Points forts**
+- Synchronisation cloud multi-appareils inégalée (concevoir sur un ordinateur portable, relever la densité sur le téléphone) — la raison de changement la plus souvent citée.
+- Interface épurée, moderne, non écrasante ; prise en main rapide.
+- Système de brassins robuste (chaque brassin = une variation d'une recette mère) + suivi de fermentation ; intégrations Tilt/Grainfather (le graphique Tilt intégré à l'app est un déclencheur d'achat nommément cité).
+- Sans publicité, support développeur réactif, peu coûteux (~20 $/an).
 
-**Complaints / gaps**
-- Subscription-only for full features; no one-time purchase — recurring-cost resentment is the most common con.
-- Limited offline functionality (needs internet for most features).
-- Can feel feature-overwhelming at first.
-- Community library exists but **publishing recipes is paid-tier-gated**, and free users hit recipe-count limits even when *copying* a community recipe.
+**Reproches / lacunes**
+- Abonnement obligatoire pour les fonctionnalités complètes ; pas d'achat unique — le ressentiment lié au coût récurrent est le reproche le plus fréquent.
+- Fonctionnement hors ligne limité (la plupart des fonctionnalités nécessitent Internet).
+- Peut sembler surchargé en fonctionnalités au premier abord.
+- Une bibliothèque communautaire existe, mais **la publication de recettes est réservée à l'abonnement payant**, et les utilisateurs gratuits atteignent une limite de nombre de recettes même lorsqu'ils *copient* une recette de la communauté.
 
-### BeerSmith Mobile (one-time purchase; desktop heritage) — worst-rated (≈2.9★ App Store)
+### BeerSmith Mobile (achat unique ; héritage desktop) — la moins bien notée (≈2,9★ App Store)
 
-**Praise**
-- Most established/trusted calculation engine in the hobby; very accurate once tuned.
-- Integrated brew-day timer with step-by-step reminders.
-- One-time purchase, no subscription.
+**Points forts**
+- Le moteur de calcul le plus établi et le plus reconnu du loisir ; très précis une fois calibré.
+- Minuteur de jour de brassage intégré avec rappels étape par étape.
+- Achat unique, sans abonnement.
 
-**Complaints / gaps**
-- Painful sync: desktop → cloud → phone, so "the same recipe exists 3 times." **Strongest, most concrete pain in the set.**
-- Clunky, slow, dated nested-folder UI; search breaks inside nested folders (dev acknowledged file-storage/menu complaints).
-- Awkward flows (must go "back" to start the timer after editing).
-- No `.bsmx` import on mobile; profiles re-entered per device; sharing requires a cloud download. High learning curve.
+**Reproches / lacunes**
+- Synchronisation pénible : desktop → cloud → téléphone, si bien que « la même recette existe en 3 exemplaires ». **Le point de douleur le plus fort et le plus concret de l'ensemble.**
+- Interface à dossiers imbriqués lourde, lente et datée ; la recherche se casse à l'intérieur des dossiers imbriqués (le développeur a reconnu les plaintes sur le stockage des fichiers et les menus).
+- Parcours maladroits (il faut revenir « en arrière » pour lancer le minuteur après une modification).
+- Pas d'import `.bsmx` sur mobile ; profils à ressaisir sur chaque appareil ; le partage exige un téléchargement depuis le cloud. Courbe d'apprentissage élevée.
 
-### Brewer's Friend (web-first + apps; calculators reputation)
+### Brewer's Friend (web d'abord + apps ; réputation des calculateurs)
 
-**Praise**
-- Best-regarded brewing calculators ("unparalleled") and water-chemistry tools.
-- Fully web-based — recipes safe in the cloud.
-- Direct ingredient purchasing; large public recipe database.
+**Points forts**
+- Les calculateurs de brassage les mieux considérés (« sans équivalent ») et des outils de chimie de l'eau.
+- Entièrement basé sur le web — les recettes sont à l'abri dans le cloud.
+- Achat d'ingrédients direct ; vaste base de données publique de recettes.
 
-**Complaints / gaps**
-- Free tier capped at 5 recipes **and shows ads**; sync/ad-removal require Premium.
-- Weak mobile usability (timer hard to find); some "regret the annual fee" and switched away.
-- Reported Android bugs (gravity not updating, metric↔imperial errors, edits not saving) with slow fixes.
+**Reproches / lacunes**
+- Niveau gratuit plafonné à 5 recettes **et avec publicités** ; la synchronisation et la suppression des publicités exigent l'offre Premium.
+- Faible ergonomie mobile (minuteur difficile à trouver) ; certains « regrettent l'abonnement annuel » et sont partis ailleurs.
+- Bugs Android signalés (densité qui ne se met pas à jour, erreurs métrique↔impérial, modifications non enregistrées) avec des corrections lentes.
 
-### BrewBuddy (iOS utility) — contrast point, not a direct competitor
-- Deliberately minimal offline calculators; no accounts, no data saved, no tracking.
-- Confirms a niche that distrusts cloud/subscription apps and just wants offline tools.
+### BrewBuddy (utilitaire iOS) — point de contraste, pas un concurrent direct
+- Calculateurs hors ligne volontairement minimalistes ; pas de comptes, pas de données sauvegardées, pas de suivi.
+- Confirme l'existence d'une niche qui se méfie des apps cloud/abonnement et veut simplement des outils hors ligne.
 
-### Adjacent / signal points
-- **Grainfather app:** calculations diverge from Brewfather for the same recipe (equipment profiles) — friction moving recipes between ecosystems.
-- **AHA Brew Guru** (recipe + deals + community app): **sunset Feb 1, 2026**, folded back into the AHA website; "limited content," mixed feedback. A dedicated community/recipe app that failed to sustain — a caution for the community hero.
-- **Build-A-Beer:** free app whose headline feature is **AI clone-recipe generation** from a beer's characteristics + "share your creations." Direct competitor to the clone/share angle — track it.
+### Points adjacents / signaux
+- **App Grainfather :** les calculs divergent de Brewfather pour une même recette (profils d'équipement) — friction lors du déplacement de recettes entre écosystèmes.
+- **AHA Brew Guru** (app recette + bons plans + communauté) : **arrêtée le 1er février 2026**, réintégrée au site web de l'AHA ; « contenu limité », retours mitigés. Une app communauté/recettes dédiée qui n'a pas su perdurer — une mise en garde pour le pilier communautaire.
+- **Build-A-Beer :** app gratuite dont la fonctionnalité phare est la **génération de recettes de clone par IA** à partir des caractéristiques d'une bière + « partagez vos créations ». Concurrent direct sur l'angle clone/partage — à surveiller.
 
-## Top unmet needs (ranked by signal strength)
+## Principaux besoins non satisfaits (classés par force du signal)
 
-1. **Frictionless sync + true offline without paying or duplicating data** — *very frequent.* BeerSmith triple-copy is the loudest single complaint; Brewfather online dependency echoes it. Brewing happens in garages/cellars with poor connectivity.
-2. **Subscription / paywall friction** — *very frequent.* Free tiers feel crippled (publishing, sync, import/export gated).
-3. **Modern, uncluttered mobile UX** — *frequent.* Brewfather wins precisely by being clean — UX is a proven differentiator.
-4. **Reliable recipe organization & search** — *moderate.* BeerSmith search breaks in nested folders.
-5. **Easy, low-friction recipe sharing** — *moderate.* Sharing is awkward (cloud download / paid publishing). Demand exists but is partly served.
-6. **Bug-free reliability & accurate calculations** — *moderate.* Cross-app calculation divergence undermines trust when moving recipes.
-7. **Inventory / cost tracking, device integrations (Tilt)** — *occasional but loyalty-driving.*
+1. **Synchronisation sans friction + véritable hors ligne sans payer ni dupliquer les données** — *très fréquent.* Le triple exemplaire de BeerSmith est la plainte unique la plus bruyante ; la dépendance en ligne de Brewfather y fait écho. Le brassage se fait dans des garages/caves à mauvaise connectivité.
+2. **Friction liée à l'abonnement / au paywall** — *très fréquent.* Les niveaux gratuits semblent bridés (publication, synchronisation, import/export verrouillés).
+3. **UX mobile moderne et épurée** — *fréquent.* Brewfather gagne précisément en étant épuré — l'UX est un différenciateur prouvé.
+4. **Organisation et recherche de recettes fiables** — *modéré.* La recherche de BeerSmith se casse dans les dossiers imbriqués.
+5. **Partage de recettes facile et sans friction** — *modéré.* Le partage est maladroit (téléchargement cloud / publication payante). La demande existe mais n'est que partiellement satisfaite.
+6. **Fiabilité sans bugs et calculs précis** — *modéré.* La divergence des calculs entre apps mine la confiance lors du déplacement des recettes.
+7. **Suivi des stocks / des coûts, intégrations matérielles (Tilt)** — *occasionnel mais facteur de fidélité.*
 
-## Signal on the SHARING / CLONING / COMMUNITY hero hypothesis
+## Signal sur l'hypothèse du pilier PARTAGE / CLONAGE / COMMUNAUTÉ
 
-- **Cloning commercial beers: strong, durable demand.** AHA 50-state clone guides, BrewDog *DIY Dog*, Beer Maverick 100+, Build-A-Beer all exist because demand is real and recurring. Validates the clone angle.
-- **Community recipe libraries: validated but partly served and hard to monetize.** Brewfather/Brewer's Friend show users want to browse/copy others' recipes — but publishing is paywalled and copying is capped, leaving an opening for a more open, sharing-first model. Caution: Brew Guru's Feb-2026 sunset shows in-app social is unproven as a *primary* retention driver; most "community" lives on Reddit/Discord/Facebook/forums today.
-- **Implication:** the *cloning + open sharing* combination is the most defensible hero. Frame pure "social" as connective tissue around clone-sharing, not a standalone feature. Foundation features target the top-4 unmet needs and are table-stakes for retention.
+- **Cloner des bières commerciales : demande forte et durable.** Les guides de clones des 50 États de l'AHA, *DIY Dog* de BrewDog, les 100+ de Beer Maverick, Build-A-Beer existent tous parce que la demande est réelle et récurrente. Valide l'angle clone.
+- **Bibliothèques de recettes communautaires : validées mais partiellement satisfaites et difficiles à monétiser.** Brewfather/Brewer's Friend montrent que les utilisateurs veulent parcourir/copier les recettes des autres — mais la publication est derrière un paywall et la copie est plafonnée, ce qui laisse une ouverture pour un modèle plus ouvert, centré sur le partage. Prudence : l'arrêt de Brew Guru en février 2026 montre que le social intégré à l'app n'est pas prouvé comme moteur *principal* de rétention ; aujourd'hui, l'essentiel de la « communauté » vit sur Reddit/Discord/Facebook/les forums.
+- **Implication :** la combinaison *clonage + partage ouvert* est le pilier le plus défendable. Présenter le « social » pur comme le tissu conjonctif autour du partage de clones, et non comme une fonctionnalité autonome. Les fonctionnalités fondations ciblent les 4 premiers besoins non satisfaits et constituent le minimum vital pour la rétention.
 
 ## Sources
 - https://homebrewacademy.com/brewing-software-comparison/

--- a/docs/marketing/needs-study/01-desk-competitors.md
+++ b/docs/marketing/needs-study/01-desk-competitors.md
@@ -1,0 +1,86 @@
+# Desk Research — Competitor App Reviews
+
+Source families: App Store / Google Play review summaries, Reddit/forum comparisons, comparison
+blogs, official docs. **Caveat:** HomeBrewTalk and some review pages returned 403; Reddit thread
+bodies were not retrievable, so a few claims lean on search snippets and are flagged. Star ratings
+are listing summaries at time of search (May 2026).
+
+## Per-competitor findings
+
+### Brewfather (cloud-based; the sentiment leader)
+
+**Praise**
+- Best-in-class cross-device cloud sync (design on laptop, log gravity on phone) — the most-cited reason to switch.
+- Clean, modern, non-overwhelming UI; fast onboarding.
+- Strong batch system (each brew = a variation of a master recipe) + fermentation tracking; Tilt/Grainfather integrations (the in-app Tilt chart is a named purchase driver).
+- Ad-free, responsive dev support, cheap (~$20/yr).
+
+**Complaints / gaps**
+- Subscription-only for full features; no one-time purchase — recurring-cost resentment is the most common con.
+- Limited offline functionality (needs internet for most features).
+- Can feel feature-overwhelming at first.
+- Community library exists but **publishing recipes is paid-tier-gated**, and free users hit recipe-count limits even when *copying* a community recipe.
+
+### BeerSmith Mobile (one-time purchase; desktop heritage) — worst-rated (≈2.9★ App Store)
+
+**Praise**
+- Most established/trusted calculation engine in the hobby; very accurate once tuned.
+- Integrated brew-day timer with step-by-step reminders.
+- One-time purchase, no subscription.
+
+**Complaints / gaps**
+- Painful sync: desktop → cloud → phone, so "the same recipe exists 3 times." **Strongest, most concrete pain in the set.**
+- Clunky, slow, dated nested-folder UI; search breaks inside nested folders (dev acknowledged file-storage/menu complaints).
+- Awkward flows (must go "back" to start the timer after editing).
+- No `.bsmx` import on mobile; profiles re-entered per device; sharing requires a cloud download. High learning curve.
+
+### Brewer's Friend (web-first + apps; calculators reputation)
+
+**Praise**
+- Best-regarded brewing calculators ("unparalleled") and water-chemistry tools.
+- Fully web-based — recipes safe in the cloud.
+- Direct ingredient purchasing; large public recipe database.
+
+**Complaints / gaps**
+- Free tier capped at 5 recipes **and shows ads**; sync/ad-removal require Premium.
+- Weak mobile usability (timer hard to find); some "regret the annual fee" and switched away.
+- Reported Android bugs (gravity not updating, metric↔imperial errors, edits not saving) with slow fixes.
+
+### BrewBuddy (iOS utility) — contrast point, not a direct competitor
+- Deliberately minimal offline calculators; no accounts, no data saved, no tracking.
+- Confirms a niche that distrusts cloud/subscription apps and just wants offline tools.
+
+### Adjacent / signal points
+- **Grainfather app:** calculations diverge from Brewfather for the same recipe (equipment profiles) — friction moving recipes between ecosystems.
+- **AHA Brew Guru** (recipe + deals + community app): **sunset Feb 1, 2026**, folded back into the AHA website; "limited content," mixed feedback. A dedicated community/recipe app that failed to sustain — a caution for the community hero.
+- **Build-A-Beer:** free app whose headline feature is **AI clone-recipe generation** from a beer's characteristics + "share your creations." Direct competitor to the clone/share angle — track it.
+
+## Top unmet needs (ranked by signal strength)
+
+1. **Frictionless sync + true offline without paying or duplicating data** — *very frequent.* BeerSmith triple-copy is the loudest single complaint; Brewfather online dependency echoes it. Brewing happens in garages/cellars with poor connectivity.
+2. **Subscription / paywall friction** — *very frequent.* Free tiers feel crippled (publishing, sync, import/export gated).
+3. **Modern, uncluttered mobile UX** — *frequent.* Brewfather wins precisely by being clean — UX is a proven differentiator.
+4. **Reliable recipe organization & search** — *moderate.* BeerSmith search breaks in nested folders.
+5. **Easy, low-friction recipe sharing** — *moderate.* Sharing is awkward (cloud download / paid publishing). Demand exists but is partly served.
+6. **Bug-free reliability & accurate calculations** — *moderate.* Cross-app calculation divergence undermines trust when moving recipes.
+7. **Inventory / cost tracking, device integrations (Tilt)** — *occasional but loyalty-driving.*
+
+## Signal on the SHARING / CLONING / COMMUNITY hero hypothesis
+
+- **Cloning commercial beers: strong, durable demand.** AHA 50-state clone guides, BrewDog *DIY Dog*, Beer Maverick 100+, Build-A-Beer all exist because demand is real and recurring. Validates the clone angle.
+- **Community recipe libraries: validated but partly served and hard to monetize.** Brewfather/Brewer's Friend show users want to browse/copy others' recipes — but publishing is paywalled and copying is capped, leaving an opening for a more open, sharing-first model. Caution: Brew Guru's Feb-2026 sunset shows in-app social is unproven as a *primary* retention driver; most "community" lives on Reddit/Discord/Facebook/forums today.
+- **Implication:** the *cloning + open sharing* combination is the most defensible hero. Frame pure "social" as connective tissue around clone-sharing, not a standalone feature. Foundation features target the top-4 unmet needs and are table-stakes for retention.
+
+## Sources
+- https://homebrewacademy.com/brewing-software-comparison/
+- https://play.google.com/store/apps/details?id=com.warpkode.brewfather&hl=en_US
+- https://docs.brewfather.app/library
+- https://docs.brewfather.app/faq
+- https://hazyandhoppy.com/why-i-switched-to-the-brewfather-app/
+- https://apps.apple.com/us/app/beersmith-mobile-home-brewing/id640670118
+- https://apps.apple.com/us/app/brewers-friend/id1580297037
+- https://apps.apple.com/us/app/brewbuddy-homebrew-tools/id6450740421
+- https://homebrewersassociation.org/news/brew-guru-sunsetting-feb-1/
+- https://homebrewersassociation.org/top-50-commercial-clone-beer-recipes/
+- https://beermaverick.com/over-100-commercial-beer-clone-recipes-from-the-breweries-themselves/
+- https://buildabeer.app/

--- a/docs/marketing/needs-study/02-desk-reddit.md
+++ b/docs/marketing/needs-study/02-desk-reddit.md
@@ -1,0 +1,82 @@
+# Desk Research — r/Homebrewing
+
+**Method / uncertainty flag:** Reddit blocks automated fetching (both `www.reddit.com` and
+`old.reddit.com`), and `site:reddit.com` queries were deflected. Findings are triangulated from
+(a) the closely-mirrored HomeBrewTalk and Brewer's Friend forums, (b) high-traffic clone-recipe
+compilations whose existence is itself a demand signal, and (c) the official Brewfather sharing
+model. Frequency signals are **inferred**, not thread counts. Ranking is directional.
+
+## Ranked recurring themes
+
+### 1. Demand to clone a specific commercial/craft beer — VERY HIGH
+Reproducing a named beer is one of the most common goals. Structural signal: large editorial
+compilations exist purely to satisfy it (AHA "Top 50 Commercial Clone Recipes," Beer Maverick
+"100+ Commercial Beer Clone Recipes," style-specific roundups). Most-cloned targets cluster around
+hype/hard-to-get beers: Pliny the Elder, Tree House Julius, WeldWerks Juicy Bits, Founders,
+Deschutes. Driven by aspiration (recreate a beer you love / can't easily buy).
+
+### 2. "Clone recipes are only a starting point" — accuracy/reproducibility frustration — HIGH
+Published clones often don't taste like the original or are outdated. The canonical 2009 Pliny
+recipe was called "horribly bitter" and "didn't taste anything like Pliny." Brewers treat published
+recipes as a base guideline and adapt them to their own system. This is a need for *iterative,
+versioned, community-validated* clones — not one static PDF.
+
+### 3. Recipe organization / brew-log tracking — chronic, unsolved-feeling — HIGH
+Persistent thread genre about keeping recipes, brew logs, tasting notes and batch history in one
+reviewable place. People bounce between Excel, Word, notebooks and BeerSmith; the frustration is
+wanting "everything in one view" and notes that stay "meaningful when reviewing them later."
+
+### 4. App churn & feature gaps (Brewfather vs Brewer's Friend vs BeerSmith) — HIGH
+Comparing/switching apps is perennial. Drivers: BeerSmith powerful but dated/clunky; Brewfather
+modern UI + multi-device (the current darling); Brewer's Friend web-based but weaker mobile and
+confusing water calculators. Migration friction and water-chemistry UX are the loudest specifics.
+
+### 5. Recipe-SHARING tooling is weak — attribution, multi-group, bulk export — MEDIUM-HIGH
+From Brewer's Friend feature requests: sharing **strips authorship** ("intellectual property
+concerns"); you can share with only **one group** at a time (users want multi-club sharing with
+credit preserved); no **bulk export** of selected recipes. Sharing is wanted but feels like an afterthought.
+
+### 6. Recipe discovery & social layer is thin — MEDIUM
+Brewfather's public Library has browse/search, key stats, and up/down votes/views/downloads — but
+**no comments, no following, limited profiles**, and **publishing requires a paid subscription**.
+Discovery exists; conversation around a recipe does not. Clear whitespace.
+
+### 7. Recipe scaling / efficiency conversion when adopting someone else's recipe — MEDIUM
+A recipe built on another brewer's equipment/efficiency doesn't translate cleanly — the hidden tax
+on any sharing feature. Sharing only works if the platform re-scales to the recipient's system.
+(Lower confidence — inferred from calculator discussions.)
+
+## Targeted assessments
+
+- **Desire to clone specific beers:** strong and central, not niche. Validates the hero angle.
+- **Willingness to share own recipes vs just consume:** net-positive but with a consumption skew.
+  Genuine sharing culture exists, but more people *seek* clones than *publish* polished ones, and
+  sharers care about **attribution/credit**. A low-effort, credited sharing flow could convert lurkers.
+- **Do they complain current sharing is bad?** Yes, concretely: authorship stripped, single-group-only,
+  no bulk export (Brewer's Friend); paywalled publishing, no comments/follows (Brewfather).
+
+## Signal on the community/clone hero hypothesis
+
+**Supported, with caveats.** Cloning a specific beer is a top-tier, emotionally-driven motivation,
+and the dissatisfaction is not "no tools exist" but "tools clone poorly, share clumsily, and don't
+talk to each other." The strongest differentiated wedge is the **intersection**: a
+community-validated, versioned, credited, auto-rescaled clone recipe — i.e. solving themes 2, 5, 6, 7
+together. Nobody owns "the place where the community collaboratively dials in the Pliny/Julius clone
+and you fork it to your system." Foundation features (organization + tracking) are demanded
+(themes 3, 4) and must be solid, but they are not where you win.
+
+**Caveat / next step:** relative frequency of "clone" vs "organization" vs "sharing" is inferred,
+not measured on the subreddit. Harden by sampling r/Homebrewing threads via the Reddit API and
+tagging by theme. Note r/TheBrewery skews pro/commercial — weaker proxy for the intermediate-homebrewer persona.
+
+## Sources
+- https://homebrewersassociation.org/top-50-commercial-clone-beer-recipes/
+- https://beermaverick.com/over-100-commercial-beer-clone-recipes-from-the-breweries-themselves/
+- https://beermaverick.com/top-recipes-to-homebrew-the-most-iconic-hazy-ipas-ever/
+- https://www.brewersfriend.com/forum/threads/has-anyone-in-this-forum-attempted-a-pliny-clone.11917/
+- https://www.brewersfriend.com/forum/threads/suggested-fixes-and-features.12138/
+- https://homebrewtalk.com/threads/brew-logs-and-recipe-tracking.498700/
+- https://homebrewtalk.com/threads/brewfather-or-brewers-friend.694796/
+- https://homebrewtalk.com/threads/brewfather-vs-brewers-friend.673669/
+- https://docs.brewfather.app/library
+- https://homebrewacademy.com/brewing-software-comparison/

--- a/docs/marketing/needs-study/02-desk-reddit.md
+++ b/docs/marketing/needs-study/02-desk-reddit.md
@@ -1,73 +1,84 @@
-# Desk Research — r/Homebrewing
+# Recherche documentaire — r/Homebrewing
 
-**Method / uncertainty flag:** Reddit blocks automated fetching (both `www.reddit.com` and
-`old.reddit.com`), and `site:reddit.com` queries were deflected. Findings are triangulated from
-(a) the closely-mirrored HomeBrewTalk and Brewer's Friend forums, (b) high-traffic clone-recipe
-compilations whose existence is itself a demand signal, and (c) the official Brewfather sharing
-model. Frequency signals are **inferred**, not thread counts. Ranking is directional.
+**Méthode / incertitude :** Reddit bloque la récupération automatisée (à la fois `www.reddit.com` et
+`old.reddit.com`), et les requêtes `site:reddit.com` ont été déviées. Les constats sont triangulés à partir
+(a) des forums HomeBrewTalk et Brewer's Friend, très similaires, (b) de compilations de recettes de clones
+à fort trafic dont l'existence même est un signal de demande, et (c) du modèle officiel de partage de
+Brewfather. Les signaux de fréquence sont **déduits**, et non issus de comptages de fils. Le classement est
+indicatif.
 
-## Ranked recurring themes
+## Thèmes récurrents classés
 
-### 1. Demand to clone a specific commercial/craft beer — VERY HIGH
-Reproducing a named beer is one of the most common goals. Structural signal: large editorial
-compilations exist purely to satisfy it (AHA "Top 50 Commercial Clone Recipes," Beer Maverick
-"100+ Commercial Beer Clone Recipes," style-specific roundups). Most-cloned targets cluster around
-hype/hard-to-get beers: Pliny the Elder, Tree House Julius, WeldWerks Juicy Bits, Founders,
-Deschutes. Driven by aspiration (recreate a beer you love / can't easily buy).
+### 1. Demande de cloner une bière commerciale/artisanale précise — TRÈS ÉLEVÉE
+Reproduire une bière nommée est l'un des objectifs les plus courants. Signal structurel : de vastes
+compilations éditoriales existent uniquement pour le satisfaire (AHA « Top 50 Commercial Clone Recipes »,
+Beer Maverick « 100+ Commercial Beer Clone Recipes », tours d'horizon par style). Les cibles les plus
+clonées se concentrent autour des bières hype/difficiles à trouver : Pliny the Elder, Tree House Julius,
+WeldWerks Juicy Bits, Founders, Deschutes. Motivées par l'aspiration (recréer une bière qu'on aime / qu'on
+ne peut pas se procurer facilement).
 
-### 2. "Clone recipes are only a starting point" — accuracy/reproducibility frustration — HIGH
-Published clones often don't taste like the original or are outdated. The canonical 2009 Pliny
-recipe was called "horribly bitter" and "didn't taste anything like Pliny." Brewers treat published
-recipes as a base guideline and adapt them to their own system. This is a need for *iterative,
-versioned, community-validated* clones — not one static PDF.
+### 2. « Les recettes de clone ne sont qu'un point de départ » — frustration sur la précision/reproductibilité — ÉLEVÉE
+Les clones publiés n'ont souvent pas le goût de l'original ou sont obsolètes. La recette canonique de Pliny
+de 2009 a été qualifiée d'« horriblement amère » et « ne ressemblait en rien à la Pliny ». Les brasseurs
+traitent les recettes publiées comme une base de référence et les adaptent à leur propre système. C'est un
+besoin de clones *itératifs, versionnés, validés par la communauté* — et non d'un seul PDF figé.
 
-### 3. Recipe organization / brew-log tracking — chronic, unsolved-feeling — HIGH
-Persistent thread genre about keeping recipes, brew logs, tasting notes and batch history in one
-reviewable place. People bounce between Excel, Word, notebooks and BeerSmith; the frustration is
-wanting "everything in one view" and notes that stay "meaningful when reviewing them later."
+### 3. Organisation des recettes / suivi du journal de brassage — chronique, donne le sentiment de n'être jamais résolu — ÉLEVÉ
+Genre de fil persistant à propos de conserver recettes, journaux de brassage, notes de dégustation et
+historique des brassins dans un même endroit consultable. Les gens jonglent entre Excel, Word, carnets et
+BeerSmith ; la frustration, c'est de vouloir « tout dans une seule vue » et des notes qui restent « utiles
+quand on les relit plus tard ».
 
-### 4. App churn & feature gaps (Brewfather vs Brewer's Friend vs BeerSmith) — HIGH
-Comparing/switching apps is perennial. Drivers: BeerSmith powerful but dated/clunky; Brewfather
-modern UI + multi-device (the current darling); Brewer's Friend web-based but weaker mobile and
-confusing water calculators. Migration friction and water-chemistry UX are the loudest specifics.
+### 4. Abandon d'apps et lacunes de fonctionnalités (Brewfather vs Brewer's Friend vs BeerSmith) — ÉLEVÉ
+Comparer/changer d'app est un sujet perpétuel. Moteurs : BeerSmith puissant mais daté/lourd ; Brewfather
+interface moderne + multi-appareils (le chouchou du moment) ; Brewer's Friend basé sur le web mais plus
+faible sur mobile et calculateurs d'eau déroutants. La friction de migration et l'UX de la chimie de l'eau
+sont les points concrets les plus bruyants.
 
-### 5. Recipe-SHARING tooling is weak — attribution, multi-group, bulk export — MEDIUM-HIGH
-From Brewer's Friend feature requests: sharing **strips authorship** ("intellectual property
-concerns"); you can share with only **one group** at a time (users want multi-club sharing with
-credit preserved); no **bulk export** of selected recipes. Sharing is wanted but feels like an afterthought.
+### 5. L'outillage de PARTAGE de recettes est faible — attribution, multi-groupe, export en lot — MOYEN-ÉLEVÉ
+D'après les demandes de fonctionnalités sur Brewer's Friend : le partage **supprime la paternité** (« préoccupations
+de propriété intellectuelle ») ; on ne peut partager qu'avec **un seul groupe** à la fois (les utilisateurs
+veulent un partage multi-club avec le crédit préservé) ; pas d'**export en lot** des recettes sélectionnées.
+Le partage est désiré mais donne l'impression d'être une réflexion après coup.
 
-### 6. Recipe discovery & social layer is thin — MEDIUM
-Brewfather's public Library has browse/search, key stats, and up/down votes/views/downloads — but
-**no comments, no following, limited profiles**, and **publishing requires a paid subscription**.
-Discovery exists; conversation around a recipe does not. Clear whitespace.
+### 6. La couche de découverte et sociale autour des recettes est mince — MOYEN
+La bibliothèque publique de Brewfather propose navigation/recherche, statistiques clés et votes
+positifs/négatifs/vues/téléchargements — mais **pas de commentaires, pas de suivi, profils limités**, et
+**la publication nécessite un abonnement payant**. La découverte existe ; la conversation autour d'une recette,
+non. Espace clairement vacant.
 
-### 7. Recipe scaling / efficiency conversion when adopting someone else's recipe — MEDIUM
-A recipe built on another brewer's equipment/efficiency doesn't translate cleanly — the hidden tax
-on any sharing feature. Sharing only works if the platform re-scales to the recipient's system.
-(Lower confidence — inferred from calculator discussions.)
+### 7. Mise à l'échelle / conversion de l'efficacité lors de l'adoption de la recette d'un autre — MOYEN
+Une recette construite sur l'équipement/l'efficacité d'un autre brasseur ne se transpose pas proprement —
+la taxe cachée de toute fonctionnalité de partage. Le partage ne fonctionne que si la plateforme remet à
+l'échelle pour le système du destinataire. (Confiance plus faible — déduit des discussions sur les
+calculateurs.)
 
-## Targeted assessments
+## Évaluations ciblées
 
-- **Desire to clone specific beers:** strong and central, not niche. Validates the hero angle.
-- **Willingness to share own recipes vs just consume:** net-positive but with a consumption skew.
-  Genuine sharing culture exists, but more people *seek* clones than *publish* polished ones, and
-  sharers care about **attribution/credit**. A low-effort, credited sharing flow could convert lurkers.
-- **Do they complain current sharing is bad?** Yes, concretely: authorship stripped, single-group-only,
-  no bulk export (Brewer's Friend); paywalled publishing, no comments/follows (Brewfather).
+- **Désir de cloner des bières précises :** fort et central, pas de niche. Valide l'angle pilier.
+- **Volonté de partager ses propres recettes plutôt que de seulement consommer :** globalement positive mais
+  avec un biais vers la consommation. Une vraie culture du partage existe, mais plus de gens *cherchent* des
+  clones qu'ils n'en *publient* de soignés, et ceux qui partagent tiennent à l'**attribution/au crédit**. Un
+  flux de partage à faible effort et créditant pourrait convertir les observateurs passifs.
+- **Se plaignent-ils que le partage actuel est mauvais ?** Oui, concrètement : paternité supprimée, un seul
+  groupe à la fois, pas d'export en lot (Brewer's Friend) ; publication derrière paywall, pas de
+  commentaires/suivis (Brewfather).
 
-## Signal on the community/clone hero hypothesis
+## Signal sur l'hypothèse du pilier communauté/clone
 
-**Supported, with caveats.** Cloning a specific beer is a top-tier, emotionally-driven motivation,
-and the dissatisfaction is not "no tools exist" but "tools clone poorly, share clumsily, and don't
-talk to each other." The strongest differentiated wedge is the **intersection**: a
-community-validated, versioned, credited, auto-rescaled clone recipe — i.e. solving themes 2, 5, 6, 7
-together. Nobody owns "the place where the community collaboratively dials in the Pliny/Julius clone
-and you fork it to your system." Foundation features (organization + tracking) are demanded
-(themes 3, 4) and must be solid, but they are not where you win.
+**Soutenue, avec des réserves.** Cloner une bière précise est une motivation de premier ordre, à forte
+charge émotionnelle, et l'insatisfaction n'est pas « aucun outil n'existe » mais « les outils clonent mal,
+partagent maladroitement et ne communiquent pas entre eux ». Le coin différenciateur le plus fort est
+l'**intersection** : une recette de clone validée par la communauté, versionnée, créditée et remise à
+l'échelle automatiquement — c'est-à-dire résoudre ensemble les thèmes 2, 5, 6 et 7. Personne ne possède
+« l'endroit où la communauté affine collectivement le clone de Pliny/Julius et où tu le forkes pour ton
+système ». Les fonctionnalités fondations (organisation + suivi) sont demandées (thèmes 3 et 4) et doivent
+être solides, mais ce n'est pas là que l'on gagne.
 
-**Caveat / next step:** relative frequency of "clone" vs "organization" vs "sharing" is inferred,
-not measured on the subreddit. Harden by sampling r/Homebrewing threads via the Reddit API and
-tagging by theme. Note r/TheBrewery skews pro/commercial — weaker proxy for the intermediate-homebrewer persona.
+**Réserve / étape suivante :** la fréquence relative de « clone » vs « organisation » vs « partage » est
+déduite, pas mesurée sur le subreddit. À consolider en échantillonnant des fils de r/Homebrewing via l'API
+Reddit et en les étiquetant par thème. Noter que r/TheBrewery penche pro/commercial — un proxy plus faible
+pour le persona du brasseur amateur intermédiaire.
 
 ## Sources
 - https://homebrewersassociation.org/top-50-commercial-clone-beer-recipes/

--- a/docs/marketing/needs-study/03-desk-forums.md
+++ b/docs/marketing/needs-study/03-desk-forums.md
@@ -1,87 +1,96 @@
-# Desk Research — Forums (HomeBrewTalk + brassageamateur.com)
+# Desk research — Forums (HomeBrewTalk + brassageamateur.com)
 
-**Method note:** HomeBrewTalk.com blocks automated fetches (HTTP 403), so HBT findings rely on
-search-result snippets (titles + indexed excerpts), not full-thread reads. brassageamateur.com pages
-were fetched directly. Frequency signals are qualitative (recurrence of distinct threads), not
-scraped post-counts.
+**Note méthodologique :** HomeBrewTalk.com bloque les requêtes automatisées (HTTP 403), si bien que les
+constats sur HBT reposent sur des extraits de résultats de recherche (titres + extraits indexés), et non
+sur la lecture intégrale des fils. Les pages de brassageamateur.com ont été récupérées directement. Les
+signaux de fréquence sont qualitatifs (récurrence de fils distincts), et non issus d'un comptage de
+messages.
 
-## Ranked recurring themes
+## Thèmes récurrents, classés
 
-### 1. Demand for clone recipes of specific commercial beers — VERY HIGH
-The single most recurrent topic. Continuous "clone of X" request threads on both forums, plus
-meta-threads asking where to *find* clones.
-- HBT has a long-running clone culture ("Why I Clone Commercial Brews"; "Is there a Clone Recipe database?").
-- brassageamateur has a **dedicated clone sub-forum: 133 threads / 170+ shared recipes** (Orval,
+### 1. Demande de recettes clones de bières commerciales précises — TRÈS ÉLEVÉE
+Le sujet le plus récurrent de tous. Flux continu de fils « clone de X » sur les deux forums, plus des
+méta-fils demandant *où trouver* des clones.
+- HBT entretient une longue culture du clone (« Why I Clone Commercial Brews » ; « Is there a Clone Recipe database? »).
+- brassageamateur dispose d'un **sous-forum dédié aux clones : 133 fils / 170+ recettes partagées** (Orval,
   Westmalle, Duvel, Rochefort 10, Westvleteren 12, Hoegaarden, Kronenbourg 1664, Guinness, Punk IPA),
-  popular threads with 85–149 replies, active into 2025–2026.
+  avec des fils populaires totalisant 85 à 149 réponses, actifs jusqu'en 2025-2026.
 
-**Assessment:** Clone demand is real, sustained, self-organizing. The recurring "is there a clone
-database?" question is direct evidence of an unmet need for a *searchable, curated* clone repository
-— the core angle. Caveat to manage in copy: 5-gal cloning can't perfectly match commercial conditions.
+**Évaluation :** La demande de clones est réelle, durable, auto-organisée. La question récurrente « existe-t-il
+une base de données de clones ? » est une preuve directe d'un besoin non satisfait : un dépôt de clones
+*recherchable et curé* — l'angle central. Réserve à gérer dans le discours : un clonage sur 5 gallons ne peut
+pas reproduire parfaitement les conditions commerciales.
 
-### 2. Tool/app dissatisfaction & comparison shopping — HIGH
-Constant "which software / X vs Y" threads; users not fully satisfied with any. Specific complaints:
-- **Data loss / not trusting the tool as source of truth** ("I have lost enough recipes... I stopped using brewing software as my source").
-- **Subscription fatigue** ("I don't see the value in the subscription model").
-- **Weak inventory↔recipe linkage** (Brewer's Friend "still lacks inventory management"; can't filter recipes by stock).
-- **Poor data portability / migration pain** (BeerXML import losing data; can't separate recipes from batches).
-- Apps are "largely self-learning" (steep, undocumented UX).
+### 2. Insatisfaction vis-à-vis des outils/apps & comparaison avant achat — ÉLEVÉE
+Flux constant de fils « quel logiciel / X vs Y » ; aucun utilisateur pleinement satisfait. Plaintes précises :
+- **Perte de données / méfiance envers l'outil comme source de vérité** (« I have lost enough recipes... I stopped using brewing software as my source »).
+- **Lassitude des abonnements** (« I don't see the value in the subscription model »).
+- **Faible liaison inventaire↔recette** (Brewer's Friend « still lacks inventory management » ; impossible de filtrer les recettes par stock).
+- **Mauvaise portabilité des données / migration pénible** (import BeerXML qui perd des données ; impossible de séparer recettes et brassins).
+- Les apps sont « largement auto-apprises » (UX abrupte, non documentée).
 
-**Assessment:** Openings = reliability/no-data-loss, fair pricing, gentle onboarding, real
-recipe↔inventory linkage. Incumbents are mature on calculation — competing on calc alone loses.
+**Évaluation :** Les ouvertures = fiabilité/zéro perte de données, tarification juste, prise en main douce, vraie
+liaison recette↔inventaire. Les acteurs en place sont matures sur le calcul — se battre sur le calcul seul est
+perdu d'avance.
 
-### 3. Recipe organization pain ("too many recipes, no good system") — HIGH
-Persistent threads ("Organizing recipes?", "Personal Recipe Database/Records?", "Organization Tips").
-Users fall back to **binders, BJCP-category tabs, Evernote tags, Google Docs, multi-tab spreadsheets**
-— i.e. they *leave the brewing apps* to organize. BeerSmith folders criticized as rigid.
+### 3. Douleur d'organisation des recettes (« trop de recettes, aucun bon système ») — ÉLEVÉE
+Fils persistants (« Organizing recipes? », « Personal Recipe Database/Records? », « Organization Tips »).
+Les utilisateurs se rabattent sur des **classeurs, des onglets par catégorie BJCP, des tags Evernote, Google Docs,
+des tableurs multi-onglets** — autrement dit ils *quittent les apps de brassage* pour organiser. Les dossiers
+BeerSmith sont critiqués comme rigides.
 
-**Assessment:** Tagging/filtering (by style, ingredient, batch outcome) is a concrete requested win.
-Users defecting to general-purpose tools = brewing apps under-serve organization.
+**Évaluation :** Le tag/filtrage (par style, ingrédient, résultat de brassin) est un gain concret réclamé. Des
+utilisateurs qui défectent vers des outils généralistes = les apps de brassage desservent mal l'organisation.
 
-### 4. Brew-day / fermentation tracking ("I built my own because nothing was good enough") — HIGH
-Heavy volume on logging brew day + fermentation. Strong DIY signal — multiple users built their own
-apps (e.g. "I couldn't find a good fermentation log-app for cider/mead, so I built one"). Growing
-interest in connected hydrometers (Tilt, iSpindel) feeding fermentation graphs.
+### 4. Suivi de brassin / fermentation (« j'ai construit le mien parce que rien n'était assez bon ») — ÉLEVÉE
+Fort volume sur la journalisation du jour de brassage + de la fermentation. Signal DIY fort — plusieurs
+utilisateurs ont construit leurs propres apps (ex. « I couldn't find a good fermentation log-app for cider/mead, so I built one »). Intérêt croissant pour les
+densimètres connectés (Tilt, iSpindel) alimentant des courbes de fermentation.
 
-**Assessment:** Tracking is a validated foundation feature; "built my own" threads = unmet need.
-Tilt/iSpindel import is a recurring ask — flag as v0.2+ (scope).
+**Évaluation :** Le suivi est une fonctionnalité socle validée ; les fils « j'ai construit le mien » = besoin non
+satisfait. L'import Tilt/iSpindel est une demande récurrente — à signaler en v0.2+ (périmètre).
 
-### 5. Recipe sharing & willingness to share — MEDIUM-HIGH, mostly POSITIVE
-Homebrewers are culturally open ("flattered to share... an honor"; "willing to share any recipe").
-Existing mechanisms are fragmented/fading: BeerSmith Cloud search, the defunct Hopville, BeerXML
-export; recurring "download a full BeerXML database" requests. brassageamateur effectively *is* a
-communal recipe library.
+### 5. Partage de recettes & disposition à partager — MOYENNE-ÉLEVÉE, majoritairement POSITIVE
+Les brasseurs amateurs sont culturellement ouverts (« flattered to share... an honor » ; « willing to share any recipe »).
+Les mécanismes existants sont fragmentés/déclinants : recherche BeerSmith Cloud, le défunt Hopville, l'export
+BeerXML ; demandes récurrentes pour « télécharger une base BeerXML complète ». brassageamateur *est* de fait une
+bibliothèque communautaire de recettes.
 
-**Assessment:** Willingness is high; the gap is a *good* sharing/discovery surface — the bar is
-"better than a forum thread + BeerXML file," needing frictionless BeerXML/BeerJSON import/export to
-interoperate (not lock-in). Caveat: commercial breweries are protective; *homebrewer-to-homebrewer*
-is the open lane.
+**Évaluation :** La disposition est élevée ; le manque est une *bonne* surface de partage/découverte — la barre est
+« mieux qu'un fil de forum + un fichier BeerXML », nécessitant un import/export BeerXML/BeerJSON sans friction pour
+interopérer (pas d'enfermement). Réserve : les brasseries commerciales sont protectrices ; le couloir ouvert est
+*de brasseur amateur à brasseur amateur*.
 
-## English (HomeBrewTalk) vs French (brassageamateur)
+## Anglophone (HomeBrewTalk) vs francophone (brassageamateur)
 
 | Dimension | HomeBrewTalk (EN) | brassageamateur (FR) |
 |---|---|---|
-| Scale & cadence | Very large, high-volume, many parallel threads | Smaller but tight-knit; structured sub-forums; multi-year threads |
-| Clone targets | US/UK craft + macro (Manny's, Heineken, Spaten, Smithwick's) | Belgian/Trappist + French (Orval, Westvleteren, Duvel, Kronenbourg 1664, Météor) |
-| Tooling | Commercial apps: BeerSmith, Brewfather, Brewer's Friend | Free/open + homegrown: **Beerxcel (Excel), Joliebulle (open-source), Little Bock**, BYOB |
-| Sharing model | App clouds + BeerXML files; forum text | Forum *is* the shared library; communal Beerxcel/recipe DBs; values free tools |
-| Pricing sensitivity | Subscription-skeptical but pays | More resistant to paywalls (Little Bock going paid drew friction) |
-| Instability | Mature, stable incumbents | **Joliebulle closed (2010–2025)** — appeared uncertain in this pass, later **confirmed** in `03b`/`03d` |
+| Échelle & cadence | Très grand, fort volume, nombreux fils parallèles | Plus petit mais soudé ; sous-forums structurés ; fils sur plusieurs années |
+| Cibles de clones | Craft US/UK + macro (Manny's, Heineken, Spaten, Smithwick's) | Belge/trappiste + français (Orval, Westvleteren, Duvel, Kronenbourg 1664, Météor) |
+| Outillage | Apps commerciales : BeerSmith, Brewfather, Brewer's Friend | Gratuit/open + maison : **Beerxcel (Excel), Joliebulle (open-source), Little Bock**, BYOB |
+| Modèle de partage | Clouds d'apps + fichiers BeerXML ; texte de forum | Le forum *est* la bibliothèque partagée ; bases Beerxcel/recettes communautaires ; attachement aux outils gratuits |
+| Sensibilité au prix | Sceptique sur l'abonnement mais paie | Plus réticent aux paywalls (le passage payant de Little Bock a généré des frictions) |
+| Instabilité | Acteurs matures, stables | **Joliebulle fermé (2010-2025)** — incertain à cette passe, ensuite **confirmé** dans `03b`/`03d` |
 
-**Bilingual implications**
-- Localize clone seed-content per region (Belgian/Trappist for FR; US/UK craft for EN) — clone catalogs are not interchangeable. (`03d` finds FR *macro lager* is NOT a meaningful clone target, despite Kronenbourg 1664 appearing in the sub-forum list above — treat the FR clone-targets cell as raw observation, not a seed-content priority.)
-- FR audience more price-sensitive and free-tool-loyal → the freemium boundary matters more there (consistent with keeping BeerXML/BeerJSON export paid only if the free tier stays genuinely useful).
-- FR expects responsive, present maintainers → community management is part of the product.
-- BeerXML import/export is table-stakes both sides (capture migrants from BeerSmith/Brewfather EN, Joliebulle/Little Bock FR).
+**Implications bilingues**
+- Localiser le contenu d'amorçage de clones par région (belge/trappiste pour FR ; craft US/UK pour EN) — les
+  catalogues de clones ne sont pas interchangeables. (`03d` constate que la *lager macro* FR n'est PAS une cible
+  de clone significative, malgré la présence de Kronenbourg 1664 dans la liste du sous-forum ci-dessus — traiter
+  la cellule des cibles de clones FR comme une observation brute, non une priorité de contenu d'amorçage.)
+- Audience FR plus sensible au prix et plus fidèle aux outils gratuits → la frontière freemium y compte davantage
+  (cohérent avec le maintien de l'export BeerXML/BeerJSON en payant uniquement si le palier gratuit reste réellement utile).
+- L'audience FR attend des mainteneurs réactifs et présents → l'animation de communauté fait partie du produit.
+- L'import/export BeerXML est un prérequis des deux côtés (capter les migrants de BeerSmith/Brewfather EN, Joliebulle/Little Bock FR).
 
-## Net read for positioning
-The differentiator (community for cloning + sharing) maps directly onto the two highest-frequency
-unmet needs: a searchable curated *clone* database (#1) and a *better sharing surface than forum
-threads* (#5), on top of two validated foundations users currently hack together — organization (#3)
-and tracking (#4). The moat is **not** calculation; it is curation + community + reliability + fair
-pricing + frictionless import/export.
+## Lecture nette pour le positionnement
+Le différenciateur (communauté pour le clonage + le partage) recouvre directement les deux besoins non satisfaits
+les plus fréquents : une base de *clones* curée et recherchable (#1) et une *meilleure surface de partage que les
+fils de forum* (#5), par-dessus deux socles validés que les utilisateurs bricolent aujourd'hui — l'organisation (#3)
+et le suivi (#4). Le fossé défensif n'est **pas** le calcul ; c'est curation + communauté + fiabilité + tarification
+juste + import/export sans friction.
 
-**Key uncertainties:** HBT findings snippet-based (403); frequency qualitative. (Joliebulle closure, flagged uncertain in this pass, was later **confirmed** in `03b`/`03d`.)
+**Incertitudes clés :** constats HBT fondés sur des extraits (403) ; fréquence qualitative. (La fermeture de
+Joliebulle, signalée comme incertaine à cette passe, a ensuite été **confirmée** dans `03b`/`03d`.)
 
 ## Sources
 - https://www.homebrewtalk.com/threads/is-there-a-clone-recipe-database.679618/

--- a/docs/marketing/needs-study/03-desk-forums.md
+++ b/docs/marketing/needs-study/03-desk-forums.md
@@ -1,0 +1,104 @@
+# Desk Research — Forums (HomeBrewTalk + brassageamateur.com)
+
+**Method note:** HomeBrewTalk.com blocks automated fetches (HTTP 403), so HBT findings rely on
+search-result snippets (titles + indexed excerpts), not full-thread reads. brassageamateur.com pages
+were fetched directly. Frequency signals are qualitative (recurrence of distinct threads), not
+scraped post-counts.
+
+## Ranked recurring themes
+
+### 1. Demand for clone recipes of specific commercial beers — VERY HIGH
+The single most recurrent topic. Continuous "clone of X" request threads on both forums, plus
+meta-threads asking where to *find* clones.
+- HBT has a long-running clone culture ("Why I Clone Commercial Brews"; "Is there a Clone Recipe database?").
+- brassageamateur has a **dedicated clone sub-forum: 133 threads / 170+ shared recipes** (Orval,
+  Westmalle, Duvel, Rochefort 10, Westvleteren 12, Hoegaarden, Kronenbourg 1664, Guinness, Punk IPA),
+  popular threads with 85–149 replies, active into 2025–2026.
+
+**Assessment:** Clone demand is real, sustained, self-organizing. The recurring "is there a clone
+database?" question is direct evidence of an unmet need for a *searchable, curated* clone repository
+— the core angle. Caveat to manage in copy: 5-gal cloning can't perfectly match commercial conditions.
+
+### 2. Tool/app dissatisfaction & comparison shopping — HIGH
+Constant "which software / X vs Y" threads; users not fully satisfied with any. Specific complaints:
+- **Data loss / not trusting the tool as source of truth** ("I have lost enough recipes... I stopped using brewing software as my source").
+- **Subscription fatigue** ("I don't see the value in the subscription model").
+- **Weak inventory↔recipe linkage** (Brewer's Friend "still lacks inventory management"; can't filter recipes by stock).
+- **Poor data portability / migration pain** (BeerXML import losing data; can't separate recipes from batches).
+- Apps are "largely self-learning" (steep, undocumented UX).
+
+**Assessment:** Openings = reliability/no-data-loss, fair pricing, gentle onboarding, real
+recipe↔inventory linkage. Incumbents are mature on calculation — competing on calc alone loses.
+
+### 3. Recipe organization pain ("too many recipes, no good system") — HIGH
+Persistent threads ("Organizing recipes?", "Personal Recipe Database/Records?", "Organization Tips").
+Users fall back to **binders, BJCP-category tabs, Evernote tags, Google Docs, multi-tab spreadsheets**
+— i.e. they *leave the brewing apps* to organize. BeerSmith folders criticized as rigid.
+
+**Assessment:** Tagging/filtering (by style, ingredient, batch outcome) is a concrete requested win.
+Users defecting to general-purpose tools = brewing apps under-serve organization.
+
+### 4. Brew-day / fermentation tracking ("I built my own because nothing was good enough") — HIGH
+Heavy volume on logging brew day + fermentation. Strong DIY signal — multiple users built their own
+apps (e.g. "I couldn't find a good fermentation log-app for cider/mead, so I built one"). Growing
+interest in connected hydrometers (Tilt, iSpindel) feeding fermentation graphs.
+
+**Assessment:** Tracking is a validated foundation feature; "built my own" threads = unmet need.
+Tilt/iSpindel import is a recurring ask — flag as v0.2+ (scope).
+
+### 5. Recipe sharing & willingness to share — MEDIUM-HIGH, mostly POSITIVE
+Homebrewers are culturally open ("flattered to share... an honor"; "willing to share any recipe").
+Existing mechanisms are fragmented/fading: BeerSmith Cloud search, the defunct Hopville, BeerXML
+export; recurring "download a full BeerXML database" requests. brassageamateur effectively *is* a
+communal recipe library.
+
+**Assessment:** Willingness is high; the gap is a *good* sharing/discovery surface — the bar is
+"better than a forum thread + BeerXML file," needing frictionless BeerXML/BeerJSON import/export to
+interoperate (not lock-in). Caveat: commercial breweries are protective; *homebrewer-to-homebrewer*
+is the open lane.
+
+## English (HomeBrewTalk) vs French (brassageamateur)
+
+| Dimension | HomeBrewTalk (EN) | brassageamateur (FR) |
+|---|---|---|
+| Scale & cadence | Very large, high-volume, many parallel threads | Smaller but tight-knit; structured sub-forums; multi-year threads |
+| Clone targets | US/UK craft + macro (Manny's, Heineken, Spaten, Smithwick's) | Belgian/Trappist + French (Orval, Westvleteren, Duvel, Kronenbourg 1664, Météor) |
+| Tooling | Commercial apps: BeerSmith, Brewfather, Brewer's Friend | Free/open + homegrown: **Beerxcel (Excel), Joliebulle (open-source), Little Bock**, BYOB |
+| Sharing model | App clouds + BeerXML files; forum text | Forum *is* the shared library; communal Beerxcel/recipe DBs; values free tools |
+| Pricing sensitivity | Subscription-skeptical but pays | More resistant to paywalls (Little Bock going paid drew friction) |
+| Instability | Mature, stable incumbents | **Joliebulle status uncertain** (one source: closed early 2025; but joliebulle.org + "Joliebulle Studio" appear active) — *conflicting/unconfirmed* |
+
+**Bilingual implications**
+- Localize clone seed-content per region (Belgian/Trappist + French macro for FR; US/UK craft for EN) — clone catalogs are not interchangeable.
+- FR audience more price-sensitive and free-tool-loyal → the freemium boundary matters more there (consistent with keeping BeerXML/BeerJSON export paid only if the free tier stays genuinely useful).
+- FR expects responsive, present maintainers → community management is part of the product.
+- BeerXML import/export is table-stakes both sides (capture migrants from BeerSmith/Brewfather EN, Joliebulle/Little Bock FR).
+
+## Net read for positioning
+The differentiator (community for cloning + sharing) maps directly onto the two highest-frequency
+unmet needs: a searchable curated *clone* database (#1) and a *better sharing surface than forum
+threads* (#5), on top of two validated foundations users currently hack together — organization (#3)
+and tracking (#4). The moat is **not** calculation; it is curation + community + reliability + fair
+pricing + frictionless import/export.
+
+**Key uncertainties:** HBT findings snippet-based (403); frequency qualitative; Joliebulle closure unconfirmed.
+
+## Sources
+- https://www.homebrewtalk.com/threads/is-there-a-clone-recipe-database.679618/
+- https://www.homebrewtalk.com/threads/why-i-clone-commercial-brews.678756/
+- https://www.brassageamateur.com/forum/viewforum.php?f=95
+- https://homebrewtalk.com/threads/comparing-homebrewing-software.679134/
+- https://homebrewtalk.com/threads/brewfather-vs-brewers-friend.673669/
+- https://homebrewtalk.com/threads/scaling-with-beersmith-vs-brewfather-troubles.692447/
+- https://homebrewtalk.com/threads/organizing-recipes.232447/
+- https://www.homebrewtalk.com/threads/personal-recipe-database-records.99384/
+- https://homebrewtalk.com/threads/organization-tips-for-homebrewers.678855/
+- https://homebrewtalk.com/threads/i-couldnt-find-a-good-fermentation-log-app-for-cider-mead-so-i-built-one.738999/
+- https://homebrewtalk.com/threads/phone-app-for-detailed-brew-day-notes.484531/
+- https://homebrewtalk.com/threads/brew-logs-and-recipe-tracking.498700/
+- https://www.homebrewtalk.com/threads/recipes-kept-secret.199276/
+- https://homebrewtalk.com/threads/where-can-i-download-a-full-beerxml-database.486803/
+- https://www.brassageamateur.com/forum/viewtopic.php?t=42555
+- https://www.brassageamateur.com/forum/viewtopic.php?t=29232
+- https://joliebulle.org/
+- https://univers-biere.net/logiciels.php

--- a/docs/marketing/needs-study/03-desk-forums.md
+++ b/docs/marketing/needs-study/03-desk-forums.md
@@ -66,10 +66,10 @@ is the open lane.
 | Tooling | Commercial apps: BeerSmith, Brewfather, Brewer's Friend | Free/open + homegrown: **Beerxcel (Excel), Joliebulle (open-source), Little Bock**, BYOB |
 | Sharing model | App clouds + BeerXML files; forum text | Forum *is* the shared library; communal Beerxcel/recipe DBs; values free tools |
 | Pricing sensitivity | Subscription-skeptical but pays | More resistant to paywalls (Little Bock going paid drew friction) |
-| Instability | Mature, stable incumbents | **Joliebulle status uncertain** (one source: closed early 2025; but joliebulle.org + "Joliebulle Studio" appear active) — *conflicting/unconfirmed* |
+| Instability | Mature, stable incumbents | **Joliebulle closed (2010–2025)** — appeared uncertain in this pass, later **confirmed** in `03b`/`03d` |
 
 **Bilingual implications**
-- Localize clone seed-content per region (Belgian/Trappist + French macro for FR; US/UK craft for EN) — clone catalogs are not interchangeable.
+- Localize clone seed-content per region (Belgian/Trappist for FR; US/UK craft for EN) — clone catalogs are not interchangeable. (`03d` finds FR *macro lager* is NOT a meaningful clone target, despite Kronenbourg 1664 appearing in the sub-forum list above — treat the FR clone-targets cell as raw observation, not a seed-content priority.)
 - FR audience more price-sensitive and free-tool-loyal → the freemium boundary matters more there (consistent with keeping BeerXML/BeerJSON export paid only if the free tier stays genuinely useful).
 - FR expects responsive, present maintainers → community management is part of the product.
 - BeerXML import/export is table-stakes both sides (capture migrants from BeerSmith/Brewfather EN, Joliebulle/Little Bock FR).
@@ -81,7 +81,7 @@ threads* (#5), on top of two validated foundations users currently hack together
 and tracking (#4). The moat is **not** calculation; it is curation + community + reliability + fair
 pricing + frictionless import/export.
 
-**Key uncertainties:** HBT findings snippet-based (403); frequency qualitative; Joliebulle closure unconfirmed.
+**Key uncertainties:** HBT findings snippet-based (403); frequency qualitative. (Joliebulle closure, flagged uncertain in this pass, was later **confirmed** in `03b`/`03d`.)
 
 ## Sources
 - https://www.homebrewtalk.com/threads/is-there-a-clone-recipe-database.679618/

--- a/docs/marketing/needs-study/03b-desk-french.md
+++ b/docs/marketing/needs-study/03b-desk-french.md
@@ -1,0 +1,119 @@
+# Desk Research — French-Language Sources
+
+Dedicated French pass to rebalance an English-skewed corpus (the product is bilingual FR + EN).
+Covers FR blogs, software sites, the forum's own sharing app, FB/YouTube/Discord signal.
+brassageamateur.com cited only where it adds NEW specifics. Confidence flagged per claim.
+
+## Ranked French-specific themes / needs
+
+### 1. Cloning commercial beers is mainstream, first-class — VERY HIGH
+"Brasser un clone" is settled vocabulary; hundreds of clone recipes live in FR tool libraries and on blogs.
+- https://comment-brasser-sa-biere.fr/recette-ipa/
+- https://labrowar.blogspot.com/2016/01/recette-clone-orval.html
+- https://www.littlebock.fr/recettes-bieres/24/nom/punk-ipa-clone
+
+### 2. Tools must do the tedious math AND auto-rescale to the brewer's equipment — HIGH
+FR blogs frame software value as offloading OG/FG, IBU, EBC/SRM, ABV, mash steps; mash-efficiency
+customization that "automatically adjusts recipe quantities" is explicitly wanted. (Directly supports
+the auto-rescale enabler of the hero.)
+- https://blog.littlebock.fr/creer-recette-biere-logiciel-brassage/
+- https://www.brassageamateur.com/forum/viewtopic.php?t=42555
+
+### 3. French-language UI matters — English is a stated dealbreaker — HIGH (FR-specific)
+Brewfather (the strongest tool) is repeatedly flagged as "en anglais, ce qui peut être rédhibitoire."
+A genuine competitive lever absent from the English corpus.
+- https://univers-biere.net/logiciels.php
+
+### 4. Community recipe sharing is wanted — and ALREADY PARTIALLY SERVED in FR — HIGH
+brassageamateur.com built its own "BrewRecipes" app (BeerXML import, search/filter, community ratings,
+350+ recipes); Little Bock's public library is a core draw. So in FR the sharing angle competes against
+incumbents, not a vacuum.
+- https://www.brassageamateur.com/wiki/Beerxml
+- https://www.littlebock.fr/
+
+### 5. Brew/fermentation tracking expected but bolted on — MEDIUM-HIGH
+Per-brassin notes/measures, history, fermentation graph, brew-day reminders. Brewfather wins via device
+integrations (iSpindel, Tilt, Plaato); Little Bock offers per-brassin notes. Caveat: in the main
+"quel logiciel" debate, the focus was ease-of-use/offline/calc accuracy, not tracking.
+- https://apps.apple.com/fr/app/brewfather/id1488585822
+
+### 6. Tool reliability / data-durability anxiety — MEDIUM (strategically important)
+Little Bock suffered a major hosting outage (OVH SBG3) with a degraded read-only backup; some calc
+distrust. Joliebulle's shutdown amplifies fear of losing recipe history. → BeerXML import/export +
+reliability are TRUST features, not nice-to-haves.
+- https://www.brassageamateur.com/forum/viewtopic.php?t=37899
+
+### 7. Strong price sensitivity / low-cost ethos — MEDIUM-HIGH
+Recurrent "brasser pour pas cher"; pro tools rejected as overkill ("Easybeer 29€/mois… beaucoup trop
+cher… un simple fichier Excel suffit"). A generous free tier is near-mandatory; paid features must be
+clearly amateur-relevant (consistent with export-as-paid).
+- https://www.happybeertime.com/blog/2016/12/26/5-conseils-brasser-amateur-facon-low-cost/
+
+## French tooling landscape
+
+- **Little Bock** (littlebock.fr) — FR online recipe builder + community library + profiles + per-brassin
+  notes + inventory. **Active, freemium** (free tier capped). Often called the best/most intuitive FR tool;
+  criticized for a limited free tier, carbonation calc overestimation, and a past outage. Maintainer
+  present but slowed.
+- **Joliebulle** (joliebulle.org) — open-source desktop tool, loved for being simple/offline/free.
+  **CLOSED — confirmed** (lifespan stated 2010–2025; site in past tense). No official successor; community
+  redirects to Little Bock / Brewfather / Brewtarget. → **displaced user base actively seeking a home =
+  concrete acquisition opportunity.** (A Gumroad page persists; purchasability post-shutdown uncertain.)
+- **Beerxcel** — free Excel all-in-one; comprehensive but hard to learn; dev active on forum. Active, free.
+- **Brewtarget** — open-source, free, cross-platform, FR manual; functional but dated (v4.01, Aug 2024).
+- **Brewfather** — online, freemium; best fermentation tracking via device integrations; recurrent
+  complaint = English-only.
+- **BeerSmith** — FR translation/community exists; legacy paid heavyweight, not heavily tested by FR users.
+- **BiboWeb** — could NOT be confirmed this pass. **Unverified** — probe before citing.
+- Also: BYOB (free web), Brewy (free Android), Easybeer (pro, 29€/mo, "too expensive" for amateurs).
+
+Sources: https://univers-biere.net/logiciels.php · https://joliebulle.org/ · https://www.littlebock.fr/fonctionnalites-et-tarifs
+
+## French clone targets
+
+- **Belgian / Trappist** (strong FR/BE cultural anchor): Orval, La Chouffe, Westmalle Triple, Belgian
+  quad. Lean on *Brew Like a Monk*, EBC/IBU/attenuation matching.
+- **International craft icons**, dominated by **BrewDog Punk IPA** (many clone versions, fed by BrewDog's
+  "DIY DOG" release); general IPA/APA clones common.
+- **French macro lager (Kronenbourg/1664, Heineken-style) did NOT surface as a meaningful clone target** —
+  demand skews Belgian abbey/Trappist + craft IPA. (Soft/negative finding; corrects an earlier assumption
+  that FR macro lager was a primary clone target.)
+
+Sources: https://univers-biere.net/rec_chouffe.php · https://labrowar.blogspot.com/2016/01/recette-clone-orval.html · https://www.littlebock.fr/recettes-bieres/24/nom/punk-ipa-clone
+
+## French audience specifics (marketing)
+
+- **High, culturally explicit price sensitivity.** Generous free tier near-mandatory; paid must be amateur-relevant.
+- **Free/open-tool loyalty.** A purely closed SaaS meets cultural friction (Joliebulle/Brewtarget/Beerxcel ethos).
+- **High expectations of maintainer presence + data durability.** Active devs are rewarded; tool deaths/outages
+  created real anxiety → portability + reliability are trust levers.
+- **Where the FR community congregates:**
+  - **Forum (brassageamateur.com)** = structured hub — and hosts its own recipe-sharing app, so it is a
+    *partial direct competitor* on the sharing axis.
+  - **Facebook** = high-volume informal layer (national "brassage.amateur.biere" + regional groups).
+  - **Discord** = support/chat layer (Joliebulle ran a praised one), not a recipe repository.
+  - **YouTube** FR channels active (Bricole Brassicole, Brassage TV, Craft My Brewery) — partnership/marketing, tutorial-skewed.
+  - **Local clubs/associations** (ABAHF, Fauve Homebrew Club) = real in-person layer.
+
+Sources: https://www.brassageamateur.com/wiki/Beerxml · https://fr-fr.facebook.com/brassage.amateur.biere/ · https://abahf.ovh/ · https://www.youtube.com/c/BricoleBrassicole
+
+## Does FR confirm or diverge from EN?
+
+Mostly **CONFIRMS** (a good saturation signal), with FR-specific sharpenings:
+
+- Clone demand high → **confirmed**, arguably stronger/more legitimate in FR.
+- Sharing wanted → **confirmed**, BUT already partially served in FR (forum BrewRecipes + Little Bock) →
+  differentiation must come from **versioning + credit/attribution + auto-rescale**, not "sharing exists."
+- Attribution-sensitivity → **only weakly corroborated in FR** (strong in EN). **Do not assume it transfers —
+  test explicitly in interviews.**
+- Organization/tracking hacked together → **confirmed**; no FR tool unifies organization + versioned sharing + tracking.
+- Don't compete on calculation → **confirmed and reinforced** (calc is table-stakes; tools already trusted/distrusted on it).
+
+**FR-specific strategic adds:** (1) French-first UI is a real competitive lever; (2) Joliebulle's 2025 death =
+displaced users seeking a home; (3) data durability + BeerXML portability are trust-critical after recent FR tool failures.
+
+## Uncertainties flagged
+- BiboWeb unverified.
+- Joliebulle Gumroad purchasability post-shutdown unclear.
+- FR attribution-sensitivity under-evidenced — do not assume parity with EN.
+- FB group member counts not retrieved.

--- a/docs/marketing/needs-study/03b-desk-french.md
+++ b/docs/marketing/needs-study/03b-desk-french.md
@@ -1,119 +1,119 @@
-# Desk Research — French-Language Sources
+# Desk research — Sources francophones
 
-Dedicated French pass to rebalance an English-skewed corpus (the product is bilingual FR + EN).
-Covers FR blogs, software sites, the forum's own sharing app, FB/YouTube/Discord signal.
-brassageamateur.com cited only where it adds NEW specifics. Confidence flagged per claim.
+Passe francophone dédiée pour rééquilibrer un corpus biaisé vers l'anglais (le produit est bilingue FR + EN).
+Couvre les blogs FR, les sites de logiciels, l'app de partage du forum lui-même, ainsi que les signaux FB/YouTube/Discord.
+brassageamateur.com n'est cité que là où il apporte des spécificités NOUVELLES. Confiance signalée par affirmation.
 
-## Ranked French-specific themes / needs
+## Thèmes / besoins spécifiques à la France, classés
 
-### 1. Cloning commercial beers is mainstream, first-class — VERY HIGH
-"Brasser un clone" is settled vocabulary; hundreds of clone recipes live in FR tool libraries and on blogs.
+### 1. Le clonage de bières commerciales est courant, de premier rang — TRÈS ÉLEVÉ
+« Brasser un clone » est un vocabulaire établi ; des centaines de recettes de clones vivent dans les bibliothèques d'outils FR et sur les blogs.
 - https://comment-brasser-sa-biere.fr/recette-ipa/
 - https://labrowar.blogspot.com/2016/01/recette-clone-orval.html
 - https://www.littlebock.fr/recettes-bieres/24/nom/punk-ipa-clone
 
-### 2. Tools must do the tedious math AND auto-rescale to the brewer's equipment — HIGH
-FR blogs frame software value as offloading OG/FG, IBU, EBC/SRM, ABV, mash steps; mash-efficiency
-customization that "automatically adjusts recipe quantities" is explicitly wanted. (Directly supports
-the auto-rescale enabler of the hero.)
+### 2. Les outils doivent faire les calculs fastidieux ET ré-échelonner automatiquement vers l'équipement du brasseur — ÉLEVÉ
+Les blogs FR présentent la valeur du logiciel comme le fait de déléguer OG/FG, IBU, EBC/SRM, ABV, les paliers d'empâtage ;
+la personnalisation du rendement d'empâtage qui « ajuste automatiquement les quantités de la recette » est explicitement souhaitée.
+(Soutient directement le facteur de ré-échelonnage automatique du discours phare.)
 - https://blog.littlebock.fr/creer-recette-biere-logiciel-brassage/
 - https://www.brassageamateur.com/forum/viewtopic.php?t=42555
 
-### 3. French-language UI matters — English is a stated dealbreaker — HIGH (FR-specific)
-Brewfather (the strongest tool) is repeatedly flagged as "en anglais, ce qui peut être rédhibitoire."
-A genuine competitive lever absent from the English corpus.
+### 3. L'interface en français compte — l'anglais est un point de blocage déclaré — ÉLEVÉ (spécifique FR)
+Brewfather (l'outil le plus solide) est régulièrement signalé comme « en anglais, ce qui peut être rédhibitoire ».
+Un véritable levier concurrentiel absent du corpus anglophone.
 - https://univers-biere.net/logiciels.php
 
-### 4. Community recipe sharing is wanted — and ALREADY PARTIALLY SERVED in FR — HIGH
-brassageamateur.com built its own "BrewRecipes" app (BeerXML import, search/filter, community ratings,
-350+ recipes); Little Bock's public library is a core draw. So in FR the sharing angle competes against
-incumbents, not a vacuum.
+### 4. Le partage communautaire de recettes est souhaité — et DÉJÀ PARTIELLEMENT SERVI en FR — ÉLEVÉ
+brassageamateur.com a construit sa propre app « BrewRecipes » (import BeerXML, recherche/filtre, notes communautaires,
+350+ recettes) ; la bibliothèque publique de Little Bock est un atout central. Donc en FR l'angle du partage affronte
+des acteurs en place, et non un vide.
 - https://www.brassageamateur.com/wiki/Beerxml
 - https://www.littlebock.fr/
 
-### 5. Brew/fermentation tracking expected but bolted on — MEDIUM-HIGH
-Per-brassin notes/measures, history, fermentation graph, brew-day reminders. Brewfather wins via device
-integrations (iSpindel, Tilt, Plaato); Little Bock offers per-brassin notes. Caveat: in the main
-"quel logiciel" debate, the focus was ease-of-use/offline/calc accuracy, not tracking.
+### 5. Suivi de brassin/fermentation attendu mais ajouté en surcouche — MOYEN-ÉLEVÉ
+Notes/mesures par brassin, historique, courbe de fermentation, rappels de jour de brassage. Brewfather l'emporte grâce
+aux intégrations d'appareils (iSpindel, Tilt, Plaato) ; Little Bock propose des notes par brassin. Réserve : dans le débat
+principal « quel logiciel », l'accent portait sur la facilité d'usage/hors-ligne/précision de calcul, pas sur le suivi.
 - https://apps.apple.com/fr/app/brewfather/id1488585822
 
-### 6. Tool reliability / data-durability anxiety — MEDIUM (strategically important)
-Little Bock suffered a major hosting outage (OVH SBG3) with a degraded read-only backup; some calc
-distrust. Joliebulle's shutdown amplifies fear of losing recipe history. → BeerXML import/export +
-reliability are TRUST features, not nice-to-haves.
+### 6. Anxiété de fiabilité / durabilité des données des outils — MOYEN (stratégiquement important)
+Little Bock a subi une panne d'hébergement majeure (OVH SBG3) avec une sauvegarde dégradée en lecture seule ; une certaine
+méfiance sur le calcul. La fermeture de Joliebulle amplifie la peur de perdre l'historique des recettes. → L'import/export
+BeerXML + la fiabilité sont des fonctionnalités de CONFIANCE, pas des options accessoires.
 - https://www.brassageamateur.com/forum/viewtopic.php?t=37899
 
-### 7. Strong price sensitivity / low-cost ethos — MEDIUM-HIGH
-Recurrent "brasser pour pas cher"; pro tools rejected as overkill ("Easybeer 29€/mois… beaucoup trop
-cher… un simple fichier Excel suffit"). A generous free tier is near-mandatory; paid features must be
-clearly amateur-relevant (consistent with export-as-paid).
+### 7. Forte sensibilité au prix / éthos low-cost — MOYEN-ÉLEVÉ
+Récurrent « brasser pour pas cher » ; outils pro rejetés comme surdimensionnés (« Easybeer 29€/mois… beaucoup trop
+cher… un simple fichier Excel suffit »). Un palier gratuit généreux est quasi obligatoire ; les fonctionnalités payantes
+doivent être clairement pertinentes pour l'amateur (cohérent avec l'export-en-payant).
 - https://www.happybeertime.com/blog/2016/12/26/5-conseils-brasser-amateur-facon-low-cost/
 
-## French tooling landscape
+## Paysage des outils francophones
 
-- **Little Bock** (littlebock.fr) — FR online recipe builder + community library + profiles + per-brassin
-  notes + inventory. **Active, freemium** (free tier capped). Often called the best/most intuitive FR tool;
-  criticized for a limited free tier, carbonation calc overestimation, and a past outage. Maintainer
-  present but slowed.
-- **Joliebulle** (joliebulle.org) — open-source desktop tool, loved for being simple/offline/free.
-  **CLOSED — confirmed** (lifespan stated 2010–2025; site in past tense). No official successor; community
-  redirects to Little Bock / Brewfather / Brewtarget. → **displaced user base actively seeking a home =
-  concrete acquisition opportunity.** (A Gumroad page persists; purchasability post-shutdown uncertain.)
-- **Beerxcel** — free Excel all-in-one; comprehensive but hard to learn; dev active on forum. Active, free.
-- **Brewtarget** — open-source, free, cross-platform, FR manual; functional but dated (v4.01, Aug 2024).
-- **Brewfather** — online, freemium; best fermentation tracking via device integrations; recurrent
-  complaint = English-only.
-- **BeerSmith** — FR translation/community exists; legacy paid heavyweight, not heavily tested by FR users.
-- **BiboWeb** — could NOT be confirmed this pass. **Unverified** — probe before citing.
-- Also: BYOB (free web), Brewy (free Android), Easybeer (pro, 29€/mo, "too expensive" for amateurs).
+- **Little Bock** (littlebock.fr) — créateur de recettes en ligne FR + bibliothèque communautaire + profils + notes
+  par brassin + inventaire. **Actif, freemium** (palier gratuit plafonné). Souvent cité comme le meilleur/le plus intuitif
+  des outils FR ; critiqué pour un palier gratuit limité, une surestimation du calcul de carbonatation et une panne passée.
+  Mainteneur présent mais ralenti.
+- **Joliebulle** (joliebulle.org) — outil de bureau open-source, apprécié pour sa simplicité/hors-ligne/gratuité.
+  **FERMÉ — confirmé** (durée de vie indiquée 2010-2025 ; site au passé). Pas de successeur officiel ; la communauté
+  redirige vers Little Bock / Brewfather / Brewtarget. → **base d'utilisateurs déplacée cherchant activement un point
+  d'attache = opportunité d'acquisition concrète.** (Une page Gumroad subsiste ; achetabilité post-fermeture incertaine.)
+- **Beerxcel** — tout-en-un Excel gratuit ; complet mais difficile à apprendre ; développeur actif sur le forum. Actif, gratuit.
+- **Brewtarget** — open-source, gratuit, multi-plateforme, manuel FR ; fonctionnel mais daté (v4.01, août 2024).
+- **Brewfather** — en ligne, freemium ; meilleur suivi de fermentation via intégrations d'appareils ; plainte récurrente = anglais uniquement.
+- **BeerSmith** — traduction/communauté FR existante ; poids lourd payant historique, peu testé par les utilisateurs FR.
+- **BiboWeb** — n'a PAS pu être confirmé à cette passe. **Non vérifié** — sonder avant de citer.
+- Aussi : BYOB (web gratuit), Brewy (Android gratuit), Easybeer (pro, 29€/mois, « trop cher » pour les amateurs).
 
-Sources: https://univers-biere.net/logiciels.php · https://joliebulle.org/ · https://www.littlebock.fr/fonctionnalites-et-tarifs
+Sources : https://univers-biere.net/logiciels.php · https://joliebulle.org/ · https://www.littlebock.fr/fonctionnalites-et-tarifs
 
-## French clone targets
+## Cibles de clones françaises
 
-- **Belgian / Trappist** (strong FR/BE cultural anchor): Orval, La Chouffe, Westmalle Triple, Belgian
-  quad. Lean on *Brew Like a Monk*, EBC/IBU/attenuation matching.
-- **International craft icons**, dominated by **BrewDog Punk IPA** (many clone versions, fed by BrewDog's
-  "DIY DOG" release); general IPA/APA clones common.
-- **French macro lager (Kronenbourg/1664, Heineken-style) did NOT surface as a meaningful clone target** —
-  demand skews Belgian abbey/Trappist + craft IPA. (Soft/negative finding; corrects an earlier assumption
-  that FR macro lager was a primary clone target.)
+- **Belge / trappiste** (fort ancrage culturel FR/BE) : Orval, La Chouffe, Westmalle Triple, quadruple belge. S'appuyer
+  sur *Brew Like a Monk*, l'appariement EBC/IBU/atténuation.
+- **Icônes craft internationales**, dominées par la **BrewDog Punk IPA** (nombreuses versions de clones, alimentées par
+  la publication « DIY DOG » de BrewDog) ; clones d'IPA/APA génériques courants.
+- **La lager macro française (Kronenbourg/1664, style Heineken) N'a PAS émergé comme cible de clone significative** —
+  la demande penche vers l'abbaye/trappiste belge + l'IPA craft. (Constat faible/négatif ; corrige une hypothèse
+  antérieure selon laquelle la lager macro FR était une cible de clone primaire.)
 
-Sources: https://univers-biere.net/rec_chouffe.php · https://labrowar.blogspot.com/2016/01/recette-clone-orval.html · https://www.littlebock.fr/recettes-bieres/24/nom/punk-ipa-clone
+Sources : https://univers-biere.net/rec_chouffe.php · https://labrowar.blogspot.com/2016/01/recette-clone-orval.html · https://www.littlebock.fr/recettes-bieres/24/nom/punk-ipa-clone
 
-## French audience specifics (marketing)
+## Spécificités de l'audience française (marketing)
 
-- **High, culturally explicit price sensitivity.** Generous free tier near-mandatory; paid must be amateur-relevant.
-- **Free/open-tool loyalty.** A purely closed SaaS meets cultural friction (Joliebulle/Brewtarget/Beerxcel ethos).
-- **High expectations of maintainer presence + data durability.** Active devs are rewarded; tool deaths/outages
-  created real anxiety → portability + reliability are trust levers.
-- **Where the FR community congregates:**
-  - **Forum (brassageamateur.com)** = structured hub — and hosts its own recipe-sharing app, so it is a
-    *partial direct competitor* on the sharing axis.
-  - **Facebook** = high-volume informal layer (national "brassage.amateur.biere" + regional groups).
-  - **Discord** = support/chat layer (Joliebulle ran a praised one), not a recipe repository.
-  - **YouTube** FR channels active (Bricole Brassicole, Brassage TV, Craft My Brewery) — partnership/marketing, tutorial-skewed.
-  - **Local clubs/associations** (ABAHF, Fauve Homebrew Club) = real in-person layer.
+- **Sensibilité au prix forte, culturellement explicite.** Palier gratuit généreux quasi obligatoire ; le payant doit être pertinent pour l'amateur.
+- **Fidélité aux outils gratuits/open.** Un SaaS purement fermé rencontre une friction culturelle (éthos Joliebulle/Brewtarget/Beerxcel).
+- **Fortes attentes de présence du mainteneur + durabilité des données.** Les développeurs actifs sont récompensés ; les
+  morts d'outils/pannes ont créé une réelle anxiété → portabilité + fiabilité sont des leviers de confiance.
+- **Où se rassemble la communauté FR :**
+  - **Forum (brassageamateur.com)** = hub structuré — et héberge sa propre app de partage de recettes, c'est donc un
+    *concurrent direct partiel* sur l'axe du partage.
+  - **Facebook** = couche informelle à fort volume (groupe national « brassage.amateur.biere » + groupes régionaux).
+  - **Discord** = couche support/discussion (Joliebulle en animait un apprécié), pas un dépôt de recettes.
+  - **YouTube** chaînes FR actives (Bricole Brassicole, Brassage TV, Craft My Brewery) — partenariat/marketing, orienté tutoriel.
+  - **Clubs/associations locaux** (ABAHF, Fauve Homebrew Club) = vraie couche en présentiel.
 
-Sources: https://www.brassageamateur.com/wiki/Beerxml · https://fr-fr.facebook.com/brassage.amateur.biere/ · https://abahf.ovh/ · https://www.youtube.com/c/BricoleBrassicole
+Sources : https://www.brassageamateur.com/wiki/Beerxml · https://fr-fr.facebook.com/brassage.amateur.biere/ · https://abahf.ovh/ · https://www.youtube.com/c/BricoleBrassicole
 
-## Does FR confirm or diverge from EN?
+## La FR confirme-t-elle ou diverge-t-elle de l'EN ?
 
-Mostly **CONFIRMS** (a good saturation signal), with FR-specific sharpenings:
+Majoritairement **CONFIRME** (bon signal de saturation), avec des affinages spécifiques à la FR :
 
-- Clone demand high → **confirmed**, arguably stronger/more legitimate in FR.
-- Sharing wanted → **confirmed**, BUT already partially served in FR (forum BrewRecipes + Little Bock) →
-  differentiation must come from **versioning + credit/attribution + auto-rescale**, not "sharing exists."
-- Attribution-sensitivity → **only weakly corroborated in FR** (strong in EN). **Do not assume it transfers —
-  test explicitly in interviews.**
-- Organization/tracking hacked together → **confirmed**; no FR tool unifies organization + versioned sharing + tracking.
-- Don't compete on calculation → **confirmed and reinforced** (calc is table-stakes; tools already trusted/distrusted on it).
+- Demande de clones élevée → **confirmée**, sans doute plus forte/plus légitime en FR.
+- Partage souhaité → **confirmé**, MAIS déjà partiellement servi en FR (BrewRecipes du forum + Little Bock) →
+  la différenciation doit venir du **versionnage + crédit/attribution + ré-échelonnage automatique**, pas de « le partage existe ».
+- Sensibilité à l'attribution → **seulement faiblement corroborée en FR** (forte en EN). **Ne pas supposer qu'elle se
+  transfère — la tester explicitement en entretiens.**
+- Organisation/suivi bricolés → **confirmé** ; aucun outil FR n'unifie organisation + partage versionné + suivi.
+- Ne pas se battre sur le calcul → **confirmé et renforcé** (le calcul est un prérequis ; les outils sont déjà jugés fiables/non fiables là-dessus).
 
-**FR-specific strategic adds:** (1) French-first UI is a real competitive lever; (2) Joliebulle's 2025 death =
-displaced users seeking a home; (3) data durability + BeerXML portability are trust-critical after recent FR tool failures.
+**Ajouts stratégiques spécifiques FR :** (1) une interface « français d'abord » est un vrai levier concurrentiel ;
+(2) la mort de Joliebulle en 2025 = utilisateurs déplacés cherchant un point d'attache ; (3) la durabilité des données +
+la portabilité BeerXML sont critiques pour la confiance après les récents échecs d'outils FR.
 
-## Uncertainties flagged
-- BiboWeb unverified.
-- Joliebulle Gumroad purchasability post-shutdown unclear.
-- FR attribution-sensitivity under-evidenced — do not assume parity with EN.
-- FB group member counts not retrieved.
+## Incertitudes signalées
+- BiboWeb non vérifié.
+- Achetabilité Gumroad de Joliebulle post-fermeture incertaine.
+- Sensibilité FR à l'attribution sous-documentée — ne pas supposer la parité avec l'EN.
+- Nombres de membres des groupes FB non récupérés.

--- a/docs/marketing/needs-study/03c-desk-market-data.md
+++ b/docs/marketing/needs-study/03c-desk-market-data.md
@@ -1,0 +1,94 @@
+# Desk Research — Quantitative / Market Data
+
+A quantitative layer added on top of the qualitative passes. **Read the reliability flag on every
+figure.** Legend: **[HIGH]** trade-body/platform-published · **[MED]** third-party analytics estimate
+(Similarweb/AppBrain) · **[LOW]** blog/secondary estimate · **[N/F]** not found (do not invent).
+
+## Market size / population
+
+| Metric | Figure | Reliability | Source |
+|---|---|---|---|
+| US homebrewers | ~1.1–1.2 million | [HIGH] | AHA / Brewers Association (2015, 2017) |
+| US homebrew production | >1.4M barrels/yr (~1% of US beer) | [HIGH] | AHA (2017) |
+| AHA paid membership | "more than 20,000" (some pages 30,000+) | [MED] (AHA pages inconsistent) | AHA |
+| US homebrew supply shops | 815 (2015) | [HIGH] | AHA economic study |
+| US homebrew direct shop revenue | $764M (2015) | [HIGH] | AHA economic study |
+| US homebrew total economic impact | $1.225B incl. multiplier; ~11,672 jobs | [HIGH] | AHA economic study |
+| Registered AHA homebrew clubs | 2,100+ (US + worldwide) | [HIGH] | AHA Club Connection |
+| **France / Europe homebrewer count** | **NOT FOUND** | [N/F] | — genuine data gap |
+
+**Equipment / machine market value** — report scopes diverge wildly; directional only:
+- Home-brewing **equipment** (hobby): ~$2.08B (2023) → $3.38B (2030), ~7.65% CAGR [MED]. **Use this as the TAM anchor.**
+- Home-brewing **machine** reports ($26B–$85B) almost certainly bundle countertop appliances/commercial kit — **not comparable**; do not cite as hobby TAM.
+
+## Demand signals
+
+- **Google Trends** — [N/F] for indexed values this pass (needs a manual capture). Qualitative proxy:
+  clone-recipe content is a large, evergreen vertical (BYO 300-recipe clone book; Beer Maverick "100+
+  official brewery clones"; Northern Brewer/Homebrew Finds clone hubs) → durable, non-seasonal demand [LOW].
+- **App scale:**
+  - Brewfather ≈ 230,000 Play downloads, ~510/day, 4.9/5 [MED].
+  - BeerSmith Recipe Cloud = 43,000 registered users; claims "world's largest single recipe repository" [HIGH/MED].
+  - Brewer's Friend ≈ 14,000 Android downloads [MED].
+- **Public recipe-DB sizes (differentiator-relevant):**
+  - Brewer's Friend = **320,000+ public recipes** [HIGH].
+  - Brewfather library = "thousands", no exact count [MED/N-F].
+  - Grainfather app = "1000s" [MED]. Little Bock (FR) = no published count [N/F].
+
+**Takeaway:** incumbents already host large public recipe corpora (Brewer's Friend 320k+) — but they are
+*repositories with weak social / clone-lineage features*. The cloning-and-sharing community angle is not
+their core. That gap is the quantitatively-supportable wedge.
+
+## Uncovered competitors / adjacent products
+
+| Product | What it is | Status | Clone / community / sharing? |
+|---|---|---|---|
+| Grainfather Community app | Recipe builder + brew controller, hardware-tied; 1000s recipes; device integrations | Active, hardware-led | Yes, but ecosystem-gated |
+| Brew Ninja | Commercial **brewery management** (B2B) | Active | No (pro/commercial) |
+| BrewBench | Open-source brew **controller / fermentation monitor** | Active, niche/DIY | No |
+| Captain Brew | Free recipe builder + discovery + calculators | Active | Partial (discovery; no clone lineage) |
+| Plaato / Brewbrain Float / Tilt / iSpindel | Fermentation telemetry devices + apps | Active hardware | No (telemetry only) |
+| Brewspy / monitor.beer | Aggregators for fermentation-device data | Active | No |
+| BeerSmith Recipe Cloud | Web recipe repository (43k users) | Active | Partial (repo, weak social) |
+| Brewist / Brewterix | named but [N/F] — no reliable info; do not characterize | — | — |
+
+**Pattern:** the fermentation-device category is **adjacent, not competitive** (telemetry, not recipe
+community). The recipe-community space is genuinely thin beyond Brewer's Friend, BeerSmith Cloud,
+Brewfather — and none lead with **clone lineage / social cloning** as their headline.
+
+## Reddit numbers
+
+- **r/Homebrewing ≈ 1.2M members** [MED]. Notably ≈ the entire AHA US-homebrewer estimate — the sub
+  alone is roughly the size of the US homebrew population, indicating strong international + lapsed-hobbyist reach.
+- Thread-level vote/comment counts: [N/F] this pass (Reddit not directly fetchable).
+
+## Adjacent markets (brief)
+
+- **Germany** — among Europe's largest homebrew scenes. **MaischeMalzundMehr** (recipe DB) and
+  **Hobbybrauer.de** (forum) are heavily cross-referenced and Brewfather-importable. No published
+  counts [N/F]. A **future-expansion / localization signal** (DE after FR+EN), not an immediate competitor.
+
+## Data gaps to state honestly in the report
+
+1. France/Europe homebrewer population — **not found**; state explicitly, do not estimate.
+2. Google Trends indexed values — need a manual capture.
+3. Brewfather / Little Bock exact recipe-library counts — not published.
+4. Equipment-vs-machine market reports disagree ~40x by scope; only ~$2B hobby-equipment / ~7.5% CAGR is safe to cite.
+
+## Sources
+- https://homebrewersassociation.org/news/economic-impact-homebrewing/
+- https://homebrewersassociation.org/news/1-1-million-americans-homebrew-beer/
+- https://www.brewersassociation.org/press-releases/study-1-1-million-americans-homebrew-beer/
+- https://homebrewersassociation.org/homebrew-clubs/
+- https://www.similarweb.com/app/google-play/com.warpkode.brewfather/statistics/
+- https://beersmithrecipes.com/help
+- https://www.brewersfriend.com/homebrew-recipes/
+- https://www.appbrain.com/app/brewers-friend/com.brewersfriend.app
+- https://us.grainfather.com/pages/app-showcase
+- https://www.brewninja.net/
+- https://github.com/brewbench/monitor
+- https://captainbrew.com/homebrew-recipes
+- https://monitor.beer/
+- https://gummysearch.com/r/Homebrewing/
+- https://www.maischemalzundmehr.de/
+- https://hobbybrauer.de/forum/

--- a/docs/marketing/needs-study/03c-desk-market-data.md
+++ b/docs/marketing/needs-study/03c-desk-market-data.md
@@ -1,79 +1,79 @@
-# Desk Research — Quantitative / Market Data
+# Desk research — Données quantitatives / de marché
 
-A quantitative layer added on top of the qualitative passes. **Read the reliability flag on every
-figure.** Legend: **[HIGH]** trade-body/platform-published · **[MED]** third-party analytics estimate
-(Similarweb/AppBrain) · **[LOW]** blog/secondary estimate · **[N/F]** not found (do not invent).
+Une couche quantitative ajoutée par-dessus les passes qualitatives. **Lire le drapeau de fiabilité sur chaque
+chiffre.** Légende : **[HIGH]** publié par un organisme professionnel/une plateforme · **[MED]** estimation
+analytique tierce (Similarweb/AppBrain) · **[LOW]** estimation de blog/secondaire · **[N/F]** non trouvé (ne pas inventer).
 
-## Market size / population
+## Taille du marché / population
 
-| Metric | Figure | Reliability | Source |
+| Métrique | Chiffre | Fiabilité | Source |
 |---|---|---|---|
-| US homebrewers | ~1.1–1.2 million | [HIGH] | AHA / Brewers Association (2015, 2017) |
-| US homebrew production | >1.4M barrels/yr (~1% of US beer) | [HIGH] | AHA (2017) |
-| AHA paid membership | "more than 20,000" (some pages 30,000+) | [MED] (AHA pages inconsistent) | AHA |
-| US homebrew supply shops | 815 (2015) | [HIGH] | AHA economic study |
-| US homebrew direct shop revenue | $764M (2015) | [HIGH] | AHA economic study |
-| US homebrew total economic impact | $1.225B incl. multiplier; ~11,672 jobs | [HIGH] | AHA economic study |
-| Registered AHA homebrew clubs | 2,100+ (US + worldwide) | [HIGH] | AHA Club Connection |
-| **France / Europe homebrewer count** | **NOT FOUND** | [N/F] | — genuine data gap |
+| Brasseurs amateurs US | ~1,1-1,2 million | [HIGH] | AHA / Brewers Association (2015, 2017) |
+| Production homebrew US | >1,4 M de barils/an (~1 % de la bière US) | [HIGH] | AHA (2017) |
+| Adhésions payantes AHA | « more than 20,000 » (certaines pages 30 000+) | [MED] (pages AHA incohérentes) | AHA |
+| Magasins de fournitures homebrew US | 815 (2015) | [HIGH] | étude économique AHA |
+| Revenu direct des magasins homebrew US | 764 M$ (2015) | [HIGH] | étude économique AHA |
+| Impact économique total du homebrew US | 1,225 Md$ effet multiplicateur inclus ; ~11 672 emplois | [HIGH] | étude économique AHA |
+| Clubs de homebrew enregistrés AHA | 2 100+ (US + monde) | [HIGH] | AHA Club Connection |
+| **Nombre de brasseurs amateurs France / Europe** | **NON TROUVÉ** | [N/F] | — véritable lacune de données |
 
-**Equipment / machine market value** — report scopes diverge wildly; directional only:
-- Home-brewing **equipment** (hobby): ~$2.08B (2023) → $3.38B (2030), ~7.65% CAGR [MED]. **Use this as the TAM anchor.**
-- Home-brewing **machine** reports ($26B–$85B) almost certainly bundle countertop appliances/commercial kit — **not comparable**; do not cite as hobby TAM.
+**Valeur du marché de l'équipement / des machines** — les périmètres des rapports divergent énormément ; à titre indicatif seulement :
+- **Équipement** de brassage maison (loisir) : ~2,08 Md$ (2023) → 3,38 Md$ (2030), ~7,65 % de TCAC [MED]. **À utiliser comme ancrage de TAM.**
+- Rapports sur les **machines** de brassage maison (26 Md$-85 Md$) regroupent presque certainement les appareils de comptoir/le matériel commercial — **non comparable** ; ne pas citer comme TAM du loisir.
 
-## Demand signals
+## Signaux de demande
 
-- **Google Trends** — [N/F] for indexed values this pass (needs a manual capture). Qualitative proxy:
-  clone-recipe content is a large, evergreen vertical (BYO 300-recipe clone book; Beer Maverick "100+
-  official brewery clones"; Northern Brewer/Homebrew Finds clone hubs) → durable, non-seasonal demand [LOW].
-- **App scale:**
-  - Brewfather ≈ 230,000 Play downloads, ~510/day, 4.9/5 [MED].
-  - BeerSmith Recipe Cloud = 43,000 registered users; claims "world's largest single recipe repository" [HIGH/MED].
-  - Brewer's Friend ≈ 14,000 Android downloads [MED].
-- **Public recipe-DB sizes (differentiator-relevant):**
-  - Brewer's Friend = **320,000+ public recipes** [HIGH].
-  - Brewfather library = "thousands", no exact count [MED/N-F].
-  - Grainfather app = "1000s" [MED]. Little Bock (FR) = no published count [N/F].
+- **Google Trends** — [N/F] pour les valeurs indexées à cette passe (nécessite une capture manuelle). Proxy qualitatif :
+  le contenu de recettes de clones est une verticale vaste et pérenne (livre de 300 recettes de clones de BYO ; Beer Maverick
+  « 100+ official brewery clones » ; hubs de clones Northern Brewer/Homebrew Finds) → demande durable, non saisonnière [LOW].
+- **Échelle des apps :**
+  - Brewfather ≈ 230 000 téléchargements Play, ~510/jour, 4,9/5 [MED].
+  - BeerSmith Recipe Cloud = 43 000 utilisateurs enregistrés ; revendique « world's largest single recipe repository » [HIGH/MED].
+  - Brewer's Friend ≈ 14 000 téléchargements Android [MED].
+- **Tailles des bases de recettes publiques (pertinent pour le différenciateur) :**
+  - Brewer's Friend = **320 000+ recettes publiques** [HIGH].
+  - Bibliothèque Brewfather = « thousands », pas de compte exact [MED/N-F].
+  - App Grainfather = « 1000s » [MED]. Little Bock (FR) = aucun compte publié [N/F].
 
-**Takeaway:** incumbents already host large public recipe corpora (Brewer's Friend 320k+) — but they are
-*repositories with weak social / clone-lineage features*. The cloning-and-sharing community angle is not
-their core. That gap is the quantitatively-supportable wedge.
+**À retenir :** les acteurs en place hébergent déjà de larges corpus publics de recettes (Brewer's Friend 320k+) — mais ce
+sont des *dépôts aux fonctionnalités sociales / de lignée de clones faibles*. L'angle communauté de clonage-et-partage n'est
+pas leur cœur. Cette lacune est le coin défendable quantitativement.
 
-## Uncovered competitors / adjacent products
+## Concurrents découverts / produits adjacents
 
-| Product | What it is | Status | Clone / community / sharing? |
+| Produit | Ce que c'est | Statut | Clone / communauté / partage ? |
 |---|---|---|---|
-| Grainfather Community app | Recipe builder + brew controller, hardware-tied; 1000s recipes; device integrations | Active, hardware-led | Yes, but ecosystem-gated |
-| Brew Ninja | Commercial **brewery management** (B2B) | Active | No (pro/commercial) |
-| BrewBench | Open-source brew **controller / fermentation monitor** | Active, niche/DIY | No |
-| Captain Brew | Free recipe builder + discovery + calculators | Active | Partial (discovery; no clone lineage) |
-| Plaato / Brewbrain Float / Tilt / iSpindel | Fermentation telemetry devices + apps | Active hardware | No (telemetry only) |
-| Brewspy / monitor.beer | Aggregators for fermentation-device data | Active | No |
-| BeerSmith Recipe Cloud | Web recipe repository (43k users) | Active | Partial (repo, weak social) |
-| Brewist / Brewterix | named but [N/F] — no reliable info; do not characterize | — | — |
+| Grainfather Community app | Créateur de recettes + contrôleur de brassage, lié au matériel ; milliers de recettes ; intégrations d'appareils | Actif, mené par le matériel | Oui, mais verrouillé à l'écosystème |
+| Brew Ninja | **Gestion de brasserie** commerciale (B2B) | Actif | Non (pro/commercial) |
+| BrewBench | **Contrôleur / moniteur de fermentation** open-source | Actif, niche/DIY | Non |
+| Captain Brew | Créateur de recettes gratuit + découverte + calculateurs | Actif | Partiel (découverte ; pas de lignée de clones) |
+| Plaato / Brewbrain Float / Tilt / iSpindel | Appareils de télémétrie de fermentation + apps | Matériel actif | Non (télémétrie seulement) |
+| Brewspy / monitor.beer | Agrégateurs pour les données d'appareils de fermentation | Actif | Non |
+| BeerSmith Recipe Cloud | Dépôt de recettes web (43k utilisateurs) | Actif | Partiel (dépôt, social faible) |
+| Brewist / Brewterix | nommés mais [N/F] — aucune info fiable ; ne pas caractériser | — | — |
 
-**Pattern:** the fermentation-device category is **adjacent, not competitive** (telemetry, not recipe
-community). The recipe-community space is genuinely thin beyond Brewer's Friend, BeerSmith Cloud,
-Brewfather — and none lead with **clone lineage / social cloning** as their headline.
+**Schéma :** la catégorie des appareils de fermentation est **adjacente, non concurrente** (télémétrie, pas communauté de
+recettes). L'espace de la communauté de recettes est réellement maigre au-delà de Brewer's Friend, BeerSmith Cloud,
+Brewfather — et aucun ne met en avant la **lignée de clones / le clonage social** comme accroche.
 
-## Reddit numbers
+## Chiffres Reddit
 
-- **r/Homebrewing ≈ 1.2M members** [MED]. Notably ≈ the entire AHA US-homebrewer estimate — the sub
-  alone is roughly the size of the US homebrew population, indicating strong international + lapsed-hobbyist reach.
-- Thread-level vote/comment counts: [N/F] this pass (Reddit not directly fetchable).
+- **r/Homebrewing ≈ 1,2 M de membres** [MED]. Notamment ≈ l'estimation entière des brasseurs amateurs US de l'AHA — le
+  subreddit à lui seul fait à peu près la taille de la population homebrew US, ce qui indique une forte portée internationale + de loisirs lapsés.
+- Comptes de votes/commentaires au niveau des fils : [N/F] à cette passe (Reddit non directement récupérable).
 
-## Adjacent markets (brief)
+## Marchés adjacents (bref)
 
-- **Germany** — among Europe's largest homebrew scenes. **MaischeMalzundMehr** (recipe DB) and
-  **Hobbybrauer.de** (forum) are heavily cross-referenced and Brewfather-importable. No published
-  counts [N/F]. A **future-expansion / localization signal** (DE after FR+EN), not an immediate competitor.
+- **Allemagne** — parmi les plus grandes scènes homebrew d'Europe. **MaischeMalzundMehr** (base de recettes) et
+  **Hobbybrauer.de** (forum) sont fortement référencés mutuellement et importables dans Brewfather. Pas de comptes
+  publiés [N/F]. Un **signal d'expansion future / de localisation** (DE après FR+EN), pas un concurrent immédiat.
 
-## Data gaps to state honestly in the report
+## Lacunes de données à énoncer honnêtement dans le rapport
 
-1. France/Europe homebrewer population — **not found**; state explicitly, do not estimate.
-2. Google Trends indexed values — need a manual capture.
-3. Brewfather / Little Bock exact recipe-library counts — not published.
-4. Equipment-vs-machine market reports disagree ~40x by scope; only ~$2B hobby-equipment / ~7.5% CAGR is safe to cite.
+1. Population des brasseurs amateurs France/Europe — **non trouvée** ; l'énoncer explicitement, ne pas estimer.
+2. Valeurs indexées Google Trends — nécessitent une capture manuelle.
+3. Comptes exacts des bibliothèques de recettes Brewfather / Little Bock — non publiés.
+4. Les rapports équipement-vs-machines divergent d'environ 40x selon le périmètre ; seuls les ~2 Md$ d'équipement-loisir / ~7,5 % de TCAC sont sûrs à citer.
 
 ## Sources
 - https://homebrewersassociation.org/news/economic-impact-homebrewing/

--- a/docs/marketing/needs-study/03d-desk-french-market.md
+++ b/docs/marketing/needs-study/03d-desk-french-market.md
@@ -1,0 +1,87 @@
+# Desk Research — French Homebrew Market (snowball pass)
+
+Snowball pass aimed at the biggest data gap: the size of the FRENCH / EU amateur-homebrewer base.
+**Vocabulary kept strictly separate:** *brasseur amateur* (hobbyist — TARGET) vs *microbrasserie /
+brasseur artisanal* (professional — adjacent, not the target). Reliability flags as in `03c`.
+
+## French homebrewer population — the honest answer
+
+**[N/F] There is NO official or reliable count of French amateur homebrewers**, confirmed by insiders:
+- The admin of BrassageAmateur.com: *"Tu ne trouveras aucun chiffre officiel"* — no official figure exists.
+- Expertise Bière Conseil (2023): *"Paradoxe : une pratique répandue et en croissance, mais des chiffres
+  inexistants"* — no registry, no centralized monitoring.
+
+**Best community-size proxies (no national total derivable):**
+- **BrassageAmateur.com** (reference FR forum, since 2003): **~22,467 registered members, ~498k posts,
+  36,250 topics**; peak 5,321 simultaneous users (Feb 2026). Cumulative registrations, francophone (not FR-only). [MED]
+- **549 beer-related associations** in France's RNA (2020-04-01), one category being *brassage amateur*;
+  no per-category membership; excludes Alsace-Moselle (real total higher); densest in North/Pas-de-Calais. [MED]
+- **FNABRA** (Fédération Nationale des Associations Brassicoles, 2002; EBCU member 2022): *"plusieurs
+  milliers de membres"* (mixes amateur brewers + tasting clubs — not a pure homebrewer count). [MED]
+- **Paris Beer Club > 300 members**; runs an annual amateur brewing competition. [MED]
+- Competition turnout (activity signal): Les Amis de la Bière 27th amateur competition (Sept 2025) judged
+  **61 beers** (18 entrants at the 1998 first edition) — competitive participation grows slowly, small in absolute terms. [MED]
+
+## French homebrew market signals
+
+- **Recent legalization (strategically important):** amateur homebrewing was clarified/legalized
+  **2021-01-01** via **Article 520 bis CGI** (2021 Finance Law). Home-brewed beer for personal/family/guest
+  use is excise-exempt and freed from warehouse-keeper obligations, provided it is not sold. The hobby only
+  fully left the legal grey-zone ~5 years ago — which partly explains the missing historical data and signals
+  a young, expanding legal market. [HIGH]
+- **Saveur Bière** (2007; FR online leader; AB InBev since 2016): ~105 employees, CA "plusieurs dizaines de
+  millions d'euros"; reported rising demand; brewing kit among best-sellers. **Rebranded PerfectDraft Europe
+  in 2023**, pivoting toward the draft-machine line (a partial move *away* from pure homebrew kit retail). [MED]
+- **Mature France-based supplier ecosystem** (was import-dependent): Rolling Beers, Brouwland, Autobrasseur,
+  Le Comptoir du Brasseur, Radis et Capucine, etc.; extract-kit vs all-grain segmentation; Amazon.fr "Kits de
+  brassage maison" bestseller category. Qualitative growth, **no hard sales figures [N/F]**. [MED/LOW]
+
+## French craft microbrewery context (PROFESSIONAL — adjacent, well documented)
+
+Useful for beer-culture vitality, clone targets, B2B/partnership angles — **not the target**:
+- **~2,500–2,589 breweries in France (2024–2025); France is #1 in Europe by brewery count**; 10,000+ references. [HIGH]
+- Growth then maturation: ~200 (2006) → 1,600 (2018) → ~2,500 (2024); ~7× between 2011–2022; +15% over 5 years. [HIGH]
+- **Now plateauing:** 2025 ≈ 209 closures vs 213 openings (~4 closures/week) — professional segment matured. [HIGH]
+- Sector employment ~130,500; FR per-capita consumption ~33 L/yr (lowest in EU); SNBI represents independents. [HIGH/MED]
+
+## Homebrewer profile / demographics
+
+- **France: [N/F]** — no demographic study found (only anecdote: more curious newcomers starting).
+- **US proxy (use cautiously):** AHA/Brewers Association 2017 (18k+ respondents): 1.1M (now ~1.2M); avg age
+  **42**, 52% aged 30–49, predominantly male, 68% college-educated, ~68% household income ≥$75k; **40% started
+  within the prior 4 years** (strong newcomer influx). [HIGH for US]
+
+## New leads / snowball threads to follow
+
+- **BrassageAmateur.com** — largest FR community; single best venue for a direct user survey to fill the data gap + competition (BRASSAM) reach.
+- **FNABRA** — could be asked directly for an aggregate member/club estimate.
+- **Projet Amertume** (already bookmarked in memory) — brewery time-series + associations list.
+- Regional/club leads: Les Amis de la Bière (FIBA), ABAHF, Paris Beer Club, BAF, Elsassbrau.
+- Events/salons: Salon du Brasseur, Saint-Malo Craft Beer Expo, CRAB, FIBA.
+- Supplier blogs/communities as funnels: Saveur Bière/PerfectDraft, Rolling Beers, Brouwland, Autobrasseur, Carnet d'un brasseur amateur.
+- Studies to chase: AHA full demographic deck (US benchmark); Belgian Brewers Federation report (only structured EU data, per forum admin); EBCU.
+
+## Strategic note
+
+**Reinforces the strategy.** The absence of any official homebrewer count is itself a moat — no incumbent owns
+this data; Brasse-Bouillon could *become* the dataset by instrumenting its own community. Recent (2021)
+legalization + a now-mature FR supplier ecosystem + a saturating *professional* microbrewery market all point
+to a young, under-served, growing *hobbyist* base whose natural pull is community + clone/share. Caveat: the
+only hard demographics (age 30–49, male, educated, affluent, recent starters) are US — validate on FR users in interviews.
+
+## Sources
+- https://www.brassageamateur.com/forum/ftopic23796.html
+- https://expertise-biere-conseil.com/2023/03/brassage-amateur-etat-des-lieux-dune-activite-en-expansion/
+- https://www.brassageamateur.com/forum/
+- https://www.happybeertime.com/blog/2020/10/06/recensement-des-associations-liees-a-la-biere-en-france/
+- https://www.fnabra.org/associations-membres/
+- https://www.parisbeerclub.fr/concours-de-brassage
+- https://www.amis-biere.org/category/brassage-amateur/
+- https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006163065
+- https://www.assemblee-nationale.fr/dyn/15/amendements/3360C/CION_FIN/CF1540
+- https://www.lejournaldesentreprises.com/hauts-de-france/article/saveur-biere-fait-face-une-hausse-de-la-demande-et-recrute-495310
+- https://brasseurs-de-france.com/tout-savoir-sur-la-biere/le-marche-de-la-biere/
+- http://projet.amertume.free.fr/html/evolution_nombre_brasseries.htm
+- https://fr.statista.com/statistiques/830080/nombre-micro-brasseries-france/
+- https://homebrewersassociation.org/news/1-1-million-americans-homebrew-beer/
+- https://www.insee.fr/fr/statistiques/6535287

--- a/docs/marketing/needs-study/03d-desk-french-market.md
+++ b/docs/marketing/needs-study/03d-desk-french-market.md
@@ -1,73 +1,74 @@
-# Desk Research — French Homebrew Market (snowball pass)
+# Desk research — Marché français du homebrew (passe boule de neige)
 
-Snowball pass aimed at the biggest data gap: the size of the FRENCH / EU amateur-homebrewer base.
-**Vocabulary kept strictly separate:** *brasseur amateur* (hobbyist — TARGET) vs *microbrasserie /
-brasseur artisanal* (professional — adjacent, not the target). Reliability flags as in `03c`.
+Passe boule de neige visant la plus grande lacune de données : la taille de la base FRANÇAISE / UE de brasseurs amateurs.
+**Vocabulaire maintenu strictement distinct :** *brasseur amateur* (hobbyiste — CIBLE) vs *microbrasserie /
+brasseur artisanal* (professionnel — adjacent, pas la cible). Drapeaux de fiabilité comme dans `03c`.
 
-## French homebrewer population — the honest answer
+## Population de brasseurs amateurs français — la réponse honnête
 
-**[N/F] There is NO official or reliable count of French amateur homebrewers**, confirmed by insiders:
-- The admin of BrassageAmateur.com: *"Tu ne trouveras aucun chiffre officiel"* — no official figure exists.
-- Expertise Bière Conseil (2023): *"Paradoxe : une pratique répandue et en croissance, mais des chiffres
-  inexistants"* — no registry, no centralized monitoring.
+**[N/F] Il n'existe AUCUN comptage officiel ou fiable des brasseurs amateurs français**, confirmé par des initiés :
+- L'admin de BrassageAmateur.com : *« Tu ne trouveras aucun chiffre officiel »* — aucun chiffre officiel n'existe.
+- Expertise Bière Conseil (2023) : *« Paradoxe : une pratique répandue et en croissance, mais des chiffres
+  inexistants »* — pas de registre, pas de suivi centralisé.
 
-**Best community-size proxies (no national total derivable):**
-- **BrassageAmateur.com** (reference FR forum, since 2003): **~22,467 registered members, ~498k posts,
-  36,250 topics**; peak 5,321 simultaneous users (Feb 2026). Cumulative registrations, francophone (not FR-only). [MED]
-- **549 beer-related associations** in France's RNA (2020-04-01), one category being *brassage amateur*;
-  no per-category membership; excludes Alsace-Moselle (real total higher); densest in North/Pas-de-Calais. [MED]
-- **FNABRA** (Fédération Nationale des Associations Brassicoles, 2002; EBCU member 2022): *"plusieurs
-  milliers de membres"* (mixes amateur brewers + tasting clubs — not a pure homebrewer count). [MED]
-- **Paris Beer Club > 300 members**; runs an annual amateur brewing competition. [MED]
-- Competition turnout (activity signal): Les Amis de la Bière 27th amateur competition (Sept 2025) judged
-  **61 beers** (18 entrants at the 1998 first edition) — competitive participation grows slowly, small in absolute terms. [MED]
+**Meilleurs proxys de taille de communauté (aucun total national dérivable) :**
+- **BrassageAmateur.com** (forum FR de référence, depuis 2003) : **~22 467 membres enregistrés, ~498k messages,
+  36 250 sujets** ; pic de 5 321 utilisateurs simultanés (févr. 2026). Inscriptions cumulées, francophone (pas FR uniquement). [MED]
+- **549 associations liées à la bière** dans le RNA français (2020-04-01), une catégorie étant *brassage amateur* ;
+  pas d'adhésion par catégorie ; exclut l'Alsace-Moselle (total réel plus élevé) ; plus dense dans le Nord/Pas-de-Calais. [MED]
+- **FNABRA** (Fédération Nationale des Associations Brassicoles, 2002 ; membre EBCU 2022) : *« plusieurs
+  milliers de membres »* (mélange brasseurs amateurs + clubs de dégustation — pas un comptage pur de brasseurs amateurs). [MED]
+- **Paris Beer Club > 300 membres** ; organise un concours annuel de brassage amateur. [MED]
+- Affluence aux concours (signal d'activité) : 27e concours amateur des Amis de la Bière (sept. 2025) a jugé
+  **61 bières** (18 inscrits à la 1re édition de 1998) — la participation compétitive croît lentement, faible en valeur absolue. [MED]
 
-## French homebrew market signals
+## Signaux du marché français du homebrew
 
-- **Recent legalization (strategically important):** amateur homebrewing was clarified/legalized
-  **2021-01-01** via **Article 520 bis CGI** (2021 Finance Law). Home-brewed beer for personal/family/guest
-  use is excise-exempt and freed from warehouse-keeper obligations, provided it is not sold. The hobby only
-  fully left the legal grey-zone ~5 years ago — which partly explains the missing historical data and signals
-  a young, expanding legal market. [HIGH]
-- **Saveur Bière** (2007; FR online leader; AB InBev since 2016): ~105 employees, CA "plusieurs dizaines de
-  millions d'euros"; reported rising demand; brewing kit among best-sellers. **Rebranded PerfectDraft Europe
-  in 2023**, pivoting toward the draft-machine line (a partial move *away* from pure homebrew kit retail). [MED]
-- **Mature France-based supplier ecosystem** (was import-dependent): Rolling Beers, Brouwland, Autobrasseur,
-  Le Comptoir du Brasseur, Radis et Capucine, etc.; extract-kit vs all-grain segmentation; Amazon.fr "Kits de
-  brassage maison" bestseller category. Qualitative growth, **no hard sales figures [N/F]**. [MED/LOW]
+- **Légalisation récente (stratégiquement importante) :** le brassage amateur a été clarifié/légalisé
+  **2021-01-01** via l'**Article 520 bis CGI** (loi de finances 2021). La bière brassée à domicile pour usage
+  personnel/familial/entre invités est exonérée d'accise et libérée des obligations d'entrepositaire agréé, à condition
+  de ne pas être vendue. Le loisir n'a pleinement quitté la zone grise juridique qu'il y a ~5 ans — ce qui explique en
+  partie l'absence de données historiques et signale un marché légal jeune, en expansion. [HIGH]
+- **Saveur Bière** (2007 ; leader FR en ligne ; AB InBev depuis 2016) : ~105 employés, CA « plusieurs dizaines de
+  millions d'euros » ; demande en hausse rapportée ; kit de brassage parmi les meilleures ventes. **Rebaptisé PerfectDraft
+  Europe en 2023**, pivotant vers la gamme de machines à pression (un mouvement partiel *à l'écart* de la vente de pur kit de homebrew). [MED]
+- **Écosystème mature de fournisseurs basés en France** (était dépendant des imports) : Rolling Beers, Brouwland, Autobrasseur,
+  Le Comptoir du Brasseur, Radis et Capucine, etc. ; segmentation kit-extrait vs tout-grain ; catégorie best-seller Amazon.fr
+  « Kits de brassage maison ». Croissance qualitative, **aucun chiffre de vente solide [N/F]**. [MED/LOW]
 
-## French craft microbrewery context (PROFESSIONAL — adjacent, well documented)
+## Contexte des microbrasseries artisanales françaises (PROFESSIONNEL — adjacent, bien documenté)
 
-Useful for beer-culture vitality, clone targets, B2B/partnership angles — **not the target**:
-- **~2,500–2,589 breweries in France (2024–2025); France is #1 in Europe by brewery count**; 10,000+ references. [HIGH]
-- Growth then maturation: ~200 (2006) → 1,600 (2018) → ~2,500 (2024); ~7× between 2011–2022; +15% over 5 years. [HIGH]
-- **Now plateauing:** 2025 ≈ 209 closures vs 213 openings (~4 closures/week) — professional segment matured. [HIGH]
-- Sector employment ~130,500; FR per-capita consumption ~33 L/yr (lowest in EU); SNBI represents independents. [HIGH/MED]
+Utile pour la vitalité de la culture bière, les cibles de clones, les angles B2B/partenariat — **pas la cible** :
+- **~2 500-2 589 brasseries en France (2024-2025) ; la France est n°1 en Europe par nombre de brasseries** ; 10 000+ références. [HIGH]
+- Croissance puis maturation : ~200 (2006) → 1 600 (2018) → ~2 500 (2024) ; ~7x entre 2011-2022 ; +15 % sur 5 ans. [HIGH]
+- **Maintenant en plateau :** 2025 ≈ 209 fermetures vs 213 ouvertures (~4 fermetures/semaine) — segment professionnel arrivé à maturité. [HIGH]
+- Emploi du secteur ~130 500 ; consommation FR par habitant ~33 L/an (la plus basse de l'UE) ; le SNBI représente les indépendants. [HIGH/MED]
 
-## Homebrewer profile / demographics
+## Profil / démographie des brasseurs amateurs
 
-- **France: [N/F]** — no demographic study found (only anecdote: more curious newcomers starting).
-- **US proxy (use cautiously):** AHA/Brewers Association 2017 (18k+ respondents): 1.1M (now ~1.2M); avg age
-  **42**, 52% aged 30–49, predominantly male, 68% college-educated, ~68% household income ≥$75k; **40% started
-  within the prior 4 years** (strong newcomer influx). [HIGH for US]
+- **France : [N/F]** — aucune étude démographique trouvée (seulement de l'anecdotique : davantage de nouveaux venus curieux qui se lancent).
+- **Proxy US (à utiliser avec prudence) :** AHA/Brewers Association 2017 (18k+ répondants) : 1,1 M (désormais ~1,2 M) ; âge moyen
+  **42**, 52 % âgés de 30 à 49 ans, majoritairement hommes, 68 % diplômés du supérieur, ~68 % de revenu de ménage ≥75k$ ; **40 % ont commencé
+  au cours des 4 années précédentes** (fort afflux de nouveaux venus). [HIGH pour les US]
 
-## New leads / snowball threads to follow
+## Nouvelles pistes / fils boule de neige à suivre
 
-- **BrassageAmateur.com** — largest FR community; single best venue for a direct user survey to fill the data gap + competition (BRASSAM) reach.
-- **FNABRA** — could be asked directly for an aggregate member/club estimate.
-- **Projet Amertume** (already bookmarked in memory) — brewery time-series + associations list.
-- Regional/club leads: Les Amis de la Bière (FIBA), ABAHF, Paris Beer Club, BAF, Elsassbrau.
-- Events/salons: Salon du Brasseur, Saint-Malo Craft Beer Expo, CRAB, FIBA.
-- Supplier blogs/communities as funnels: Saveur Bière/PerfectDraft, Rolling Beers, Brouwland, Autobrasseur, Carnet d'un brasseur amateur.
-- Studies to chase: AHA full demographic deck (US benchmark); Belgian Brewers Federation report (only structured EU data, per forum admin); EBCU.
+- **BrassageAmateur.com** — plus grande communauté FR ; meilleur lieu unique pour une enquête utilisateur directe afin de combler la lacune de données + portée du concours (BRASSAM).
+- **FNABRA** — pourrait être sollicitée directement pour une estimation agrégée de membres/clubs.
+- **Projet Amertume** (déjà mis en favori en mémoire) — série temporelle des brasseries + liste d'associations.
+- Pistes régionales/clubs : Les Amis de la Bière (FIBA), ABAHF, Paris Beer Club, BAF, Elsassbrau.
+- Événements/salons : Salon du Brasseur, Saint-Malo Craft Beer Expo, CRAB, FIBA.
+- Blogs/communautés de fournisseurs comme entonnoirs : Saveur Bière/PerfectDraft, Rolling Beers, Brouwland, Autobrasseur, Carnet d'un brasseur amateur.
+- Études à poursuivre : deck démographique complet de l'AHA (référence US) ; rapport de la Fédération belge des brasseurs (seules données UE structurées, selon l'admin du forum) ; EBCU.
 
-## Strategic note
+## Note stratégique
 
-**Reinforces the strategy.** The absence of any official homebrewer count is itself a moat — no incumbent owns
-this data; Brasse-Bouillon could *become* the dataset by instrumenting its own community. Recent (2021)
-legalization + a now-mature FR supplier ecosystem + a saturating *professional* microbrewery market all point
-to a young, under-served, growing *hobbyist* base whose natural pull is community + clone/share. Caveat: the
-only hard demographics (age 30–49, male, educated, affluent, recent starters) are US — validate on FR users in interviews.
+**Renforce la stratégie.** L'absence de tout comptage officiel des brasseurs amateurs est en soi un fossé défensif — aucun
+acteur en place ne possède cette donnée ; Brasse-Bouillon pourrait *devenir* le jeu de données en instrumentant sa propre
+communauté. La légalisation récente (2021) + un écosystème de fournisseurs FR désormais mature + un marché *professionnel* des
+microbrasseries en saturation pointent tous vers une base de *hobbyistes* jeune, sous-servie, en croissance, dont l'attraction
+naturelle est communauté + clone/partage. Réserve : les seules démographies solides (30-49 ans, hommes, diplômés, aisés,
+débutants récents) sont américaines — à valider sur les utilisateurs FR en entretiens.
 
 ## Sources
 - https://www.brassageamateur.com/forum/ftopic23796.html

--- a/docs/marketing/needs-study/04-synthesis.md
+++ b/docs/marketing/needs-study/04-synthesis.md
@@ -9,8 +9,8 @@ FR-specific and market-context refinements below.
 ## Headline
 
 The differentiating hypothesis — **a community for cloning and sharing recipes** — is **supported**
-by all three sources, and **sharpened**: the defensible wedge is not "social" or "clone list" alone,
-but their intersection.
+across all six desk passes, and **sharpened**: the defensible wedge is not "social" or "clone list"
+alone, but their intersection.
 
 ## The sharpened wedge
 

--- a/docs/marketing/needs-study/04-synthesis.md
+++ b/docs/marketing/needs-study/04-synthesis.md
@@ -1,0 +1,104 @@
+# Synthesis — Needs Map & Positioning
+
+Consolidation of six desk-research passes (`01` competitors, `02` Reddit, `03` forums, `03b` French
+sources, `03c` market/quant data, `03d` French market). This is a hypothesis set built from secondary
+research; it is **not yet confirmed** by primary research (interviews). Read `00-method.md` for
+limitations. Later passes largely **confirmed** earlier findings (a saturation signal) while adding the
+FR-specific and market-context refinements below.
+
+## Headline
+
+The differentiating hypothesis — **a community for cloning and sharing recipes** — is **supported**
+by all three sources, and **sharpened**: the defensible wedge is not "social" or "clone list" alone,
+but their intersection.
+
+## The sharpened wedge
+
+> The place where the community collaboratively dials in the clone of a specific beer, with a
+> recipe that is **versioned, credited to its authors, and auto-rescaled** to each brewer's equipment.
+
+No incumbent owns this. Today the market splits into:
+- **Static clone lists** (AHA, Beer Maverick, BrewDog DIY Dog) — no iteration loop, no rescaling.
+- **Calculators with a recipe library** (Brewfather, Brewer's Friend, BeerSmith) — publishing
+  paywalled, sharing strips authorship, no conversation around a recipe.
+
+## Needs map (ranked by signal, with hero/foundation tag)
+
+| # | Need | Signal | Role |
+|---|---|---|---|
+| 1 | Searchable, curated **clone** repository for specific beers | Very high | **Hero** |
+| 2 | **Versioned / community-validated** clones (not a static, often-wrong PDF) | High | **Hero** |
+| 3 | Low-friction **sharing with author credit** (multi-group, bulk, attribution kept) | Med-high | **Hero** |
+| 4 | Auto **rescaling** of a shared recipe to the recipient's equipment | Medium | Hero enabler |
+| 5 | Reliable **organization & search** (tags by style/ingredient/outcome) | High | Foundation |
+| 6 | Solid **brew-day / fermentation tracking** (logs, notes, history) | High | Foundation |
+| 7 | **Frictionless sync + offline** without paying or duplicating data | Very high | Foundation / table-stakes |
+| 8 | **Fair pricing** (subscription/paywall fatigue; crippled free tiers) | Very high | Table-stakes |
+| 9 | **Data portability** — BeerXML/BeerJSON import/export, no lock-in, no data loss | High | Table-stakes |
+| 10 | Modern, uncluttered **mobile UX** | Frequent | Table-stakes |
+
+Heroes 1-4 are where Brasse-Bouillon can win. 5-10 are required to be credible and to retain, but
+do not differentiate (incumbents already do most, and win on calculation).
+
+## What the evidence says about each risky belief
+
+- **Do brewers want to clone specific beers?** Yes — strong, durable, emotionally-driven. *Validated.*
+- **Will they share their own recipes (not just consume)?** Net-positive culture, but with a
+  consumption skew and a hard condition: **attribution/credit must be preserved**. *Plausible, to confirm in interviews.*
+- **Is the need already met elsewhere?** No — clones are wrong/static, sharing tools strip authorship
+  and paywall publishing, and there's no conversation layer. *Gap is real.*
+- **Would they switch tools?** Risky — incumbents are entrenched on calculation and own the user's
+  history. Mitigation: don't fight on calc; lead with the clone/community loop + BeerXML import to
+  lower switching cost. *Highest-risk belief — test explicitly.*
+
+## Strategic guardrails (from the evidence)
+
+- **Don't compete on calculation.** Moat = curation + community + reliability + fair pricing + interop.
+- **Frame community as connective tissue around clone-sharing**, not standalone social
+  (cf. AHA Brew Guru community app sunset Feb 2026).
+- **Bilingual ≠ duplicated.** Localize clone seed-content per region; respect the FR audience's
+  higher price-sensitivity and expectation of a present maintainer.
+- **Watch Build-A-Beer** (AI clone generation + share) — the closest direct competitor to the wedge.
+
+## Market context (from `03c` / `03d`)
+
+- **TAM anchor:** ~$2B home-brewing *hobby-equipment* market, ~7.5% CAGR (ignore the $26B–$85B "machine"
+  reports — different scope). US homebrewers ≈ 1.1–1.2M; r/Homebrewing ≈ 1.2M members.
+- **Incumbent recipe corpora are large** (Brewer's Friend 320k+ public recipes) but lead with *repository +
+  calculators*, not clone-lineage/social — quantitatively confirming the wedge is open.
+- **France: no official homebrewer count exists** (confirmed by insiders) — a data gap that is itself a moat:
+  Brasse-Bouillon could *become* the dataset by instrumenting its community. Proxies: brassageamateur ≈ 22.5k
+  members; 549 beer associations; FNABRA "several thousand" members.
+- **French hobby only legalized 2021** (Art. 520 bis CGI) → young, expanding legal market; mature FR supplier
+  ecosystem; the *professional* microbrewery market (France #1 in Europe, ~2,500) is now plateauing.
+- **Only hard demographics are US** (age 30–49, male, educated, affluent, 40% recent starters) — validate on FR.
+
+## French-specific refinements (from `03b`)
+
+- **French-first UI is a real competitive lever** — Brewfather's English-only is a stated dealbreaker
+  for part of the FR audience. Bilingual is not just localization; it is a wedge in FR.
+- **In FR, sharing is already partially served** (brassageamateur's own BrewRecipes app + Little Bock's
+  public library). So FR differentiation cannot be "sharing exists" — it must be
+  **versioning + author credit + auto-rescale**.
+- **Joliebulle closed (2010–2025, confirmed)** → a displaced FR user base is actively seeking a new home.
+  Concrete acquisition opportunity; BeerXML import lowers their switching cost.
+- **Data durability + BeerXML portability are trust-critical in FR** after recent tool failures
+  (Joliebulle death, Little Bock outage). Reliability is a marketing message, not just an SLA.
+- **FR clone targets** skew Belgian / Trappist (Orval, La Chouffe, Westmalle) + craft (Punk IPA).
+  French macro lager did NOT surface as a meaningful target (corrects an earlier assumption).
+- **Attribution-sensitivity is strong in EN but under-evidenced in FR** — do not assume it transfers;
+  test explicitly in interviews (see below).
+
+## One-sentence positioning (draft, to validate)
+
+> For regular homebrewers who want to reliably recreate the beers they love, Brasse-Bouillon is the
+> community recipe app where clones are collaboratively refined, credited, and rescaled to your own
+> setup — with the recipe organization and brew tracking you'd expect, and no lock-in.
+
+## Next step: primary research
+
+Confirm or refute with 10-15 interviews of regular homebrewers, recruited from r/Homebrewing (EN) and
+brassageamateur (FR). Priority beliefs to test: (a) **attribution-sensitivity** — strong in EN,
+under-evidenced in FR, so probe both audiences; (b) **switching** — would they leave an entrenched tool;
+(c) whether the **versioning + auto-rescale** angle is felt as a real need or a nice-to-have. Build the
+interview guide with the `customer-research` skill. Findings feed `05-report.md`.

--- a/docs/marketing/needs-study/04-synthesis.md
+++ b/docs/marketing/needs-study/04-synthesis.md
@@ -1,104 +1,112 @@
-# Synthesis — Needs Map & Positioning
+# Synthèse — Carte des besoins & Positionnement
 
-Consolidation of six desk-research passes (`01` competitors, `02` Reddit, `03` forums, `03b` French
-sources, `03c` market/quant data, `03d` French market). This is a hypothesis set built from secondary
-research; it is **not yet confirmed** by primary research (interviews). Read `00-method.md` for
-limitations. Later passes largely **confirmed** earlier findings (a saturation signal) while adding the
-FR-specific and market-context refinements below.
+Consolidation de six passes de desk research (`01` concurrents, `02` Reddit, `03` forums, `03b` sources
+françaises, `03c` données marché / quantitatives, `03d` marché français). Il s'agit d'un ensemble
+d'hypothèses construit à partir de la recherche secondaire ; il n'est **pas encore confirmé** par la
+recherche primaire (entretiens). Lire `00-method.md` pour les limites. Les passes ultérieures ont
+largement **confirmé** les conclusions antérieures (un signal de saturation) tout en ajoutant les
+raffinements spécifiques au marché FR et au contexte marché ci-dessous.
 
-## Headline
+## Message clé
 
-The differentiating hypothesis — **a community for cloning and sharing recipes** — is **supported**
-across all six desk passes, and **sharpened**: the defensible wedge is not "social" or "clone list"
-alone, but their intersection.
+L'hypothèse différenciante — **une communauté pour cloner et partager des recettes** — est **soutenue**
+à travers les six passes de desk research, et **affinée** : le créneau défendable n'est pas le « social »
+ou la « liste de clones » seuls, mais leur intersection.
 
-## The sharpened wedge
+## Le créneau affiné
 
-> The place where the community collaboratively dials in the clone of a specific beer, with a
-> recipe that is **versioned, credited to its authors, and auto-rescaled** to each brewer's equipment.
+> L'endroit où la communauté met au point de manière collaborative le clone d'une bière précise, avec une
+> recette **versionnée, créditée à ses auteurs et automatiquement remise à l'échelle** de l'équipement de chaque brasseur.
 
-No incumbent owns this. Today the market splits into:
-- **Static clone lists** (AHA, Beer Maverick, BrewDog DIY Dog) — no iteration loop, no rescaling.
-- **Calculators with a recipe library** (Brewfather, Brewer's Friend, BeerSmith) — publishing
-  paywalled, sharing strips authorship, no conversation around a recipe.
+Aucun acteur en place ne possède cela. Aujourd'hui, le marché se divise en :
+- **Listes de clones statiques** (AHA, Beer Maverick, BrewDog DIY Dog) — pas de boucle d'itération, pas de remise à l'échelle.
+- **Calculateurs avec une bibliothèque de recettes** (Brewfather, Brewer's Friend, BeerSmith) — publication
+  derrière un paywall, le partage supprime la paternité, aucune conversation autour d'une recette.
 
-## Needs map (ranked by signal, with hero/foundation tag)
+## Carte des besoins (classés par signal, avec étiquette hero/socle)
 
-| # | Need | Signal | Role |
+| # | Besoin | Signal | Rôle |
 |---|---|---|---|
-| 1 | Searchable, curated **clone** repository for specific beers | Very high | **Hero** |
-| 2 | **Versioned / community-validated** clones (not a static, often-wrong PDF) | High | **Hero** |
-| 3 | Low-friction **sharing with author credit** (multi-group, bulk, attribution kept) | Med-high | **Hero** |
-| 4 | Auto **rescaling** of a shared recipe to the recipient's equipment | Medium | Hero enabler |
-| 5 | Reliable **organization & search** (tags by style/ingredient/outcome) | High | Foundation |
-| 6 | Solid **brew-day / fermentation tracking** (logs, notes, history) | High | Foundation |
-| 7 | **Frictionless sync + offline** without paying or duplicating data | Very high | Foundation / table-stakes |
-| 8 | **Fair pricing** (subscription/paywall fatigue; crippled free tiers) | Very high | Table-stakes |
-| 9 | **Data portability** — BeerXML/BeerJSON import/export, no lock-in, no data loss | High | Table-stakes |
-| 10 | Modern, uncluttered **mobile UX** | Frequent | Table-stakes |
+| 1 | Dépôt **de clones** consultable et organisé pour des bières précises | Très élevé | **Hero** |
+| 2 | Clones **versionnés / validés par la communauté** (et non un PDF statique, souvent erroné) | Élevé | **Hero** |
+| 3 | **Partage à faible friction avec crédit de l'auteur** (multi-groupe, en lot, paternité conservée) | Moyen-élevé | **Hero** |
+| 4 | **Remise à l'échelle** automatique d'une recette partagée vers l'équipement du destinataire | Moyen | Facilitateur hero |
+| 5 | **Organisation & recherche** fiables (tags par style / ingrédient / résultat) | Élevé | Socle |
+| 6 | **Suivi de jour de brassage / fermentation** solide (journaux, notes, historique) | Élevé | Socle |
+| 7 | **Synchronisation + hors-ligne sans friction** sans payer ni dupliquer les données | Très élevé | Socle / table-stakes |
+| 8 | **Tarification juste** (fatigue des abonnements/paywalls ; offres gratuites bridées) | Très élevé | Table-stakes |
+| 9 | **Portabilité des données** — import/export BeerXML/BeerJSON, pas de verrouillage, pas de perte de données | Élevé | Table-stakes |
+| 10 | **UX mobile** moderne et épurée | Fréquent | Table-stakes |
 
-Heroes 1-4 are where Brasse-Bouillon can win. 5-10 are required to be credible and to retain, but
-do not differentiate (incumbents already do most, and win on calculation).
+Les hero 1-4 sont là où Brasse-Bouillon peut gagner. Les 5-10 sont indispensables pour être crédible et
+fidéliser, mais ne différencient pas (les acteurs en place font déjà la plupart, et gagnent sur le calcul).
 
-## What the evidence says about each risky belief
+## Ce que les preuves disent de chaque croyance à risque
 
-- **Do brewers want to clone specific beers?** Yes — strong, durable, emotionally-driven. *Validated.*
-- **Will they share their own recipes (not just consume)?** Net-positive culture, but with a
-  consumption skew and a hard condition: **attribution/credit must be preserved**. *Plausible, to confirm in interviews.*
-- **Is the need already met elsewhere?** No — clones are wrong/static, sharing tools strip authorship
-  and paywall publishing, and there's no conversation layer. *Gap is real.*
-- **Would they switch tools?** Risky — incumbents are entrenched on calculation and own the user's
-  history. Mitigation: don't fight on calc; lead with the clone/community loop + BeerXML import to
-  lower switching cost. *Highest-risk belief — test explicitly.*
+- **Les brasseurs veulent-ils cloner des bières précises ?** Oui — fort, durable, porté par l'émotion. *Validé.*
+- **Partageront-ils leurs propres recettes (et pas seulement consommer) ?** Culture globalement positive, mais
+  avec un biais vers la consommation et une condition impérative : **la paternité / le crédit doit être préservé**. *Plausible, à confirmer en entretiens.*
+- **Le besoin est-il déjà satisfait ailleurs ?** Non — les clones sont erronés/statiques, les outils de partage
+  suppriment la paternité et mettent la publication derrière un paywall, et il n'y a pas de couche de conversation. *L'écart est réel.*
+- **Changeraient-ils d'outil ?** Risqué — les acteurs en place sont retranchés sur le calcul et possèdent
+  l'historique de l'utilisateur. Atténuation : ne pas se battre sur le calcul ; mener avec la boucle clone/communauté
+  + l'import BeerXML pour abaisser le coût de changement. *Croyance la plus risquée — à tester explicitement.*
 
-## Strategic guardrails (from the evidence)
+## Garde-fous stratégiques (issus des preuves)
 
-- **Don't compete on calculation.** Moat = curation + community + reliability + fair pricing + interop.
-- **Frame community as connective tissue around clone-sharing**, not standalone social
-  (cf. AHA Brew Guru community app sunset Feb 2026).
-- **Bilingual ≠ duplicated.** Localize clone seed-content per region; respect the FR audience's
-  higher price-sensitivity and expectation of a present maintainer.
-- **Watch Build-A-Beer** (AI clone generation + share) — the closest direct competitor to the wedge.
+- **Ne pas concurrencer sur le calcul.** Le rempart = curation + communauté + fiabilité + tarification juste + interopérabilité.
+- **Présenter la communauté comme le tissu conjonctif autour du partage de clones**, et non comme un réseau
+  social autonome (cf. arrêt de l'application communautaire AHA Brew Guru en février 2026).
+- **Bilingue ≠ dupliqué.** Localiser le contenu d'amorçage des clones par région ; respecter la plus grande
+  sensibilité au prix de l'audience FR et son attente d'un mainteneur présent.
+- **Surveiller Build-A-Beer** (génération de clones par IA + partage) — le concurrent direct le plus proche du créneau.
 
-## Market context (from `03c` / `03d`)
+## Contexte marché (issu de `03c` / `03d`)
 
-- **TAM anchor:** ~$2B home-brewing *hobby-equipment* market, ~7.5% CAGR (ignore the $26B–$85B "machine"
-  reports — different scope). US homebrewers ≈ 1.1–1.2M; r/Homebrewing ≈ 1.2M members.
-- **Incumbent recipe corpora are large** (Brewer's Friend 320k+ public recipes) but lead with *repository +
-  calculators*, not clone-lineage/social — quantitatively confirming the wedge is open.
-- **France: no official homebrewer count exists** (confirmed by insiders) — a data gap that is itself a moat:
-  Brasse-Bouillon could *become* the dataset by instrumenting its community. Proxies: brassageamateur ≈ 22.5k
-  members; 549 beer associations; FNABRA "several thousand" members.
-- **French hobby only legalized 2021** (Art. 520 bis CGI) → young, expanding legal market; mature FR supplier
-  ecosystem; the *professional* microbrewery market (France #1 in Europe, ~2,500) is now plateauing.
-- **Only hard demographics are US** (age 30–49, male, educated, affluent, 40% recent starters) — validate on FR.
+- **Ancrage du TAM :** marché des *équipements de loisir* du brassage maison d'environ 2 Md$, ~7,5 % de TCAC
+  (ignorer les rapports « machines » à 26-85 Md$ — périmètre différent). Brasseurs amateurs US ≈ 1,1-1,2 M ;
+  r/Homebrewing ≈ 1,2 M de membres.
+- **Les corpus de recettes des acteurs en place sont vastes** (Brewer's Friend 320 k+ recettes publiques) mais
+  mènent avec un *dépôt + des calculateurs*, et non avec la lignée de clones / le social — confirmant
+  quantitativement que le créneau est ouvert.
+- **France : aucun décompte officiel des brasseurs amateurs n'existe** (confirmé par des initiés) — un manque de
+  données qui est lui-même un rempart : Brasse-Bouillon pourrait *devenir* le jeu de données en instrumentant sa
+  communauté. Approximations : brassageamateur ≈ 22,5 k membres ; 549 associations de bière ; FNABRA « plusieurs milliers » de membres.
+- **Loisir français légalisé seulement en 2021** (Art. 520 bis CGI) → marché légal jeune et en expansion ;
+  écosystème de fournisseurs FR mature ; le marché *professionnel* des microbrasseries (France n°1 en Europe, ~2 500)
+  plafonne désormais.
+- **Les seules données démographiques solides sont américaines** (âge 30-49 ans, masculin, diplômé, aisé, 40 % de
+  débutants récents) — à valider en FR.
 
-## French-specific refinements (from `03b`)
+## Raffinements spécifiques à la France (issus de `03b`)
 
-- **French-first UI is a real competitive lever** — Brewfather's English-only is a stated dealbreaker
-  for part of the FR audience. Bilingual is not just localization; it is a wedge in FR.
-- **In FR, sharing is already partially served** (brassageamateur's own BrewRecipes app + Little Bock's
-  public library). So FR differentiation cannot be "sharing exists" — it must be
-  **versioning + author credit + auto-rescale**.
-- **Joliebulle closed (2010–2025, confirmed)** → a displaced FR user base is actively seeking a new home.
-  Concrete acquisition opportunity; BeerXML import lowers their switching cost.
-- **Data durability + BeerXML portability are trust-critical in FR** after recent tool failures
-  (Joliebulle death, Little Bock outage). Reliability is a marketing message, not just an SLA.
-- **FR clone targets** skew Belgian / Trappist (Orval, La Chouffe, Westmalle) + craft (Punk IPA).
-  French macro lager did NOT surface as a meaningful target (corrects an earlier assumption).
-- **Attribution-sensitivity is strong in EN but under-evidenced in FR** — do not assume it transfers;
-  test explicitly in interviews (see below).
+- **Une UI en priorité française est un véritable levier concurrentiel** — le tout-anglais de Brewfather est un
+  facteur rédhibitoire déclaré pour une partie de l'audience FR. Le bilinguisme n'est pas qu'une localisation ;
+  c'est un créneau en FR.
+- **En FR, le partage est déjà partiellement servi** (l'application BrewRecipes de brassageamateur elle-même + la
+  bibliothèque publique de Little Bock). La différenciation FR ne peut donc pas être « le partage existe » — elle
+  doit être **versioning + crédit de l'auteur + remise à l'échelle automatique**.
+- **Joliebulle a fermé (2010-2025, confirmé)** → une base d'utilisateurs FR déplacée cherche activement un nouveau
+  foyer. Opportunité d'acquisition concrète ; l'import BeerXML abaisse leur coût de changement.
+- **La durabilité des données + la portabilité BeerXML sont critiques pour la confiance en FR** après les récentes
+  défaillances d'outils (mort de Joliebulle, panne de Little Bock). La fiabilité est un message marketing, pas seulement un SLA.
+- **Les cibles de clones FR** penchent vers le belge / trappiste (Orval, La Chouffe, Westmalle) + le craft (Punk IPA).
+  La lager macro française n'a PAS émergé comme une cible significative (corrige une hypothèse antérieure).
+- **La sensibilité à la paternité est forte en EN mais peu étayée en FR** — ne pas supposer qu'elle se transfère ;
+  à tester explicitement en entretiens (voir ci-dessous).
 
-## One-sentence positioning (draft, to validate)
+## Positionnement en une phrase (brouillon, à valider)
 
-> For regular homebrewers who want to reliably recreate the beers they love, Brasse-Bouillon is the
-> community recipe app where clones are collaboratively refined, credited, and rescaled to your own
-> setup — with the recipe organization and brew tracking you'd expect, and no lock-in.
+> Pour les brasseurs amateurs réguliers qui veulent recréer de façon fiable les bières qu'ils aiment,
+> Brasse-Bouillon est l'application de recettes communautaire où les clones sont affinés collaborativement,
+> crédités et remis à l'échelle de votre propre installation — avec l'organisation des recettes et le suivi
+> de brassage que vous attendez, et sans verrouillage.
 
-## Next step: primary research
+## Étape suivante : recherche primaire
 
-Confirm or refute with 10-15 interviews of regular homebrewers, recruited from r/Homebrewing (EN) and
-brassageamateur (FR). Priority beliefs to test: (a) **attribution-sensitivity** — strong in EN,
-under-evidenced in FR, so probe both audiences; (b) **switching** — would they leave an entrenched tool;
-(c) whether the **versioning + auto-rescale** angle is felt as a real need or a nice-to-have. The
-interview guide is in `05-interview-guide.md` (built with the `customer-research` skill). Findings feed `06-report.md`.
+Confirmer ou infirmer avec 10-15 entretiens de brasseurs amateurs réguliers, recrutés sur r/Homebrewing (EN) et
+brassageamateur (FR). Croyances prioritaires à tester : (a) **sensibilité à la paternité** — forte en EN,
+peu étayée en FR, donc sonder les deux audiences ; (b) **changement d'outil** — quitteraient-ils un outil
+retranché ; (c) si l'angle **versioning + remise à l'échelle automatique** est ressenti comme un besoin réel ou
+un simple agrément. Le guide d'entretien se trouve dans `05-interview-guide.md` (construit avec le skill
+`customer-research`). Les conclusions alimentent `06-report.md`.

--- a/docs/marketing/needs-study/04-synthesis.md
+++ b/docs/marketing/needs-study/04-synthesis.md
@@ -100,5 +100,5 @@ do not differentiate (incumbents already do most, and win on calculation).
 Confirm or refute with 10-15 interviews of regular homebrewers, recruited from r/Homebrewing (EN) and
 brassageamateur (FR). Priority beliefs to test: (a) **attribution-sensitivity** — strong in EN,
 under-evidenced in FR, so probe both audiences; (b) **switching** — would they leave an entrenched tool;
-(c) whether the **versioning + auto-rescale** angle is felt as a real need or a nice-to-have. Build the
-interview guide with the `customer-research` skill. Findings feed `05-report.md`.
+(c) whether the **versioning + auto-rescale** angle is felt as a real need or a nice-to-have. The
+interview guide is in `05-interview-guide.md` (built with the `customer-research` skill). Findings feed `06-report.md`.

--- a/docs/marketing/needs-study/04b-prioritized-backlog.md
+++ b/docs/marketing/needs-study/04b-prioritized-backlog.md
@@ -1,0 +1,86 @@
+# Prioritized Backlog — Needs → Features → Build Order
+
+This page turns the desk findings into a **prioritized build order**: which real need each feature
+serves, how strong the opportunity is, how confident we are, and in what order to build.
+
+::: warning Read this first
+This ranking is built on **secondary research** (desk) — strong hypotheses, not field-confirmed truth.
+Two biases to keep in mind:
+1. The desk scan mostly probed **intermediate** pains (clone, sharing, sync), so it **under-weights the
+   beginner guided-assistant need** — which is real but evidenced only indirectly (the "I built my own
+   brew-day app" threads, the steep-UX complaints, the 40% newcomer inflow). Those rows are tagged
+   *under-probed* and the interviews must confirm them.
+2. The founder is a **beginner** building (first) for **beginners** — so we deliberately sequence
+   **assistant-first**, even where the raw desk score would put the intermediate clone wedge on top.
+:::
+
+## Prioritization rule
+
+> **Opportunity = Importance (how strong/frequent the need) × Under-served (how poorly incumbents do it).**
+> Then **sequence by journey stage**, starting with the beginner assistant (acquisition), because that is
+> the founder's accessible segment and the lowest-risk entry (a daily-useful utility beats a
+> community that needs a crowd to exist — cf. AHA Brew Guru's 2026 shutdown).
+
+**Confidence labels:** `validated` (strong, multi-source desk signal) · `hypothesis` (inferred, plausible)
+· `under-probed` (real but thinly evidenced — interviews must confirm).
+
+## The journey = the spine
+
+```
+Stage 1 — BEGINNER (guided assistant)   →  ACQUISITION   →  the 4-step journey
+Stage 2 — REGULAR  (organize & track)   →  RETENTION
+Stage 3 — INTERMEDIATE (clone & share)  →  DEPTH         →  the desk's headline wedge
+```
+
+## Stage 1 — Beginner assistant · the 4-step journey (build first)
+
+| Need | Feature | Opportunity | Confidence |
+|---|---|---|---|
+| Don't ruin a brew; know what to do, when & why | **Guided step-by-step brew-day assistant** (mash/boil/cooling, timers, temps, the "why") | High × High = **High** | under-probed |
+| Succeed on the very first batch, no jargon | **Beginner-calibrated recipe catalog** (curated, IBU/ABV/volume shown) — journey step 1 | High × Med-High = **High** | hypothesis |
+| Know where my fermentation stands | **Fermentation tracking** (days, gravity, temperature, progress bar) — journey step 3 | High × Med = **Med-High** | validated |
+| Finish & celebrate | **Bottling + label + share with friends** — journey step 4 | Med × Med = **Med** | hypothesis |
+| Brewing happens offline (garage/cellar) | **Offline-tolerant**, no forced sync / no data duplication | High × High = **High** | validated |
+| Tools feel overwhelming | **Clean, uncluttered, playful UX** (the proven differentiator) | High × Med = **Med** (quality bar) | validated |
+
+## Stage 2 — Regular brewer · organize & track (retention)
+
+| Need | Feature | Opportunity | Confidence |
+|---|---|---|---|
+| My recipes are scattered (notebooks, sheets) | **Recipe organization & search** (tags by style/ingredient/outcome) | High × Med-High = **High** | validated |
+| Remember what I did across batches | **Batch history / brew log** with reviewable notes | High × Med = **Med-High** | validated |
+| Don't trap my data | **BeerXML / BeerJSON import-export** (no lock-in, lossless) | High × Med = **Med-High** | validated |
+| Reliability / don't lose my history | **Durable storage, no data loss** (a trust message, esp. FR after Joliebulle/Little Bock) | High × Med = **Med-High** | validated |
+
+## Stage 3 — Intermediate · clone & community (depth — the desk wedge)
+
+| Need | Feature | Opportunity | Confidence |
+|---|---|---|---|
+| Recreate a specific beer I love | **Searchable, curated clone repository** | Very High × High = **Very High** | validated |
+| Published clones are wrong / static | **Versioned, community-validated clones** (the iteration loop nobody owns) | High × Very High = **High** | hypothesis |
+| Share without losing authorship | **Sharing with author credit** (multi-group, bulk export) | Med-High × High = **High** | validated (EN) / hypothesis (FR) |
+| A shared recipe doesn't fit my kit | **Auto-rescale to the recipient's equipment** | Med × High = **Med-High** | hypothesis |
+
+**Cross-cutting (all stages):** a **fair, generous free tier** — paywall fatigue is one of the strongest
+desk signals; it's a pricing principle, not a feature. Don't compete on calculation (incumbents win there).
+
+## Build order (the answer to "what do we implement, and in what order")
+
+1. **P0 — the assistant entry (Stage 1):** guided brew-day assistant + beginner catalog + fermentation
+   tracking + clean UX + offline tolerance. *This is the wedge we ship and validate first.*
+2. **P1 — retention (Stage 2):** organization & search, batch history, BeerXML import/export, durability.
+3. **P2 — depth (Stage 3):** clone repository → versioned clones → credited sharing → auto-rescale.
+
+The clone repository scores **Very High** on raw opportunity, but it lives in Stage 3 because it serves
+intermediates and needs a crowd. We **enter** by the assistant and **grow into** the community — "the app
+that grows with the brewer."
+
+## What the interviews must settle (ties to the [interview guide](/05-interview-guide))
+
+- **The biggest open risk:** is the **beginner assistant** truly a strong, willing-to-pay-attention need,
+  or do brewers "graduate" past it too fast to build a business on? (the *under-probed* rows above).
+- Whether **attribution-sensitivity** holds in FR as it does in EN.
+- Whether **versioning + auto-rescale** is felt as a real need or a nice-to-have.
+- Whether intermediates would **switch** from an entrenched tool.
+
+Until these are answered, treat the order above as the **best current bet**, not a settled roadmap.

--- a/docs/marketing/needs-study/04b-prioritized-backlog.md
+++ b/docs/marketing/needs-study/04b-prioritized-backlog.md
@@ -1,86 +1,88 @@
-# Prioritized Backlog — Needs → Features → Build Order
+# Backlog priorisé — Besoins → Fonctionnalités → Ordre de construction
 
-This page turns the desk findings into a **prioritized build order**: which real need each feature
-serves, how strong the opportunity is, how confident we are, and in what order to build.
+Cette page transforme les conclusions du desk research en un **ordre de construction priorisé** : quel besoin
+réel chaque fonctionnalité sert, à quel point l'opportunité est forte, à quel point nous sommes confiants, et
+dans quel ordre construire.
 
 ::: warning Read this first
-This ranking is built on **secondary research** (desk) — strong hypotheses, not field-confirmed truth.
-Two biases to keep in mind:
-1. The desk scan mostly probed **intermediate** pains (clone, sharing, sync), so it **under-weights the
-   beginner guided-assistant need** — which is real but evidenced only indirectly (the "I built my own
-   brew-day app" threads, the steep-UX complaints, the 40% newcomer inflow). Those rows are tagged
-   *under-probed* and the interviews must confirm them.
-2. The founder is a **beginner** building (first) for **beginners** — so we deliberately sequence
-   **assistant-first**, even where the raw desk score would put the intermediate clone wedge on top.
+Ce classement repose sur la **recherche secondaire** (desk) — des hypothèses solides, pas une vérité confirmée sur le terrain.
+Deux biais à garder à l'esprit :
+1. Le desk research a surtout sondé les points de douleur **intermédiaires** (clone, partage, synchronisation), il
+   **sous-pondère donc le besoin d'assistant guidé pour débutant** — réel mais étayé seulement indirectement (les fils
+   « j'ai construit ma propre application de jour de brassage », les plaintes sur une UX trop ardue, les 40 % de flux de
+   nouveaux arrivants). Ces lignes sont taguées *sous-sondé* et les entretiens doivent les confirmer.
+2. Le fondateur est un **débutant** qui construit (d'abord) pour des **débutants** — nous séquençons donc délibérément
+   **l'assistant en premier**, même là où le score brut du desk placerait le créneau de clone intermédiaire en tête.
 :::
 
-## Prioritization rule
+## Règle de priorisation
 
-> **Opportunity = Importance (how strong/frequent the need) × Under-served (how poorly incumbents do it).**
-> Then **sequence by journey stage**, starting with the beginner assistant (acquisition), because that is
-> the founder's accessible segment and the lowest-risk entry (a daily-useful utility beats a
-> community that needs a crowd to exist — cf. AHA Brew Guru's 2026 shutdown).
+> **Opportunité = Importance (force/fréquence du besoin) × Sous-servi (mauvaise qualité du traitement par les acteurs en place).**
+> Puis **séquencer par étape du parcours**, en commençant par l'assistant débutant (acquisition), parce que c'est
+> le segment accessible au fondateur et l'entrée la moins risquée (un utilitaire utile au quotidien bat une
+> communauté qui a besoin d'une foule pour exister — cf. l'arrêt d'AHA Brew Guru en 2026).
 
-**Confidence labels:** `validated` (strong, multi-source desk signal) · `hypothesis` (inferred, plausible)
-· `under-probed` (real but thinly evidenced — interviews must confirm).
+**Étiquettes de confiance :** `validé` (signal de desk fort et multi-sources) · `hypothèse` (déduit, plausible)
+· `sous-sondé` (réel mais faiblement étayé — les entretiens doivent confirmer).
 
-## The journey = the spine
+## Le parcours = la colonne vertébrale
 
 ```
-Stage 1 — BEGINNER (guided assistant)   →  ACQUISITION   →  the 4-step journey
-Stage 2 — REGULAR  (organize & track)   →  RETENTION
-Stage 3 — INTERMEDIATE (clone & share)  →  DEPTH         →  the desk's headline wedge
+Étape 1 — DÉBUTANT (assistant guidé)        →  ACQUISITION   →  le parcours en 4 étapes
+Étape 2 — RÉGULIER (organiser & suivre)     →  RÉTENTION
+Étape 3 — INTERMÉDIAIRE (cloner & partager) →  PROFONDEUR     →  le créneau phare du desk
 ```
 
-## Stage 1 — Beginner assistant · the 4-step journey (build first)
+## Étape 1 — Assistant débutant · le parcours en 4 étapes (construire en premier)
 
-| Need | Feature | Opportunity | Confidence |
+| Besoin | Fonctionnalité | Opportunité | Confiance |
 |---|---|---|---|
-| Don't ruin a brew; know what to do, when & why | **Guided step-by-step brew-day assistant** (mash/boil/cooling, timers, temps, the "why") | High × High = **High** | under-probed |
-| Succeed on the very first batch, no jargon | **Beginner-calibrated recipe catalog** (curated, IBU/ABV/volume shown) — journey step 1 | High × Med-High = **High** | hypothesis |
-| Know where my fermentation stands | **Fermentation tracking** (days, gravity, temperature, progress bar) — journey step 3 | High × Med = **Med-High** | validated |
-| Finish & celebrate | **Bottling + label + share with friends** — journey step 4 | Med × Med = **Med** | hypothesis |
-| Brewing happens offline (garage/cellar) | **Offline-tolerant**, no forced sync / no data duplication | High × High = **High** | validated |
-| Tools feel overwhelming | **Clean, uncluttered, playful UX** (the proven differentiator) | High × Med = **Med** (quality bar) | validated |
+| Ne pas rater un brassage ; savoir quoi faire, quand & pourquoi | **Assistant de jour de brassage guidé pas à pas** (empâtage/ébullition/refroidissement, minuteurs, températures, le « pourquoi ») | Élevé × Élevé = **Élevé** | sous-sondé |
+| Réussir dès le tout premier lot, sans jargon | **Catalogue de recettes calibré pour débutant** (organisé, IBU/ABV/volume affichés) — étape 1 du parcours | Élevé × Moyen-élevé = **Élevé** | hypothèse |
+| Savoir où en est ma fermentation | **Suivi de fermentation** (jours, densité, température, barre de progression) — étape 3 du parcours | Élevé × Moyen = **Moyen-élevé** | validé |
+| Terminer & célébrer | **Mise en bouteille + étiquette + partage avec des amis** — étape 4 du parcours | Moyen × Moyen = **Moyen** | hypothèse |
+| Le brassage se fait hors-ligne (garage/cave) | **Tolérant au hors-ligne**, pas de synchronisation forcée / pas de duplication des données | Élevé × Élevé = **Élevé** | validé |
+| Les outils donnent une impression de surcharge | **UX épurée, sans encombrement et ludique** (le différenciateur éprouvé) | Élevé × Moyen = **Moyen** (exigence de qualité) | validé |
 
-## Stage 2 — Regular brewer · organize & track (retention)
+## Étape 2 — Brasseur régulier · organiser & suivre (rétention)
 
-| Need | Feature | Opportunity | Confidence |
+| Besoin | Fonctionnalité | Opportunité | Confiance |
 |---|---|---|---|
-| My recipes are scattered (notebooks, sheets) | **Recipe organization & search** (tags by style/ingredient/outcome) | High × Med-High = **High** | validated |
-| Remember what I did across batches | **Batch history / brew log** with reviewable notes | High × Med = **Med-High** | validated |
-| Don't trap my data | **BeerXML / BeerJSON import-export** (no lock-in, lossless) | High × Med = **Med-High** | validated |
-| Reliability / don't lose my history | **Durable storage, no data loss** (a trust message, esp. FR after Joliebulle/Little Bock) | High × Med = **Med-High** | validated |
+| Mes recettes sont éparpillées (carnets, feuilles) | **Organisation & recherche de recettes** (tags par style/ingrédient/résultat) | Élevé × Moyen-élevé = **Élevé** | validé |
+| Me souvenir de ce que j'ai fait d'un lot à l'autre | **Historique de lots / journal de brassage** avec notes consultables | Élevé × Moyen = **Moyen-élevé** | validé |
+| Ne pas enfermer mes données | **Import-export BeerXML / BeerJSON** (pas de verrouillage, sans perte) | Élevé × Moyen = **Moyen-élevé** | validé |
+| Fiabilité / ne pas perdre mon historique | **Stockage durable, pas de perte de données** (un message de confiance, surtout en FR après Joliebulle/Little Bock) | Élevé × Moyen = **Moyen-élevé** | validé |
 
-## Stage 3 — Intermediate · clone & community (depth — the desk wedge)
+## Étape 3 — Intermédiaire · cloner & communauté (profondeur — le créneau du desk)
 
-| Need | Feature | Opportunity | Confidence |
+| Besoin | Fonctionnalité | Opportunité | Confiance |
 |---|---|---|---|
-| Recreate a specific beer I love | **Searchable, curated clone repository** | Very High × High = **Very High** | validated |
-| Published clones are wrong / static | **Versioned, community-validated clones** (the iteration loop nobody owns) | High × Very High = **High** | hypothesis |
-| Share without losing authorship | **Sharing with author credit** (multi-group, bulk export) | Med-High × High = **High** | validated (EN) / hypothesis (FR) |
-| A shared recipe doesn't fit my kit | **Auto-rescale to the recipient's equipment** | Med × High = **Med-High** | hypothesis |
+| Recréer une bière précise que j'aime | **Dépôt de clones consultable et organisé** | Très élevé × Élevé = **Très élevé** | validé |
+| Les clones publiés sont erronés / statiques | **Clones versionnés, validés par la communauté** (la boucle d'itération que personne ne possède) | Élevé × Très élevé = **Élevé** | hypothèse |
+| Partager sans perdre la paternité | **Partage avec crédit de l'auteur** (multi-groupe, export en lot) | Moyen-élevé × Élevé = **Élevé** | validé (EN) / hypothèse (FR) |
+| Une recette partagée ne correspond pas à mon matériel | **Remise à l'échelle automatique vers l'équipement du destinataire** | Moyen × Élevé = **Moyen-élevé** | hypothèse |
 
-**Cross-cutting (all stages):** a **fair, generous free tier** — paywall fatigue is one of the strongest
-desk signals; it's a pricing principle, not a feature. Don't compete on calculation (incumbents win there).
+**Transversal (toutes les étapes) :** une **offre gratuite juste et généreuse** — la fatigue des paywalls est l'un
+des signaux les plus forts du desk ; c'est un principe de tarification, pas une fonctionnalité. Ne pas concurrencer
+sur le calcul (les acteurs en place y gagnent).
 
-## Build order (the answer to "what do we implement, and in what order")
+## Ordre de construction (la réponse à « qu'implémente-t-on, et dans quel ordre »)
 
-1. **P0 — the assistant entry (Stage 1):** guided brew-day assistant + beginner catalog + fermentation
-   tracking + clean UX + offline tolerance. *This is the wedge we ship and validate first.*
-2. **P1 — retention (Stage 2):** organization & search, batch history, BeerXML import/export, durability.
-3. **P2 — depth (Stage 3):** clone repository → versioned clones → credited sharing → auto-rescale.
+1. **P0 — l'entrée par l'assistant (Étape 1) :** assistant de jour de brassage guidé + catalogue débutant + suivi
+   de fermentation + UX épurée + tolérance au hors-ligne. *C'est le créneau que nous livrons et validons en premier.*
+2. **P1 — rétention (Étape 2) :** organisation & recherche, historique de lots, import/export BeerXML, durabilité.
+3. **P2 — profondeur (Étape 3) :** dépôt de clones → clones versionnés → partage crédité → remise à l'échelle automatique.
 
-The clone repository scores **Very High** on raw opportunity, but it lives in Stage 3 because it serves
-intermediates and needs a crowd. We **enter** by the assistant and **grow into** the community — "the app
-that grows with the brewer."
+Le dépôt de clones obtient un score **Très élevé** en opportunité brute, mais il vit à l'Étape 3 parce qu'il sert
+les intermédiaires et a besoin d'une foule. Nous **entrons** par l'assistant et **grandissons vers** la communauté —
+« l'application qui grandit avec le brasseur ».
 
-## What the interviews must settle (ties to the [interview guide](/05-interview-guide))
+## Ce que les entretiens doivent trancher (liens vers le [guide d'entretien](/05-interview-guide))
 
-- **The biggest open risk:** is the **beginner assistant** truly a strong, willing-to-pay-attention need,
-  or do brewers "graduate" past it too fast to build a business on? (the *under-probed* rows above).
-- Whether **attribution-sensitivity** holds in FR as it does in EN.
-- Whether **versioning + auto-rescale** is felt as a real need or a nice-to-have.
-- Whether intermediates would **switch** from an entrenched tool.
+- **Le plus grand risque ouvert :** l'**assistant débutant** est-il vraiment un besoin fort, qui mérite qu'on s'y attarde,
+  ou les brasseurs « passent-ils ce stade » trop vite pour en faire une activité viable ? (les lignes *sous-sondé* ci-dessus).
+- Si la **sensibilité à la paternité** tient en FR comme en EN.
+- Si le **versioning + la remise à l'échelle automatique** est ressenti comme un besoin réel ou un simple agrément.
+- Si les intermédiaires **changeraient** d'un outil retranché.
 
-Until these are answered, treat the order above as the **best current bet**, not a settled roadmap.
+Tant que ces questions ne sont pas tranchées, traitez l'ordre ci-dessus comme le **meilleur pari actuel**, et non comme une feuille de route arrêtée.

--- a/docs/marketing/needs-study/04b-prioritized-backlog.md
+++ b/docs/marketing/needs-study/04b-prioritized-backlog.md
@@ -4,7 +4,7 @@ Cette page transforme les conclusions du desk research en un **ordre de construc
 réel chaque fonctionnalité sert, à quel point l'opportunité est forte, à quel point nous sommes confiants, et
 dans quel ordre construire.
 
-::: warning Read this first
+::: warning À lire d'abord
 Ce classement repose sur la **recherche secondaire** (desk) — des hypothèses solides, pas une vérité confirmée sur le terrain.
 Deux biais à garder à l'esprit :
 1. Le desk research a surtout sondé les points de douleur **intermédiaires** (clone, partage, synchronisation), il

--- a/docs/marketing/needs-study/05-interview-guide.md
+++ b/docs/marketing/needs-study/05-interview-guide.md
@@ -1,0 +1,125 @@
+# Brewer Interview Guide — Needs Validation
+
+Primary-research instrument for the marketing needs study (epic #1075, sub-issue #1076).
+Built on a Jobs-to-be-Done (JTBD) frame: understand the *job* a homebrewer is trying to get done,
+not whether they like our idea. **Bilingual** — run in EN on r/Homebrewing, in FR on brassageamateur.
+
+## Golden rules (read before every interview)
+
+- **Never pitch.** The interviewee must not know what we're building until the very end (optional).
+  The moment they sense an app, they answer to be polite — useless data.
+- **Ask about the past, not the future.** "Tell me about the last time you…" beats "Would you use…".
+  Memories are facts; predictions are fiction.
+- **Dig into stories, not opinions.** When they make a claim, ask for the specific episode behind it.
+- **Embrace silence.** Let them fill it. The best signal comes after the pause.
+- **Capture verbatim.** Record exact words (with consent) — the language is gold for copy later.
+
+## Target & recruitment
+
+- **Segment:** regular / intermediate homebrewers (brew several times a year; not first-batch beginners,
+  not all-grain pros wedded to a tool). Screen for it (Q0).
+- **Recruit from:** r/Homebrewing (EN), brassageamateur.com (FR). Aim 10-15 total, mixed EN/FR.
+- **Format:** 25-35 min, voice if possible. Ask consent to record + to quote anonymously.
+
+## What we're trying to learn (the 3 risky beliefs)
+
+| # | Belief under test | If FALSE, then… |
+|---|---|---|
+| B1 | They want to **clone specific beers** and would value **versioned, community-refined** clones | The "hero" loses its emotional pull |
+| B2 | Sharers care about **author credit / attribution** (strong EN, unproven FR) | The credit/attribution mechanic is wasted effort |
+| B3 | They'd **switch** from their current tool, and **auto-rescale** of shared recipes is a real need | The wedge isn't enough to overcome inertia |
+
+The questions below are sequenced to surface these without naming them.
+
+---
+
+## Section 0 — Screen & warm-up (3 min)
+
+- **EN:** How long have you been brewing, and roughly how many batches a year? What's your setup?
+- **FR:** Tu brasses depuis combien de temps, et à peu près combien de brassins par an ? Quel est ton matériel ?
+
+*(Keep if: brews regularly, beyond first batches, not a hardcore single-tool pro. Otherwise thank & end.)*
+
+## Section 1 — The job & current workflow (8 min) — JTBD / pains
+
+- **EN:** Walk me through your last brew, from choosing what to brew to drinking it. Where did the recipe come from?
+- **FR:** Raconte-moi ton dernier brassin, du choix de la recette jusqu'à la dégustation. D'où venait la recette ?
+
+- **EN:** Where do your recipes live today? Show me / describe it. What's annoying about that?
+- **FR:** Où sont stockées tes recettes aujourd'hui ? Montre-moi / décris. Qu'est-ce qui t'agace là-dedans ?
+
+- **EN:** Tell me about the last time you couldn't find or organize a recipe the way you wanted.
+- **FR:** Parle-moi de la dernière fois où tu n'as pas réussi à retrouver ou organiser une recette comme tu voulais.
+
+*Tags: pain, current-alternative, vocabulary, foundation-need (organize/track).*
+
+## Section 2 — Cloning a specific beer (7 min) — probes B1
+
+- **EN:** Have you ever tried to recreate a specific commercial beer you love? Tell me about that — start to finish.
+- **FR:** As-tu déjà essayé de reproduire une bière commerciale précise que tu aimes ? Raconte — du début à la fin.
+
+- **EN:** Where did you get the clone recipe? Did it come out like the original? What did you do next?
+- **FR:** Où as-tu trouvé la recette de clone ? Le résultat ressemblait-il à l'originale ? Qu'as-tu fait ensuite ?
+
+- **EN:** (If they adapted it) How did you know what to change? Did you write your version down anywhere?
+- **FR:** (S'ils l'ont adaptée) Comment savais-tu quoi changer ? As-tu noté ta version quelque part ?
+
+*Tags: B1 clone-desire, B1 versioning-need (do they iterate?), trigger, desired-outcome.*
+
+## Section 3 — Sharing & community (7 min) — probes B2
+
+- **EN:** Have you ever shared one of your recipes with another brewer? What happened? How did you share it?
+- **FR:** As-tu déjà partagé une de tes recettes avec un autre brasseur ? Comment ? Que s'est-il passé ?
+
+- **EN:** When you see a recipe online, do you care who created it? Why / why not?
+- **FR:** Quand tu vois une recette en ligne, est-ce que ça compte pour toi de savoir qui l'a créée ? Pourquoi ?
+
+- **EN:** (If they shared) How did you feel about others using or changing your recipe? Did you want credit?
+- **FR:** (S'ils ont partagé) Qu'as-tu ressenti à l'idée que d'autres utilisent ou modifient ta recette ? Voulais-tu être crédité ?
+
+*Tags: B2 attribution-sensitivity (note EN vs FR!), sharing-willingness, social-job.*
+
+## Section 4 — Tools & switching (6 min) — probes B3
+
+- **EN:** What apps or tools do you use for brewing today? What made you pick that one?
+- **FR:** Quels logiciels ou outils utilises-tu pour brasser aujourd'hui ? Pourquoi celui-là ?
+
+- **EN:** What would have to be true for you to move your recipes to a different tool? What's stopped you before?
+- **FR:** Qu'est-ce qui devrait être vrai pour que tu déplaces tes recettes vers un autre outil ? Qu'est-ce qui t'en a empêché jusqu'ici ?
+
+- **EN:** When you take someone else's recipe, how do you adjust it to your own equipment? Walk me through it.
+- **FR:** Quand tu prends la recette de quelqu'un d'autre, comment l'adaptes-tu à ton propre matériel ? Décris-moi.
+
+*Tags: B3 switching-barrier, B3 rescale-need, current-alternative, objection.*
+
+## Section 5 — Wrap (3 min)
+
+- **EN:** If you had a magic wand for the recipe side of brewing, what would you change? Anything I didn't ask about?
+- **FR:** Si tu avais une baguette magique pour la partie recettes du brassage, que changerais-tu ? Un sujet que j'ai oublié ?
+
+- **EN:** Who else like you should I talk to? (referral)
+- **FR:** Qui d'autre, dans ton genre, devrais-je interviewer ? (recommandation)
+
+*(Optional, only at the very end: briefly describe the concept and watch the honest reaction — but data above is what counts.)*
+
+---
+
+## After each interview — capture sheet
+
+Fill within 1 hour, per `customer-research` extraction fields:
+
+- **Source / language / date / profile** (years brewing, batches/yr, setup, EN or FR).
+- **JTBD** (functional / emotional / social).
+- **Top pains** (verbatim, mark unprompted + emotional ones).
+- **Trigger events.**
+- **Desired outcomes** (exact quotes = money quotes).
+- **Alternatives considered** (tools, forums, doing nothing).
+- **Per-belief verdict:** B1 / B2 / B3 → supports / refutes / unclear, with the quote that decides it.
+
+## Synthesis (after ~10 interviews)
+
+- Cluster pains by theme; score frequency × intensity; **confidence label** (High = 3+ independent
+  sources, unprompted, consistent; Medium = 2 sources or prompted; Low = single source).
+- **Compare EN vs FR explicitly** on B2 (attribution) — this is the known divergence to resolve.
+- Feed verdicts + money quotes into the final report (`06-report.md`).
+- Sample-bias caveat: r/Homebrewing skews technical/opinionated; forum posters skew "stuck" — weight accordingly.

--- a/docs/marketing/needs-study/05-interview-guide.md
+++ b/docs/marketing/needs-study/05-interview-guide.md
@@ -1,46 +1,49 @@
-# Brewer Interview Guide — Needs Validation
+# Guide d'entretien brasseur — Validation des besoins
 
-Primary-research instrument for the marketing needs study (epic #1075, sub-issue #1076).
-Built on a Jobs-to-be-Done (JTBD) frame: understand the *job* a homebrewer is trying to get done,
-not whether they like our idea. **Bilingual** — run in EN on r/Homebrewing, in FR on brassageamateur.
+Instrument de recherche primaire pour l'étude de besoins marketing (épic #1075, sous-issue #1076).
+Construit sur un cadre Jobs-to-be-Done (JTBD) : comprendre le *job* qu'un brasseur amateur cherche à
+accomplir, et non s'il aime notre idée. **Bilingue** — mené en EN sur r/Homebrewing, en FR sur brassageamateur.
 
-## Golden rules (read before every interview)
+## Règles d'or (à lire avant chaque entretien)
 
-- **Never pitch.** The interviewee must not know what we're building until the very end (optional).
-  The moment they sense an app, they answer to be polite — useless data.
-- **Ask about the past, not the future.** "Tell me about the last time you…" beats "Would you use…".
-  Memories are facts; predictions are fiction.
-- **Dig into stories, not opinions.** When they make a claim, ask for the specific episode behind it.
-- **Embrace silence.** Let them fill it. The best signal comes after the pause.
-- **Capture verbatim.** Record exact words (with consent) — the language is gold for copy later.
+- **Ne jamais pitcher.** L'interviewé ne doit pas savoir ce que nous construisons avant la toute fin
+  (optionnel). Dès qu'il devine une app, il répond par politesse — données inutiles.
+- **Interroger le passé, pas le futur.** « Parle-moi de la dernière fois où tu… » vaut mieux que
+  « Utiliserais-tu… ». Les souvenirs sont des faits ; les prédictions sont de la fiction.
+- **Creuser les histoires, pas les opinions.** Quand l'interviewé avance une affirmation, demande l'épisode
+  précis qui se cache derrière.
+- **Accueillir le silence.** Laisse-le le combler. Le meilleur signal arrive après la pause.
+- **Capturer mot pour mot.** Note les mots exacts (avec consentement) — le langage est précieux pour la
+  rédaction publicitaire plus tard.
 
-## Target & recruitment
+## Cible et recrutement
 
-- **Segment:** regular / intermediate homebrewers (brew several times a year; not first-batch beginners,
-  not all-grain pros wedded to a tool). Screen for it (Q0).
-- **Recruit from:** r/Homebrewing (EN), brassageamateur.com (FR). Aim 10-15 total, mixed EN/FR.
-- **Format:** 25-35 min, voice if possible. Ask consent to record + to quote anonymously.
+- **Segment :** brasseurs amateurs réguliers / intermédiaires (brassent plusieurs fois par an ; ni débutants
+  au premier brassin, ni pros tout-grain attachés à un seul outil). Filtrer pour cela (Q0).
+- **Recruter depuis :** r/Homebrewing (EN), brassageamateur.com (FR). Viser 10-15 au total, mélange EN/FR.
+- **Format :** 25-35 min, en voix si possible. Demander le consentement pour enregistrer + pour citer
+  anonymement.
 
-## What we're trying to learn (the 3 risky beliefs)
+## Ce que nous cherchons à apprendre (les 3 croyances risquées)
 
-| # | Belief under test | If FALSE, then… |
+| # | Croyance testée | Si FAUSSE, alors… |
 |---|---|---|
-| B1 | They want to **clone specific beers** and would value **versioned, community-refined** clones | The "hero" loses its emotional pull |
-| B2 | Sharers care about **author credit / attribution** (strong EN, unproven FR) | The credit/attribution mechanic is wasted effort |
-| B3 | They'd **switch** from their current tool, and **auto-rescale** of shared recipes is a real need | The wedge isn't enough to overcome inertia |
+| B1 | Ils veulent **cloner des bières précises** et valoriseraient des clones **versionnés, affinés par la communauté** | Le « pilier » perd son attrait émotionnel |
+| B2 | Ceux qui partagent tiennent au **crédit / à l'attribution de l'auteur** (fort en EN, non prouvé en FR) | Le mécanisme de crédit/attribution est un effort gaspillé |
+| B3 | Ils **changeraient** d'outil actuel, et la **remise à l'échelle automatique** des recettes partagées est un vrai besoin | Le coin n'est pas suffisant pour vaincre l'inertie |
 
-The questions below are sequenced to surface these without naming them.
+Les questions ci-dessous sont séquencées pour faire émerger ces croyances sans les nommer.
 
 ---
 
-## Section 0 — Screen & warm-up (3 min)
+## Section 0 — Filtrage et mise en confiance (3 min)
 
 - **EN:** How long have you been brewing, and roughly how many batches a year? What's your setup?
 - **FR:** Tu brasses depuis combien de temps, et à peu près combien de brassins par an ? Quel est ton matériel ?
 
-*(Keep if: brews regularly, beyond first batches, not a hardcore single-tool pro. Otherwise thank & end.)*
+*(Conserver si : brasse régulièrement, au-delà des premiers brassins, pas un pro attaché à un seul outil. Sinon remercier et clore.)*
 
-## Section 1 — The job & current workflow (8 min) — JTBD / pains
+## Section 1 — Le job et le flux de travail actuel (8 min) — JTBD / douleurs
 
 - **EN:** Walk me through your last brew, from choosing what to brew to drinking it. Where did the recipe come from?
 - **FR:** Raconte-moi ton dernier brassin, du choix de la recette jusqu'à la dégustation. D'où venait la recette ?
@@ -51,9 +54,9 @@ The questions below are sequenced to surface these without naming them.
 - **EN:** Tell me about the last time you couldn't find or organize a recipe the way you wanted.
 - **FR:** Parle-moi de la dernière fois où tu n'as pas réussi à retrouver ou organiser une recette comme tu voulais.
 
-*Tags: pain, current-alternative, vocabulary, foundation-need (organize/track).*
+*Étiquettes : douleur, alternative actuelle, vocabulaire, besoin fondation (organiser/suivre).*
 
-## Section 2 — Cloning a specific beer (7 min) — probes B1
+## Section 2 — Cloner une bière précise (7 min) — sonde B1
 
 - **EN:** Have you ever tried to recreate a specific commercial beer you love? Tell me about that — start to finish.
 - **FR:** As-tu déjà essayé de reproduire une bière commerciale précise que tu aimes ? Raconte — du début à la fin.
@@ -64,9 +67,9 @@ The questions below are sequenced to surface these without naming them.
 - **EN:** (If they adapted it) How did you know what to change? Did you write your version down anywhere?
 - **FR:** (S'ils l'ont adaptée) Comment savais-tu quoi changer ? As-tu noté ta version quelque part ?
 
-*Tags: B1 clone-desire, B1 versioning-need (do they iterate?), trigger, desired-outcome.*
+*Étiquettes : B1 désir-de-clone, B1 besoin-de-versionnement (itèrent-ils ?), déclencheur, résultat-souhaité.*
 
-## Section 3 — Sharing & community (7 min) — probes B2
+## Section 3 — Partage et communauté (7 min) — sonde B2
 
 - **EN:** Have you ever shared one of your recipes with another brewer? What happened? How did you share it?
 - **FR:** As-tu déjà partagé une de tes recettes avec un autre brasseur ? Comment ? Que s'est-il passé ?
@@ -77,9 +80,9 @@ The questions below are sequenced to surface these without naming them.
 - **EN:** (If they shared) How did you feel about others using or changing your recipe? Did you want credit?
 - **FR:** (S'ils ont partagé) Qu'as-tu ressenti à l'idée que d'autres utilisent ou modifient ta recette ? Voulais-tu être crédité ?
 
-*Tags: B2 attribution-sensitivity (note EN vs FR!), sharing-willingness, social-job.*
+*Étiquettes : B2 sensibilité-à-l'attribution (noter EN vs FR !), volonté-de-partage, job-social.*
 
-## Section 4 — Tools & switching (6 min) — probes B3
+## Section 4 — Outils et changement d'outil (6 min) — sonde B3
 
 - **EN:** What apps or tools do you use for brewing today? What made you pick that one?
 - **FR:** Quels logiciels ou outils utilises-tu pour brasser aujourd'hui ? Pourquoi celui-là ?
@@ -90,9 +93,9 @@ The questions below are sequenced to surface these without naming them.
 - **EN:** When you take someone else's recipe, how do you adjust it to your own equipment? Walk me through it.
 - **FR:** Quand tu prends la recette de quelqu'un d'autre, comment l'adaptes-tu à ton propre matériel ? Décris-moi.
 
-*Tags: B3 switching-barrier, B3 rescale-need, current-alternative, objection.*
+*Étiquettes : B3 barrière-au-changement, B3 besoin-de-remise-à-l'échelle, alternative actuelle, objection.*
 
-## Section 5 — Wrap (3 min)
+## Section 5 — Conclusion (3 min)
 
 - **EN:** If you had a magic wand for the recipe side of brewing, what would you change? Anything I didn't ask about?
 - **FR:** Si tu avais une baguette magique pour la partie recettes du brassage, que changerais-tu ? Un sujet que j'ai oublié ?
@@ -100,26 +103,27 @@ The questions below are sequenced to surface these without naming them.
 - **EN:** Who else like you should I talk to? (referral)
 - **FR:** Qui d'autre, dans ton genre, devrais-je interviewer ? (recommandation)
 
-*(Optional, only at the very end: briefly describe the concept and watch the honest reaction — but data above is what counts.)*
+*(Optionnel, uniquement à la toute fin : décrire brièvement le concept et observer la réaction honnête — mais ce sont les données ci-dessus qui comptent.)*
 
 ---
 
-## After each interview — capture sheet
+## Après chaque entretien — fiche de capture
 
-Fill within 1 hour, per `customer-research` extraction fields:
+À remplir dans l'heure, selon les champs d'extraction de `customer-research` :
 
-- **Source / language / date / profile** (years brewing, batches/yr, setup, EN or FR).
-- **JTBD** (functional / emotional / social).
-- **Top pains** (verbatim, mark unprompted + emotional ones).
-- **Trigger events.**
-- **Desired outcomes** (exact quotes = money quotes).
-- **Alternatives considered** (tools, forums, doing nothing).
-- **Per-belief verdict:** B1 / B2 / B3 → supports / refutes / unclear, with the quote that decides it.
+- **Source / langue / date / profil** (années de brassage, brassins/an, matériel, EN ou FR).
+- **JTBD** (fonctionnel / émotionnel / social).
+- **Principales douleurs** (mot pour mot, marquer celles qui sont spontanées + émotionnelles).
+- **Événements déclencheurs.**
+- **Résultats souhaités** (citations exactes = citations en or).
+- **Alternatives envisagées** (outils, forums, ne rien faire).
+- **Verdict par croyance :** B1 / B2 / B3 → soutient / réfute / incertain, avec la citation qui tranche.
 
-## Synthesis (after ~10 interviews)
+## Synthèse (après ~10 entretiens)
 
-- Cluster pains by theme; score frequency × intensity; **confidence label** (High = 3+ independent
-  sources, unprompted, consistent; Medium = 2 sources or prompted; Low = single source).
-- **Compare EN vs FR explicitly** on B2 (attribution) — this is the known divergence to resolve.
-- Feed verdicts + money quotes into the final report (`06-report.md`).
-- Sample-bias caveat: r/Homebrewing skews technical/opinionated; forum posters skew "stuck" — weight accordingly.
+- Regrouper les douleurs par thème ; scorer fréquence × intensité ; **label de confiance** (Élevé = 3+ sources
+  indépendantes, spontanées, cohérentes ; Moyen = 2 sources ou suscitées ; Faible = source unique).
+- **Comparer EN vs FR explicitement** sur B2 (attribution) — c'est la divergence connue à résoudre.
+- Injecter les verdicts + citations en or dans le rapport final (`06-report.md`).
+- Mise en garde sur le biais d'échantillon : r/Homebrewing penche technique/affirmé ; les posteurs de forums
+  penchent « bloqués » — pondérer en conséquence.

--- a/docs/marketing/needs-study/b1-environnement.md
+++ b/docs/marketing/needs-study/b1-environnement.md
@@ -1,0 +1,16 @@
+# B1 · Environnement (PESTEL)
+
+Analyse **dimensionnée au stade du projet** : on ne garde que ce qui change une décision. Première version
+amorcée depuis le desk (`03c`/`03d`) — à compléter si une dimension devient décisive.
+
+| Dimension | Ce qui compte pour Brasse-Bouillon | Source / confiance |
+|---|---|---|
+| **Politique / Légal** | Le brassage amateur a été **clarifié / légalisé en France au 1ᵉʳ janvier 2021** (Article 520 bis CGI) : bière pour usage personnel/familial exonérée, hors vente. → marché légal **jeune et en expansion**. Cadre « loi Évin » à respecter dans toute communication (déjà géré côté site). | [HIGH] — `03d` |
+| **Économique** | Écosystème de fournisseurs FR désormais mature ; sensibilité prix forte (« brasser pour pas cher ») → un tier gratuit généreux est quasi obligatoire. Marché *pro* des microbrasseries qui plafonne (≈2 500, n°1 en Europe). | [MED] — `03c`/`03d` |
+| **Social** | Fort afflux de **nouveaux brasseurs** (US : 40 % ont commencé < 4 ans) ; culture de partage positive ; communauté FR fidèle aux outils gratuits/open. → un public débutant nombreux et bienveillant. | [HIGH/MED] — `03c`/`03d` |
+| **Technologique** | Outils existants jugés complexes / « steep UX » ; intérêt croissant pour les hydromètres connectés (Tilt, iSpindel) ; interopérabilité **BeerXML/BeerJSON** = table-stakes. | [MED] — `01`/`03` |
+| **Écologique** | Peu structurant à ce stade (ingrédients locaux, réemploi de bouteilles = arguments mineurs). | [LOW] |
+| **Démographique** | Seules données dures = US (âge 30-49, majoritairement masculin, éduqué, aisé). **Aucun chiffre FR officiel** — à valider en terrain. | [N/F] FR — `03d` |
+
+**Décision que ça change :** le couple « marché jeune (légalisé 2021) + afflux de débutants + sensibilité
+prix » conforte la **tête de pont débutant** + le **freemium**. Rien ici ne contredit le cap.

--- a/docs/marketing/needs-study/b4-swot.md
+++ b/docs/marketing/needs-study/b4-swot.md
@@ -1,0 +1,20 @@
+# B4 · SWOT
+
+Première synthèse SWOT issue du desk — *à valider/affiner après le terrain*. Croise l'interne
+(forces/faiblesses du projet) et l'externe (opportunités/menaces du marché).
+
+| Interne | |
+|---|---|
+| **Forces** | Fondateur = membre de sa cible (débutant) → empathie & dogfooding. Conviction forte. Créneau différenciant identifié (clone versionné/crédité/re-scalé). Charte & site déjà en place. |
+| **Faiblesses** | Solo, temps contraint. **Pas dans la cible intermédiaire** (pour la couche communauté). Budget **0 €**. Recrutement terrain **à froid** (nouveau dans les communautés). Pas encore de produit testable. |
+
+| Externe | |
+|---|---|
+| **Opportunités** | Afflux de débutants (marché légalisé 2021). **Aucune donnée FR** sur les brasseurs amateurs → devenir la donnée. **Joliebulle fermé (2010-2025)** → base d'utilisateurs FR orphelins. Incumbents complexes → place pour du « simple ». |
+| **Menaces** | **Build-A-Beer** (clone IA + partage) = concurrent direct. Incumbents installés (Brewfather/BeerSmith) gagnent sur le calcul. Les apps **communautaires meurent** (AHA Brew Guru, fév. 2026) → ne pas mener par la communauté seule. |
+
+**Lecture stratégique (TOWS) :** s'appuyer sur la force « fondateur-dans-la-cible » pour attaquer
+l'opportunité « afflux de débutants » via l'**assistant guidé** (entrée à faible risque), tout en
+neutralisant la menace « les communautés meurent » en faisant de la communauté une **couche de rétention**,
+pas le moteur initial. Compenser la faiblesse « pas dans la cible intermédiaire » par la
+[recherche terrain](/c-resultats).

--- a/docs/marketing/needs-study/c-diffusion.md
+++ b/docs/marketing/needs-study/c-diffusion.md
@@ -1,0 +1,111 @@
+# C · Kit de diffusion du sondage
+
+Posts **prêts à coller** pour recruter des réponses au [sondage](/c-sondage), de façon passive et
+respectueuse des communautés. Remplace `[LIEN DU SONDAGE]` par l'URL réelle du Google Form une fois créé.
+
+::: tip Principes (pour ne pas se faire retirer / downvoter)
+- **Cadrage « débutant qui apprend »**, jamais « teste mon app ».
+- **Lire les règles** de chaque communauté ; demander aux **modérateurs** en cas de doute ; poster dans
+  le **fil dédié** si les sondages hors-fil sont interdits.
+- **Contribuer un peu d'abord** (réponses utiles), puis poster — pas débarquer juste pour demander.
+- **Promettre de partager les résultats agrégés** → forte hausse de bienveillance et de réponses.
+- **Note RGPD** : le contact (Q12) est **optionnel** et **jamais partagé**.
+- Ne pas spammer plusieurs endroits le même jour.
+:::
+
+## 1 · Forum brassageamateur.com (FR)
+
+**Titre :** Débutant — comment gérez-vous vos recettes et vos brassins ? (petit questionnaire)
+
+```
+Bonjour à tous,
+
+Je débute le brassage et j'essaie de comprendre comment vous, brasseurs plus
+expérimentés, gérez vos recettes, vos brassins et vos notes au quotidien.
+
+J'ai préparé un court questionnaire (3-5 min) pour apprendre de vos pratiques —
+ça m'aiderait énormément. Je partagerai bien sûr une synthèse des réponses ici
+même, pour que ça serve à tout le monde.
+
+[LIEN DU SONDAGE]
+
+Merci beaucoup pour votre temps ! (Un contact est demandé en option à la fin,
+uniquement si vous acceptez un échange ; il n'est jamais partagé.)
+```
+
+## 2 · Groupes Facebook brassage (FR)
+
+```
+Salut le groupe,
+
+Je débute le brassage et je cherche à comprendre comment vous gérez vos recettes
+et vos brassins. Petit questionnaire de 3-5 min — ça m'aide beaucoup, et je
+partagerai les résultats au groupe.
+
+[LIEN DU SONDAGE]
+
+Merci ! (Contact optionnel en fin de questionnaire, jamais partagé.)
+```
+
+## 3 · LinkedIn (FR, build-in-public)
+
+Ton « j'apprends » (≈80 %), pas de lien externe dans le corps → **lien en premier commentaire**.
+Publier idéalement mardi ~11h ; répondre aux commentaires dans l'heure.
+
+**Corps du post :**
+
+```
+Je me lance dans une étude de besoins pour Brasse-Bouillon — et je redécouvre une
+évidence : écouter avant de coder change tout.
+
+Je suis en reconversion, je construis une app pour les brasseurs amateurs. Mais je
+suis moi-même débutant en brassage. Le piège serait de concevoir « pour moi ».
+Alors je fais l'inverse : je vais demander aux brasseurs ce qui les bloque
+vraiment, avant d'écrire une ligne de code de plus.
+
+Première étape concrète, toute simple : un court questionnaire pour les brasseurs
+amateurs. Si tu brasses (ou si tu connais quelqu'un qui brasse), le lien est en
+commentaire. Je partagerai ce que j'apprends, ici, au fil de l'eau.
+
+#brassage #buildinpublic #reconversion #produit
+```
+
+**Premier commentaire (à poster juste après) :** `Le questionnaire (3-5 min) : [LIEN DU SONDAGE] — merci à ceux qui prennent le temps !`
+
+## 4 · r/Homebrewing (EN, rules-aware)
+
+⚠ Lire d'abord les règles du sub : beaucoup interdisent les sondages hors fil dédié. Proposer aux modos.
+
+**Title:** New to brewing — how do you manage your recipes and batches? (quick survey)
+
+```
+Hi all,
+
+I'm new to homebrewing and trying to understand how more experienced brewers
+manage their recipes, batches and notes.
+
+I put together a short survey (3-5 min) to learn from your practices — it would
+really help, and I'll share a summary of the results back here.
+
+[SURVEY LINK]
+
+Thanks for your time! (Optional contact at the end, only if you're open to a chat;
+never shared.) Mods — happy to move this to a dedicated thread if you prefer.
+```
+
+## 5 · CTA site web — section « Participer » (FR)
+
+À câbler quand le lien existe (lien, pas iframe, pour le consentement RGPD ; parité FR/EN obligatoire).
+
+```
+Aide-nous à construire la bonne app
+
+Brasse-Bouillon se construit avec vous. Répondez à notre court questionnaire
+(3-5 min) : vos réponses orientent directement ce qu'on développe.
+
+[ Bouton : Donner mon avis → [LIEN DU SONDAGE] ]
+
+Contact optionnel, jamais partagé.
+```
+
+*(Version anglaise du CTA : voir la page [Distribution](/en/c-distribution).)*

--- a/docs/marketing/needs-study/c-resultats.md
+++ b/docs/marketing/needs-study/c-resultats.md
@@ -1,0 +1,28 @@
+# C · Résultats du terrain
+
+::: warning À venir
+La recherche primaire **n'a pas encore démarré**. Cette page accueillera les résultats des entretiens et
+du sondage. C'est **l'action n°1** de l'étude (validation-first) — voir le [guide d'entretien](/05-interview-guide).
+:::
+
+## Plan de terrain (5-6 semaines, solo, 0 budget, à froid)
+
+- **Qualitatif — 10-15 entretiens** de brasseurs (EN via r/Homebrewing, FR via brassageamateur), cadrage
+  « débutant qui apprend ». Cible réaliste vu les contraintes : **viser la profondeur**, accepter un
+  échantillon modeste et l'**afficher honnêtement**.
+- **Quantitatif — un sondage** (Google Forms) diffusé dans les communautés, pour chiffrer les besoins et
+  commencer à combler le **trou de données FR**.
+
+## Hypothèses prioritaires à trancher
+
+1. **Le besoin « assistant débutant »** est-il fort et durable, ou les brasseurs « grandissent »-ils trop
+   vite pour en faire un produit ? *(le risque le plus important — sous-sondé par le desk)*
+2. **Sensibilité à l'attribution** : forte en EN, sous-évidée en FR — à confirmer des deux côtés.
+3. **Versioning + re-mise à l'échelle** : vrai besoin ou « nice-to-have » ?
+4. **Bascule d'outil** : un intermédiaire quitterait-il un outil installé ?
+
+## Restitution attendue
+
+Carte des besoins confirmée (fréquence × intensité, étiquette de confiance), verbatims clés, comparaison
+**EN vs FR**, et verdict par hypothèse (soutient / réfute / non concluant) → alimente la
+[synthèse](/04-synthesis), le [backlog](/04b-prioritized-backlog) et le [Lean Canvas](/lean-canvas).

--- a/docs/marketing/needs-study/c-sondage.md
+++ b/docs/marketing/needs-study/c-sondage.md
@@ -1,0 +1,54 @@
+# C · Sondage (questionnaire)
+
+Instrument **passif** de recherche primaire : un court questionnaire (3-5 min) diffusé dans les
+communautés de brasseurs, qui collecte en parallèle pendant que l'analyse continue. Conçu pour valider les
+hypothèses de l'étude et commencer à **chiffrer** les besoins (et combler le trou de données FR).
+
+::: tip Méthode
+Court et surtout **fermé** (max de réponses, données chiffrables) + 2 questions ouvertes pour le *pourquoi*.
+Dernière question = **opt-in** pour un échange de 15 min → les volontaires viennent à toi, sans démarchage.
+Cadrage « débutant qui apprend » (pas « teste mon app »). À créer en **Google Forms** (gratuit).
+:::
+
+## Texte d'introduction (à mettre en tête du formulaire / du post)
+
+> Je débute le brassage et je cherche à comprendre comment vous, brasseurs, gérez vos recettes et vos
+> brassins. 3-5 minutes, ça m'aiderait énormément. Merci beaucoup !
+
+## Questions
+
+1. **Depuis combien de temps brasses-tu ?** — `< 6 mois` · `6 mois–2 ans` · `2–5 ans` · `5 ans et +`
+2. **Combien de brassins par an, environ ?** — `0–2` · `3–6` · `7–12` · `12 et +`
+3. **Tu brasses où ?** — `France` · `Belgique` · `Suisse` · `Québec` · `Autre`
+4. **Où vivent tes recettes et tes notes de brassin aujourd'hui ?** *(plusieurs réponses)* — `Dans ma tête` · `Papier / carnet` · `Tableur (Excel, Sheets)` · `Une application` · `Sur un forum` · `Autre`
+5. **Quel(s) outil(s) ou app utilises-tu ?** *(plusieurs réponses)* — `Brewfather` · `BeerSmith` · `Little Bock` · `Brewer's Friend` · `Aucun` · `Autre`
+6. **Qu'est-ce qui t'agace le plus dans ta façon de gérer tes recettes / brassins ?** *(réponse libre, courte)*
+7. **T'arrive-t-il de rater un brassin, ou d'être perdu pendant le processus ?** — `Souvent` · `Parfois` · `Rarement` · `Jamais`
+8. **As-tu déjà essayé de reproduire (cloner) une bière commerciale précise ?** — `Oui, réussi` · `Oui, mais déçu du résultat` · `Jamais essayé, mais j'aimerais` · `Pas intéressé`
+9. **Partages-tu tes recettes avec d'autres brasseurs ?** — `Souvent` · `Parfois` · `Non, mais je serais ouvert` · `Non, je préfère les garder`
+10. **Si tu partages une recette, être crédité comme auteur, ça compte pour toi ?** — `Beaucoup` · `Un peu` · `Pas du tout` · `Je ne partage pas`
+11. **Qu'est-ce qui te ferait essayer une nouvelle app de brassage ?** *(plusieurs réponses)* — `La simplicité` · `Gratuit` · `Un suivi guidé pas-à-pas` · `Une communauté` · `Pouvoir importer mes recettes` · `Autre`
+12. **Serais-tu d'accord pour un échange de 15 min, pour m'en dire plus ?** — `Oui` *(→ e-mail ou pseudo)* · `Non`
+
+## Ce que chaque question teste
+
+| Questions | Hypothèse / objectif |
+|---|---|
+| 1, 2 | **Segment** (débutant / régulier / intermédiaire) — clé pour trancher assistant vs communauté |
+| 3 | Comble le **trou de données FR** (répartition géographique) |
+| 4, 5, 6 | **Pratiques & douleurs** actuelles (outils, organisation) — le *pourquoi* |
+| 7 | Hypothèse **assistant** (peur de rater, besoin de guidage — surtout débutants) |
+| 8 | Hypothèse **clone** (désir de reproduire une bière) |
+| 9, 10 | Hypothèses **partage** + **attribution** (forte en EN, à confirmer en FR) |
+| 11 | **Déclencheur d'adoption** / bascule d'outil |
+| 12 | **Opt-in entretien** — récupère des volontaires sans démarchage |
+
+## Diffusion (passive, 0 €)
+
+- **brassageamateur.com** (FR) — section appropriée, en se présentant honnêtement comme débutant.
+- **r/Homebrewing** (EN, [version anglaise](/en/c-survey)) — respecter les règles anti-promo du sub.
+- Groupes Facebook brassage FR.
+- Laisser collecter **2-3 semaines** ; viser un échantillon modeste mais **affiché honnêtement**.
+
+Les résultats alimenteront la page [Résultats](/c-resultats), puis la [synthèse](/04-synthesis), le
+[backlog](/04b-prioritized-backlog) et le [Lean Canvas](/lean-canvas).

--- a/docs/marketing/needs-study/d-strategie.md
+++ b/docs/marketing/needs-study/d-strategie.md
@@ -1,0 +1,32 @@
+# D · Stratégie & plan d'action
+
+::: warning À venir
+Cette section se rédige **après** la validation terrain (sinon on planifie peut-être le mauvais produit).
+Le squelette ci-dessous fixe les rubriques attendues ; on les remplit une fois les hypothèses tranchées.
+:::
+
+## STP — Segmentation, Ciblage, Positionnement
+
+- **Segmentation** : brasseurs débutants / réguliers / intermédiaires (× FR / EN).
+- **Ciblage** : tête de pont = **débutants** (acquisition), puis montée en gamme dans le parcours.
+- **Positionnement** : voir l'[énoncé de positionnement](/04-synthesis) (à confirmer en terrain).
+
+## Mix (adapté au numérique)
+
+- **Produit** : l'assistant guidé d'abord ([backlog priorisé](/04b-prioritized-backlog)).
+- **Prix** : freemium ; cœur gratuit, export BeerXML/BeerJSON payant ; tier gratuit généreux (sensibilité FR).
+- **Distribution** : stores + site ; entrée par les communautés.
+- **Communication** : build-in-public (LinkedIn FR + Indie Hackers EN), présence « écoute d'abord » dans les communautés brasseurs.
+
+## Plan d'action & KPIs
+
+- **Canaux de départ (2)** : communautés brasseurs (produit) + LinkedIn (fondateur).
+- **Rythme** : 1 publication/semaine (journal de bord, pas de la pub).
+- **KPIs** (voir [Lean Canvas](/lean-canvas)) : taux de complétion d'un brassin, rétention S4, recettes
+  créées/partagées, NPS.
+- **Boucle** : lancer → mesurer → itérer.
+
+## Légitimité réseaux
+
+*Construire en public* est légitime **dès maintenant** ; *vendre / acquérir* viendra quand il y aura un
+produit testable.

--- a/docs/marketing/needs-study/en/00-method.md
+++ b/docs/marketing/needs-study/en/00-method.md
@@ -1,0 +1,63 @@
+# Marketing Needs Study — Method
+
+## Why this study exists
+
+No formal user-needs study had ever been done for Brasse-Bouillon. Before investing further
+in features and positioning, we run a proper marketing needs study to identify what
+intermediate homebrewers actually want, validate (or kill) our differentiating hypothesis,
+and ground product decisions in evidence rather than assumption.
+
+## Strategic frame (decided during the kickoff debrief)
+
+- **Primary target (beachhead):** regular / intermediate homebrewers; international / English-speaking
+  first, French also in scope.
+- **Product language:** bilingual FR + EN (implies an i18n effort tracked as a separate epic).
+- **Positioning hypothesis:**
+  - **Hook (hero):** a community for cloning and sharing beer recipes.
+  - **Foundation (table-stakes):** recipe organization + brew/fermentation tracking.
+- **Starting channels (2):** r/Homebrewing (users) + Indie Hackers (founder build-in-public);
+  LinkedIn kept in French for the founder's reconversion narrative.
+
+## Research design
+
+Two phases, cheap-to-expensive:
+
+1. **Secondary research (desk research) — DONE.** Mine what already exists publicly: competitor
+   app reviews, Reddit, homebrewing forums. Cheap, fast, generates hypotheses.
+2. **Primary research — TODO.** Talk to real brewers: a structured interview guide
+   (via the `customer-research` skill) + 10-15 interviews to confirm or refute the desk findings.
+
+The order matters: secondary first to build hypotheses, primary second to confirm with real people.
+
+## Secondary research execution
+
+Six desk passes across source families:
+
+- `01-desk-competitors.md` — reviews of Brewfather, BeerSmith, Brewer's Friend, BrewBuddy, and adjacent apps.
+- `02-desk-reddit.md` — r/Homebrewing recurring questions and pains.
+- `03-desk-forums.md` — HomeBrewTalk (EN) + brassageamateur.com (FR).
+- `03b-desk-french.md` — dedicated French-language pass (FR blogs, tools, community channels).
+- `03c-desk-market-data.md` — quantitative layer (market size, downloads, recipe-DB sizes, uncovered competitors).
+- `03d-desk-french-market.md` — snowball pass on the French homebrewer population / market (fills the FR data gap).
+- `04-synthesis.md` — consolidated needs map + market context + one-sentence positioning statement.
+- `05-interview-guide.md` — bilingual primary-research instrument (JTBD interview guide).
+- `06-report.md` — final report (epic closure deliverable; written after primary research).
+
+## Method limitations (read before trusting the numbers)
+
+- **Reddit and HomeBrewTalk block automated fetching (HTTP 403).** r/Homebrewing findings are
+  *inferred* from adjacent forums and from the prevalence of clone-recipe compilations, not from
+  direct thread reads or upvote counts. HomeBrewTalk findings rely on search-result snippets.
+  brassageamateur.com was fetched directly.
+- **Frequency signals are qualitative** (recurrence of distinct threads / reviews), not scraped counts.
+  Treat rankings as directional.
+- **Forums over-represent people who are stuck** — a strong hypothesis generator, not proof.
+  This is exactly why primary research (interviews) follows.
+- To harden: read a sample of r/Homebrewing threads via an authenticated/API path and tag posts by
+  theme for true counts.
+
+## Status
+
+- Secondary research: complete (captured in `01`–`03d`, consolidated in `04`).
+- Primary research: not started.
+- Final report: not started.

--- a/docs/marketing/needs-study/en/01-desk-competitors.md
+++ b/docs/marketing/needs-study/en/01-desk-competitors.md
@@ -1,0 +1,86 @@
+# Desk Research — Competitor App Reviews
+
+Source families: App Store / Google Play review summaries, Reddit/forum comparisons, comparison
+blogs, official docs. **Caveat:** HomeBrewTalk and some review pages returned 403; Reddit thread
+bodies were not retrievable, so a few claims lean on search snippets and are flagged. Star ratings
+are listing summaries at time of search (May 2026).
+
+## Per-competitor findings
+
+### Brewfather (cloud-based; the sentiment leader)
+
+**Praise**
+- Best-in-class cross-device cloud sync (design on laptop, log gravity on phone) — the most-cited reason to switch.
+- Clean, modern, non-overwhelming UI; fast onboarding.
+- Strong batch system (each brew = a variation of a master recipe) + fermentation tracking; Tilt/Grainfather integrations (the in-app Tilt chart is a named purchase driver).
+- Ad-free, responsive dev support, cheap (~$20/yr).
+
+**Complaints / gaps**
+- Subscription-only for full features; no one-time purchase — recurring-cost resentment is the most common con.
+- Limited offline functionality (needs internet for most features).
+- Can feel feature-overwhelming at first.
+- Community library exists but **publishing recipes is paid-tier-gated**, and free users hit recipe-count limits even when *copying* a community recipe.
+
+### BeerSmith Mobile (one-time purchase; desktop heritage) — worst-rated (≈2.9★ App Store)
+
+**Praise**
+- Most established/trusted calculation engine in the hobby; very accurate once tuned.
+- Integrated brew-day timer with step-by-step reminders.
+- One-time purchase, no subscription.
+
+**Complaints / gaps**
+- Painful sync: desktop → cloud → phone, so "the same recipe exists 3 times." **Strongest, most concrete pain in the set.**
+- Clunky, slow, dated nested-folder UI; search breaks inside nested folders (dev acknowledged file-storage/menu complaints).
+- Awkward flows (must go "back" to start the timer after editing).
+- No `.bsmx` import on mobile; profiles re-entered per device; sharing requires a cloud download. High learning curve.
+
+### Brewer's Friend (web-first + apps; calculators reputation)
+
+**Praise**
+- Best-regarded brewing calculators ("unparalleled") and water-chemistry tools.
+- Fully web-based — recipes safe in the cloud.
+- Direct ingredient purchasing; large public recipe database.
+
+**Complaints / gaps**
+- Free tier capped at 5 recipes **and shows ads**; sync/ad-removal require Premium.
+- Weak mobile usability (timer hard to find); some "regret the annual fee" and switched away.
+- Reported Android bugs (gravity not updating, metric↔imperial errors, edits not saving) with slow fixes.
+
+### BrewBuddy (iOS utility) — contrast point, not a direct competitor
+- Deliberately minimal offline calculators; no accounts, no data saved, no tracking.
+- Confirms a niche that distrusts cloud/subscription apps and just wants offline tools.
+
+### Adjacent / signal points
+- **Grainfather app:** calculations diverge from Brewfather for the same recipe (equipment profiles) — friction moving recipes between ecosystems.
+- **AHA Brew Guru** (recipe + deals + community app): **sunset Feb 1, 2026**, folded back into the AHA website; "limited content," mixed feedback. A dedicated community/recipe app that failed to sustain — a caution for the community hero.
+- **Build-A-Beer:** free app whose headline feature is **AI clone-recipe generation** from a beer's characteristics + "share your creations." Direct competitor to the clone/share angle — track it.
+
+## Top unmet needs (ranked by signal strength)
+
+1. **Frictionless sync + true offline without paying or duplicating data** — *very frequent.* BeerSmith triple-copy is the loudest single complaint; Brewfather online dependency echoes it. Brewing happens in garages/cellars with poor connectivity.
+2. **Subscription / paywall friction** — *very frequent.* Free tiers feel crippled (publishing, sync, import/export gated).
+3. **Modern, uncluttered mobile UX** — *frequent.* Brewfather wins precisely by being clean — UX is a proven differentiator.
+4. **Reliable recipe organization & search** — *moderate.* BeerSmith search breaks in nested folders.
+5. **Easy, low-friction recipe sharing** — *moderate.* Sharing is awkward (cloud download / paid publishing). Demand exists but is partly served.
+6. **Bug-free reliability & accurate calculations** — *moderate.* Cross-app calculation divergence undermines trust when moving recipes.
+7. **Inventory / cost tracking, device integrations (Tilt)** — *occasional but loyalty-driving.*
+
+## Signal on the SHARING / CLONING / COMMUNITY hero hypothesis
+
+- **Cloning commercial beers: strong, durable demand.** AHA 50-state clone guides, BrewDog *DIY Dog*, Beer Maverick 100+, Build-A-Beer all exist because demand is real and recurring. Validates the clone angle.
+- **Community recipe libraries: validated but partly served and hard to monetize.** Brewfather/Brewer's Friend show users want to browse/copy others' recipes — but publishing is paywalled and copying is capped, leaving an opening for a more open, sharing-first model. Caution: Brew Guru's Feb-2026 sunset shows in-app social is unproven as a *primary* retention driver; most "community" lives on Reddit/Discord/Facebook/forums today.
+- **Implication:** the *cloning + open sharing* combination is the most defensible hero. Frame pure "social" as connective tissue around clone-sharing, not a standalone feature. Foundation features target the top-4 unmet needs and are table-stakes for retention.
+
+## Sources
+- https://homebrewacademy.com/brewing-software-comparison/
+- https://play.google.com/store/apps/details?id=com.warpkode.brewfather&hl=en_US
+- https://docs.brewfather.app/library
+- https://docs.brewfather.app/faq
+- https://hazyandhoppy.com/why-i-switched-to-the-brewfather-app/
+- https://apps.apple.com/us/app/beersmith-mobile-home-brewing/id640670118
+- https://apps.apple.com/us/app/brewers-friend/id1580297037
+- https://apps.apple.com/us/app/brewbuddy-homebrew-tools/id6450740421
+- https://homebrewersassociation.org/news/brew-guru-sunsetting-feb-1/
+- https://homebrewersassociation.org/top-50-commercial-clone-beer-recipes/
+- https://beermaverick.com/over-100-commercial-beer-clone-recipes-from-the-breweries-themselves/
+- https://buildabeer.app/

--- a/docs/marketing/needs-study/en/02-desk-reddit.md
+++ b/docs/marketing/needs-study/en/02-desk-reddit.md
@@ -1,0 +1,82 @@
+# Desk Research — r/Homebrewing
+
+**Method / uncertainty flag:** Reddit blocks automated fetching (both `www.reddit.com` and
+`old.reddit.com`), and `site:reddit.com` queries were deflected. Findings are triangulated from
+(a) the closely-mirrored HomeBrewTalk and Brewer's Friend forums, (b) high-traffic clone-recipe
+compilations whose existence is itself a demand signal, and (c) the official Brewfather sharing
+model. Frequency signals are **inferred**, not thread counts. Ranking is directional.
+
+## Ranked recurring themes
+
+### 1. Demand to clone a specific commercial/craft beer — VERY HIGH
+Reproducing a named beer is one of the most common goals. Structural signal: large editorial
+compilations exist purely to satisfy it (AHA "Top 50 Commercial Clone Recipes," Beer Maverick
+"100+ Commercial Beer Clone Recipes," style-specific roundups). Most-cloned targets cluster around
+hype/hard-to-get beers: Pliny the Elder, Tree House Julius, WeldWerks Juicy Bits, Founders,
+Deschutes. Driven by aspiration (recreate a beer you love / can't easily buy).
+
+### 2. "Clone recipes are only a starting point" — accuracy/reproducibility frustration — HIGH
+Published clones often don't taste like the original or are outdated. The canonical 2009 Pliny
+recipe was called "horribly bitter" and "didn't taste anything like Pliny." Brewers treat published
+recipes as a base guideline and adapt them to their own system. This is a need for *iterative,
+versioned, community-validated* clones — not one static PDF.
+
+### 3. Recipe organization / brew-log tracking — chronic, unsolved-feeling — HIGH
+Persistent thread genre about keeping recipes, brew logs, tasting notes and batch history in one
+reviewable place. People bounce between Excel, Word, notebooks and BeerSmith; the frustration is
+wanting "everything in one view" and notes that stay "meaningful when reviewing them later."
+
+### 4. App churn & feature gaps (Brewfather vs Brewer's Friend vs BeerSmith) — HIGH
+Comparing/switching apps is perennial. Drivers: BeerSmith powerful but dated/clunky; Brewfather
+modern UI + multi-device (the current darling); Brewer's Friend web-based but weaker mobile and
+confusing water calculators. Migration friction and water-chemistry UX are the loudest specifics.
+
+### 5. Recipe-SHARING tooling is weak — attribution, multi-group, bulk export — MEDIUM-HIGH
+From Brewer's Friend feature requests: sharing **strips authorship** ("intellectual property
+concerns"); you can share with only **one group** at a time (users want multi-club sharing with
+credit preserved); no **bulk export** of selected recipes. Sharing is wanted but feels like an afterthought.
+
+### 6. Recipe discovery & social layer is thin — MEDIUM
+Brewfather's public Library has browse/search, key stats, and up/down votes/views/downloads — but
+**no comments, no following, limited profiles**, and **publishing requires a paid subscription**.
+Discovery exists; conversation around a recipe does not. Clear whitespace.
+
+### 7. Recipe scaling / efficiency conversion when adopting someone else's recipe — MEDIUM
+A recipe built on another brewer's equipment/efficiency doesn't translate cleanly — the hidden tax
+on any sharing feature. Sharing only works if the platform re-scales to the recipient's system.
+(Lower confidence — inferred from calculator discussions.)
+
+## Targeted assessments
+
+- **Desire to clone specific beers:** strong and central, not niche. Validates the hero angle.
+- **Willingness to share own recipes vs just consume:** net-positive but with a consumption skew.
+  Genuine sharing culture exists, but more people *seek* clones than *publish* polished ones, and
+  sharers care about **attribution/credit**. A low-effort, credited sharing flow could convert lurkers.
+- **Do they complain current sharing is bad?** Yes, concretely: authorship stripped, single-group-only,
+  no bulk export (Brewer's Friend); paywalled publishing, no comments/follows (Brewfather).
+
+## Signal on the community/clone hero hypothesis
+
+**Supported, with caveats.** Cloning a specific beer is a top-tier, emotionally-driven motivation,
+and the dissatisfaction is not "no tools exist" but "tools clone poorly, share clumsily, and don't
+talk to each other." The strongest differentiated wedge is the **intersection**: a
+community-validated, versioned, credited, auto-rescaled clone recipe — i.e. solving themes 2, 5, 6, 7
+together. Nobody owns "the place where the community collaboratively dials in the Pliny/Julius clone
+and you fork it to your system." Foundation features (organization + tracking) are demanded
+(themes 3, 4) and must be solid, but they are not where you win.
+
+**Caveat / next step:** relative frequency of "clone" vs "organization" vs "sharing" is inferred,
+not measured on the subreddit. Harden by sampling r/Homebrewing threads via the Reddit API and
+tagging by theme. Note r/TheBrewery skews pro/commercial — weaker proxy for the intermediate-homebrewer persona.
+
+## Sources
+- https://homebrewersassociation.org/top-50-commercial-clone-beer-recipes/
+- https://beermaverick.com/over-100-commercial-beer-clone-recipes-from-the-breweries-themselves/
+- https://beermaverick.com/top-recipes-to-homebrew-the-most-iconic-hazy-ipas-ever/
+- https://www.brewersfriend.com/forum/threads/has-anyone-in-this-forum-attempted-a-pliny-clone.11917/
+- https://www.brewersfriend.com/forum/threads/suggested-fixes-and-features.12138/
+- https://homebrewtalk.com/threads/brew-logs-and-recipe-tracking.498700/
+- https://homebrewtalk.com/threads/brewfather-or-brewers-friend.694796/
+- https://homebrewtalk.com/threads/brewfather-vs-brewers-friend.673669/
+- https://docs.brewfather.app/library
+- https://homebrewacademy.com/brewing-software-comparison/

--- a/docs/marketing/needs-study/en/03-desk-forums.md
+++ b/docs/marketing/needs-study/en/03-desk-forums.md
@@ -1,0 +1,104 @@
+# Desk Research — Forums (HomeBrewTalk + brassageamateur.com)
+
+**Method note:** HomeBrewTalk.com blocks automated fetches (HTTP 403), so HBT findings rely on
+search-result snippets (titles + indexed excerpts), not full-thread reads. brassageamateur.com pages
+were fetched directly. Frequency signals are qualitative (recurrence of distinct threads), not
+scraped post-counts.
+
+## Ranked recurring themes
+
+### 1. Demand for clone recipes of specific commercial beers — VERY HIGH
+The single most recurrent topic. Continuous "clone of X" request threads on both forums, plus
+meta-threads asking where to *find* clones.
+- HBT has a long-running clone culture ("Why I Clone Commercial Brews"; "Is there a Clone Recipe database?").
+- brassageamateur has a **dedicated clone sub-forum: 133 threads / 170+ shared recipes** (Orval,
+  Westmalle, Duvel, Rochefort 10, Westvleteren 12, Hoegaarden, Kronenbourg 1664, Guinness, Punk IPA),
+  popular threads with 85–149 replies, active into 2025–2026.
+
+**Assessment:** Clone demand is real, sustained, self-organizing. The recurring "is there a clone
+database?" question is direct evidence of an unmet need for a *searchable, curated* clone repository
+— the core angle. Caveat to manage in copy: 5-gal cloning can't perfectly match commercial conditions.
+
+### 2. Tool/app dissatisfaction & comparison shopping — HIGH
+Constant "which software / X vs Y" threads; users not fully satisfied with any. Specific complaints:
+- **Data loss / not trusting the tool as source of truth** ("I have lost enough recipes... I stopped using brewing software as my source").
+- **Subscription fatigue** ("I don't see the value in the subscription model").
+- **Weak inventory↔recipe linkage** (Brewer's Friend "still lacks inventory management"; can't filter recipes by stock).
+- **Poor data portability / migration pain** (BeerXML import losing data; can't separate recipes from batches).
+- Apps are "largely self-learning" (steep, undocumented UX).
+
+**Assessment:** Openings = reliability/no-data-loss, fair pricing, gentle onboarding, real
+recipe↔inventory linkage. Incumbents are mature on calculation — competing on calc alone loses.
+
+### 3. Recipe organization pain ("too many recipes, no good system") — HIGH
+Persistent threads ("Organizing recipes?", "Personal Recipe Database/Records?", "Organization Tips").
+Users fall back to **binders, BJCP-category tabs, Evernote tags, Google Docs, multi-tab spreadsheets**
+— i.e. they *leave the brewing apps* to organize. BeerSmith folders criticized as rigid.
+
+**Assessment:** Tagging/filtering (by style, ingredient, batch outcome) is a concrete requested win.
+Users defecting to general-purpose tools = brewing apps under-serve organization.
+
+### 4. Brew-day / fermentation tracking ("I built my own because nothing was good enough") — HIGH
+Heavy volume on logging brew day + fermentation. Strong DIY signal — multiple users built their own
+apps (e.g. "I couldn't find a good fermentation log-app for cider/mead, so I built one"). Growing
+interest in connected hydrometers (Tilt, iSpindel) feeding fermentation graphs.
+
+**Assessment:** Tracking is a validated foundation feature; "built my own" threads = unmet need.
+Tilt/iSpindel import is a recurring ask — flag as v0.2+ (scope).
+
+### 5. Recipe sharing & willingness to share — MEDIUM-HIGH, mostly POSITIVE
+Homebrewers are culturally open ("flattered to share... an honor"; "willing to share any recipe").
+Existing mechanisms are fragmented/fading: BeerSmith Cloud search, the defunct Hopville, BeerXML
+export; recurring "download a full BeerXML database" requests. brassageamateur effectively *is* a
+communal recipe library.
+
+**Assessment:** Willingness is high; the gap is a *good* sharing/discovery surface — the bar is
+"better than a forum thread + BeerXML file," needing frictionless BeerXML/BeerJSON import/export to
+interoperate (not lock-in). Caveat: commercial breweries are protective; *homebrewer-to-homebrewer*
+is the open lane.
+
+## English (HomeBrewTalk) vs French (brassageamateur)
+
+| Dimension | HomeBrewTalk (EN) | brassageamateur (FR) |
+|---|---|---|
+| Scale & cadence | Very large, high-volume, many parallel threads | Smaller but tight-knit; structured sub-forums; multi-year threads |
+| Clone targets | US/UK craft + macro (Manny's, Heineken, Spaten, Smithwick's) | Belgian/Trappist + French (Orval, Westvleteren, Duvel, Kronenbourg 1664, Météor) |
+| Tooling | Commercial apps: BeerSmith, Brewfather, Brewer's Friend | Free/open + homegrown: **Beerxcel (Excel), Joliebulle (open-source), Little Bock**, BYOB |
+| Sharing model | App clouds + BeerXML files; forum text | Forum *is* the shared library; communal Beerxcel/recipe DBs; values free tools |
+| Pricing sensitivity | Subscription-skeptical but pays | More resistant to paywalls (Little Bock going paid drew friction) |
+| Instability | Mature, stable incumbents | **Joliebulle closed (2010–2025)** — appeared uncertain in this pass, later **confirmed** in `03b`/`03d` |
+
+**Bilingual implications**
+- Localize clone seed-content per region (Belgian/Trappist for FR; US/UK craft for EN) — clone catalogs are not interchangeable. (`03d` finds FR *macro lager* is NOT a meaningful clone target, despite Kronenbourg 1664 appearing in the sub-forum list above — treat the FR clone-targets cell as raw observation, not a seed-content priority.)
+- FR audience more price-sensitive and free-tool-loyal → the freemium boundary matters more there (consistent with keeping BeerXML/BeerJSON export paid only if the free tier stays genuinely useful).
+- FR expects responsive, present maintainers → community management is part of the product.
+- BeerXML import/export is table-stakes both sides (capture migrants from BeerSmith/Brewfather EN, Joliebulle/Little Bock FR).
+
+## Net read for positioning
+The differentiator (community for cloning + sharing) maps directly onto the two highest-frequency
+unmet needs: a searchable curated *clone* database (#1) and a *better sharing surface than forum
+threads* (#5), on top of two validated foundations users currently hack together — organization (#3)
+and tracking (#4). The moat is **not** calculation; it is curation + community + reliability + fair
+pricing + frictionless import/export.
+
+**Key uncertainties:** HBT findings snippet-based (403); frequency qualitative. (Joliebulle closure, flagged uncertain in this pass, was later **confirmed** in `03b`/`03d`.)
+
+## Sources
+- https://www.homebrewtalk.com/threads/is-there-a-clone-recipe-database.679618/
+- https://www.homebrewtalk.com/threads/why-i-clone-commercial-brews.678756/
+- https://www.brassageamateur.com/forum/viewforum.php?f=95
+- https://homebrewtalk.com/threads/comparing-homebrewing-software.679134/
+- https://homebrewtalk.com/threads/brewfather-vs-brewers-friend.673669/
+- https://homebrewtalk.com/threads/scaling-with-beersmith-vs-brewfather-troubles.692447/
+- https://homebrewtalk.com/threads/organizing-recipes.232447/
+- https://www.homebrewtalk.com/threads/personal-recipe-database-records.99384/
+- https://homebrewtalk.com/threads/organization-tips-for-homebrewers.678855/
+- https://homebrewtalk.com/threads/i-couldnt-find-a-good-fermentation-log-app-for-cider-mead-so-i-built-one.738999/
+- https://homebrewtalk.com/threads/phone-app-for-detailed-brew-day-notes.484531/
+- https://homebrewtalk.com/threads/brew-logs-and-recipe-tracking.498700/
+- https://www.homebrewtalk.com/threads/recipes-kept-secret.199276/
+- https://homebrewtalk.com/threads/where-can-i-download-a-full-beerxml-database.486803/
+- https://www.brassageamateur.com/forum/viewtopic.php?t=42555
+- https://www.brassageamateur.com/forum/viewtopic.php?t=29232
+- https://joliebulle.org/
+- https://univers-biere.net/logiciels.php

--- a/docs/marketing/needs-study/en/03b-desk-french.md
+++ b/docs/marketing/needs-study/en/03b-desk-french.md
@@ -1,0 +1,119 @@
+# Desk Research — French-Language Sources
+
+Dedicated French pass to rebalance an English-skewed corpus (the product is bilingual FR + EN).
+Covers FR blogs, software sites, the forum's own sharing app, FB/YouTube/Discord signal.
+brassageamateur.com cited only where it adds NEW specifics. Confidence flagged per claim.
+
+## Ranked French-specific themes / needs
+
+### 1. Cloning commercial beers is mainstream, first-class — VERY HIGH
+"Brasser un clone" is settled vocabulary; hundreds of clone recipes live in FR tool libraries and on blogs.
+- https://comment-brasser-sa-biere.fr/recette-ipa/
+- https://labrowar.blogspot.com/2016/01/recette-clone-orval.html
+- https://www.littlebock.fr/recettes-bieres/24/nom/punk-ipa-clone
+
+### 2. Tools must do the tedious math AND auto-rescale to the brewer's equipment — HIGH
+FR blogs frame software value as offloading OG/FG, IBU, EBC/SRM, ABV, mash steps; mash-efficiency
+customization that "automatically adjusts recipe quantities" is explicitly wanted. (Directly supports
+the auto-rescale enabler of the hero.)
+- https://blog.littlebock.fr/creer-recette-biere-logiciel-brassage/
+- https://www.brassageamateur.com/forum/viewtopic.php?t=42555
+
+### 3. French-language UI matters — English is a stated dealbreaker — HIGH (FR-specific)
+Brewfather (the strongest tool) is repeatedly flagged as "en anglais, ce qui peut être rédhibitoire."
+A genuine competitive lever absent from the English corpus.
+- https://univers-biere.net/logiciels.php
+
+### 4. Community recipe sharing is wanted — and ALREADY PARTIALLY SERVED in FR — HIGH
+brassageamateur.com built its own "BrewRecipes" app (BeerXML import, search/filter, community ratings,
+350+ recipes); Little Bock's public library is a core draw. So in FR the sharing angle competes against
+incumbents, not a vacuum.
+- https://www.brassageamateur.com/wiki/Beerxml
+- https://www.littlebock.fr/
+
+### 5. Brew/fermentation tracking expected but bolted on — MEDIUM-HIGH
+Per-brassin notes/measures, history, fermentation graph, brew-day reminders. Brewfather wins via device
+integrations (iSpindel, Tilt, Plaato); Little Bock offers per-brassin notes. Caveat: in the main
+"quel logiciel" debate, the focus was ease-of-use/offline/calc accuracy, not tracking.
+- https://apps.apple.com/fr/app/brewfather/id1488585822
+
+### 6. Tool reliability / data-durability anxiety — MEDIUM (strategically important)
+Little Bock suffered a major hosting outage (OVH SBG3) with a degraded read-only backup; some calc
+distrust. Joliebulle's shutdown amplifies fear of losing recipe history. → BeerXML import/export +
+reliability are TRUST features, not nice-to-haves.
+- https://www.brassageamateur.com/forum/viewtopic.php?t=37899
+
+### 7. Strong price sensitivity / low-cost ethos — MEDIUM-HIGH
+Recurrent "brasser pour pas cher"; pro tools rejected as overkill ("Easybeer 29€/mois… beaucoup trop
+cher… un simple fichier Excel suffit"). A generous free tier is near-mandatory; paid features must be
+clearly amateur-relevant (consistent with export-as-paid).
+- https://www.happybeertime.com/blog/2016/12/26/5-conseils-brasser-amateur-facon-low-cost/
+
+## French tooling landscape
+
+- **Little Bock** (littlebock.fr) — FR online recipe builder + community library + profiles + per-brassin
+  notes + inventory. **Active, freemium** (free tier capped). Often called the best/most intuitive FR tool;
+  criticized for a limited free tier, carbonation calc overestimation, and a past outage. Maintainer
+  present but slowed.
+- **Joliebulle** (joliebulle.org) — open-source desktop tool, loved for being simple/offline/free.
+  **CLOSED — confirmed** (lifespan stated 2010–2025; site in past tense). No official successor; community
+  redirects to Little Bock / Brewfather / Brewtarget. → **displaced user base actively seeking a home =
+  concrete acquisition opportunity.** (A Gumroad page persists; purchasability post-shutdown uncertain.)
+- **Beerxcel** — free Excel all-in-one; comprehensive but hard to learn; dev active on forum. Active, free.
+- **Brewtarget** — open-source, free, cross-platform, FR manual; functional but dated (v4.01, Aug 2024).
+- **Brewfather** — online, freemium; best fermentation tracking via device integrations; recurrent
+  complaint = English-only.
+- **BeerSmith** — FR translation/community exists; legacy paid heavyweight, not heavily tested by FR users.
+- **BiboWeb** — could NOT be confirmed this pass. **Unverified** — probe before citing.
+- Also: BYOB (free web), Brewy (free Android), Easybeer (pro, 29€/mo, "too expensive" for amateurs).
+
+Sources: https://univers-biere.net/logiciels.php · https://joliebulle.org/ · https://www.littlebock.fr/fonctionnalites-et-tarifs
+
+## French clone targets
+
+- **Belgian / Trappist** (strong FR/BE cultural anchor): Orval, La Chouffe, Westmalle Triple, Belgian
+  quad. Lean on *Brew Like a Monk*, EBC/IBU/attenuation matching.
+- **International craft icons**, dominated by **BrewDog Punk IPA** (many clone versions, fed by BrewDog's
+  "DIY DOG" release); general IPA/APA clones common.
+- **French macro lager (Kronenbourg/1664, Heineken-style) did NOT surface as a meaningful clone target** —
+  demand skews Belgian abbey/Trappist + craft IPA. (Soft/negative finding; corrects an earlier assumption
+  that FR macro lager was a primary clone target.)
+
+Sources: https://univers-biere.net/rec_chouffe.php · https://labrowar.blogspot.com/2016/01/recette-clone-orval.html · https://www.littlebock.fr/recettes-bieres/24/nom/punk-ipa-clone
+
+## French audience specifics (marketing)
+
+- **High, culturally explicit price sensitivity.** Generous free tier near-mandatory; paid must be amateur-relevant.
+- **Free/open-tool loyalty.** A purely closed SaaS meets cultural friction (Joliebulle/Brewtarget/Beerxcel ethos).
+- **High expectations of maintainer presence + data durability.** Active devs are rewarded; tool deaths/outages
+  created real anxiety → portability + reliability are trust levers.
+- **Where the FR community congregates:**
+  - **Forum (brassageamateur.com)** = structured hub — and hosts its own recipe-sharing app, so it is a
+    *partial direct competitor* on the sharing axis.
+  - **Facebook** = high-volume informal layer (national "brassage.amateur.biere" + regional groups).
+  - **Discord** = support/chat layer (Joliebulle ran a praised one), not a recipe repository.
+  - **YouTube** FR channels active (Bricole Brassicole, Brassage TV, Craft My Brewery) — partnership/marketing, tutorial-skewed.
+  - **Local clubs/associations** (ABAHF, Fauve Homebrew Club) = real in-person layer.
+
+Sources: https://www.brassageamateur.com/wiki/Beerxml · https://fr-fr.facebook.com/brassage.amateur.biere/ · https://abahf.ovh/ · https://www.youtube.com/c/BricoleBrassicole
+
+## Does FR confirm or diverge from EN?
+
+Mostly **CONFIRMS** (a good saturation signal), with FR-specific sharpenings:
+
+- Clone demand high → **confirmed**, arguably stronger/more legitimate in FR.
+- Sharing wanted → **confirmed**, BUT already partially served in FR (forum BrewRecipes + Little Bock) →
+  differentiation must come from **versioning + credit/attribution + auto-rescale**, not "sharing exists."
+- Attribution-sensitivity → **only weakly corroborated in FR** (strong in EN). **Do not assume it transfers —
+  test explicitly in interviews.**
+- Organization/tracking hacked together → **confirmed**; no FR tool unifies organization + versioned sharing + tracking.
+- Don't compete on calculation → **confirmed and reinforced** (calc is table-stakes; tools already trusted/distrusted on it).
+
+**FR-specific strategic adds:** (1) French-first UI is a real competitive lever; (2) Joliebulle's 2025 death =
+displaced users seeking a home; (3) data durability + BeerXML portability are trust-critical after recent FR tool failures.
+
+## Uncertainties flagged
+- BiboWeb unverified.
+- Joliebulle Gumroad purchasability post-shutdown unclear.
+- FR attribution-sensitivity under-evidenced — do not assume parity with EN.
+- FB group member counts not retrieved.

--- a/docs/marketing/needs-study/en/03c-desk-market-data.md
+++ b/docs/marketing/needs-study/en/03c-desk-market-data.md
@@ -1,0 +1,94 @@
+# Desk Research — Quantitative / Market Data
+
+A quantitative layer added on top of the qualitative passes. **Read the reliability flag on every
+figure.** Legend: **[HIGH]** trade-body/platform-published · **[MED]** third-party analytics estimate
+(Similarweb/AppBrain) · **[LOW]** blog/secondary estimate · **[N/F]** not found (do not invent).
+
+## Market size / population
+
+| Metric | Figure | Reliability | Source |
+|---|---|---|---|
+| US homebrewers | ~1.1–1.2 million | [HIGH] | AHA / Brewers Association (2015, 2017) |
+| US homebrew production | >1.4M barrels/yr (~1% of US beer) | [HIGH] | AHA (2017) |
+| AHA paid membership | "more than 20,000" (some pages 30,000+) | [MED] (AHA pages inconsistent) | AHA |
+| US homebrew supply shops | 815 (2015) | [HIGH] | AHA economic study |
+| US homebrew direct shop revenue | $764M (2015) | [HIGH] | AHA economic study |
+| US homebrew total economic impact | $1.225B incl. multiplier; ~11,672 jobs | [HIGH] | AHA economic study |
+| Registered AHA homebrew clubs | 2,100+ (US + worldwide) | [HIGH] | AHA Club Connection |
+| **France / Europe homebrewer count** | **NOT FOUND** | [N/F] | — genuine data gap |
+
+**Equipment / machine market value** — report scopes diverge wildly; directional only:
+- Home-brewing **equipment** (hobby): ~$2.08B (2023) → $3.38B (2030), ~7.65% CAGR [MED]. **Use this as the TAM anchor.**
+- Home-brewing **machine** reports ($26B–$85B) almost certainly bundle countertop appliances/commercial kit — **not comparable**; do not cite as hobby TAM.
+
+## Demand signals
+
+- **Google Trends** — [N/F] for indexed values this pass (needs a manual capture). Qualitative proxy:
+  clone-recipe content is a large, evergreen vertical (BYO 300-recipe clone book; Beer Maverick "100+
+  official brewery clones"; Northern Brewer/Homebrew Finds clone hubs) → durable, non-seasonal demand [LOW].
+- **App scale:**
+  - Brewfather ≈ 230,000 Play downloads, ~510/day, 4.9/5 [MED].
+  - BeerSmith Recipe Cloud = 43,000 registered users; claims "world's largest single recipe repository" [HIGH/MED].
+  - Brewer's Friend ≈ 14,000 Android downloads [MED].
+- **Public recipe-DB sizes (differentiator-relevant):**
+  - Brewer's Friend = **320,000+ public recipes** [HIGH].
+  - Brewfather library = "thousands", no exact count [MED/N-F].
+  - Grainfather app = "1000s" [MED]. Little Bock (FR) = no published count [N/F].
+
+**Takeaway:** incumbents already host large public recipe corpora (Brewer's Friend 320k+) — but they are
+*repositories with weak social / clone-lineage features*. The cloning-and-sharing community angle is not
+their core. That gap is the quantitatively-supportable wedge.
+
+## Uncovered competitors / adjacent products
+
+| Product | What it is | Status | Clone / community / sharing? |
+|---|---|---|---|
+| Grainfather Community app | Recipe builder + brew controller, hardware-tied; 1000s recipes; device integrations | Active, hardware-led | Yes, but ecosystem-gated |
+| Brew Ninja | Commercial **brewery management** (B2B) | Active | No (pro/commercial) |
+| BrewBench | Open-source brew **controller / fermentation monitor** | Active, niche/DIY | No |
+| Captain Brew | Free recipe builder + discovery + calculators | Active | Partial (discovery; no clone lineage) |
+| Plaato / Brewbrain Float / Tilt / iSpindel | Fermentation telemetry devices + apps | Active hardware | No (telemetry only) |
+| Brewspy / monitor.beer | Aggregators for fermentation-device data | Active | No |
+| BeerSmith Recipe Cloud | Web recipe repository (43k users) | Active | Partial (repo, weak social) |
+| Brewist / Brewterix | named but [N/F] — no reliable info; do not characterize | — | — |
+
+**Pattern:** the fermentation-device category is **adjacent, not competitive** (telemetry, not recipe
+community). The recipe-community space is genuinely thin beyond Brewer's Friend, BeerSmith Cloud,
+Brewfather — and none lead with **clone lineage / social cloning** as their headline.
+
+## Reddit numbers
+
+- **r/Homebrewing ≈ 1.2M members** [MED]. Notably ≈ the entire AHA US-homebrewer estimate — the sub
+  alone is roughly the size of the US homebrew population, indicating strong international + lapsed-hobbyist reach.
+- Thread-level vote/comment counts: [N/F] this pass (Reddit not directly fetchable).
+
+## Adjacent markets (brief)
+
+- **Germany** — among Europe's largest homebrew scenes. **MaischeMalzundMehr** (recipe DB) and
+  **Hobbybrauer.de** (forum) are heavily cross-referenced and Brewfather-importable. No published
+  counts [N/F]. A **future-expansion / localization signal** (DE after FR+EN), not an immediate competitor.
+
+## Data gaps to state honestly in the report
+
+1. France/Europe homebrewer population — **not found**; state explicitly, do not estimate.
+2. Google Trends indexed values — need a manual capture.
+3. Brewfather / Little Bock exact recipe-library counts — not published.
+4. Equipment-vs-machine market reports disagree ~40x by scope; only ~$2B hobby-equipment / ~7.5% CAGR is safe to cite.
+
+## Sources
+- https://homebrewersassociation.org/news/economic-impact-homebrewing/
+- https://homebrewersassociation.org/news/1-1-million-americans-homebrew-beer/
+- https://www.brewersassociation.org/press-releases/study-1-1-million-americans-homebrew-beer/
+- https://homebrewersassociation.org/homebrew-clubs/
+- https://www.similarweb.com/app/google-play/com.warpkode.brewfather/statistics/
+- https://beersmithrecipes.com/help
+- https://www.brewersfriend.com/homebrew-recipes/
+- https://www.appbrain.com/app/brewers-friend/com.brewersfriend.app
+- https://us.grainfather.com/pages/app-showcase
+- https://www.brewninja.net/
+- https://github.com/brewbench/monitor
+- https://captainbrew.com/homebrew-recipes
+- https://monitor.beer/
+- https://gummysearch.com/r/Homebrewing/
+- https://www.maischemalzundmehr.de/
+- https://hobbybrauer.de/forum/

--- a/docs/marketing/needs-study/en/03d-desk-french-market.md
+++ b/docs/marketing/needs-study/en/03d-desk-french-market.md
@@ -1,0 +1,87 @@
+# Desk Research — French Homebrew Market (snowball pass)
+
+Snowball pass aimed at the biggest data gap: the size of the FRENCH / EU amateur-homebrewer base.
+**Vocabulary kept strictly separate:** *brasseur amateur* (hobbyist — TARGET) vs *microbrasserie /
+brasseur artisanal* (professional — adjacent, not the target). Reliability flags as in `03c`.
+
+## French homebrewer population — the honest answer
+
+**[N/F] There is NO official or reliable count of French amateur homebrewers**, confirmed by insiders:
+- The admin of BrassageAmateur.com: *"Tu ne trouveras aucun chiffre officiel"* — no official figure exists.
+- Expertise Bière Conseil (2023): *"Paradoxe : une pratique répandue et en croissance, mais des chiffres
+  inexistants"* — no registry, no centralized monitoring.
+
+**Best community-size proxies (no national total derivable):**
+- **BrassageAmateur.com** (reference FR forum, since 2003): **~22,467 registered members, ~498k posts,
+  36,250 topics**; peak 5,321 simultaneous users (Feb 2026). Cumulative registrations, francophone (not FR-only). [MED]
+- **549 beer-related associations** in France's RNA (2020-04-01), one category being *brassage amateur*;
+  no per-category membership; excludes Alsace-Moselle (real total higher); densest in North/Pas-de-Calais. [MED]
+- **FNABRA** (Fédération Nationale des Associations Brassicoles, 2002; EBCU member 2022): *"plusieurs
+  milliers de membres"* (mixes amateur brewers + tasting clubs — not a pure homebrewer count). [MED]
+- **Paris Beer Club > 300 members**; runs an annual amateur brewing competition. [MED]
+- Competition turnout (activity signal): Les Amis de la Bière 27th amateur competition (Sept 2025) judged
+  **61 beers** (18 entrants at the 1998 first edition) — competitive participation grows slowly, small in absolute terms. [MED]
+
+## French homebrew market signals
+
+- **Recent legalization (strategically important):** amateur homebrewing was clarified/legalized
+  **2021-01-01** via **Article 520 bis CGI** (2021 Finance Law). Home-brewed beer for personal/family/guest
+  use is excise-exempt and freed from warehouse-keeper obligations, provided it is not sold. The hobby only
+  fully left the legal grey-zone ~5 years ago — which partly explains the missing historical data and signals
+  a young, expanding legal market. [HIGH]
+- **Saveur Bière** (2007; FR online leader; AB InBev since 2016): ~105 employees, CA "plusieurs dizaines de
+  millions d'euros"; reported rising demand; brewing kit among best-sellers. **Rebranded PerfectDraft Europe
+  in 2023**, pivoting toward the draft-machine line (a partial move *away* from pure homebrew kit retail). [MED]
+- **Mature France-based supplier ecosystem** (was import-dependent): Rolling Beers, Brouwland, Autobrasseur,
+  Le Comptoir du Brasseur, Radis et Capucine, etc.; extract-kit vs all-grain segmentation; Amazon.fr "Kits de
+  brassage maison" bestseller category. Qualitative growth, **no hard sales figures [N/F]**. [MED/LOW]
+
+## French craft microbrewery context (PROFESSIONAL — adjacent, well documented)
+
+Useful for beer-culture vitality, clone targets, B2B/partnership angles — **not the target**:
+- **~2,500–2,589 breweries in France (2024–2025); France is #1 in Europe by brewery count**; 10,000+ references. [HIGH]
+- Growth then maturation: ~200 (2006) → 1,600 (2018) → ~2,500 (2024); ~7× between 2011–2022; +15% over 5 years. [HIGH]
+- **Now plateauing:** 2025 ≈ 209 closures vs 213 openings (~4 closures/week) — professional segment matured. [HIGH]
+- Sector employment ~130,500; FR per-capita consumption ~33 L/yr (lowest in EU); SNBI represents independents. [HIGH/MED]
+
+## Homebrewer profile / demographics
+
+- **France: [N/F]** — no demographic study found (only anecdote: more curious newcomers starting).
+- **US proxy (use cautiously):** AHA/Brewers Association 2017 (18k+ respondents): 1.1M (now ~1.2M); avg age
+  **42**, 52% aged 30–49, predominantly male, 68% college-educated, ~68% household income ≥$75k; **40% started
+  within the prior 4 years** (strong newcomer influx). [HIGH for US]
+
+## New leads / snowball threads to follow
+
+- **BrassageAmateur.com** — largest FR community; single best venue for a direct user survey to fill the data gap + competition (BRASSAM) reach.
+- **FNABRA** — could be asked directly for an aggregate member/club estimate.
+- **Projet Amertume** (already bookmarked in memory) — brewery time-series + associations list.
+- Regional/club leads: Les Amis de la Bière (FIBA), ABAHF, Paris Beer Club, BAF, Elsassbrau.
+- Events/salons: Salon du Brasseur, Saint-Malo Craft Beer Expo, CRAB, FIBA.
+- Supplier blogs/communities as funnels: Saveur Bière/PerfectDraft, Rolling Beers, Brouwland, Autobrasseur, Carnet d'un brasseur amateur.
+- Studies to chase: AHA full demographic deck (US benchmark); Belgian Brewers Federation report (only structured EU data, per forum admin); EBCU.
+
+## Strategic note
+
+**Reinforces the strategy.** The absence of any official homebrewer count is itself a moat — no incumbent owns
+this data; Brasse-Bouillon could *become* the dataset by instrumenting its own community. Recent (2021)
+legalization + a now-mature FR supplier ecosystem + a saturating *professional* microbrewery market all point
+to a young, under-served, growing *hobbyist* base whose natural pull is community + clone/share. Caveat: the
+only hard demographics (age 30–49, male, educated, affluent, recent starters) are US — validate on FR users in interviews.
+
+## Sources
+- https://www.brassageamateur.com/forum/ftopic23796.html
+- https://expertise-biere-conseil.com/2023/03/brassage-amateur-etat-des-lieux-dune-activite-en-expansion/
+- https://www.brassageamateur.com/forum/
+- https://www.happybeertime.com/blog/2020/10/06/recensement-des-associations-liees-a-la-biere-en-france/
+- https://www.fnabra.org/associations-membres/
+- https://www.parisbeerclub.fr/concours-de-brassage
+- https://www.amis-biere.org/category/brassage-amateur/
+- https://www.legifrance.gouv.fr/codes/id/LEGISCTA000006163065
+- https://www.assemblee-nationale.fr/dyn/15/amendements/3360C/CION_FIN/CF1540
+- https://www.lejournaldesentreprises.com/hauts-de-france/article/saveur-biere-fait-face-une-hausse-de-la-demande-et-recrute-495310
+- https://brasseurs-de-france.com/tout-savoir-sur-la-biere/le-marche-de-la-biere/
+- http://projet.amertume.free.fr/html/evolution_nombre_brasseries.htm
+- https://fr.statista.com/statistiques/830080/nombre-micro-brasseries-france/
+- https://homebrewersassociation.org/news/1-1-million-americans-homebrew-beer/
+- https://www.insee.fr/fr/statistiques/6535287

--- a/docs/marketing/needs-study/en/04-synthesis.md
+++ b/docs/marketing/needs-study/en/04-synthesis.md
@@ -1,0 +1,104 @@
+# Synthesis — Needs Map & Positioning
+
+Consolidation of six desk-research passes (`01` competitors, `02` Reddit, `03` forums, `03b` French
+sources, `03c` market/quant data, `03d` French market). This is a hypothesis set built from secondary
+research; it is **not yet confirmed** by primary research (interviews). Read `00-method.md` for
+limitations. Later passes largely **confirmed** earlier findings (a saturation signal) while adding the
+FR-specific and market-context refinements below.
+
+## Headline
+
+The differentiating hypothesis — **a community for cloning and sharing recipes** — is **supported**
+across all six desk passes, and **sharpened**: the defensible wedge is not "social" or "clone list"
+alone, but their intersection.
+
+## The sharpened wedge
+
+> The place where the community collaboratively dials in the clone of a specific beer, with a
+> recipe that is **versioned, credited to its authors, and auto-rescaled** to each brewer's equipment.
+
+No incumbent owns this. Today the market splits into:
+- **Static clone lists** (AHA, Beer Maverick, BrewDog DIY Dog) — no iteration loop, no rescaling.
+- **Calculators with a recipe library** (Brewfather, Brewer's Friend, BeerSmith) — publishing
+  paywalled, sharing strips authorship, no conversation around a recipe.
+
+## Needs map (ranked by signal, with hero/foundation tag)
+
+| # | Need | Signal | Role |
+|---|---|---|---|
+| 1 | Searchable, curated **clone** repository for specific beers | Very high | **Hero** |
+| 2 | **Versioned / community-validated** clones (not a static, often-wrong PDF) | High | **Hero** |
+| 3 | Low-friction **sharing with author credit** (multi-group, bulk, attribution kept) | Med-high | **Hero** |
+| 4 | Auto **rescaling** of a shared recipe to the recipient's equipment | Medium | Hero enabler |
+| 5 | Reliable **organization & search** (tags by style/ingredient/outcome) | High | Foundation |
+| 6 | Solid **brew-day / fermentation tracking** (logs, notes, history) | High | Foundation |
+| 7 | **Frictionless sync + offline** without paying or duplicating data | Very high | Foundation / table-stakes |
+| 8 | **Fair pricing** (subscription/paywall fatigue; crippled free tiers) | Very high | Table-stakes |
+| 9 | **Data portability** — BeerXML/BeerJSON import/export, no lock-in, no data loss | High | Table-stakes |
+| 10 | Modern, uncluttered **mobile UX** | Frequent | Table-stakes |
+
+Heroes 1-4 are where Brasse-Bouillon can win. 5-10 are required to be credible and to retain, but
+do not differentiate (incumbents already do most, and win on calculation).
+
+## What the evidence says about each risky belief
+
+- **Do brewers want to clone specific beers?** Yes — strong, durable, emotionally-driven. *Validated.*
+- **Will they share their own recipes (not just consume)?** Net-positive culture, but with a
+  consumption skew and a hard condition: **attribution/credit must be preserved**. *Plausible, to confirm in interviews.*
+- **Is the need already met elsewhere?** No — clones are wrong/static, sharing tools strip authorship
+  and paywall publishing, and there's no conversation layer. *Gap is real.*
+- **Would they switch tools?** Risky — incumbents are entrenched on calculation and own the user's
+  history. Mitigation: don't fight on calc; lead with the clone/community loop + BeerXML import to
+  lower switching cost. *Highest-risk belief — test explicitly.*
+
+## Strategic guardrails (from the evidence)
+
+- **Don't compete on calculation.** Moat = curation + community + reliability + fair pricing + interop.
+- **Frame community as connective tissue around clone-sharing**, not standalone social
+  (cf. AHA Brew Guru community app sunset Feb 2026).
+- **Bilingual ≠ duplicated.** Localize clone seed-content per region; respect the FR audience's
+  higher price-sensitivity and expectation of a present maintainer.
+- **Watch Build-A-Beer** (AI clone generation + share) — the closest direct competitor to the wedge.
+
+## Market context (from `03c` / `03d`)
+
+- **TAM anchor:** ~$2B home-brewing *hobby-equipment* market, ~7.5% CAGR (ignore the $26B–$85B "machine"
+  reports — different scope). US homebrewers ≈ 1.1–1.2M; r/Homebrewing ≈ 1.2M members.
+- **Incumbent recipe corpora are large** (Brewer's Friend 320k+ public recipes) but lead with *repository +
+  calculators*, not clone-lineage/social — quantitatively confirming the wedge is open.
+- **France: no official homebrewer count exists** (confirmed by insiders) — a data gap that is itself a moat:
+  Brasse-Bouillon could *become* the dataset by instrumenting its community. Proxies: brassageamateur ≈ 22.5k
+  members; 549 beer associations; FNABRA "several thousand" members.
+- **French hobby only legalized 2021** (Art. 520 bis CGI) → young, expanding legal market; mature FR supplier
+  ecosystem; the *professional* microbrewery market (France #1 in Europe, ~2,500) is now plateauing.
+- **Only hard demographics are US** (age 30–49, male, educated, affluent, 40% recent starters) — validate on FR.
+
+## French-specific refinements (from `03b`)
+
+- **French-first UI is a real competitive lever** — Brewfather's English-only is a stated dealbreaker
+  for part of the FR audience. Bilingual is not just localization; it is a wedge in FR.
+- **In FR, sharing is already partially served** (brassageamateur's own BrewRecipes app + Little Bock's
+  public library). So FR differentiation cannot be "sharing exists" — it must be
+  **versioning + author credit + auto-rescale**.
+- **Joliebulle closed (2010–2025, confirmed)** → a displaced FR user base is actively seeking a new home.
+  Concrete acquisition opportunity; BeerXML import lowers their switching cost.
+- **Data durability + BeerXML portability are trust-critical in FR** after recent tool failures
+  (Joliebulle death, Little Bock outage). Reliability is a marketing message, not just an SLA.
+- **FR clone targets** skew Belgian / Trappist (Orval, La Chouffe, Westmalle) + craft (Punk IPA).
+  French macro lager did NOT surface as a meaningful target (corrects an earlier assumption).
+- **Attribution-sensitivity is strong in EN but under-evidenced in FR** — do not assume it transfers;
+  test explicitly in interviews (see below).
+
+## One-sentence positioning (draft, to validate)
+
+> For regular homebrewers who want to reliably recreate the beers they love, Brasse-Bouillon is the
+> community recipe app where clones are collaboratively refined, credited, and rescaled to your own
+> setup — with the recipe organization and brew tracking you'd expect, and no lock-in.
+
+## Next step: primary research
+
+Confirm or refute with 10-15 interviews of regular homebrewers, recruited from r/Homebrewing (EN) and
+brassageamateur (FR). Priority beliefs to test: (a) **attribution-sensitivity** — strong in EN,
+under-evidenced in FR, so probe both audiences; (b) **switching** — would they leave an entrenched tool;
+(c) whether the **versioning + auto-rescale** angle is felt as a real need or a nice-to-have. The
+interview guide is in `05-interview-guide.md` (built with the `customer-research` skill). Findings feed `06-report.md`.

--- a/docs/marketing/needs-study/en/04b-prioritized-backlog.md
+++ b/docs/marketing/needs-study/en/04b-prioritized-backlog.md
@@ -1,0 +1,86 @@
+# Prioritized Backlog — Needs → Features → Build Order
+
+This page turns the desk findings into a **prioritized build order**: which real need each feature
+serves, how strong the opportunity is, how confident we are, and in what order to build.
+
+::: warning Read this first
+This ranking is built on **secondary research** (desk) — strong hypotheses, not field-confirmed truth.
+Two biases to keep in mind:
+1. The desk scan mostly probed **intermediate** pains (clone, sharing, sync), so it **under-weights the
+   beginner guided-assistant need** — which is real but evidenced only indirectly (the "I built my own
+   brew-day app" threads, the steep-UX complaints, the 40% newcomer inflow). Those rows are tagged
+   *under-probed* and the interviews must confirm them.
+2. The founder is a **beginner** building (first) for **beginners** — so we deliberately sequence
+   **assistant-first**, even where the raw desk score would put the intermediate clone wedge on top.
+:::
+
+## Prioritization rule
+
+> **Opportunity = Importance (how strong/frequent the need) × Under-served (how poorly incumbents do it).**
+> Then **sequence by journey stage**, starting with the beginner assistant (acquisition), because that is
+> the founder's accessible segment and the lowest-risk entry (a daily-useful utility beats a
+> community that needs a crowd to exist — cf. AHA Brew Guru's 2026 shutdown).
+
+**Confidence labels:** `validated` (strong, multi-source desk signal) · `hypothesis` (inferred, plausible)
+· `under-probed` (real but thinly evidenced — interviews must confirm).
+
+## The journey = the spine
+
+```
+Stage 1 — BEGINNER (guided assistant)   →  ACQUISITION   →  the 4-step journey
+Stage 2 — REGULAR  (organize & track)   →  RETENTION
+Stage 3 — INTERMEDIATE (clone & share)  →  DEPTH         →  the desk's headline wedge
+```
+
+## Stage 1 — Beginner assistant · the 4-step journey (build first)
+
+| Need | Feature | Opportunity | Confidence |
+|---|---|---|---|
+| Don't ruin a brew; know what to do, when & why | **Guided step-by-step brew-day assistant** (mash/boil/cooling, timers, temps, the "why") | High × High = **High** | under-probed |
+| Succeed on the very first batch, no jargon | **Beginner-calibrated recipe catalog** (curated, IBU/ABV/volume shown) — journey step 1 | High × Med-High = **High** | hypothesis |
+| Know where my fermentation stands | **Fermentation tracking** (days, gravity, temperature, progress bar) — journey step 3 | High × Med = **Med-High** | validated |
+| Finish & celebrate | **Bottling + label + share with friends** — journey step 4 | Med × Med = **Med** | hypothesis |
+| Brewing happens offline (garage/cellar) | **Offline-tolerant**, no forced sync / no data duplication | High × High = **High** | validated |
+| Tools feel overwhelming | **Clean, uncluttered, playful UX** (the proven differentiator) | High × Med = **Med** (quality bar) | validated |
+
+## Stage 2 — Regular brewer · organize & track (retention)
+
+| Need | Feature | Opportunity | Confidence |
+|---|---|---|---|
+| My recipes are scattered (notebooks, sheets) | **Recipe organization & search** (tags by style/ingredient/outcome) | High × Med-High = **High** | validated |
+| Remember what I did across batches | **Batch history / brew log** with reviewable notes | High × Med = **Med-High** | validated |
+| Don't trap my data | **BeerXML / BeerJSON import-export** (no lock-in, lossless) | High × Med = **Med-High** | validated |
+| Reliability / don't lose my history | **Durable storage, no data loss** (a trust message, esp. FR after Joliebulle/Little Bock) | High × Med = **Med-High** | validated |
+
+## Stage 3 — Intermediate · clone & community (depth — the desk wedge)
+
+| Need | Feature | Opportunity | Confidence |
+|---|---|---|---|
+| Recreate a specific beer I love | **Searchable, curated clone repository** | Very High × High = **Very High** | validated |
+| Published clones are wrong / static | **Versioned, community-validated clones** (the iteration loop nobody owns) | High × Very High = **High** | hypothesis |
+| Share without losing authorship | **Sharing with author credit** (multi-group, bulk export) | Med-High × High = **High** | validated (EN) / hypothesis (FR) |
+| A shared recipe doesn't fit my kit | **Auto-rescale to the recipient's equipment** | Med × High = **Med-High** | hypothesis |
+
+**Cross-cutting (all stages):** a **fair, generous free tier** — paywall fatigue is one of the strongest
+desk signals; it's a pricing principle, not a feature. Don't compete on calculation (incumbents win there).
+
+## Build order (the answer to "what do we implement, and in what order")
+
+1. **P0 — the assistant entry (Stage 1):** guided brew-day assistant + beginner catalog + fermentation
+   tracking + clean UX + offline tolerance. *This is the wedge we ship and validate first.*
+2. **P1 — retention (Stage 2):** organization & search, batch history, BeerXML import/export, durability.
+3. **P2 — depth (Stage 3):** clone repository → versioned clones → credited sharing → auto-rescale.
+
+The clone repository scores **Very High** on raw opportunity, but it lives in Stage 3 because it serves
+intermediates and needs a crowd. We **enter** by the assistant and **grow into** the community — "the app
+that grows with the brewer."
+
+## What the interviews must settle (ties to the [interview guide](/en/05-interview-guide))
+
+- **The biggest open risk:** is the **beginner assistant** truly a strong, willing-to-pay-attention need,
+  or do brewers "graduate" past it too fast to build a business on? (the *under-probed* rows above).
+- Whether **attribution-sensitivity** holds in FR as it does in EN.
+- Whether **versioning + auto-rescale** is felt as a real need or a nice-to-have.
+- Whether intermediates would **switch** from an entrenched tool.
+
+Until these are answered, treat the order above as the **best current bet**, not a settled roadmap.

--- a/docs/marketing/needs-study/en/05-interview-guide.md
+++ b/docs/marketing/needs-study/en/05-interview-guide.md
@@ -1,0 +1,125 @@
+# Brewer Interview Guide — Needs Validation
+
+Primary-research instrument for the marketing needs study (epic #1075, sub-issue #1076).
+Built on a Jobs-to-be-Done (JTBD) frame: understand the *job* a homebrewer is trying to get done,
+not whether they like our idea. **Bilingual** — run in EN on r/Homebrewing, in FR on brassageamateur.
+
+## Golden rules (read before every interview)
+
+- **Never pitch.** The interviewee must not know what we're building until the very end (optional).
+  The moment they sense an app, they answer to be polite — useless data.
+- **Ask about the past, not the future.** "Tell me about the last time you…" beats "Would you use…".
+  Memories are facts; predictions are fiction.
+- **Dig into stories, not opinions.** When they make a claim, ask for the specific episode behind it.
+- **Embrace silence.** Let them fill it. The best signal comes after the pause.
+- **Capture verbatim.** Record exact words (with consent) — the language is gold for copy later.
+
+## Target & recruitment
+
+- **Segment:** regular / intermediate homebrewers (brew several times a year; not first-batch beginners,
+  not all-grain pros wedded to a tool). Screen for it (Q0).
+- **Recruit from:** r/Homebrewing (EN), brassageamateur.com (FR). Aim 10-15 total, mixed EN/FR.
+- **Format:** 25-35 min, voice if possible. Ask consent to record + to quote anonymously.
+
+## What we're trying to learn (the 3 risky beliefs)
+
+| # | Belief under test | If FALSE, then… |
+|---|---|---|
+| B1 | They want to **clone specific beers** and would value **versioned, community-refined** clones | The "hero" loses its emotional pull |
+| B2 | Sharers care about **author credit / attribution** (strong EN, unproven FR) | The credit/attribution mechanic is wasted effort |
+| B3 | They'd **switch** from their current tool, and **auto-rescale** of shared recipes is a real need | The wedge isn't enough to overcome inertia |
+
+The questions below are sequenced to surface these without naming them.
+
+---
+
+## Section 0 — Screen & warm-up (3 min)
+
+- **EN:** How long have you been brewing, and roughly how many batches a year? What's your setup?
+- **FR:** Tu brasses depuis combien de temps, et à peu près combien de brassins par an ? Quel est ton matériel ?
+
+*(Keep if: brews regularly, beyond first batches, not a hardcore single-tool pro. Otherwise thank & end.)*
+
+## Section 1 — The job & current workflow (8 min) — JTBD / pains
+
+- **EN:** Walk me through your last brew, from choosing what to brew to drinking it. Where did the recipe come from?
+- **FR:** Raconte-moi ton dernier brassin, du choix de la recette jusqu'à la dégustation. D'où venait la recette ?
+
+- **EN:** Where do your recipes live today? Show me / describe it. What's annoying about that?
+- **FR:** Où sont stockées tes recettes aujourd'hui ? Montre-moi / décris. Qu'est-ce qui t'agace là-dedans ?
+
+- **EN:** Tell me about the last time you couldn't find or organize a recipe the way you wanted.
+- **FR:** Parle-moi de la dernière fois où tu n'as pas réussi à retrouver ou organiser une recette comme tu voulais.
+
+*Tags: pain, current-alternative, vocabulary, foundation-need (organize/track).*
+
+## Section 2 — Cloning a specific beer (7 min) — probes B1
+
+- **EN:** Have you ever tried to recreate a specific commercial beer you love? Tell me about that — start to finish.
+- **FR:** As-tu déjà essayé de reproduire une bière commerciale précise que tu aimes ? Raconte — du début à la fin.
+
+- **EN:** Where did you get the clone recipe? Did it come out like the original? What did you do next?
+- **FR:** Où as-tu trouvé la recette de clone ? Le résultat ressemblait-il à l'originale ? Qu'as-tu fait ensuite ?
+
+- **EN:** (If they adapted it) How did you know what to change? Did you write your version down anywhere?
+- **FR:** (S'ils l'ont adaptée) Comment savais-tu quoi changer ? As-tu noté ta version quelque part ?
+
+*Tags: B1 clone-desire, B1 versioning-need (do they iterate?), trigger, desired-outcome.*
+
+## Section 3 — Sharing & community (7 min) — probes B2
+
+- **EN:** Have you ever shared one of your recipes with another brewer? What happened? How did you share it?
+- **FR:** As-tu déjà partagé une de tes recettes avec un autre brasseur ? Comment ? Que s'est-il passé ?
+
+- **EN:** When you see a recipe online, do you care who created it? Why / why not?
+- **FR:** Quand tu vois une recette en ligne, est-ce que ça compte pour toi de savoir qui l'a créée ? Pourquoi ?
+
+- **EN:** (If they shared) How did you feel about others using or changing your recipe? Did you want credit?
+- **FR:** (S'ils ont partagé) Qu'as-tu ressenti à l'idée que d'autres utilisent ou modifient ta recette ? Voulais-tu être crédité ?
+
+*Tags: B2 attribution-sensitivity (note EN vs FR!), sharing-willingness, social-job.*
+
+## Section 4 — Tools & switching (6 min) — probes B3
+
+- **EN:** What apps or tools do you use for brewing today? What made you pick that one?
+- **FR:** Quels logiciels ou outils utilises-tu pour brasser aujourd'hui ? Pourquoi celui-là ?
+
+- **EN:** What would have to be true for you to move your recipes to a different tool? What's stopped you before?
+- **FR:** Qu'est-ce qui devrait être vrai pour que tu déplaces tes recettes vers un autre outil ? Qu'est-ce qui t'en a empêché jusqu'ici ?
+
+- **EN:** When you take someone else's recipe, how do you adjust it to your own equipment? Walk me through it.
+- **FR:** Quand tu prends la recette de quelqu'un d'autre, comment l'adaptes-tu à ton propre matériel ? Décris-moi.
+
+*Tags: B3 switching-barrier, B3 rescale-need, current-alternative, objection.*
+
+## Section 5 — Wrap (3 min)
+
+- **EN:** If you had a magic wand for the recipe side of brewing, what would you change? Anything I didn't ask about?
+- **FR:** Si tu avais une baguette magique pour la partie recettes du brassage, que changerais-tu ? Un sujet que j'ai oublié ?
+
+- **EN:** Who else like you should I talk to? (referral)
+- **FR:** Qui d'autre, dans ton genre, devrais-je interviewer ? (recommandation)
+
+*(Optional, only at the very end: briefly describe the concept and watch the honest reaction — but data above is what counts.)*
+
+---
+
+## After each interview — capture sheet
+
+Fill within 1 hour, per `customer-research` extraction fields:
+
+- **Source / language / date / profile** (years brewing, batches/yr, setup, EN or FR).
+- **JTBD** (functional / emotional / social).
+- **Top pains** (verbatim, mark unprompted + emotional ones).
+- **Trigger events.**
+- **Desired outcomes** (exact quotes = money quotes).
+- **Alternatives considered** (tools, forums, doing nothing).
+- **Per-belief verdict:** B1 / B2 / B3 → supports / refutes / unclear, with the quote that decides it.
+
+## Synthesis (after ~10 interviews)
+
+- Cluster pains by theme; score frequency × intensity; **confidence label** (High = 3+ independent
+  sources, unprompted, consistent; Medium = 2 sources or prompted; Low = single source).
+- **Compare EN vs FR explicitly** on B2 (attribution) — this is the known divergence to resolve.
+- Feed verdicts + money quotes into the final report (`06-report.md`).
+- Sample-bias caveat: r/Homebrewing skews technical/opinionated; forum posters skew "stuck" — weight accordingly.

--- a/docs/marketing/needs-study/en/b1-environnement.md
+++ b/docs/marketing/needs-study/en/b1-environnement.md
@@ -1,0 +1,16 @@
+# B1 · Environment (PESTEL)
+
+**Right-sized to the project's stage** — keep only what changes a decision. First pass seeded from the
+desk (`03c`/`03d`); expand only if a dimension becomes decisive.
+
+| Dimension | What matters for Brasse-Bouillon | Source / confidence |
+|---|---|---|
+| **Political / Legal** | Amateur homebrewing was **clarified / legalized in France on Jan 1, 2021** (Article 520 bis CGI): personal/family use, excise-exempt, not for sale. → a **young, expanding legal market**. "Loi Évin" framing applies to all communications (already handled on the site). | [HIGH] — `03d` |
+| **Economic** | Mature FR supplier ecosystem; strong price sensitivity → a generous free tier is near-mandatory. The *professional* microbrewery market is plateauing (≈2,500, #1 in Europe). | [MED] — `03c`/`03d` |
+| **Social** | Strong inflow of **new brewers** (US: 40% started < 4 years ago); positive sharing culture; FR community loyal to free/open tools. → a large, welcoming beginner audience. | [HIGH/MED] |
+| **Technological** | Existing tools seen as complex / steep UX; growing interest in connected hydrometers (Tilt, iSpindel); **BeerXML/BeerJSON** interoperability = table-stakes. | [MED] — `01`/`03` |
+| **Environmental** | Minor at this stage (local ingredients, bottle reuse = weak arguments). | [LOW] |
+| **Demographic** | Only hard data is US (age 30-49, mostly male, educated, affluent). **No official FR figure** — validate in the field. | [N/F] FR — `03d` |
+
+**Decision it changes:** "young market (legalized 2021) + beginner inflow + price sensitivity" reinforces
+the **beginner beachhead** + **freemium**. Nothing here contradicts the direction.

--- a/docs/marketing/needs-study/en/b4-swot.md
+++ b/docs/marketing/needs-study/en/b4-swot.md
@@ -1,0 +1,19 @@
+# B4 · SWOT
+
+First SWOT synthesis from the desk — *to validate/refine after the field work*. Crosses internal
+(project strengths/weaknesses) with external (market opportunities/threats).
+
+| Internal | |
+|---|---|
+| **Strengths** | Founder = member of the target (beginner) → empathy & dogfooding. Strong conviction. A differentiated wedge identified (versioned/credited/auto-rescaled clone). Charter & site already in place. |
+| **Weaknesses** | Solo, limited time. **Not in the intermediate segment** (for the community layer). **Zero budget.** Cold field recruiting (new to the communities). No testable product yet. |
+
+| External | |
+|---|---|
+| **Opportunities** | Beginner inflow (market legalized 2021). **No FR data** on homebrewers → become the dataset. **Joliebulle closed (2010-2025)** → orphaned FR user base. Complex incumbents → room for "simple". |
+| **Threats** | **Build-A-Beer** (AI clone + share) = direct competitor. Entrenched incumbents (Brewfather/BeerSmith) win on calculation. **Community apps die** (AHA Brew Guru, Feb 2026) → don't lead with community alone. |
+
+**Strategic read (TOWS):** use the "founder-in-the-target" strength to attack the "beginner inflow"
+opportunity via the **guided assistant** (low-risk entry), while neutralizing the "communities die" threat
+by making community a **retention layer**, not the initial engine. Offset the "not in the intermediate
+segment" weakness with the [field research](/en/c-resultats).

--- a/docs/marketing/needs-study/en/c-distribution.md
+++ b/docs/marketing/needs-study/en/c-distribution.md
@@ -1,0 +1,108 @@
+# C · Survey distribution kit
+
+**Ready-to-paste** posts to recruit responses to the [survey](/en/c-survey), passively and respectfully
+of each community. Replace `[SURVEY LINK]` with the real Google Form URL once created.
+
+::: tip Principles (so you don't get removed / downvoted)
+- **"Beginner who's learning" framing**, never "test my app".
+- **Read each community's rules**; ask **mods** when unsure; post in the **dedicated thread** if standalone surveys aren't allowed.
+- **Contribute a little first** (helpful replies), then post — don't show up only to ask.
+- **Promise to share aggregate results** → big boost to goodwill and response rate.
+- **Privacy note**: the contact (Q12) is **optional** and **never shared**.
+- Don't spam several places the same day.
+:::
+
+## 1 · brassageamateur.com forum (FR)
+
+**Title:** Débutant — comment gérez-vous vos recettes et vos brassins ? (petit questionnaire)
+
+```
+Bonjour à tous,
+
+Je débute le brassage et j'essaie de comprendre comment vous, brasseurs plus
+expérimentés, gérez vos recettes, vos brassins et vos notes au quotidien.
+
+J'ai préparé un court questionnaire (3-5 min) pour apprendre de vos pratiques —
+ça m'aiderait énormément. Je partagerai bien sûr une synthèse des réponses ici.
+
+[LIEN DU SONDAGE]
+
+Merci beaucoup ! (Contact optionnel à la fin, jamais partagé.)
+```
+
+## 2 · Facebook brewing groups (FR)
+
+```
+Salut le groupe,
+
+Je débute le brassage et je cherche à comprendre comment vous gérez vos recettes
+et vos brassins. Petit questionnaire de 3-5 min — ça m'aide beaucoup, et je
+partagerai les résultats au groupe.
+
+[LIEN DU SONDAGE]
+
+Merci ! (Contact optionnel, jamais partagé.)
+```
+
+## 3 · LinkedIn (FR, build-in-public)
+
+"Learning" tone (~80%), no external link in the body → **link in the first comment**. Post ideally
+Tuesday ~11am; reply to comments within the hour.
+
+**Post body:**
+
+```
+Je me lance dans une étude de besoins pour Brasse-Bouillon — et je redécouvre une
+évidence : écouter avant de coder change tout.
+
+Je suis en reconversion, je construis une app pour les brasseurs amateurs. Mais je
+suis moi-même débutant en brassage. Le piège serait de concevoir « pour moi ».
+Alors je fais l'inverse : je vais demander aux brasseurs ce qui les bloque
+vraiment, avant d'écrire une ligne de code de plus.
+
+Première étape concrète : un court questionnaire pour les brasseurs amateurs. Si
+tu brasses (ou connais quelqu'un qui brasse), le lien est en commentaire. Je
+partagerai ce que j'apprends, au fil de l'eau.
+
+#brassage #buildinpublic #reconversion #produit
+```
+
+**First comment:** `Le questionnaire (3-5 min) : [LIEN DU SONDAGE] — merci !`
+
+## 4 · r/Homebrewing (EN, rules-aware)
+
+⚠ Read the sub's rules first: many disallow surveys outside a dedicated thread. Offer to move it.
+
+**Title:** New to brewing — how do you manage your recipes and batches? (quick survey)
+
+```
+Hi all,
+
+I'm new to homebrewing and trying to understand how more experienced brewers
+manage their recipes, batches and notes.
+
+I put together a short survey (3-5 min) to learn from your practices — it would
+really help, and I'll share a summary of the results back here.
+
+[SURVEY LINK]
+
+Thanks for your time! (Optional contact at the end, only if you're open to a chat;
+never shared.) Mods — happy to move this to a dedicated thread if you prefer.
+```
+
+## 5 · Website CTA — "Participate" section (EN)
+
+To wire once the link exists (link, not iframe, for GDPR consent; FR/EN parity required).
+
+```
+Help us build the right app
+
+Brasse-Bouillon is built with you. Take our short survey (3-5 min): your answers
+directly shape what we build.
+
+[ Button: Share your view → [SURVEY LINK] ]
+
+Optional contact, never shared.
+```
+
+*(French CTA version: see the [Diffusion](/c-diffusion) page.)*

--- a/docs/marketing/needs-study/en/c-resultats.md
+++ b/docs/marketing/needs-study/en/c-resultats.md
@@ -1,0 +1,28 @@
+# C · Field results
+
+::: warning To come
+Primary research **has not started yet**. This page will hold the interview and survey results. It is the
+study's **#1 action** (validation-first) — see the [interview guide](/en/05-interview-guide).
+:::
+
+## Field plan (5-6 weeks, solo, zero budget, cold)
+
+- **Qualitative — 10-15 interviews** of brewers (EN via r/Homebrewing, FR via brassageamateur), framed as
+  "a beginner who's learning". Realistic target given the constraints: **aim for depth**, accept a modest
+  sample, and **state it honestly**.
+- **Quantitative — a survey** (Google Forms) distributed in the communities, to quantify needs and begin
+  filling the **FR data gap**.
+
+## Priority hypotheses to settle
+
+1. Is the **beginner-assistant need** strong and durable, or do brewers "graduate" too fast to build a
+   business on it? *(the biggest risk — under-probed by the desk)*
+2. **Attribution-sensitivity**: strong in EN, under-evidenced in FR — confirm both.
+3. **Versioning + auto-rescale**: real need or nice-to-have?
+4. **Switching**: would an intermediate leave an entrenched tool?
+
+## Expected output
+
+Confirmed needs map (frequency × intensity, confidence label), key verbatims, **EN vs FR** comparison, and
+a per-hypothesis verdict (supports / refutes / inconclusive) → feeds the [synthesis](/en/04-synthesis), the
+[backlog](/en/04b-prioritized-backlog) and the [Lean Canvas](/en/lean-canvas).

--- a/docs/marketing/needs-study/en/c-survey.md
+++ b/docs/marketing/needs-study/en/c-survey.md
@@ -1,0 +1,54 @@
+# C · Survey (questionnaire)
+
+A **passive** primary-research instrument: a short questionnaire (3-5 min) posted in brewer communities
+that collects in the background while the analysis continues. Designed to validate the study's hypotheses
+and start to **quantify** needs (and fill the FR data gap).
+
+::: tip Method
+Short and mostly **closed** (max responses, quantifiable) + 2 open questions for the *why*. The last
+question is an **opt-in** for a 15-min chat → volunteers come to you, no cold outreach. Framed as "a
+beginner who's learning" (not "test my app"). Build it in **Google Forms** (free).
+:::
+
+## Intro text (top of the form / post)
+
+> I'm new to brewing and trying to understand how you brewers manage your recipes and your batches. 3-5
+> minutes would help me a lot. Thank you!
+
+## Questions
+
+1. **How long have you been brewing?** — `< 6 months` · `6 months–2 years` · `2–5 years` · `5+ years`
+2. **Roughly how many batches a year?** — `0–2` · `3–6` · `7–12` · `12+`
+3. **Where do you brew?** — `USA` · `UK` · `Canada` · `Europe` · `Other`
+4. **Where do your recipes and brew notes live today?** *(multiple)* — `In my head` · `Paper / notebook` · `Spreadsheet` · `An app` · `On a forum` · `Other`
+5. **Which tool(s) or app do you use?** *(multiple)* — `Brewfather` · `BeerSmith` · `Brewer's Friend` · `None` · `Other`
+6. **What annoys you most about how you manage recipes / batches today?** *(short free text)*
+7. **Do you ever ruin a batch, or feel lost during the process?** — `Often` · `Sometimes` · `Rarely` · `Never`
+8. **Have you ever tried to recreate (clone) a specific commercial beer?** — `Yes, succeeded` · `Yes, but disappointed by the result` · `Never tried, but I'd like to` · `Not interested`
+9. **Do you share your recipes with other brewers?** — `Often` · `Sometimes` · `No, but I'd be open` · `No, I keep them`
+10. **If you share a recipe, does being credited as the author matter to you?** — `A lot` · `A little` · `Not at all` · `I don't share`
+11. **What would make you try a new brewing app?** *(multiple)* — `Simplicity` · `Free` · `Step-by-step guidance` · `A community` · `Importing my recipes` · `Other`
+12. **Would you be open to a 15-min chat to tell me more?** — `Yes` *(→ email or handle)* · `No`
+
+## What each question tests
+
+| Questions | Hypothesis / goal |
+|---|---|
+| 1, 2 | **Segment** (beginner / regular / intermediate) — key to settle assistant vs community |
+| 3 | Geographic split |
+| 4, 5, 6 | Current **practices & pains** (tools, organization) — the *why* |
+| 7 | **Assistant** hypothesis (fear of failing, need for guidance — esp. beginners) |
+| 8 | **Clone** hypothesis (desire to recreate a beer) |
+| 9, 10 | **Sharing** + **attribution** hypotheses (strong in EN, to confirm in FR) |
+| 11 | **Adoption trigger** / tool switching |
+| 12 | **Interview opt-in** — recovers volunteers without cold outreach |
+
+## Distribution (passive, zero budget)
+
+- **r/Homebrewing** (EN) — respect the sub's anti-promo rules; lead with the "beginner learning" framing.
+- **brassageamateur.com** (FR, [French version](/c-sondage)).
+- Brewing Facebook groups.
+- Let it collect for **2-3 weeks**; aim for a modest but **honestly-stated** sample.
+
+Results feed the [Results](/en/c-resultats) page, then the [synthesis](/en/04-synthesis), the
+[backlog](/en/04b-prioritized-backlog) and the [Lean Canvas](/en/lean-canvas).

--- a/docs/marketing/needs-study/en/d-strategie.md
+++ b/docs/marketing/needs-study/en/d-strategie.md
@@ -1,0 +1,31 @@
+# D · Strategy & action plan
+
+::: warning To come
+This section is written **after** field validation (otherwise we may plan the wrong product). The skeleton
+below fixes the expected headings; we fill them once the hypotheses are settled.
+:::
+
+## STP — Segmentation, Targeting, Positioning
+
+- **Segmentation**: beginner / regular / intermediate brewers (× FR / EN).
+- **Targeting**: beachhead = **beginners** (acquisition), then move up the journey.
+- **Positioning**: see the [positioning statement](/en/04-synthesis) (to confirm in the field).
+
+## Mix (digital-adapted)
+
+- **Product**: the guided assistant first ([prioritized backlog](/en/04b-prioritized-backlog)).
+- **Price**: freemium; free core, paid BeerXML/BeerJSON export; generous free tier (FR sensitivity).
+- **Distribution**: stores + site; entry via communities.
+- **Communication**: build-in-public (LinkedIn FR + Indie Hackers EN), "listen-first" presence in brewer communities.
+
+## Action plan & KPIs
+
+- **Starting channels (2)**: brewer communities (product) + LinkedIn (founder).
+- **Cadence**: 1 post/week (logbook, not ads).
+- **KPIs** (see [Lean Canvas](/en/lean-canvas)): brew completion rate, week-4 retention, recipes
+  created/shared, NPS.
+- **Loop**: launch → measure → iterate.
+
+## Channel legitimacy
+
+*Building in public* is legitimate **now**; *selling / acquiring* comes when there's a testable product.

--- a/docs/marketing/needs-study/en/index.md
+++ b/docs/marketing/needs-study/en/index.md
@@ -23,10 +23,10 @@ Everything else (a launched product, a school deliverable, a future activity, a 
 
 The original four-step journey as the entry point:
 
-> 1. **Choisis ta recette** — a catalog calibrated to succeed on the first batch.
-> 2. **Brasse pas à pas** — the app tells you what to do, when, and why.
-> 3. **Suis la fermentation** — days, gravity, temperature, at a glance.
-> 4. **Mets en bouteille, savoure** — label, share, taste.
+> 1. **Pick your recipe** — a catalog calibrated to succeed on the first batch.
+> 2. **Brew step by step** — the app tells you what to do, when, and why.
+> 3. **Track fermentation** — days, gravity, temperature, at a glance.
+> 4. **Bottle it, enjoy** — label, share, taste.
 
 ## How this report is organized
 

--- a/docs/marketing/needs-study/en/index.md
+++ b/docs/marketing/needs-study/en/index.md
@@ -1,0 +1,53 @@
+# Brasse-Bouillon — Marketing Needs Study
+
+> A needs-first study: understand what brewers actually struggle with, validate (or kill) our
+> differentiating hypothesis, and prioritize what to build — grounded in evidence, not assumption.
+
+::: warning Status
+**Secondary research (desk) is complete; primary research (interviews) is pending.** The findings below
+are well-sourced **hypotheses**, not yet confirmed by talking to real brewers. Read the
+[method](/en/00-method) and its limits first. Tracked on
+[epic #1075](https://github.com/benoit-bremaud/brasse-bouillon/issues/1075).
+:::
+
+## North star
+
+Above all, Brasse-Bouillon aims to **solve one or more real, clearly-identified needs** for homebrewers.
+Everything else (a launched product, a school deliverable, a future activity, a portfolio piece) follows.
+
+## Product spine — "the app that grows with the brewer"
+
+1. **Beginner — guided assistant** → never ruin a brew, simple & playful. *(acquisition)*
+2. **Regular — organize & track** your growing batches. *(retention)*
+3. **Intermediate — clone, share, community.** *(depth)*
+
+The original four-step journey as the entry point:
+
+> 1. **Choisis ta recette** — a catalog calibrated to succeed on the first batch.
+> 2. **Brasse pas à pas** — the app tells you what to do, when, and why.
+> 3. **Suis la fermentation** — days, gravity, temperature, at a glance.
+> 4. **Mets en bouteille, savoure** — label, share, taste.
+
+## How this report is organized
+
+The report follows the **classic marketing-study plan** (A → B → C → D) for jury-grade rigor — but
+**right-sized to the project's stage** and executed **validation-first** (the field guides the analysis,
+not the reverse). Guiding principle: *every section must change a decision; otherwise keep it minimal.*
+
+- **A — Scope:** [objectives, scope & method](/en/00-method).
+- **B — Market analysis:** [environment (PESTEL)](/en/b1-environnement) ·
+  [market & sizing](/en/03c-desk-market-data) · [French market](/en/03d-desk-french-market) · demand & needs
+  ([Reddit](/en/02-desk-reddit), [forums](/en/03-desk-forums), [French sources](/en/03b-desk-french)) ·
+  [competition](/en/01-desk-competitors) · [SWOT](/en/b4-swot).
+- **C — Field:** [interview guide](/en/05-interview-guide) · [results](/en/c-resultats).
+- **D — Recommendation:** [synthesis & positioning](/en/04-synthesis) ·
+  [prioritized backlog](/en/04b-prioritized-backlog) · [Lean Canvas](/en/lean-canvas) ·
+  [strategy & action plan](/en/d-strategie).
+
+## Headline finding
+
+The differentiating hypothesis — **a community for cloning and sharing recipes** — is supported by the
+desk and **sharpened**: the defensible wedge is a clone recipe that is **versioned, credited, and
+auto-rescaled** to each brewer's equipment. But for the **beginner** entry point, what the desk filed as
+"table-stakes" (guided tracking, simple UX) is the **hero** — hence the journey above. The interviews will
+decide which need to build first.

--- a/docs/marketing/needs-study/en/lean-canvas.md
+++ b/docs/marketing/needs-study/en/lean-canvas.md
@@ -1,0 +1,21 @@
+# Lean Canvas (operational synthesis)
+
+One page to steer by: the study translated into actionable business hypotheses. Revisit and correct after
+the field work. *(First version — from the desk, to validate in interviews.)*
+
+| Block | Content (v1, to validate) |
+|---|---|
+| **Problem** | (1) Brewing well is intimidating for a beginner — fear of failing, jargon, complex tools. (2) Recreating a beer you love is hard (clones are wrong/static). (3) Recipes & batches scattered. |
+| **Customer segments** | **Beachhead: beginner homebrewers** (incl. the founder). Then regulars, then intermediates. Early adopters: new FR + EN brewers (40% started < 4 years ago). |
+| **Unique value proposition** | "The app that guides you step by step to nail every brew — then grows with you into a recipe community." |
+| **Solution** | Guided brew-day assistant (steps, timers, the "why") + calibrated catalog + fermentation tracking. Later: versioned/credited/auto-rescaled community clones. |
+| **Channels** | Brewer communities (FR forums, r/Homebrewing, FB groups) as a "beginner who's learning"; LinkedIn (build-in-public, FR); Indie Hackers (EN). Organic, zero budget. |
+| **Revenue** | Freemium: free core (assistant + tracking), paid = BeerXML/BeerJSON export and advanced features. Generous free tier (strong FR price sensitivity). |
+| **Cost structure** | Solo dev (time), hosting, APIs. No marketing budget — acquisition via content and community. |
+| **Key metrics** | Brews completed in-app (completion rate), week-4 retention, recipes created/shared, NPS. |
+| **Unfair advantage** | Founder = user of his own target (beginner); conviction & lived experience. FR community data exists nowhere else (Brasse-Bouillon can *become* the dataset). The versioned-clone loop nobody owns. |
+
+::: tip Reading
+The Lean Canvas is not fixed — it's the current business hypothesis. The Problem, Segments and Value-prop
+blocks are exactly what the [field research](/en/c-resultats) must confirm or correct first.
+:::

--- a/docs/marketing/needs-study/index.md
+++ b/docs/marketing/needs-study/index.md
@@ -1,52 +1,59 @@
-# Brasse-Bouillon — Marketing Needs Study
+# Brasse-Bouillon — Étude de besoins marketing
 
-> A needs-first study: understand what brewers actually struggle with, validate (or kill) our
-> differentiating hypothesis, and prioritize what to build — grounded in evidence, not assumption.
+> Une étude orientée besoins : comprendre les vraies difficultés des brasseurs, valider (ou tuer)
+> notre hypothèse différenciante, et prioriser ce qu'on construit — sur des preuves, pas des suppositions.
 
-::: warning Status
-**Secondary research (desk) is complete; primary research (interviews) is pending.** The findings
-below are well-sourced **hypotheses**, not yet confirmed by talking to real brewers. Read
-[Method](/00-method) for the limitations before trusting any ranking. Tracked on
-[epic #1075](https://github.com/benoit-bremaud/brasse-bouillon/issues/1075).
+::: warning Statut
+**La recherche secondaire (desk) est terminée ; la recherche primaire (entretiens) reste à faire.**
+Les conclusions ci-dessous sont des **hypothèses** bien sourcées, pas encore confirmées en parlant à de
+vrais brasseurs. Lire la [méthode](/00-method) et ses limites avant de prendre une priorité pour argent
+comptant. Suivi sur [epic #1075](https://github.com/benoit-bremaud/brasse-bouillon/issues/1075).
 :::
 
-## North star
+## Étoile polaire
 
-Above all, Brasse-Bouillon aims to **solve one or more real, clearly-identified needs** for
-homebrewers. Everything else (a launched product, a school deliverable, a future activity, a
-portfolio piece) follows from getting that right.
+Avant tout, Brasse-Bouillon vise à **résoudre un ou plusieurs vrais besoins clairement identifiés** chez
+les brasseurs amateurs. Tout le reste (un produit lancé, un livrable d'école, une future activité, une
+pièce de portfolio) en découle.
 
-## The product spine — "the app that grows with the brewer"
+## La colonne vertébrale produit — « l'app qui grandit avec le brasseur »
 
-The reconciliation between the founder's vision (a guided brewing assistant for beginners) and the
-desk findings (a community clone/share hub for intermediates) is a **single brewer's journey**:
+La réconciliation entre la vision du fondateur (un assistant de brassage guidé pour débutants) et les
+conclusions du desk (un hub communautaire de clones pour intermédiaires) tient en **un seul parcours** :
 
-1. **Beginner — guided assistant** → never ruin a brew, simple & playful. *(acquisition)*
-2. **Regular — organize & track** your growing batches. *(retention)*
-3. **Intermediate — clone, share, community.** *(depth)*
+1. **Débutant — assistant guidé** → ne rate aucun brassin, simple & ludique. *(acquisition)*
+2. **Régulier — organiser & suivre** ses brassins qui se multiplient. *(rétention)*
+3. **Intermédiaire — cloner, partager, communauté.** *(profondeur)*
 
-The original four-step journey, framed as the entry point ("un copilote à chaque moment, tu n'es
-jamais seul devant tes cuves") :
+Le parcours d'origine en quatre étapes, comme porte d'entrée (« un copilote à chaque moment, tu n'es
+jamais seul devant tes cuves ») :
 
 > 1. **Choisis ta recette** — un catalogue calibré pour réussir dès le premier brassin.
 > 2. **Brasse pas à pas** — l'app te dit quoi faire, quand, et pourquoi.
 > 3. **Suis la fermentation** — jours, densité, température, en un coup d'œil.
 > 4. **Mets en bouteille, savoure** — étiquette, partage, dégustation.
 
-## What this study contains
+## Comment ce rapport est organisé
 
-- **[Synthesis & positioning](/04-synthesis)** — the needs map, market context, and the draft
-  one-sentence positioning. *Start here for the conclusions.*
-- **Secondary research (desk):** [Method](/00-method) ·
-  [Competitors](/01-desk-competitors) · [r/Homebrewing](/02-desk-reddit) ·
-  [Forums EN+FR](/03-desk-forums) · [French sources](/03b-desk-french) ·
-  [Market data](/03c-desk-market-data) · [French market](/03d-desk-french-market).
-- **Primary research:** the [interview guide](/05-interview-guide) (the next step — field validation).
+Le rapport suit le **plan classique d'une étude marketing** (A → B → C → D), pour la rigueur attendue en
+soutenance — mais **dimensionné au stade du projet** et exécuté **validation-first** (le terrain guide
+l'analyse, pas l'inverse). Principe directeur : *chaque section doit changer une décision ; sinon, on la
+garde minimale.*
 
-## Headline finding
+- **A — Cadrage** : [objectifs, périmètre & méthode](/00-method).
+- **B — Analyse de marché** : [environnement (PESTEL)](/b1-environnement) ·
+  [marché & taille](/03c-desk-market-data) · [marché FR](/03d-desk-french-market) · demande & besoins
+  ([Reddit](/02-desk-reddit), [forums](/03-desk-forums), [sources FR](/03b-desk-french)) ·
+  [concurrence](/01-desk-competitors) · [SWOT](/b4-swot).
+- **C — Terrain** : [guide d'entretien](/05-interview-guide) · [résultats](/c-resultats).
+- **D — Recommandation** : [synthèse & positionnement](/04-synthesis) ·
+  [backlog priorisé](/04b-prioritized-backlog) · [Lean Canvas](/lean-canvas) ·
+  [stratégie & plan d'action](/d-strategie).
 
-The differentiating hypothesis — **a community for cloning and sharing recipes** — is supported
-across the desk passes and **sharpened**: the defensible wedge is a clone recipe that is
-**versioned, credited, and auto-rescaled** to each brewer's equipment. But for the **beginner**
-entry point, what the desk filed as "table-stakes" (guided tracking, simple UX) is the **hero** —
-hence the journey above. The field interviews will decide which need to build first.
+## Conclusion phare
+
+L'hypothèse différenciante — **une communauté pour cloner et partager des recettes** — est soutenue par
+le desk et **affinée** : le créneau défendable est une recette clone **versionnée, créditée et re-mise à
+l'échelle** automatiquement à l'équipement de chacun. Mais pour la **porte d'entrée débutant**, ce que le
+desk classait en « table-stakes » (suivi guidé, UX simple) devient le **héros** — d'où le parcours
+ci-dessus. Les entretiens trancheront quel besoin construire en premier.

--- a/docs/marketing/needs-study/index.md
+++ b/docs/marketing/needs-study/index.md
@@ -1,0 +1,52 @@
+# Brasse-Bouillon — Marketing Needs Study
+
+> A needs-first study: understand what brewers actually struggle with, validate (or kill) our
+> differentiating hypothesis, and prioritize what to build — grounded in evidence, not assumption.
+
+::: warning Status
+**Secondary research (desk) is complete; primary research (interviews) is pending.** The findings
+below are well-sourced **hypotheses**, not yet confirmed by talking to real brewers. Read
+[Method](/00-method) for the limitations before trusting any ranking. Tracked on
+[epic #1075](https://github.com/benoit-bremaud/brasse-bouillon/issues/1075).
+:::
+
+## North star
+
+Above all, Brasse-Bouillon aims to **solve one or more real, clearly-identified needs** for
+homebrewers. Everything else (a launched product, a school deliverable, a future activity, a
+portfolio piece) follows from getting that right.
+
+## The product spine — "the app that grows with the brewer"
+
+The reconciliation between the founder's vision (a guided brewing assistant for beginners) and the
+desk findings (a community clone/share hub for intermediates) is a **single brewer's journey**:
+
+1. **Beginner — guided assistant** → never ruin a brew, simple & playful. *(acquisition)*
+2. **Regular — organize & track** your growing batches. *(retention)*
+3. **Intermediate — clone, share, community.** *(depth)*
+
+The original four-step journey, framed as the entry point ("un copilote à chaque moment, tu n'es
+jamais seul devant tes cuves") :
+
+> 1. **Choisis ta recette** — un catalogue calibré pour réussir dès le premier brassin.
+> 2. **Brasse pas à pas** — l'app te dit quoi faire, quand, et pourquoi.
+> 3. **Suis la fermentation** — jours, densité, température, en un coup d'œil.
+> 4. **Mets en bouteille, savoure** — étiquette, partage, dégustation.
+
+## What this study contains
+
+- **[Synthesis & positioning](/04-synthesis)** — the needs map, market context, and the draft
+  one-sentence positioning. *Start here for the conclusions.*
+- **Secondary research (desk):** [Method](/00-method) ·
+  [Competitors](/01-desk-competitors) · [r/Homebrewing](/02-desk-reddit) ·
+  [Forums EN+FR](/03-desk-forums) · [French sources](/03b-desk-french) ·
+  [Market data](/03c-desk-market-data) · [French market](/03d-desk-french-market).
+- **Primary research:** the [interview guide](/05-interview-guide) (the next step — field validation).
+
+## Headline finding
+
+The differentiating hypothesis — **a community for cloning and sharing recipes** — is supported
+across the desk passes and **sharpened**: the defensible wedge is a clone recipe that is
+**versioned, credited, and auto-rescaled** to each brewer's equipment. But for the **beginner**
+entry point, what the desk filed as "table-stakes" (guided tracking, simple UX) is the **hero** —
+hence the journey above. The field interviews will decide which need to build first.

--- a/docs/marketing/needs-study/lean-canvas.md
+++ b/docs/marketing/needs-study/lean-canvas.md
@@ -1,0 +1,22 @@
+# Lean Canvas (synthèse opérationnelle)
+
+Une page pour piloter : la traduction de l'étude en hypothèses business actionnables. À relire et corriger
+après le terrain. *(Première version — issue du desk, à valider en entretien.)*
+
+| Bloc | Contenu (v1, à valider) |
+|---|---|
+| **Problème** | (1) Réussir son brassage est intimidant pour un débutant — peur de rater, jargon, outils complexes. (2) Reproduire une bière qu'on aime est difficile (clones faux/statiques). (3) Recettes & brassins éparpillés. |
+| **Segments de clientèle** | **Tête de pont : brasseurs amateurs débutants** (dont le fondateur). Puis réguliers, puis intermédiaires. Early adopters : nouveaux brasseurs FR + EN (40 % ont commencé < 4 ans). |
+| **Proposition de valeur unique** | « L'app qui t'accompagne pas à pas pour réussir chaque brassin — puis grandit avec toi vers une communauté de recettes. » |
+| **Solution** | Assistant de brassage guidé (étapes, timers, le « pourquoi ») + catalogue calibré + suivi de fermentation. Plus tard : clone communautaire versionné/crédité/re-scalé. |
+| **Canaux** | Communautés brasseurs (forums FR, r/Homebrewing, groupes FB) en « débutant qui apprend » ; LinkedIn (build-in-public, FR) ; Indie Hackers (EN). Organique, 0 budget. |
+| **Revenus** | Freemium : cœur gratuit (assistant + suivi), payant = export BeerXML/BeerJSON et fonctions avancées. Tier gratuit généreux (sensibilité prix FR forte). |
+| **Structure de coûts** | Dev solo (temps), hébergement, API. Pas de budget marketing — acquisition par le contenu et la communauté. |
+| **Indicateurs clés** | Brassins menés au bout dans l'app (taux de complétion), rétention semaine-4, recettes créées/partagées, NPS. |
+| **Avantage difficilement copiable** | Fondateur = utilisateur de sa cible (débutant) ; conviction & vécu. Donnée de communauté FR inexistante ailleurs (Brasse-Bouillon peut *devenir* la donnée). Boucle clone versionné que personne ne possède. |
+
+::: tip Lecture
+Le Lean Canvas n'est pas figé : c'est l'hypothèse business du moment. Les blocs « Problème », « Segments »
+et « Proposition de valeur » sont précisément ceux que la [recherche terrain](/c-resultats) doit confirmer
+ou corriger en premier.
+:::

--- a/docs/marketing/needs-study/package-lock.json
+++ b/docs/marketing/needs-study/package-lock.json
@@ -1,0 +1,2516 @@
+{
+  "name": "@brasse-bouillon/marketing-needs-study",
+  "version": "2026.05.22-1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@brasse-bouillon/marketing-needs-study",
+      "version": "2026.05.22-1",
+      "devDependencies": {
+        "vitepress": "1.6.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.18.1.tgz",
+      "integrity": "sha512-aehCadlWOGvrT91KUIZpC0MbB8KBW9yUuvTJFd2xesR7le/IsT4nJUnjCCZ4ZqZCeTcPHPV5mo//fZ5oxcSVYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.52.1.tgz",
+      "integrity": "sha512-HmXOGBOAOJPounpBzBpuY0zDYeiCpxgHnQmuA7JO6ScukcBdGp3/XM9zJk5pJx/xNGD68mbPGXWpDxGtl6BwDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.52.1.tgz",
+      "integrity": "sha512-5oo4+I8iixie9vXhCyNFCzeIr8pqA3FQ//VsLHTDvZAV4ttYOPGvYHGQq5NSalrLx5Jc3dRro/5uDOlnUMcBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.52.1.tgz",
+      "integrity": "sha512-qCDoZfx5MpX7XQzvQ3bC4tSEMkQWQMaF/ABtLuoze03Y/flR563CCSws02qIJ23oX7lxl92LsilZjINVyTdtLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.52.1.tgz",
+      "integrity": "sha512-hnGs0/lsFJ2PWDxNBz7pxreXo/Xz7gxYRcfePBUjsH26ad0kU/sgnVZd9LwWBpsQv65z2jlb5dkyaB9WE9M9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.52.1.tgz",
+      "integrity": "sha512-2VxxNc/uBysyKvGeBdSM5n9eIDKH8kWD7wd9/yqbJAiVwU4Yv6tU1LSJusHKrXV/aCu1KW7t9Gug9QyeEmtn/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.52.1.tgz",
+      "integrity": "sha512-O6mPtsw3xEfNOe6gWFpYLeAZAIljNa4Hgna3bq15PwyN7nbjTY0wXJFRbzs/0YVf75Br+SbOQUmjKxXYjDiSiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.52.1.tgz",
+      "integrity": "sha512-gA8oJOV1LnQQkDf91iebNnFInHuW0gRPEgLSOQ7EfipCEjYTHm5swm1DlH9H5RaRw4RrHuzHBegnlzc0MAstcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.52.1.tgz",
+      "integrity": "sha512-U9zZfc5xIu9wRxZkt+HceJUAD4VKHKbAyLSloJdEyMRmphXeibfrY9cxqIXBcmPeZzGhn3Imb35Dq8l19PkJhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.52.1.tgz",
+      "integrity": "sha512-a3SGNceHmkQfq77iG8Ka+w1pvwfZa/0lzEIgse30fL0kD+yKnd/dg0dQvSfFPAEt2f21DMcGkDSSeJlO3KdQjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.52.1.tgz",
+      "integrity": "sha512-z98QEguCFDpxb4S/PyrUK1igqF8tPsdbqOUUO6ON91vJ58w+Gwa6ncrI0oNXSFcrkxA5EqPKPQ2A1PBCn08TYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.52.1.tgz",
+      "integrity": "sha512-CI7+/0I11QeZM59Uc8whd2or0kqzFVjpaPn9Qpwll/krHcBAxk24WkAQ6WX+IwDVMfpont4YGbKwAmCre3vE8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.52.1.tgz",
+      "integrity": "sha512-S6bDuw9byfOvm3T71cgdoZgrgnZq6hpdMLkx52Louh57nUAmvGQESz2aojOynQHjbTiV55smvAFbgn0qT4tJrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.52.1.tgz",
+      "integrity": "sha512-tqZXM+54rWo4mk5jL5Z/flE11nPmNEdXwFBM5py9DkOmbjeCNemfVd45FyM97XdzfZ0dl9uOJC6PYn1FpkeyQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.83",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.83.tgz",
+      "integrity": "sha512-6Pp9V++XisT9RKH7FB4RLPqUDzcmLtSma0ovOEIoEWGrXtHwBFsH7oN1z8vvCVCb95fb87QgR46/zRLyN9Y3kg==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.34.tgz",
+      "integrity": "sha512-s9cLyK5mLcvZ4Agva5QgRsQyLKvts9WbU9DB6NqiZkkGEdwmcEiylj5Jbwkp680drF/NNCV8OlAJSe+yMLxaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/shared": "3.5.34",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.34.tgz",
+      "integrity": "sha512-EbF/T++k0e2MMZlJsBhzK8Sgwt0HcIPOhzn1CTB/lv6sQcyk+OWf8YeiLxZp3ro7MbbLcAfAJ6sEvjFWuNgUCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.34.tgz",
+      "integrity": "sha512-D/ihr6uZeIt6r+pVZf46RWT1fAsLFMbUP7k8G1VkiiWexriED9GrX3echHd4Abbt17zjlfiFJ8z7a3BxZOPNjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@vue/compiler-core": "3.5.34",
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.14",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.34.tgz",
+      "integrity": "sha512-cDtTHKibkThKGHH1SP+WdccquNRYQDFH6rRjQCqT9G2ltFAfoR5pUftpab/z+aM5mW9HLLVQW7hfKKQe/1GBeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.34.tgz",
+      "integrity": "sha512-y9XDjCEuBp+98k+UL5dbYkh57AHU4o6cxZedOPXw3bmrZZYLQsVHguGurq7hVrPCSrQtrnz1f9dssyFr+dMXfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.34.tgz",
+      "integrity": "sha512-mKeBYvu8tcMSLhypAHBmriUFfWXKTCF/23Z4jiCoYK3UtWepkliViNLuR90V9XOyD62mUxs9p1jsrpK3CCGIzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/shared": "3.5.34"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.34.tgz",
+      "integrity": "sha512-e8kZzERmCwUnBRVsgSQlAfrfU2rGoy0FFKPBXSlfEjc/O3KfA7QP0t1/2ZylrbchjmIKB4dPTd07A6WPr0eOrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.34",
+        "@vue/runtime-core": "3.5.34",
+        "@vue/shared": "3.5.34",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.34.tgz",
+      "integrity": "sha512-nHxmJoTrKsmrkbILRhkC9gY1G3moZbJTqCzDd7DOOzG5KH9oeJ0Unqrff5f9v0pW//jES05ZkJcNtfE8JjOIew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "vue": "3.5.34"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.34.tgz",
+      "integrity": "sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.52.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.52.1.tgz",
+      "integrity": "sha512-fHA8+kXTbjagw3jkLiaS7KKrH8qe2DyOsiUhGlN4cdT77PEsfqXZl7ewDk1hsg+pJnPlnE50XtLxjR91iJOpmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/abtesting": "1.18.1",
+        "@algolia/client-abtesting": "5.52.1",
+        "@algolia/client-analytics": "5.52.1",
+        "@algolia/client-common": "5.52.1",
+        "@algolia/client-insights": "5.52.1",
+        "@algolia/client-personalization": "5.52.1",
+        "@algolia/client-query-suggestions": "5.52.1",
+        "@algolia/client-search": "5.52.1",
+        "@algolia/ingestion": "1.52.1",
+        "@algolia/monitoring": "1.52.1",
+        "@algolia/recommend": "5.52.1",
+        "@algolia/requester-browser-xhr": "5.52.1",
+        "@algolia/requester-fetch": "5.52.1",
+        "@algolia/requester-node-http": "5.52.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.34",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.34.tgz",
+      "integrity": "sha512-WdLBG9gm02OgJIG9axd5Hpx0TFLdzVgfG2evFFu8Rur5O/IoGc5cMjnjh3tPL6GnRGsYvUhBSKVPYVcxRKpMCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.34",
+        "@vue/compiler-sfc": "3.5.34",
+        "@vue/runtime-dom": "3.5.34",
+        "@vue/server-renderer": "3.5.34",
+        "@vue/shared": "3.5.34"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/docs/marketing/needs-study/package.json
+++ b/docs/marketing/needs-study/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "description": "VitePress site presenting the Brasse-Bouillon marketing needs study (epic #1075).",
   "engines": {
-    "node": ">=20"
+    "node": ">=20 <21"
   },
   "scripts": {
     "docs:dev": "vitepress dev .",

--- a/docs/marketing/needs-study/package.json
+++ b/docs/marketing/needs-study/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@brasse-bouillon/marketing-needs-study",
+  "version": "2026.05.22-1",
+  "private": true,
+  "type": "module",
+  "description": "VitePress site presenting the Brasse-Bouillon marketing needs study (epic #1075).",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "docs:dev": "vitepress dev .",
+    "docs:build": "vitepress build .",
+    "docs:preview": "vitepress preview ."
+  },
+  "devDependencies": {
+    "vitepress": "1.6.4"
+  }
+}


### PR DESCRIPTION
## Summary

Adds the Brasse-Bouillon marketing needs study as a bilingual (FR default + EN) VitePress report site under `docs/marketing/needs-study/`, structured along the classic marketing-study plan: **A — Scope**, **B — Market analysis**, **C — Field (primary research)**, **D — Recommendation**.

Contents merged by this PR:
- **A** — objectives, scope & method.
- **B** — desk research: competitors, Reddit, forums, French sources, market sizing, French market; PESTEL + SWOT scaffolds.
- **C** — brewer interview guide, the passive survey instrument (12 questions, opt-in interview), and the survey distribution kit (forum / Facebook / r/Homebrewing / LinkedIn / website CTA).
- **D** — synthesis & positioning, prioritized needs→features backlog, Lean Canvas, strategy scaffold.

## Context

First marketing needs study ever run for the project (epic #1075). Desk research is complete; the synthesis identifies the differentiating wedge (community-maintained, versioned, credited, auto-rescaled clone recipes) over the table-stakes base (organize + track). This PR is a **save point**: field research (#1077) and the final report / positioning decision (#1078) remain open and will land in follow-up PRs. Sections C-Results and D-Strategy are intentionally stubbed until field data arrives.

The report is documentation only — `noindex` and not wired into the public site.

## Checklist

- [x] Docs site builds (`npm run docs:build`)
- [x] Bilingual parity (FR root + `/en/`)
- [x] No secrets, no credentials
- [ ] Field results + final report — follow-up (#1077, #1078)

Closes #1076
Part of #1075