### PR TITLE
feat(website): denser device-adaptive bubbles + reworked, perf-tuned dew drop

### DIFF
--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="site.css?v=20260521-2">
+  <link rel="stylesheet" href="site.css?v=20260523-2">
 </head>
 <body>
   <a class="skip-link" href="#mainContentEn">Skip to main content</a>
@@ -76,6 +76,6 @@
     </div>
   </aside>
 
-  <script src="site.js?v=20260521-2"></script>
+  <script src="site.js?v=20260523-2"></script>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -42,7 +42,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="site.css?v=20260523">
+  <link rel="stylesheet" href="site.css?v=20260523-2">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -521,7 +521,7 @@
     </div>
   </aside>
 
-  <script src="site.js?v=20260521-2"></script>
+  <script src="site.js?v=20260523-2"></script>
   <script>
     const QUESTIONNAIRE_ENDPOINT = 'https://formspree.io/f/xeellqan';
     const NEWSLETTER_ENDPOINT = 'https://formspree.io/f/mqaqqvab';

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -414,11 +414,9 @@
           rgba(255, 255, 255, 0.2) 84%,
           transparent 93%
         );
-      box-shadow:
-        /* faint dark contour gives the bubble a visible edge on light bg */
-        inset 0 0 0 0.6px rgba(108, 80, 46, 0.3),
-        inset 1px 1px 2px rgba(255, 255, 255, 0.45),
-        0 0 3px rgba(120, 90, 50, 0.18);
+      /* No box-shadow: the two radial gradients above already give the rim +
+         specular highlight. Dropping the (paint-expensive) multi-layer shadow
+         keeps hundreds of animated bubbles cheap to rasterize. */
       opacity: 0;
       /* Rise (Y) and sway (X) are split across the `translate` and
          `transform` properties so the acceleration isn't linearised by
@@ -444,6 +442,11 @@
       from { transform: translateX(calc(var(--sway) * -1)) scale(0.92); }
       to { transform: translateX(var(--sway)) scale(1.12); }
     }
+
+    /* Tab hidden: site.js sets `.anim-paused` on <html> so the compositor
+       stops spending frames on ambient motion nobody is watching. */
+    .anim-paused .bubble,
+    .anim-paused .dew-run { animation-play-state: paused; }
 
     @media (prefers-reduced-motion: reduce) {
       .bubbles { display: none; }
@@ -518,12 +521,11 @@
       width: var(--ds);
       height: var(--ds);
       pointer-events: none;
-      /* accelerating fall (gravity): slow start, speeding up. `--dr-dur` is
-         the whole cycle, mostly idle — the fall occupies only its first
-         ~22%, so a drip appears occasionally rather than looping nonstop
-         (animation-delay alone only delays the first iteration). */
-      animation: dew-run var(--dr-dur) cubic-bezier(0.6, 0.04, 0.98, 0.34)
-        var(--dr-delay) infinite;
+      /* accelerating fall (gravity): slow start, speeding up. Runs ONCE per
+         drip — site.js spawns one element, plays this single iteration, then
+         removes it on `animationend` and schedules the next drop. `forwards`
+         holds the end frame until removal so there is no snap-back. */
+      animation: dew-run var(--dr-dur) cubic-bezier(0.55, 0.06, 0.9, 0.32) forwards;
     }
 
     .dew-run__bead {
@@ -576,13 +578,13 @@
     }
 
     @keyframes dew-run {
-      /* The fall happens in the first ~22% of the cycle; the rest is idle
-         (invisible, parked at the bottom) so a drip is occasional. */
+      /* One-shot fall over the whole (short) duration. `--dr-dist` carries the
+         bead just past the card's bottom edge, so the clipped `.dew-layer`
+         masks it exactly as it leaves the card — it slides off instead of
+         stopping mid-card. Stays opaque throughout; the clip does the hiding. */
       0% { transform: translateY(0); opacity: 0; }
-      2% { opacity: 1; }
-      22% { transform: translateY(var(--dr-dist)); opacity: 1; }
-      26% { transform: translateY(var(--dr-dist)); opacity: 0; }
-      100% { transform: translateY(var(--dr-dist)); opacity: 0; }
+      10% { opacity: 1; }
+      100% { transform: translateY(var(--dr-dist)); opacity: 1; }
     }
 
     @media (prefers-reduced-motion: reduce) {

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -191,7 +191,27 @@
     if (!layer) return;
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
 
-    const count = (options && options.count) || 120;
+    // Bubble count adapts to the device so big screens feel lush while weaker
+    // phones stay smooth. Each bubble is a richly-painted, continuously
+    // animated element, so we keep the compositor comfortable:
+    //  - scale with viewport area (≈ 1 bubble per 6500 px²),
+    //  - halve it on low-memory / few-core devices,
+    //  - drop to a minimum when Data Saver is on,
+    //  - (prefers-reduced-motion already disabled the layer above).
+    function adaptiveBubbleCount() {
+      const area = window.innerWidth * window.innerHeight;
+      let n = Math.round(area / 6500);
+      if (navigator.connection?.saveData) return 60;
+      const memory = navigator.deviceMemory;
+      const cores = navigator.hardwareConcurrency;
+      if ((memory && memory <= 4) || (cores && cores <= 4)) n = Math.round(n * 0.5);
+      // Floor low so small screens really are sparser; cap kept moderate so
+      // big screens stay lush but smooth. Gradient (≈): phone ~70,
+      // tablet ~120, laptop ~160, desktop/ultrawide capped at 200.
+      return Math.max(70, Math.min(n, 200));
+    }
+
+    const count = (options && options.count) || adaptiveBubbleCount();
     const fragment = document.createDocumentFragment();
 
     for (let i = 0; i < count; i += 1) {
@@ -200,7 +220,7 @@
 
       // Strong skew towards small bubbles with a few bigger ones (like real
       // CO2): the bulk are tiny 2–6px fizz, some medium, the largest ~15px.
-      const sizeFactor = Math.pow(Math.random(), 2.4);
+      const sizeFactor = Math.pow(Math.random(), 1.3);
       const size = 2 + sizeFactor * 13;
       // Larger bubbles tend to be a touch more opaque and rise faster.
       const opacity = 0.45 + sizeFactor * 0.3 + Math.random() * 0.25;
@@ -233,6 +253,7 @@
     if (!cards.length) return;
 
     const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const dewLayers = [];
 
     cards.forEach((card) => {
       // A closed <details> hides every child except its <summary>, so for
@@ -258,7 +279,7 @@
       const cardW = host.offsetWidth || 300;
       const cardH = host.offsetHeight || 240;
       const area = cardW * cardH;
-      const beads = Math.min(110, Math.max(9, Math.round(area / 13000)));
+      const beads = Math.min(45, Math.max(6, Math.round(area / 18000)));
       for (let i = 0; i < beads; i += 1) {
         const drop = document.createElement('span');
         drop.className = 'dew';
@@ -270,34 +291,77 @@
         layer.appendChild(drop);
       }
 
-      if (!reduce) {
-        // A trickling drop is rare and expensive: at most one per card, and
-        // only on roughly half the cards, with a long random delay so a drip
-        // appears only "every so often" rather than continuously.
-        const hasRunner = Math.random() < 0.5;
-        if (hasRunner) {
-          const run = document.createElement('span');
-          run.className = 'dew-run';
-          run.style.setProperty('--dx', `${(10 + Math.random() * 80).toFixed(1)}%`);
-          run.style.setProperty('--dy', `${(5 + Math.random() * 20).toFixed(1)}%`);
-          run.style.setProperty('--ds', `${(8 + Math.random() * 5).toFixed(1)}px`);
-          run.style.setProperty('--dr-dist', `${Math.round(cardH * 0.72)}px`);
-          run.style.setProperty('--dr-trail', `${(135 + Math.random() * 105).toFixed(0)}px`);
-          // Full cycle is mostly idle (the fall is ~22% of it), so a 12–20s
-          // duration yields a drip roughly every 12–20s, plus a staggered
-          // first-appearance delay so they don't all fall in unison.
-          run.style.setProperty('--dr-dur', `${(12 + Math.random() * 8).toFixed(1)}s`);
-          run.style.setProperty('--dr-delay', `${(Math.random() * 14).toFixed(1)}s`);
-
-          const bead = document.createElement('span');
-          bead.className = 'dew-run__bead';
-          run.appendChild(bead);
-          layer.appendChild(run);
-        }
-      }
-
       host.appendChild(layer);
+      dewLayers.push({ layer, host });
     });
+
+    startDewRunner(dewLayers, reduce);
+  }
+
+  /**
+   * Drives the trickling drops globally: exactly ONE drop falls at a time,
+   * from a random card at a random position, then the next is scheduled a
+   * short while later. A single live runner at once keeps the page light and
+   * guarantees two drops never overlap. Skipped under prefers-reduced-motion.
+   */
+  function startDewRunner(layers, reduce) {
+    if (reduce || !layers.length) return;
+
+    // Only cards currently on screen are eligible — no point animating drops
+    // on cards scrolled out of view. Checked once per drip (cheap).
+    function visibleLayers() {
+      const vh = window.innerHeight || document.documentElement.clientHeight;
+      return layers.filter(({ host }) => {
+        const r = host.getBoundingClientRect();
+        return r.height > 0 && r.bottom > 0 && r.top < vh;
+      });
+    }
+
+    function dropOnce() {
+      const candidates = visibleLayers();
+      if (!candidates.length) {
+        scheduleNext();
+        return;
+      }
+      const target = candidates[Math.floor(Math.random() * candidates.length)];
+      const cardH = target.host.offsetHeight || 240;
+      const dyPct = 5 + Math.random() * 20;
+      const startPx = cardH * (dyPct / 100);
+
+      const run = document.createElement('span');
+      run.className = 'dew-run';
+      run.style.setProperty('--dx', `${(8 + Math.random() * 84).toFixed(1)}%`);
+      run.style.setProperty('--dy', `${dyPct.toFixed(1)}%`);
+      run.style.setProperty('--ds', `${(8 + Math.random() * 5).toFixed(1)}px`);
+      // Travel just past the card's bottom edge: the clipped layer hides the
+      // bead as it leaves the card, so it slides off instead of stopping.
+      run.style.setProperty('--dr-dist', `${Math.round(cardH - startPx + 28)}px`);
+      run.style.setProperty('--dr-trail', `${(135 + Math.random() * 105).toFixed(0)}px`);
+      run.style.setProperty('--dr-dur', `${(2.6 + Math.random() * 1.4).toFixed(1)}s`);
+
+      const bead = document.createElement('span');
+      bead.className = 'dew-run__bead';
+      run.appendChild(bead);
+
+      run.addEventListener(
+        'animationend',
+        () => {
+          run.remove();
+          scheduleNext();
+        },
+        { once: true }
+      );
+      target.layer.appendChild(run);
+    }
+
+    function scheduleNext() {
+      // 2.5–6.5 s between drops: a drip "every so often" (a bit more often than
+      // before), but never two at once — the next is queued only after the
+      // current one finishes.
+      window.setTimeout(dropOnce, 2500 + Math.random() * 4000);
+    }
+
+    scheduleNext();
   }
 
   function onReady(fn) {
@@ -310,6 +374,12 @@
 
   onReady(function () {
     setupBubbles();
+  });
+
+  // Pause the ambient animations while the tab is hidden — no point spending
+  // CPU/battery animating bubbles and drops nobody is looking at.
+  document.addEventListener('visibilitychange', function () {
+    document.documentElement.classList.toggle('anim-paused', document.hidden);
   });
 
   // Dew density depends on final card sizes — run once layout is settled.

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -201,12 +201,14 @@
     function adaptiveBubbleCount() {
       const area = window.innerWidth * window.innerHeight;
       let n = Math.round(area / 6500);
+      // Data Saver: a deliberate hard minimum of 60, intentionally below the
+      // normal floor (lightest possible while still hinting the effect).
       if (navigator.connection?.saveData) return 60;
       const memory = navigator.deviceMemory;
       const cores = navigator.hardwareConcurrency;
       if ((memory && memory <= 4) || (cores && cores <= 4)) n = Math.round(n * 0.5);
-      // Floor low so small screens really are sparser; cap kept moderate so
-      // big screens stay lush but smooth. Gradient (≈): phone ~70,
+      // Otherwise floor low so small screens really are sparser; cap kept
+      // moderate so big screens stay lush but smooth. Gradient (≈): phone ~70,
       // tablet ~120, laptop ~160, desktop/ultrawide capped at 200.
       return Math.max(70, Math.min(n, 200));
     }
@@ -272,7 +274,7 @@
       layer.className = 'dew-layer';
 
       // Density proportional to card area so small and large cards keep a
-      // consistent look (one bead per ~10000 px²), clamped to sane bounds.
+      // consistent look (≈ one bead per 18000 px²), clamped to sane bounds.
       // offsetWidth/Height are read only to size bead counts — the layer
       // itself is stretched to the host in CSS (100%/100%), so it stays in
       // sync after a resize instead of overflowing with a stale px width.


### PR DESCRIPTION
## Summary

Ambient-effect polish on the landing page, tuned for a good "wow vs. smooth" balance.

**Rising bubbles**
- Count now **adapts to the device**: scales with viewport area (lush on big screens, sparser on phones), halved on low-memory / few-core devices, minimal under Data Saver, clamped to **70–200** (was a flat 120). Disabled under `prefers-reduced-motion`.
- Size distribution flattened so **all sizes** show, not only tiny fizz.
- Dropped the multi-layer `box-shadow` (the two radial gradients already give the rim + highlight) so a few hundred animated bubbles stay cheap to rasterize.

**Dew trickling drop**
- A single global scheduler drives **one drop at a time** (never two at once), from a random **on-screen** card at a random position, every **2.5–6.5 s**.
- The drop travels just past its card's bottom edge and is clipped there (slides off) instead of **freezing mid-card**.
- One-shot animation removed on `animationend` (replaced the per-card infinite CSS loops).
- Thinned the static dew beads (cap 110 → 45, sparser density).

**Shared perf**
- Both effects **pause while the tab is hidden** (`visibilitychange`).
- Animation properties stay compositor-friendly (`transform`/`opacity`/`translate` only).

## Context

Follow-up polish after the on-prod lag from an over-dense bubble experiment. The goal was a dense, lively, glassy look that stays smooth on phones — achieved by adapting the element count to the device and cutting per-element paint cost, rather than a flat high number.

## Checklist

- [x] Quality gate passes (`python scripts/quality_gate.py`) + tests (8 passed)
- [x] FR + EN parity (both index pages)
- [x] Cache-bust bumped on `site.css` / `site.js`
- [x] `prefers-reduced-motion` respected; no third-party calls
- [x] No secrets, no AI attribution