### PR TITLE
fix(ci): deploy root-level .webp assets (restores the hero mascot)

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -53,7 +53,7 @@ jobs:
           src=packages/website
 
           # Glob copies — tolerate empty matches.
-          for f in "$src"/*.html "$src"/*.css "$src"/*.js "$src"/*.png "$src"/*.svg; do
+          for f in "$src"/*.html "$src"/*.css "$src"/*.js "$src"/*.png "$src"/*.svg "$src"/*.webp; do
             cp "$f" _site/
           done
 


### PR DESCRIPTION
## Summary

Production regression fix. The `website-deploy.yml` staging step copied root-level files by an extension allowlist — `*.html *.css *.js *.png *.svg` — but **not `*.webp`**. So `logo-hero.webp` (added in #1091) was never published: the header logo and hero mascot returned **404** on `brasse-bouillon.com`. This adds `*.webp` to the copy glob.

Screenshot `.webp` files were unaffected because the `screenshots/` directory is copied wholesale (`cp -R`).

## Root cause

#1091 converted the hero logo PNG → root-level WebP and removed the PNG, but the deploy glob never included `*.webp` for root assets — so the referenced file was missing on prod.

## Verification

- Before: `curl -I https://brasse-bouillon.com/logo-hero.webp` → 404.
- After deploy: `logo-hero.webp` returns 200 `image/webp`; header logo + hero mascot render again.

## Checklist

- [x] One-line glob change; root `.webp` now staged into `_site/`
- [x] No other workflow behavior changed
- [x] No secrets, no AI attribution