### PR TITLE
docs(marketing): competitive positioning map + formal positioning statement (FR + EN)

### DIFF
--- a/docs/marketing/needs-study/01-desk-competitors.md
+++ b/docs/marketing/needs-study/01-desk-competitors.md
@@ -92,12 +92,12 @@ rendre visible le **coin que personne n'occupe**. Les deux axes retenus, tirés 
 - **Brewer's Friend** — *puissant + un peu communautaire* : calculateurs réputés + parcours/copie de recettes, publication plafonnée. [MED]
 - **Little Bock** (FR) — *plutôt simple + un peu communautaire* : outil FR accessible, base de recettes, gratuit. [MED]
 - **Build-A-Beer** — *simple + communautaire* : génération de clone par IA + partage, gratuit. **Seul occupant de notre coin.** [HIGH]
-- **Brasse-Bouillon** (cible) — *simple/guidé + communautaire* : assistant débutant d'abord, puis clone versionné/crédité/re-scalé.
+- **Brasse-Bouillon** (cible) — *simple/guidé + communautaire* : assistant débutant d'abord, puis clone versionné, crédité, remis à l'échelle.
 
 **Lecture stratégique :**
 
 - Le coin *simple + communautaire* (haut-gauche) est **quasi vide** : seul **Build-A-Beer** y est → c'est notre champ de bataille, **pas** Brewfather/BeerSmith (qui dominent le bas-droit *puissant + solo*, terrain qu'on évite — cohérent avec « ne pas concourir sur le calcul »).
-- Différenciation *dans* le coin, face à Build-A-Beer : une génération IA jetable n'est pas une recette clone **versionnée + créditée + re-scalée** adossée à un **assistant guidé**. C'est la profondeur qui manque à Build-A-Beer.
+- Différenciation *dans* le coin, face à Build-A-Beer : une génération IA jetable n'est pas une recette clone **versionnée + créditée + remise à l'échelle** adossée à un **assistant guidé**. C'est la profondeur qui manque à Build-A-Beer.
 - Garde-fou : la zone communautaire est mortelle si menée *seule* (arrêt de Brew Guru, fév. 2026) → entrer par l'**assistant** (bas-gauche → haut-gauche), la communauté en **couche de rétention**.
 
 *Hypothèse à confirmer en terrain : ces placements reflètent la perception issue du desk, pas une mesure.*

--- a/docs/marketing/needs-study/01-desk-competitors.md
+++ b/docs/marketing/needs-study/01-desk-competitors.md
@@ -72,6 +72,36 @@ affirmations s'appuient sur des extraits de recherche et sont signalées comme t
 - **Bibliothèques de recettes communautaires : validées mais partiellement satisfaites et difficiles à monétiser.** Brewfather/Brewer's Friend montrent que les utilisateurs veulent parcourir/copier les recettes des autres — mais la publication est derrière un paywall et la copie est plafonnée, ce qui laisse une ouverture pour un modèle plus ouvert, centré sur le partage. Prudence : l'arrêt de Brew Guru en février 2026 montre que le social intégré à l'app n'est pas prouvé comme moteur *principal* de rétention ; aujourd'hui, l'essentiel de la « communauté » vit sur Reddit/Discord/Facebook/les forums.
 - **Implication :** la combinaison *clonage + partage ouvert* est le pilier le plus défendable. Présenter le « social » pur comme le tissu conjonctif autour du partage de clones, et non comme une fonctionnalité autonome. Les fonctionnalités fondations ciblent les 4 premiers besoins non satisfaits et constituent le minimum vital pour la rétention.
 
+## Carte de positionnement
+
+Une **carte de positionnement** place les concurrents sur deux axes qui comptent pour l'utilisateur, pour
+rendre visible le **coin que personne n'occupe**. Les deux axes retenus, tirés du desk :
+
+- **horizontal** : *Simple / guidé* ←→ *Puissant / orienté calcul-expert* ;
+- **vertical** : *Solo / privé* ←→ *Communautaire (partage de recettes)*.
+
+|  | **Simple / guidé** | **Puissant / calcul-expert** |
+|---|---|---|
+| **Communautaire (partage)** | ◎ **Brasse-Bouillon** (cible) · Build-A-Beer | Brewer's Friend |
+| **Solo / privé** | Little Bock | Brewfather · BeerSmith |
+
+**Placements (perception desk, niveau de confiance) :**
+
+- **BeerSmith** — extrême *puissant + solo* : héritage desktop, calculs profonds, partage quasi nul, données dupliquées. [HIGH]
+- **Brewfather** — *puissant + plutôt solo* : UX moderne, mais bibliothèque/publication derrière paywall → communauté bridée. [HIGH]
+- **Brewer's Friend** — *puissant + un peu communautaire* : calculateurs réputés + parcours/copie de recettes, publication plafonnée. [MED]
+- **Little Bock** (FR) — *plutôt simple + un peu communautaire* : outil FR accessible, base de recettes, gratuit. [MED]
+- **Build-A-Beer** — *simple + communautaire* : génération de clone par IA + partage, gratuit. **Seul occupant de notre coin.** [HIGH]
+- **Brasse-Bouillon** (cible) — *simple/guidé + communautaire* : assistant débutant d'abord, puis clone versionné/crédité/re-scalé.
+
+**Lecture stratégique :**
+
+- Le coin *simple + communautaire* (haut-gauche) est **quasi vide** : seul **Build-A-Beer** y est → c'est notre champ de bataille, **pas** Brewfather/BeerSmith (qui dominent le bas-droit *puissant + solo*, terrain qu'on évite — cohérent avec « ne pas concourir sur le calcul »).
+- Différenciation *dans* le coin, face à Build-A-Beer : une génération IA jetable n'est pas une recette clone **versionnée + créditée + re-scalée** adossée à un **assistant guidé**. C'est la profondeur qui manque à Build-A-Beer.
+- Garde-fou : la zone communautaire est mortelle si menée *seule* (arrêt de Brew Guru, fév. 2026) → entrer par l'**assistant** (bas-gauche → haut-gauche), la communauté en **couche de rétention**.
+
+*Hypothèse à confirmer en terrain : ces placements reflètent la perception issue du desk, pas une mesure.*
+
 ## Sources
 - https://homebrewacademy.com/brewing-software-comparison/
 - https://play.google.com/store/apps/details?id=com.warpkode.brewfather&hl=en_US

--- a/docs/marketing/needs-study/04-synthesis.md
+++ b/docs/marketing/needs-study/04-synthesis.md
@@ -105,7 +105,7 @@ fidéliser, mais ne différencient pas (les acteurs en place font déjà la plup
 > de brassage que vous attendez, et sans verrouillage.
 
 **Découpage formel (template Geoffrey Moore)** — chaque case s'appuie sur le desk et la
-[carte de positionnement](/01-desk-competitors) ; à confirmer en entretiens :
+[carte de positionnement](/01-desk-competitors#carte-de-positionnement) ; à confirmer en entretiens :
 
 | Case | Contenu |
 |---|---|

--- a/docs/marketing/needs-study/04-synthesis.md
+++ b/docs/marketing/needs-study/04-synthesis.md
@@ -95,12 +95,31 @@ fidéliser, mais ne différencient pas (les acteurs en place font déjà la plup
 - **La sensibilité à la paternité est forte en EN mais peu étayée en FR** — ne pas supposer qu'elle se transfère ;
   à tester explicitement en entretiens (voir ci-dessous).
 
-## Positionnement en une phrase (brouillon, à valider)
+## Positionnement (brouillon, à valider en terrain)
+
+**Énoncé en une phrase :**
 
 > Pour les brasseurs amateurs réguliers qui veulent recréer de façon fiable les bières qu'ils aiment,
 > Brasse-Bouillon est l'application de recettes communautaire où les clones sont affinés collaborativement,
 > crédités et remis à l'échelle de votre propre installation — avec l'organisation des recettes et le suivi
 > de brassage que vous attendez, et sans verrouillage.
+
+**Découpage formel (template Geoffrey Moore)** — chaque case s'appuie sur le desk et la
+[carte de positionnement](/01-desk-competitors) ; à confirmer en entretiens :
+
+| Case | Contenu |
+|---|---|
+| **Pour** (cible) | les brasseurs amateurs réguliers |
+| **qui** (besoin) | veulent recréer de façon fiable les bières qu'ils aiment, sans repartir de zéro |
+| **Brasse-Bouillon est** (catégorie) | l'application de recettes-clones **communautaire** |
+| **qui** (bénéfice clé) | affine collaborativement chaque clone, **crédite ses auteurs** et le **remet à l'échelle** de votre équipement — avec l'organisation et le suivi de brassage attendus, sans verrouillage |
+| **Contrairement à** (alternatives) | la génération IA *jetable* de Build-A-Beer, et les calculateurs (Brewfather, Brewer's Friend, BeerSmith) qui mettent la publication derrière un paywall et effacent la paternité |
+| **nous** (différenciation) | donnons à chaque clone une **lignée créditée et versionnée** que la communauté améliore dans le temps |
+
+**Tagline (piste, à tester) :** *« Le clone, en mieux — ensemble. »*
+
+> Garde-fou : le positionnement *mène* par l'assistant guidé (entrée à faible risque) ; la communauté
+> de clones est la **profondeur** qui retient, pas l'accroche d'acquisition (cf. arrêt de Brew Guru).
 
 ## Étape suivante : recherche primaire
 

--- a/docs/marketing/needs-study/b4-swot.md
+++ b/docs/marketing/needs-study/b4-swot.md
@@ -5,7 +5,7 @@ Première synthèse SWOT issue du desk — *à valider/affiner après le terrain
 
 | Interne | |
 |---|---|
-| **Forces** | Fondateur = membre de sa cible (débutant) → empathie & dogfooding. Conviction forte. Créneau différenciant identifié (clone versionné/crédité/re-scalé). Charte & site déjà en place. |
+| **Forces** | Fondateur = membre de sa cible (débutant) → empathie & dogfooding. Conviction forte. Créneau différenciant identifié (clone versionné, crédité, remis à l'échelle). Charte & site déjà en place. |
 | **Faiblesses** | Solo, temps contraint. **Pas dans la cible intermédiaire** (pour la couche communauté). Budget **0 €**. Recrutement terrain **à froid** (nouveau dans les communautés). Pas encore de produit testable. |
 
 | Externe | |

--- a/docs/marketing/needs-study/en/01-desk-competitors.md
+++ b/docs/marketing/needs-study/en/01-desk-competitors.md
@@ -71,6 +71,36 @@ are listing summaries at time of search (May 2026).
 - **Community recipe libraries: validated but partly served and hard to monetize.** Brewfather/Brewer's Friend show users want to browse/copy others' recipes — but publishing is paywalled and copying is capped, leaving an opening for a more open, sharing-first model. Caution: Brew Guru's Feb-2026 sunset shows in-app social is unproven as a *primary* retention driver; most "community" lives on Reddit/Discord/Facebook/forums today.
 - **Implication:** the *cloning + open sharing* combination is the most defensible hero. Frame pure "social" as connective tissue around clone-sharing, not a standalone feature. Foundation features target the top-4 unmet needs and are table-stakes for retention.
 
+## Positioning map
+
+A **positioning map** places competitors on two axes that matter to the user, to make the **corner nobody
+occupies** visible. The two axes, drawn from the desk research:
+
+- **horizontal**: *Simple / guided* ←→ *Powerful / calculation-expert*;
+- **vertical**: *Solo / private* ←→ *Community (recipe sharing)*.
+
+|  | **Simple / guided** | **Powerful / calc-expert** |
+|---|---|---|
+| **Community (sharing)** | ◎ **Brasse-Bouillon** (target) · Build-A-Beer | Brewer's Friend |
+| **Solo / private** | Little Bock | Brewfather · BeerSmith |
+
+**Placements (desk perception, confidence level):**
+
+- **BeerSmith** — far *powerful + solo*: desktop heritage, deep calculations, near-zero sharing, duplicated data. [HIGH]
+- **Brewfather** — *powerful + mostly solo*: modern UX, but library/publishing paywalled → community capped. [HIGH]
+- **Brewer's Friend** — *powerful + somewhat community*: reputed calculators + recipe browsing/copying, publishing capped. [MED]
+- **Little Bock** (FR) — *fairly simple + somewhat community*: accessible FR tool, recipe base, free. [MED]
+- **Build-A-Beer** — *simple + community*: AI clone-recipe generation + sharing, free. **Sole occupant of our corner.** [HIGH]
+- **Brasse-Bouillon** (target) — *simple/guided + community*: beginner assistant first, then versioned/credited/re-scaled clone.
+
+**Strategic reading:**
+
+- The *simple + community* corner (top-left) is **near-empty**: only **Build-A-Beer** sits there → that is our battleground, **not** Brewfather/BeerSmith (who dominate the bottom-right *powerful + solo*, terrain we avoid — consistent with "don't compete on calculation").
+- Differentiation *within* the corner, against Build-A-Beer: disposable AI generation is not a **versioned + credited + re-scaled** community clone recipe backed by a **guided assistant**. That is the depth Build-A-Beer lacks.
+- Guardrail: the community zone is lethal if led *alone* (Brew Guru sunset, Feb 2026) → enter via the **assistant** (bottom-left → top-left), community as a **retention layer**.
+
+*Hypothesis to confirm in the field: these placements reflect desk-derived perception, not a measurement.*
+
 ## Sources
 - https://homebrewacademy.com/brewing-software-comparison/
 - https://play.google.com/store/apps/details?id=com.warpkode.brewfather&hl=en_US

--- a/docs/marketing/needs-study/en/01-desk-competitors.md
+++ b/docs/marketing/needs-study/en/01-desk-competitors.md
@@ -76,7 +76,7 @@ are listing summaries at time of search (May 2026).
 A **positioning map** places competitors on two axes that matter to the user, to make the **corner nobody
 occupies** visible. The two axes, drawn from the desk research:
 
-- **horizontal**: *Simple / guided* ←→ *Powerful / calculation-expert*;
+- **horizontal**: *Simple / guided* ←→ *Powerful / calc-expert*;
 - **vertical**: *Solo / private* ←→ *Community (recipe sharing)*.
 
 |  | **Simple / guided** | **Powerful / calc-expert** |
@@ -91,12 +91,12 @@ occupies** visible. The two axes, drawn from the desk research:
 - **Brewer's Friend** — *powerful + somewhat community*: reputed calculators + recipe browsing/copying, publishing capped. [MED]
 - **Little Bock** (FR) — *fairly simple + somewhat community*: accessible FR tool, recipe base, free. [MED]
 - **Build-A-Beer** — *simple + community*: AI clone-recipe generation + sharing, free. **Sole occupant of our corner.** [HIGH]
-- **Brasse-Bouillon** (target) — *simple/guided + community*: beginner assistant first, then versioned/credited/re-scaled clone.
+- **Brasse-Bouillon** (target) — *simple/guided + community*: beginner assistant first, then versioned/credited/rescaled clone.
 
 **Strategic reading:**
 
 - The *simple + community* corner (top-left) is **near-empty**: only **Build-A-Beer** sits there → that is our battleground, **not** Brewfather/BeerSmith (who dominate the bottom-right *powerful + solo*, terrain we avoid — consistent with "don't compete on calculation").
-- Differentiation *within* the corner, against Build-A-Beer: disposable AI generation is not a **versioned + credited + re-scaled** community clone recipe backed by a **guided assistant**. That is the depth Build-A-Beer lacks.
+- Differentiation *within* the corner, against Build-A-Beer: disposable AI generation is not a **versioned + credited + rescaled** community clone recipe backed by a **guided assistant**. That is the depth Build-A-Beer lacks.
 - Guardrail: the community zone is lethal if led *alone* (Brew Guru sunset, Feb 2026) → enter via the **assistant** (bottom-left → top-left), community as a **retention layer**.
 
 *Hypothesis to confirm in the field: these placements reflect desk-derived perception, not a measurement.*

--- a/docs/marketing/needs-study/en/04-synthesis.md
+++ b/docs/marketing/needs-study/en/04-synthesis.md
@@ -98,7 +98,7 @@ do not differentiate (incumbents already do most, and win on calculation).
 > setup — with the recipe organization and brew tracking you'd expect, and no lock-in.
 
 **Formal slots (Geoffrey Moore template)** — each slot rests on the desk research and the
-[positioning map](/en/01-desk-competitors); to confirm in interviews:
+[positioning map](/en/01-desk-competitors#positioning-map); to confirm in interviews:
 
 | Slot | Content |
 |---|---|

--- a/docs/marketing/needs-study/en/04-synthesis.md
+++ b/docs/marketing/needs-study/en/04-synthesis.md
@@ -89,11 +89,30 @@ do not differentiate (incumbents already do most, and win on calculation).
 - **Attribution-sensitivity is strong in EN but under-evidenced in FR** — do not assume it transfers;
   test explicitly in interviews (see below).
 
-## One-sentence positioning (draft, to validate)
+## Positioning (draft, to validate in the field)
+
+**One-sentence statement:**
 
 > For regular homebrewers who want to reliably recreate the beers they love, Brasse-Bouillon is the
 > community recipe app where clones are collaboratively refined, credited, and rescaled to your own
 > setup — with the recipe organization and brew tracking you'd expect, and no lock-in.
+
+**Formal slots (Geoffrey Moore template)** — each slot rests on the desk research and the
+[positioning map](/en/01-desk-competitors); to confirm in interviews:
+
+| Slot | Content |
+|---|---|
+| **For** (target) | regular homebrewers |
+| **who** (need) | want to reliably recreate the beers they love, without starting from scratch |
+| **Brasse-Bouillon is** (category) | the **community** clone-recipe app |
+| **that** (key benefit) | collaboratively refines each clone, **credits its authors**, and **rescales** it to your equipment — with the organization and brew tracking you'd expect, no lock-in |
+| **Unlike** (alternatives) | Build-A-Beer's *disposable* AI generation, and calculators (Brewfather, Brewer's Friend, BeerSmith) that paywall publishing and strip authorship |
+| **we** (differentiation) | give each clone a **credited, versioned lineage** the community improves over time |
+
+**Tagline (candidate, to test):** *"The clone, made better — together."*
+
+> Guardrail: the positioning *leads* with the guided assistant (low-risk entry); the clone community is
+> the **depth** that retains, not the acquisition hook (cf. the Brew Guru sunset).
 
 ## Next step: primary research
 

--- a/docs/marketing/needs-study/lean-canvas.md
+++ b/docs/marketing/needs-study/lean-canvas.md
@@ -8,7 +8,7 @@ après le terrain. *(Première version — issue du desk, à valider en entretie
 | **Problème** | (1) Réussir son brassage est intimidant pour un débutant — peur de rater, jargon, outils complexes. (2) Reproduire une bière qu'on aime est difficile (clones faux/statiques). (3) Recettes & brassins éparpillés. |
 | **Segments de clientèle** | **Tête de pont : brasseurs amateurs débutants** (dont le fondateur). Puis réguliers, puis intermédiaires. Early adopters : nouveaux brasseurs FR + EN (40 % ont commencé < 4 ans). |
 | **Proposition de valeur unique** | « L'app qui t'accompagne pas à pas pour réussir chaque brassin — puis grandit avec toi vers une communauté de recettes. » |
-| **Solution** | Assistant de brassage guidé (étapes, timers, le « pourquoi ») + catalogue calibré + suivi de fermentation. Plus tard : clone communautaire versionné/crédité/re-scalé. |
+| **Solution** | Assistant de brassage guidé (étapes, timers, le « pourquoi ») + catalogue calibré + suivi de fermentation. Plus tard : clone communautaire versionné, crédité, remis à l'échelle. |
 | **Canaux** | Communautés brasseurs (forums FR, r/Homebrewing, groupes FB) en « débutant qui apprend » ; LinkedIn (build-in-public, FR) ; Indie Hackers (EN). Organique, 0 budget. |
 | **Revenus** | Freemium : cœur gratuit (assistant + suivi), payant = export BeerXML/BeerJSON et fonctions avancées. Tier gratuit généreux (sensibilité prix FR forte). |
 | **Structure de coûts** | Dev solo (temps), hébergement, API. Pas de budget marketing — acquisition par le contenu et la communauté. |


### PR DESCRIPTION
## Summary

Two desk-derived additions to the marketing needs study, both bilingual (FR + EN):

- **Competitive positioning map** (section B / competition): a 2×2 perceptual map — *Simple/guided ↔ Powerful/calc-expert* × *Solo/private ↔ Community* — placing Brewfather, BeerSmith, Brewer's Friend, Little Bock, Build-A-Beer, and Brasse-Bouillon. Each placement carries a confidence level. Makes the unoccupied wedge (simple + community) visible and identifies **Build-A-Beer** as the direct threat.
- **Formal positioning statement** (synthesis): the existing one-liner kept, plus a slotted Geoffrey Moore template (For / who / category / benefit / unlike / differentiation) and a candidate tagline.

## Context

Follows the desk research already merged in #1086. The desk analysis is now at maturity; these are the final desk-derivable bricks before field validation. All content is labeled "draft, to validate in the field" — the survey (#1077) will confirm or refute the placements and the positioning. Rendered as sober Markdown (a 2×2 table + slot table), no new dependencies.

## Checklist

- [x] Docs site builds (`npm run docs:build`)
- [x] Bilingual parity (FR root + `/en/`)
- [x] No secrets, no AI attribution
- [ ] Field validation — follow-up (#1077)

Part of #1075