### PR TITLE
feat(website): embed the feedback widget on all pages (FR + EN)

### DIFF
--- a/packages/website/cookies-en.html
+++ b/packages/website/cookies-en.html
@@ -86,13 +86,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/cookies-en.html
+++ b/packages/website/cookies-en.html
@@ -81,5 +81,13 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/cookies-en.html
+++ b/packages/website/cookies-en.html
@@ -56,6 +56,11 @@
       own technical mechanisms to transmit messages. No advertising or profiling cookie is set by
       the website itself.
     </p>
+    <p>
+      The feedback widget (“Report”) uses your browser’s <strong>local storage</strong> (not cookies),
+      for purely technical purposes: rate-limiting submissions and queuing your messages if the network
+      drops. This data stays on your device and is not used for any tracking.
+    </p>
 
     <h2>3. Legal basis</h2>
     <p>

--- a/packages/website/cookies.html
+++ b/packages/website/cookies.html
@@ -88,13 +88,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/cookies.html
+++ b/packages/website/cookies.html
@@ -56,6 +56,12 @@
       sur des mécanismes techniques propres au prestataire pour la transmission des messages.
       Aucun cookie publicitaire ni de profilage n’est déposé par le site lui-même.
     </p>
+    <p>
+      Le widget de retour (« Signaler ») utilise le <strong>stockage local</strong> de votre navigateur
+      (et non des cookies), à des fins purement techniques : limiter le rythme des envois et mettre vos
+      messages en file d’attente en cas de coupure réseau. Ces données restent sur votre appareil et ne
+      servent à aucun suivi.
+    </p>
 
     <h2>3. Base légale</h2>
     <p>

--- a/packages/website/cookies.html
+++ b/packages/website/cookies.html
@@ -82,5 +82,13 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/feedback-widget.js
+++ b/packages/website/feedback-widget.js
@@ -1,0 +1,26 @@
+/**
+ * Brasse-Bouillon feedback widget loader.
+ *
+ * Single source for the "Report" widget, referenced by every page so its
+ * config lives in one place (no duplicated inline snippet to keep in sync).
+ *
+ * It loads the Cloudflare Worker widget bundle ONLY on the production domain:
+ * the Worker's CORS allow-list is prod-only, so on localhost / previews the
+ * submit flow would break and the third-party request would be pointless.
+ * The dynamic import keeps the worker bundle off non-prod pages entirely.
+ */
+const PROD_HOSTS = ['brasse-bouillon.com', 'www.brasse-bouillon.com'];
+const WIDGET_SRC =
+  'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js';
+const ENDPOINT =
+  'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest';
+
+if (PROD_HOSTS.includes(window.location.hostname)) {
+  import(WIDGET_SRC)
+    .then(({ mountFeedbackWidget }) => {
+      mountFeedbackWidget({ projectId: 'brasse-bouillon', endpoint: ENDPOINT });
+    })
+    .catch(() => {
+      /* The widget is non-critical UI; ignore load/network failures. */
+    });
+}

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -77,5 +77,13 @@
   </aside>
 
   <script src="site.js?v=20260521-2"></script>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -77,13 +77,7 @@
   </aside>
 
   <script src="site.js?v=20260521-2"></script>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -577,13 +577,7 @@
       }
     });
   </script>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -577,5 +577,13 @@
       }
     });
   </script>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/legal-en.html
+++ b/packages/website/legal-en.html
@@ -102,5 +102,13 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/legal-en.html
+++ b/packages/website/legal-en.html
@@ -102,13 +102,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/legal.html
+++ b/packages/website/legal.html
@@ -102,13 +102,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/legal.html
+++ b/packages/website/legal.html
@@ -102,5 +102,13 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -118,13 +118,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -108,5 +108,13 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -51,6 +51,11 @@
       <li>Contact details (email, message) through the contact form.</li>
       <li>Newsletter subscription data (email).</li>
       <li>Product questionnaire data (profile, usage, priorities, suggestions).</li>
+      <li>
+        Feedback sent through the “Report” widget: the message you write, plus minimal technical
+        context (the page, the previous page, browser, screen size, language). Sent only when you
+        click to submit.
+      </li>
     </ul>
     <p>
       The site uses no third-party audience measurement tool and no tracking cookies.
@@ -66,8 +71,9 @@
 
     <h2>4. Recipients and international transfers</h2>
     <p>
-      Data may be processed by technical processors (Formspree for receiving forms, GitHub Pages
-      for static hosting). These services may involve transfers outside the EU (including the US).
+      Data may be processed by technical processors (Formspree for receiving forms, a Cloudflare
+      Workers service for receiving the “Report” widget feedback, GitHub Pages for static hosting).
+      These services may involve transfers outside the EU (including the US).
       Where required, appropriate safeguards are used (such as standard contractual clauses or
       equivalent mechanisms).
     </p>

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -52,9 +52,11 @@
       <li>Newsletter subscription data (email).</li>
       <li>Product questionnaire data (profile, usage, priorities, suggestions).</li>
       <li>
-        Feedback sent through the “Report” widget: the message you write, plus minimal technical
-        context (the page, the previous page, browser, screen size, language). Sent only when you
-        click to submit.
+        Feedback sent through the “Report” widget: the feedback <em>content</em> (the message you write
+        + minimal technical context — the page, the previous page, browser, screen size, language) is
+        sent only when you click to submit. Note: simply loading the widget on the page already issues a
+        request to the third-party processor (Cloudflare), which then receives your IP address and the
+        request's standard headers.
       </li>
     </ul>
     <p>
@@ -67,6 +69,7 @@
       <li><strong>Replying to messages</strong>: legitimate interest and/or pre-contractual steps.</li>
       <li><strong>Sending newsletters</strong>: explicit consent (form checkbox).</li>
       <li><strong>Improving the product</strong> through questionnaire responses: explicit consent.</li>
+      <li><strong>Handling feedback</strong> sent via the “Report” widget: legitimate interest (fixing and improving the site/product).</li>
     </ul>
 
     <h2>4. Recipients and international transfers</h2>
@@ -83,6 +86,7 @@
       <li>Contact data: up to 3 years after the last interaction.</li>
       <li>Newsletter data: until unsubscribe, or 3 years of inactivity.</li>
       <li>Questionnaire data: up to 3 years for product analysis.</li>
+      <li>“Report” widget feedback: up to 2 years, then deleted or anonymized.</li>
     </ul>
 
     <h2>6. Your rights</h2>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -108,5 +108,13 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -118,13 +118,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -52,9 +52,11 @@
       <li>Données d’inscription newsletter (email).</li>
       <li>Données de questionnaire produit (profil, usages, priorités, suggestions).</li>
       <li>
-        Retours envoyés via le widget « Signaler » : le message que vous rédigez, accompagné d’un
-        contexte technique minimal (page concernée, page précédente, navigateur, taille d’écran, langue).
-        Transmis uniquement lorsque vous cliquez pour envoyer.
+        Retours envoyés via le widget « Signaler » : le <em>contenu</em> du retour (le message que vous
+        rédigez + un contexte technique minimal — page concernée, page précédente, navigateur, taille
+        d’écran, langue) n’est transmis que lorsque vous cliquez pour envoyer. À noter : le simple
+        chargement du widget sur la page déclenche déjà une requête vers le prestataire tiers
+        (Cloudflare), qui reçoit alors votre adresse IP et les en-têtes standard de la requête.
       </li>
     </ul>
     <p>
@@ -67,6 +69,7 @@
       <li><strong>Répondre aux messages</strong> : intérêt légitime et/ou mesures précontractuelles.</li>
       <li><strong>Envoyer la newsletter</strong> : consentement explicite (case à cocher au formulaire).</li>
       <li><strong>Améliorer le produit</strong> via questionnaire : consentement explicite.</li>
+      <li><strong>Traiter les retours</strong> envoyés via le widget « Signaler » : intérêt légitime (corriger et améliorer le site/produit).</li>
     </ul>
 
     <h2>4. Destinataires et transferts internationaux</h2>
@@ -83,6 +86,7 @@
       <li>Contact : jusqu’à 3 ans après le dernier échange.</li>
       <li>Newsletter : jusqu’au désabonnement ou 3 ans d’inactivité.</li>
       <li>Questionnaire : jusqu’à 3 ans pour l’analyse produit.</li>
+      <li>Retours du widget « Signaler » : jusqu’à 2 ans, puis suppression ou anonymisation.</li>
     </ul>
 
     <h2>6. Vos droits</h2>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -51,6 +51,11 @@
       <li>Données de contact (email, message) via formulaire de contact.</li>
       <li>Données d’inscription newsletter (email).</li>
       <li>Données de questionnaire produit (profil, usages, priorités, suggestions).</li>
+      <li>
+        Retours envoyés via le widget « Signaler » : le message que vous rédigez, accompagné d’un
+        contexte technique minimal (page concernée, page précédente, navigateur, taille d’écran, langue).
+        Transmis uniquement lorsque vous cliquez pour envoyer.
+      </li>
     </ul>
     <p>
       Le site n’utilise aucun outil de mesure d’audience tiers et aucun cookie de tracking.
@@ -67,7 +72,8 @@
     <h2>4. Destinataires et transferts internationaux</h2>
     <p>
       Les données peuvent être traitées par des sous-traitants techniques (Formspree pour la réception
-      des formulaires, GitHub Pages pour l’hébergement statique). Ces services peuvent impliquer des
+      des formulaires, un service Cloudflare Workers pour la réception des retours du widget « Signaler »,
+      GitHub Pages pour l’hébergement statique). Ces services peuvent impliquer des
       transferts hors UE (notamment vers les États-Unis). Lorsque nécessaire, des garanties appropriées
       sont utilisées (clauses contractuelles types ou mécanisme équivalent).
     </p>

--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -31,7 +31,25 @@ REQUIRED_FILES = [
     "favicon.ico",
     "sitemap.xml",
     "robots.txt",
+    "feedback-widget.js",
 ]
+
+# Every public HTML page must reference the feedback widget loader (a single
+# local module) so the "Report" button is never accidentally dropped from one
+# page during a future edit.
+WIDGET_HTML_FILES = [
+    "index.html",
+    "index-en.html",
+    "legal.html",
+    "legal-en.html",
+    "privacy.html",
+    "privacy-en.html",
+    "cookies.html",
+    "cookies-en.html",
+    "terms.html",
+    "terms-en.html",
+]
+WIDGET_LOADER = "feedback-widget.js"
 
 HTML_RULES = {
     "index.html": [
@@ -176,6 +194,21 @@ def check_html_files(root: Path = ROOT) -> list[str]:
     return errors
 
 
+def check_feedback_widget(root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    for rel_path in WIDGET_HTML_FILES:
+        full_path = root / rel_path
+        if not full_path.exists():
+            continue
+        content = full_path.read_text(encoding="utf-8")
+        if WIDGET_LOADER not in content:
+            errors.append(
+                f"{rel_path}: référence au widget de feedback "
+                f"({WIDGET_LOADER}) manquante"
+            )
+    return errors
+
+
 def check_sitemap_policy(root: Path = ROOT) -> list[str]:
     sitemap_path = root / "sitemap.xml"
     if not sitemap_path.exists():
@@ -231,6 +264,7 @@ def collect_errors(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     errors.extend(check_required_files(root))
     errors.extend(check_html_files(root))
+    errors.extend(check_feedback_widget(root))
     errors.extend(check_sitemap_policy(root))
     errors.extend(check_robots_policy(root))
     return errors

--- a/packages/website/terms-en.html
+++ b/packages/website/terms-en.html
@@ -107,5 +107,13 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/terms-en.html
+++ b/packages/website/terms-en.html
@@ -107,13 +107,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/terms.html
+++ b/packages/website/terms.html
@@ -106,13 +106,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
-  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
-  <script type="module">
-    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
-    mountFeedbackWidget({
-      projectId: 'brasse-bouillon',
-      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
-    })
-  </script>
+  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <script type="module" src="feedback-widget.js?v=20260523"></script>
 </body>
 </html>

--- a/packages/website/terms.html
+++ b/packages/website/terms.html
@@ -106,5 +106,13 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
+  <!-- Feedback widget (Cloudflare Worker; submissions only from the prod domain via CORS) -->
+  <script type="module">
+    import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
+    mountFeedbackWidget({
+      projectId: 'brasse-bouillon',
+      endpoint: 'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest',
+    })
+  </script>
 </body>
 </html>

--- a/packages/website/tests/test_quality_gate.py
+++ b/packages/website/tests/test_quality_gate.py
@@ -17,9 +17,11 @@ def _create_valid_fixture(base: Path) -> None:
     _write_file(base, "README.md", "# readme\n")
     _write_file(base, "CONTRIBUTING.md", "# contributing\n")
     _write_file(base, "favicon.ico", "ico")
+    _write_file(base, "feedback-widget.js", "// feedback widget loader\n")
+    widget_tag = '<script type="module" src="feedback-widget.js"></script>'
     legal_html_template = (
         '<!DOCTYPE html><html lang="{lang}"><head>'
-        "<title>{title}</title></head><body></body></html>"
+        f"<title>{{title}}</title></head><body>{widget_tag}</body></html>"
     )
     legal_pages = [
         ("legal.html", "fr", "legal"),
@@ -57,6 +59,7 @@ def _create_valid_fixture(base: Path) -> None:
     <nav class="header-nav" id="headerNav"><a href="#features">L'app</a></nav>
   </div></header>
   <main id="mainContentFr"></main>
+  <script type="module" src="feedback-widget.js"></script>
 </body>
 </html>
 """,
@@ -75,6 +78,7 @@ def _create_valid_fixture(base: Path) -> None:
 </head>
 <body>
   <main id="mainContentEn"></main>
+  <script type="module" src="feedback-widget.js"></script>
 </body>
 </html>
 """,
@@ -152,6 +156,24 @@ class QualityGateTests(unittest.TestCase):
             errors = quality_gate.collect_errors(root)
             expected = "SoftwareApplication non autorisé"
             self.assertTrue(any(expected in err for err in errors))
+
+    def test_detects_missing_feedback_widget(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            cookies_path = root / "cookies.html"
+            cookies_path.write_text(
+                cookies_path.read_text(encoding="utf-8").replace(
+                    '<script type="module" src="feedback-widget.js"></script>',
+                    "",
+                ),
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.collect_errors(root)
+            self.assertTrue(
+                any("widget de feedback" in err for err in errors)
+            )
 
     def test_detects_missing_burger_toggle(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Adds the Cloudflare Worker feedback widget to every page of `packages/website` — `index`, `legal`, `privacy`, `cookies`, `terms`, in both FR and EN (10 pages). A plain ES-module `<script>` placed just before `</body>`; no build, no framework, no dependency.

```html
<script type="module">
  import { mountFeedbackWidget } from 'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js'
  mountFeedbackWidget({ projectId: 'brasse-bouillon', endpoint: '…/ingest' })
</script>
```

Also updates the **privacy** and **cookies** pages (FR + EN) to disclose the widget's data flow, based on inspecting `widget.js`:
- On submit it posts the user message + minimal technical context (page URL, referrer, user-agent, viewport, locale) to the Worker.
- It uses `localStorage` (not cookies) for rate-limiting and an offline outbox — local only, no tracking.

## Context

First step of the planned feedback-widget integration. The Worker is already deployed. Its CORS allow-list is the prod domain only (`www.brasse-bouillon.com` / `brasse-bouillon.com`), so submissions work **only from production** — not localhost/file:// nor `*.github.io` previews. Local testing requires adding the local origin to the Worker's `ALLOWED_ORIGINS` (in the `feedback-pipeline-worker` repo).

Note: the site has no cookie-consent banner today (its policy states no non-essential cookies, so no prior consent is required). The widget is user-triggered (click "Report" → submit) and sets no cookie, so it is consistent with that stance; the privacy/cookies pages now document it for transparency.

## Checklist

- [x] Quality gate passes (`python scripts/quality_gate.py`) + tests (8 passed)
- [x] Widget present once, just before `</body>`, on all 10 pages
- [x] FR + EN parity (widget + legal pages)
- [x] No secrets, no AI attribution
- [ ] Verify on prod after merge: "Report" button bottom-right → submit → 204 + buffered by the Worker