### PR TITLE
feat(website): native 12-question brewer survey on the landing page

### DIFF
--- a/docs/marketing/needs-study/c-diffusion.md
+++ b/docs/marketing/needs-study/c-diffusion.md
@@ -1,7 +1,8 @@
 # C · Kit de diffusion du sondage
 
 Posts **prêts à coller** pour recruter des réponses au [sondage](/c-sondage), de façon passive et
-respectueuse des communautés. Remplace `[LIEN DU SONDAGE]` par l'URL réelle du Google Form une fois créé.
+respectueuse des communautés. Le sondage est **natif sur le site** (formulaire Formspree, section
+« Participer ») : le lien à diffuser est **https://brasse-bouillon.com/#participerFr**.
 
 ::: tip Principes (pour ne pas se faire retirer / downvoter)
 - **Cadrage « débutant qui apprend »**, jamais « teste mon app ».
@@ -27,7 +28,7 @@ J'ai préparé un court questionnaire (3-5 min) pour apprendre de vos pratiques 
 ça m'aiderait énormément. Je partagerai bien sûr une synthèse des réponses ici
 même, pour que ça serve à tout le monde.
 
-[LIEN DU SONDAGE]
+https://brasse-bouillon.com/#participerFr
 
 Merci beaucoup pour votre temps ! (Un contact est demandé en option à la fin,
 uniquement si vous acceptez un échange ; il n'est jamais partagé.)
@@ -42,7 +43,7 @@ Je débute le brassage et je cherche à comprendre comment vous gérez vos recet
 et vos brassins. Petit questionnaire de 3-5 min — ça m'aide beaucoup, et je
 partagerai les résultats au groupe.
 
-[LIEN DU SONDAGE]
+https://brasse-bouillon.com/#participerFr
 
 Merci ! (Contact optionnel en fin de questionnaire, jamais partagé.)
 ```
@@ -70,11 +71,15 @@ commentaire. Je partagerai ce que j'apprends, ici, au fil de l'eau.
 #brassage #buildinpublic #reconversion #produit
 ```
 
-**Premier commentaire (à poster juste après) :** `Le questionnaire (3-5 min) : [LIEN DU SONDAGE] — merci à ceux qui prennent le temps !`
+**Premier commentaire (à poster juste après) :** `Le questionnaire (3-5 min) : https://brasse-bouillon.com/#participerFr — merci à ceux qui prennent le temps !`
 
 ## 4 · r/Homebrewing (EN, rules-aware)
 
 ⚠ Lire d'abord les règles du sub : beaucoup interdisent les sondages hors fil dédié. Proposer aux modos.
+
+> **En attente d'un formulaire EN.** Le sondage natif du site est **FR uniquement** (la page EN est encore
+> un « coming soon ») : ne pas envoyer une audience anglophone vers le formulaire FR. Garder ce post **en
+> réserve** jusqu'à la mise en ligne d'une version EN du formulaire (`[SURVEY LINK]` = à remplir alors).
 
 **Title:** New to brewing — how do you manage your recipes and batches? (quick survey)
 
@@ -95,7 +100,8 @@ never shared.) Mods — happy to move this to a dedicated thread if you prefer.
 
 ## 5 · CTA site web — section « Participer » (FR)
 
-À câbler quand le lien existe (lien, pas iframe, pour le consentement RGPD ; parité FR/EN obligatoire).
+**Déjà en place sur le site** : le formulaire est natif dans la section « Participer » de
+`index.html` (Formspree, consentement RGPD intégré). Copie de référence ci-dessous.
 
 ```
 Aide-nous à construire la bonne app
@@ -103,7 +109,7 @@ Aide-nous à construire la bonne app
 Brasse-Bouillon se construit avec vous. Répondez à notre court questionnaire
 (3-5 min) : vos réponses orientent directement ce qu'on développe.
 
-[ Bouton : Donner mon avis → [LIEN DU SONDAGE] ]
+[ Bouton : Donner mon avis → https://brasse-bouillon.com/#participerFr ]
 
 Contact optionnel, jamais partagé.
 ```

--- a/docs/marketing/needs-study/c-resultats.md
+++ b/docs/marketing/needs-study/c-resultats.md
@@ -10,7 +10,7 @@ du sondage. C'est **l'action n°1** de l'étude (validation-first) — voir le [
 - **Qualitatif — 10-15 entretiens** de brasseurs (EN via r/Homebrewing, FR via brassageamateur), cadrage
   « débutant qui apprend ». Cible réaliste vu les contraintes : **viser la profondeur**, accepter un
   échantillon modeste et l'**afficher honnêtement**.
-- **Quantitatif — un sondage** (Google Forms) diffusé dans les communautés, pour chiffrer les besoins et
+- **Quantitatif — un sondage** (formulaire natif du site, Formspree) diffusé dans les communautés, pour chiffrer les besoins et
   commencer à combler le **trou de données FR**.
 
 ## Hypothèses prioritaires à trancher

--- a/docs/marketing/needs-study/c-sondage.md
+++ b/docs/marketing/needs-study/c-sondage.md
@@ -7,7 +7,8 @@ hypothèses de l'étude et commencer à **chiffrer** les besoins (et combler le 
 ::: tip Méthode
 Court et surtout **fermé** (max de réponses, données chiffrables) + 2 questions ouvertes pour le *pourquoi*.
 Dernière question = **opt-in** pour un échange de 15 min → les volontaires viennent à toi, sans démarchage.
-Cadrage « débutant qui apprend » (pas « teste mon app »). À créer en **Google Forms** (gratuit).
+Cadrage « débutant qui apprend » (pas « teste mon app »). Hébergé en **formulaire natif sur le site**
+(Formspree), section « Participer » — pas de Google Forms.
 :::
 
 ## Texte d'introduction (à mettre en tête du formulaire / du post)

--- a/docs/marketing/needs-study/en/c-distribution.md
+++ b/docs/marketing/needs-study/en/c-distribution.md
@@ -1,7 +1,8 @@
 # C · Survey distribution kit
 
 **Ready-to-paste** posts to recruit responses to the [survey](/en/c-survey), passively and respectfully
-of each community. Replace `[SURVEY LINK]` with the real Google Form URL once created.
+of each community. The survey is **native on the site** (Formspree form, "Participate" section): the link
+to share is **https://brasse-bouillon.com/#participerFr** (FR only for now — see the r/Homebrewing note).
 
 ::: tip Principles (so you don't get removed / downvoted)
 - **"Beginner who's learning" framing**, never "test my app".
@@ -25,7 +26,7 @@ expérimentés, gérez vos recettes, vos brassins et vos notes au quotidien.
 J'ai préparé un court questionnaire (3-5 min) pour apprendre de vos pratiques —
 ça m'aiderait énormément. Je partagerai bien sûr une synthèse des réponses ici.
 
-[LIEN DU SONDAGE]
+https://brasse-bouillon.com/#participerFr
 
 Merci beaucoup ! (Contact optionnel à la fin, jamais partagé.)
 ```
@@ -39,7 +40,7 @@ Je débute le brassage et je cherche à comprendre comment vous gérez vos recet
 et vos brassins. Petit questionnaire de 3-5 min — ça m'aide beaucoup, et je
 partagerai les résultats au groupe.
 
-[LIEN DU SONDAGE]
+https://brasse-bouillon.com/#participerFr
 
 Merci ! (Contact optionnel, jamais partagé.)
 ```
@@ -67,11 +68,15 @@ partagerai ce que j'apprends, au fil de l'eau.
 #brassage #buildinpublic #reconversion #produit
 ```
 
-**First comment:** `Le questionnaire (3-5 min) : [LIEN DU SONDAGE] — merci !`
+**First comment:** `Le questionnaire (3-5 min) : https://brasse-bouillon.com/#participerFr — merci !`
 
 ## 4 · r/Homebrewing (EN, rules-aware)
 
 ⚠ Read the sub's rules first: many disallow surveys outside a dedicated thread. Offer to move it.
+
+> **Waiting on an EN form.** The native site survey is **FR only** (the EN page is still a "coming soon"):
+> don't send an English-speaking audience to the FR form. Keep this post **on hold** until an EN version of
+> the form ships (`[SURVEY LINK]` = fill in then).
 
 **Title:** New to brewing — how do you manage your recipes and batches? (quick survey)
 
@@ -92,7 +97,8 @@ never shared.) Mods — happy to move this to a dedicated thread if you prefer.
 
 ## 5 · Website CTA — "Participate" section (EN)
 
-To wire once the link exists (link, not iframe, for GDPR consent; FR/EN parity required).
+The FR survey is **already live** in the site's "Participate" section (native Formspree form). The EN copy
+below is for when the **EN site page** ships (today it is a "coming soon" stub).
 
 ```
 Help us build the right app

--- a/docs/marketing/needs-study/en/c-resultats.md
+++ b/docs/marketing/needs-study/en/c-resultats.md
@@ -10,7 +10,7 @@ study's **#1 action** (validation-first) — see the [interview guide](/en/05-in
 - **Qualitative — 10-15 interviews** of brewers (EN via r/Homebrewing, FR via brassageamateur), framed as
   "a beginner who's learning". Realistic target given the constraints: **aim for depth**, accept a modest
   sample, and **state it honestly**.
-- **Quantitative — a survey** (Google Forms) distributed in the communities, to quantify needs and begin
+- **Quantitative — a survey** (native site form, Formspree) distributed in the communities, to quantify needs and begin
   filling the **FR data gap**.
 
 ## Priority hypotheses to settle

--- a/docs/marketing/needs-study/en/c-survey.md
+++ b/docs/marketing/needs-study/en/c-survey.md
@@ -7,7 +7,8 @@ and start to **quantify** needs (and fill the FR data gap).
 ::: tip Method
 Short and mostly **closed** (max responses, quantifiable) + 2 open questions for the *why*. The last
 question is an **opt-in** for a 15-min chat → volunteers come to you, no cold outreach. Framed as "a
-beginner who's learning" (not "test my app"). Build it in **Google Forms** (free).
+beginner who's learning" (not "test my app"). Hosted as a **native form on the site** (Formspree),
+"Participate" section — no Google Forms.
 :::
 
 ## Intro text (top of the form / post)

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -42,7 +42,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="site.css?v=20260521-2">
+  <link rel="stylesheet" href="site.css?v=20260523">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -343,76 +343,145 @@
 
         <form id="questionnaireFormFr" class="questionnaire-form" data-open="false" inert>
           <div class="questionnaire-inner">
-            <input type="hidden" name="_subject" value="Nouvelle réponse - Questionnaire Brasse-Bouillon (FR)">
+            <input type="hidden" name="_subject" value="Nouvelle réponse - Sondage brasseurs Brasse-Bouillon (FR)">
             <input type="hidden" name="lang" value="fr">
             <input class="honeypot" type="text" name="_gotcha">
 
+            <p class="questionnaire-lead">
+              3 à 5 minutes pour nous aider à construire la bonne app. Tes réponses orientent directement ce
+              qu’on développe. Tout est anonyme ; un contact n’est demandé qu’à la fin, en option.
+            </p>
+
             <div class="questionnaire-grid">
               <fieldset class="form-field-full">
-                <legend>Tu en es où dans le brassage ?</legend>
+                <legend>Depuis combien de temps brasses-tu ?</legend>
                 <div class="chip-list">
-                  <label><input type="radio" name="profil" value="Curieux" required>Curieux, j’hésite à me lancer</label>
-                  <label><input type="radio" name="profil" value="Kit teste">J’ai testé un kit, j’ai envie d’aller plus loin</label>
-                  <label><input type="radio" name="profil" value="Regulier">Je brasse régulièrement, j’ai ma routine</label>
-                  <label><input type="radio" name="profil" value="Pro">Pro / micro-brasserie</label>
+                  <label><input type="radio" name="anciennete" value="< 6 mois" required>Moins de 6 mois</label>
+                  <label><input type="radio" name="anciennete" value="6 mois - 2 ans">6 mois à 2 ans</label>
+                  <label><input type="radio" name="anciennete" value="2 - 5 ans">2 à 5 ans</label>
+                  <label><input type="radio" name="anciennete" value="5 ans et +">5 ans et plus</label>
                 </div>
               </fieldset>
 
               <fieldset class="form-field-full">
-                <legend>Combien de brassins par an, en moyenne ?</legend>
+                <legend>Combien de brassins par an, environ ?</legend>
                 <div class="chip-list">
-                  <label><input type="radio" name="frequence" value="Aucun">Aucun pour l’instant</label>
-                  <label><input type="radio" name="frequence" value="1-3">1 à 3</label>
-                  <label><input type="radio" name="frequence" value="4-10">4 à 10</label>
-                  <label><input type="radio" name="frequence" value="10+">Plus de 10</label>
+                  <label><input type="radio" name="frequence" value="0-2" required>0 à 2</label>
+                  <label><input type="radio" name="frequence" value="3-6">3 à 6</label>
+                  <label><input type="radio" name="frequence" value="7-12">7 à 12</label>
+                  <label><input type="radio" name="frequence" value="12+">12 et plus</label>
                 </div>
               </fieldset>
 
               <fieldset class="form-field-full">
-                <legend>Ce qui te bloque le plus <span class="legend-hint">(jusqu’à 3 choix)</span></legend>
+                <legend>Tu brasses où ?</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="lieu" value="France">France</label>
+                  <label><input type="radio" name="lieu" value="Belgique">Belgique</label>
+                  <label><input type="radio" name="lieu" value="Suisse">Suisse</label>
+                  <label><input type="radio" name="lieu" value="Québec">Québec</label>
+                  <label><input type="radio" name="lieu" value="Autre">Autre</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>Où vivent tes recettes et tes notes de brassin aujourd’hui ? <span class="legend-hint">(plusieurs réponses)</span></legend>
                 <div class="chip-list chip-list-multi">
-                  <label><input type="checkbox" name="blocages[]" value="Calculs">Les calculs (IBU, ABV, densité)</label>
-                  <label><input type="checkbox" name="blocages[]" value="Recette">Choisir une recette adaptée</label>
-                  <label><input type="checkbox" name="blocages[]" value="Pilotage">Le pilotage des étapes le jour J</label>
-                  <label><input type="checkbox" name="blocages[]" value="Fermentation">Le suivi de la fermentation</label>
-                  <label><input type="checkbox" name="blocages[]" value="Materiel">Choisir mon matériel</label>
-                  <label><input type="checkbox" name="blocages[]" value="Reproduire">Reproduire un brassin réussi</label>
-                  <label><input type="checkbox" name="blocages[]" value="Partage">Échanger avec d’autres brasseurs</label>
-                  <label><input type="checkbox" name="blocages[]" value="Aucun">Rien, tout roule</label>
+                  <label><input type="checkbox" name="stockage[]" value="Dans ma tête">Dans ma tête</label>
+                  <label><input type="checkbox" name="stockage[]" value="Papier / carnet">Papier / carnet</label>
+                  <label><input type="checkbox" name="stockage[]" value="Tableur">Tableur (Excel, Sheets)</label>
+                  <label><input type="checkbox" name="stockage[]" value="Une application">Une application</label>
+                  <label><input type="checkbox" name="stockage[]" value="Sur un forum">Sur un forum</label>
+                  <label><input type="checkbox" name="stockage[]" value="Autre">Autre</label>
                 </div>
               </fieldset>
 
               <fieldset class="form-field-full">
-                <legend>Si tu n’avais qu’une seule fonction dans l’app, ce serait…</legend>
-                <div class="chip-list">
-                  <label><input type="radio" name="killer" value="Guide">Un guide pas-à-pas pendant le brassin</label>
-                  <label><input type="radio" name="killer" value="Calculs">Un calculateur fiable (IBU/ABV/couleur)</label>
-                  <label><input type="radio" name="killer" value="Recettes">Un livre de recettes prêtes à brasser</label>
-                  <label><input type="radio" name="killer" value="Fermentation">Un suivi de fermentation visuel</label>
-                  <label><input type="radio" name="killer" value="Journal">Un journal de mes brassins</label>
-                  <label><input type="radio" name="killer" value="Social">Un espace pour partager / comparer</label>
-                </div>
-              </fieldset>
-
-              <fieldset class="form-field-full">
-                <legend>Tu serais prêt(e) à payer pour la version complète ?</legend>
-                <div class="chip-list">
-                  <label><input type="radio" name="payant" value="Gratuit">Non, je veux du gratuit</label>
-                  <label><input type="radio" name="payant" value="Quelques euros">Quelques € / an</label>
-                  <label><input type="radio" name="payant" value="5-10">5 à 10 € / mois</label>
-                  <label><input type="radio" name="payant" value="Sais pas">Je ne sais pas encore</label>
+                <legend>Quel(s) outil(s) ou app utilises-tu ? <span class="legend-hint">(plusieurs réponses)</span></legend>
+                <div class="chip-list chip-list-multi">
+                  <label><input type="checkbox" name="outils[]" value="Brewfather">Brewfather</label>
+                  <label><input type="checkbox" name="outils[]" value="BeerSmith">BeerSmith</label>
+                  <label><input type="checkbox" name="outils[]" value="Little Bock">Little Bock</label>
+                  <label><input type="checkbox" name="outils[]" value="Brewer's Friend">Brewer’s Friend</label>
+                  <label><input type="checkbox" name="outils[]" value="Aucun">Aucun</label>
+                  <label><input type="checkbox" name="outils[]" value="Autre">Autre</label>
                 </div>
               </fieldset>
 
               <div class="form-field form-field-full">
-                <label for="qEmailFr">Email <span class="legend-hint">(optionnel — pour rester informé(e))</span></label>
+                <label for="qAgacementFr">Qu’est-ce qui t’agace le plus dans ta façon de gérer tes recettes / brassins ?</label>
+                <textarea id="qAgacementFr" name="agacement" rows="2" placeholder="En quelques mots…"></textarea>
+              </div>
+
+              <fieldset class="form-field-full">
+                <legend>T’arrive-t-il de rater un brassin, ou d’être perdu pendant le processus ?</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="difficulte" value="Souvent">Souvent</label>
+                  <label><input type="radio" name="difficulte" value="Parfois">Parfois</label>
+                  <label><input type="radio" name="difficulte" value="Rarement">Rarement</label>
+                  <label><input type="radio" name="difficulte" value="Jamais">Jamais</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>As-tu déjà essayé de reproduire (cloner) une bière commerciale précise ?</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="clone" value="Oui, réussi">Oui, réussi</label>
+                  <label><input type="radio" name="clone" value="Oui, mais déçu">Oui, mais déçu du résultat</label>
+                  <label><input type="radio" name="clone" value="Jamais, mais j'aimerais">Jamais essayé, mais j’aimerais</label>
+                  <label><input type="radio" name="clone" value="Pas intéressé">Pas intéressé</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>Partages-tu tes recettes avec d’autres brasseurs ?</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="partage" value="Souvent">Souvent</label>
+                  <label><input type="radio" name="partage" value="Parfois">Parfois</label>
+                  <label><input type="radio" name="partage" value="Non, mais ouvert">Non, mais je serais ouvert</label>
+                  <label><input type="radio" name="partage" value="Non, je garde">Non, je préfère les garder</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>Si tu partages une recette, être crédité comme auteur, ça compte pour toi ?</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="attribution" value="Beaucoup">Beaucoup</label>
+                  <label><input type="radio" name="attribution" value="Un peu">Un peu</label>
+                  <label><input type="radio" name="attribution" value="Pas du tout">Pas du tout</label>
+                  <label><input type="radio" name="attribution" value="Je ne partage pas">Je ne partage pas</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>Qu’est-ce qui te ferait essayer une nouvelle app de brassage ? <span class="legend-hint">(plusieurs réponses)</span></legend>
+                <div class="chip-list chip-list-multi">
+                  <label><input type="checkbox" name="declencheur[]" value="La simplicité">La simplicité</label>
+                  <label><input type="checkbox" name="declencheur[]" value="Gratuit">Gratuit</label>
+                  <label><input type="checkbox" name="declencheur[]" value="Suivi guidé pas-à-pas">Un suivi guidé pas-à-pas</label>
+                  <label><input type="checkbox" name="declencheur[]" value="Une communauté">Une communauté</label>
+                  <label><input type="checkbox" name="declencheur[]" value="Importer mes recettes">Pouvoir importer mes recettes</label>
+                  <label><input type="checkbox" name="declencheur[]" value="Autre">Autre</label>
+                </div>
+              </fieldset>
+
+              <fieldset class="form-field-full">
+                <legend>Serais-tu d’accord pour un échange de 15 min, pour m’en dire plus ?</legend>
+                <div class="chip-list">
+                  <label><input type="radio" name="entretien" value="Oui">Oui</label>
+                  <label><input type="radio" name="entretien" value="Non">Non</label>
+                </div>
+              </fieldset>
+
+              <div class="form-field form-field-full">
+                <label for="qEmailFr">Si oui, ton email ou pseudo <span class="legend-hint">(optionnel — jamais partagé)</span></label>
                 <input id="qEmailFr" type="email" name="email" placeholder="ton@email.fr">
               </div>
             </div>
 
             <label class="consent">
               <input type="checkbox" name="rgpd" value="accepted" required>
-              J’accepte que mes données soient utilisées dans le cadre du développement de Brasse-Bouillon.
+              J’accepte que mes réponses soient utilisées dans le cadre du développement de Brasse-Bouillon.
             </label>
             <p class="consent-note">
               Voir notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">politique de confidentialité</a>
@@ -420,7 +489,7 @@
             </p>
 
             <div class="actions actions-compact">
-              <button class="btn btn-primary" type="submit">Envoyer mon retour</button>
+              <button class="btn btn-primary" type="submit">Envoyer mes réponses</button>
             </div>
           </div>
         </form>
@@ -473,9 +542,7 @@
       formId: 'questionnaireFormFr',
       statusId: 'questionnaireStatusFr',
       endpoint: QUESTIONNAIRE_ENDPOINT,
-      checkboxLimits: [
-        { fieldName: 'blocages[]', maxChoices: 3, message: 'Maximum 3 choix pour cette question.' }
-      ],
+      checkboxLimits: [],
       messages: {
         endpointMissing: 'Endpoint Formspree du questionnaire non configuré.',
         sending: 'Envoi en cours…',

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -356,7 +356,7 @@
               <fieldset class="form-field-full">
                 <legend>Depuis combien de temps brasses-tu ?</legend>
                 <div class="chip-list">
-                  <label><input type="radio" name="anciennete" value="< 6 mois" required>Moins de 6 mois</label>
+                  <label><input type="radio" name="anciennete" value="Moins de 6 mois" required>Moins de 6 mois</label>
                   <label><input type="radio" name="anciennete" value="6 mois - 2 ans">6 mois à 2 ans</label>
                   <label><input type="radio" name="anciennete" value="2 - 5 ans">2 à 5 ans</label>
                   <label><input type="radio" name="anciennete" value="5 ans et +">5 ans et plus</label>
@@ -410,7 +410,7 @@
 
               <div class="form-field form-field-full">
                 <label for="qAgacementFr">Qu’est-ce qui t’agace le plus dans ta façon de gérer tes recettes / brassins ?</label>
-                <textarea id="qAgacementFr" name="agacement" rows="2" placeholder="En quelques mots…"></textarea>
+                <textarea id="qAgacementFr" class="textarea-compact" name="agacement" rows="2" placeholder="En quelques mots…"></textarea>
               </div>
 
               <fieldset class="form-field-full">
@@ -474,8 +474,8 @@
               </fieldset>
 
               <div class="form-field form-field-full">
-                <label for="qEmailFr">Si oui, ton email ou pseudo <span class="legend-hint">(optionnel — jamais partagé)</span></label>
-                <input id="qEmailFr" type="email" name="email" placeholder="ton@email.fr">
+                <label for="qContactFr">Si oui, ton email ou pseudo <span class="legend-hint">(optionnel — jamais partagé)</span></label>
+                <input id="qContactFr" type="text" name="contact" placeholder="ton@email.fr ou @pseudo">
               </div>
             </div>
 

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -1347,6 +1347,7 @@
     .questionnaire-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
     .form-field { display: flex; flex-direction: column; gap: 8px; }
     .form-field-full { grid-column: 1 / -1; }
+    .questionnaire-lead { margin: 0 0 4px; color: var(--ink); opacity: 0.85; font-size: 0.95rem; line-height: 1.5; }
 
     .form-field label, fieldset legend {
       font-weight: 600; color: var(--ink); font-size: 0.92rem;

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -1372,6 +1372,7 @@
     }
 
     textarea { min-height: 120px; resize: vertical; }
+    textarea.textarea-compact { min-height: 64px; }
 
     fieldset {
       margin: 0; padding: 14px 16px;


### PR DESCRIPTION
## Summary

Replaces the landing-page feedback questionnaire with the **needs-study survey** (12 questions), using the **existing tech** — the same Formspree endpoint and `BBShared.setupQuestionnaire` handler. No Google Forms, no third-party redirect: the survey is native and on-brand, which also removes the "link vs iframe" GDPR concern.

Questions: brewing tenure, batches/year, location, where recipes/notes live, tools used, biggest pain (free text), failure/feeling-lost frequency, clone attempts, sharing habits, authorship attribution, adoption trigger, and a 15-min interview opt-in with an optional contact field. Consent checkbox, honeypot, and the "Partager ton avis" toggle are preserved.

Also updates the needs-study distribution kit and survey/results pages to point at the native site form (`#participerFr`) instead of Google Forms.

## Context

The marketing needs study (#1075) needs a passive survey instrument. Rather than a separate Google Form, we reuse the site's own questionnaire infrastructure. FR only — the EN page (`index-en.html`) is a "coming soon" stub, so the r/Homebrewing (EN) distribution post is flagged on-hold until an EN form ships.

Tradeoff documented: Formspree delivers responses by email + dashboard (CSV export) rather than Google's auto-charts — acceptable for a modest passive sample.

## Checklist

- [x] Quality gate passes (`python scripts/quality_gate.py`) + gate tests (8 passed)
- [x] Study site builds (`npm run docs:build`)
- [x] Reuses existing Formspree endpoint + handler; obsolete `blocages[]` cap removed
- [x] `site.css` cache-bust bumped (`?v=20260523`); `.questionnaire-lead` style added
- [x] No secrets, no AI attribution
- [ ] EN survey form — follow-up when the EN landing page ships

Part of #1075