### PR TITLE
docs(design): UX/IA refonte study + prioritized roadmap

### DIFF
--- a/docs/design/ux-refonte/00-current-state-inventory.md
+++ b/docs/design/ux-refonte/00-current-state-inventory.md
@@ -20,25 +20,27 @@ inserts a 7th, Communauté, before Profil):
 | (demo) | Communauté | people-outline | `/social` |
 
 **Routes hidden from the bar** (`href: null` in `app/(app)/_layout.tsx`):
-Shop, Ingredients, Tools, Equipment, Social (demo-gated), plus nested
-Labels/Scan sub-routes. History: #613 moved Shop + Tools out of the bar;
-#646 anticipated a dedicated Statistiques screen (not built).
+Shop, Ingredients, Tools, Social (demo-gated), plus nested Labels/Scan
+sub-routes. (`equipment` is declared **without** `href: null` — it inherits the
+Tabs header but is simply absent from the custom `NavigationFooter` item list.)
+History: #613 moved Shop + Tools out of the bar; #646 anticipated a dedicated
+Statistiques screen (not built).
 
 ## Routes / screens (delegated app/ → src/features/*/presentation)
 
 - **dashboard**: `DashboardScreen`; nested `scan/*` (ScanScreen, PendingScansScreen, BeerInfoCardScreen, ScanResultScreen) and `labels/*` (LabelsScreen, LabelDetailsScreen, LabelSelectBatchScreen, LabelEditorScreen).
-- **recipes**: RecipesScreen, CatalogScreen, RecipeDetailsScreen (5-tab: Overview, Ingredients, Brewing, Water, Notes).
+- **recipes**: RecipesScreen, CatalogScreen, RecipeDetailsScreen (5-tab vertical side-rail, in order: Vue / Ingrédients / Eau / Brassage / Notes).
 - **batches**: BatchesScreen, BatchDetailsScreen (timeline + demo fermentation tracker), BatchFinishedScreen (celebration, demo).
 - **ingredients**: IngredientsScreen → category → details (malts/hops/yeast).
 - **tools**: ToolsHubScreen + 8 calculators (color, fermentables, hops, yeast, water, efficiency, carbonation, advanced).
-- **academy**: AcademyHubScreen (10 topics) + topic detail + placeholder.
+- **academy**: AcademyHubScreen (10 topics) + topic detail + placeholder — note the academy screens live under `src/features/tools/` (not a separate `academy` module).
 - **equipment**: EquipmentScreen. **shop**: ShopScreen + category. **social**: SocialFeedScreen (demo). **profile**: ProfileScreen. **auth**: LoginScreen.
 
 ## Feature modules (src/features/)
 
-auth, dashboard, batches, recipes, scan, labels, ingredients, equipment, tools,
-academy, shop, social. Tools and Academy are tightly linked (calculators hang
-off academy topics).
+auth, dashboard, batches, recipes, scan, labels, ingredients, equipment, tools
+(**includes academy** — academy screens are under `features/tools/`), shop,
+social. Tools and Academy are tightly linked (calculators hang off academy topics).
 
 ## Statistics / numbers — scattered (no unified feature)
 

--- a/docs/design/ux-refonte/00-current-state-inventory.md
+++ b/docs/design/ux-refonte/00-current-state-inventory.md
@@ -1,0 +1,69 @@
+# Phase 0 — Current-state inventory
+
+Factual map of the mobile app as of 2026-05-24 (no judgement here; gaps are
+analysed in [01](01-journey-menu-gap-analysis.md)). Source: code reading of
+`packages/mobile-app`.
+
+## Bottom navigation (NavigationFooter)
+
+Defined in `src/core/ui/NavigationFooter.tsx`. **Production: 6 tabs** (demo mode
+inserts a 7th, Communauté, before Profil):
+
+| # | Label | Icon | Route |
+|---|-------|------|-------|
+| 1 | Accueil | home-outline | `/dashboard` |
+| 2 | Brassins | flask-outline | `/batches` |
+| 3 | Recettes | book-outline | `/recipes` |
+| 4 | Scan | barcode-outline | `/dashboard/scan` |
+| 5 | Académie | school-outline | `/academy` |
+| 6 | Profil | person-circle-outline | `/profile` |
+| (demo) | Communauté | people-outline | `/social` |
+
+**Routes hidden from the bar** (`href: null` in `app/(app)/_layout.tsx`):
+Shop, Ingredients, Tools, Equipment, Social (demo-gated), plus nested
+Labels/Scan sub-routes. History: #613 moved Shop + Tools out of the bar;
+#646 anticipated a dedicated Statistiques screen (not built).
+
+## Routes / screens (delegated app/ → src/features/*/presentation)
+
+- **dashboard**: `DashboardScreen`; nested `scan/*` (ScanScreen, PendingScansScreen, BeerInfoCardScreen, ScanResultScreen) and `labels/*` (LabelsScreen, LabelDetailsScreen, LabelSelectBatchScreen, LabelEditorScreen).
+- **recipes**: RecipesScreen, CatalogScreen, RecipeDetailsScreen (5-tab: Overview, Ingredients, Brewing, Water, Notes).
+- **batches**: BatchesScreen, BatchDetailsScreen (timeline + demo fermentation tracker), BatchFinishedScreen (celebration, demo).
+- **ingredients**: IngredientsScreen → category → details (malts/hops/yeast).
+- **tools**: ToolsHubScreen + 8 calculators (color, fermentables, hops, yeast, water, efficiency, carbonation, advanced).
+- **academy**: AcademyHubScreen (10 topics) + topic detail + placeholder.
+- **equipment**: EquipmentScreen. **shop**: ShopScreen + category. **social**: SocialFeedScreen (demo). **profile**: ProfileScreen. **auth**: LoginScreen.
+
+## Feature modules (src/features/)
+
+auth, dashboard, batches, recipes, scan, labels, ingredients, equipment, tools,
+academy, shop, social. Tools and Academy are tightly linked (calculators hang
+off academy topics).
+
+## Statistics / numbers — scattered (no unified feature)
+
+| Location | Numbers shown |
+|----------|---------------|
+| DashboardScreen | KPI grid (active batches, actions-24h, critical alerts); demo hero (volume, OG, IBU); demo ribbon (total brassins, signed recipes, J+x/J+y); alerts list; active-batch cards |
+| BatchDetailsScreen | demo fermentation tracker (days, %, SG, OG/FG, temperature) |
+| RecipeDetailsScreen (OverviewTab) | 6-stat grid: ABV, IBU, EBC, OG, FG, target volume |
+| RecipeCard | inline IBU / ABV / volume |
+| ScanResultScreen | ABV / IBU / EBC |
+| LabelsScreen | draft count |
+| SocialFeedScreen | likes / comments (hardcoded, demo) |
+| Tools (8 calculators) | live computed outputs |
+
+A "Période d'analyse" filter (Year / 90d / 30d) exists on the dashboard but is
+pinned to "year" (#646 planned to move it to a Statistiques screen).
+
+## Profile screen (ProfileScreen)
+
+Thin: header (avatar + display name), account card (email, username, role),
+refresh button, logout (with confirmation modal). **No settings, preferences,
+subscription, equipment link, or stats.**
+
+## Demo-mode gating
+
+Hero card, ribbon stats, fermentation tracker, celebration screen, and the
+Communauté tab all depend on `dataSource.useDemoData`. In production these are
+hidden — see [01](01-journey-menu-gap-analysis.md) for the journey impact.

--- a/docs/design/ux-refonte/01-journey-menu-gap-analysis.md
+++ b/docs/design/ux-refonte/01-journey-menu-gap-analysis.md
@@ -1,0 +1,51 @@
+# Phase 1 — Journey ↔ menu gap analysis
+
+Mapping the 4 marketing journeys to where they actually live in the app, and
+flagging gaps. Reachability assessed from the current navigation
+([00](00-current-state-inventory.md)).
+
+## The 4 journeys vs the app
+
+| Journey | Implemented by | Entry point(s) | Verdict |
+|---------|----------------|----------------|---------|
+| **1. Choose a recipe** | RecipesScreen → CatalogScreen → RecipeDetailsScreen | Recettes tab (visible) + dashboard CTA | **OK** — direct, in the bar |
+| **2. Brew step-by-step** | BatchesScreen → BatchDetailsScreen | Brassins tab + dashboard hero/alerts | **OK** — direct, in the bar |
+| **3. Follow fermentation** | BatchDetailsScreen fermentation section | inside a batch | **GAP — demo-only.** The fermentation tracker renders only when `useDemoData` is true; in production the journey the site promises is **not visible**. |
+| **4. Bottle & taste (label)** | LabelsScreen → SelectBatch → Editor → Details | dashboard "Voir plus" sheet only | **GAP — buried.** Labels are not in the bar; reachable only via a secondary action sheet (2+ taps, low discoverability). |
+
+## Gaps and findings
+
+1. **Fermentation (J3) is production-invisible.** The headline "follow your
+   fermentation day by day" has no production surface. Either the feature must
+   ship (depends on the fermenter-data epic) or the marketing claim is ahead of
+   the build. Decision needed: gate the claim, or prioritise a minimal manual
+   fermentation log.
+2. **Bottling/labels (J4) is buried.** A core narrative step sits behind "Voir
+   plus". It should have a first-class, predictable entry (from the batch it
+   belongs to, and/or a visible destination).
+3. **Bottom bar is overloaded (6–7 tabs).** Above the 3–5 heuristic. Académie
+   (education) competes for a primary slot with the 4 journey-critical
+   destinations. Scan is journey-adjacent (recognise a beer → clone it) and
+   deserves prominence, but as a 6th equal tab it dilutes the set.
+4. **Statistics are scattered across 8 surfaces** with no home. The same
+   metrics (ABV/IBU/EBC, batch progress) are re-rendered in different shapes.
+   #646 already anticipated a Statistiques screen. There is duplication risk and
+   no place for cross-batch/cross-recipe insight.
+5. **Profile is thin and orphaned.** It holds only account fields + logout,
+   yet it is the natural home for secondary destinations (Equipment, Shop,
+   settings, and a Statistics entry) that are currently hidden via `href: null`.
+6. **Hidden routes with no stable home.** Ingredients, Tools, Equipment, Shop
+   are reachable only indirectly. Tools (calculators) overlaps conceptually with
+   Académie — the split is not obvious to users.
+7. **Recipe detail uses a left-side menu** (reported in live review) — a desktop
+   pattern; on mobile it narrows the content column and fights thumb reach.
+
+## Themes feeding the target IA
+
+- Promote the **4 journeys** to first-class, visible destinations; demote
+  education/tools/secondary to a discoverable-but-not-primary tier.
+- Give **Scan** a prominent, journey-aligned placement.
+- Create a **single home for statistics** and for **secondary destinations**
+  (profile/account hub).
+- Replace per-screen anti-patterns (left menu, oversized hero) with consistent
+  mobile patterns (top tabs/scroll, compact hero).

--- a/docs/design/ux-refonte/02-target-ia.md
+++ b/docs/design/ux-refonte/02-target-ia.md
@@ -1,0 +1,85 @@
+# Phase 2 — Target information architecture
+
+Proposed IA grounded in the gaps ([01](01-journey-menu-gap-analysis.md)) and the
+design principles ([README](README.md)). Decisions taken with the founder on
+2026-05-24: no hamburger, no left-side menu for primary nav, keep a visible
+bottom bar, unify statistics, optimise profile, harmonise menus, KISS/YAGNI.
+
+## Bottom navigation — 5 destinations + central Scan
+
+Drop from 6–7 tabs to **5**, organised around the journeys, with **Scan as a
+prominent central action** (it is the entry to "recognise → clone", the killer
+path for the craft audience):
+
+```
+┌───────────────────────────────────────────────┐
+│  Accueil   Recettes   (Scan)   Brassins  Profil │
+│   home      book      ◉ FAB    flask     person │
+└───────────────────────────────────────────────┘
+```
+
+- **Accueil** — dashboard / overview (incl. an entry to Statistics).
+- **Recettes** — journey 1 (choose/clone/customise).
+- **Scan** — centre, visually elevated (FAB-style); journey 0 (recognise a beer).
+- **Brassins** — journeys 2 & 3 (brew + fermentation live inside a batch).
+- **Profil** — account hub (see below): secondary destinations + settings + stats entry.
+
+Rationale: 4 visible journey destinations + Scan, all one tap, thumb-reachable.
+Within the 3–5 heuristic. No hamburger (hides nav), no left menu (desktop pattern).
+
+### Where the demoted items go
+
+| Currently | Target home |
+|-----------|-------------|
+| Académie + Tools (calculators) | A single **"Apprendre & outils"** hub, entered from Accueil or Profil (education + calculators belong together) |
+| Équipement | Profil → "Mon matériel" |
+| Boutique | Profil → "Boutique" |
+| Communauté (demo) | Stays demo-gated; when real, candidate to replace a slot or live under Accueil |
+| Étiquettes (journey 4) | First-class **from the batch** ("Créer l'étiquette" on a finished batch) + listed in Profil |
+
+## Unified Statistics feature
+
+Create one **Statistiques** destination (entered from Accueil and Profil) that
+consolidates the numbers scattered across 8 surfaces today:
+
+- **My brewing** — batches brewed, in progress, success rate, volume brewed.
+- **Per-batch** — fermentation curve (when data exists), timeline adherence.
+- **Recipes** — most-brewed, signed/cloned counts.
+- **Period filter** — the existing Year / 90d / 30d control (#646) finally gets a home.
+
+Contextual mini-stats (the 6-stat recipe grid, batch progress) **stay in place**
+on their screens — Statistics aggregates *across* entities, it doesn't remove
+the at-a-glance numbers. KISS: start with brewing + per-batch; recipes/period as v0.2.
+
+## Profile → account hub
+
+Promote the thin profile into a hub:
+
+- Identity (avatar, name, email, role) — as today.
+- **Mon matériel** (Equipment), **Boutique** (Shop), **Statistiques** (entry).
+- **Réglages** (settings: units, language — ties to the bilingual FR/EN epic).
+- Logout.
+
+## Screen-level patterns (consistency)
+
+- **Compact hero** everywhere (recipe detail, scan result, celebration): the hero
+  states identity in ≤ ~25% of the viewport; stats/sections start above the fold.
+  (Flagship: recipe detail — the #1082 named target.)
+- **Recipe detail sections**: replace the left-side menu with a **sticky top
+  segmented control** (Aperçu · Ingrédients · Brassage · Eau · Notes) or a single
+  vertical scroll with section headers. Never a left menu on mobile.
+- **One brand moment**: compact header in-app, hero brand only on auth (shipped #1093).
+
+## Harmonisation rules (to enforce going forward)
+
+1. A capability has **exactly one** primary home; no duplicate entry points.
+2. Bottom bar = journeys only; education/tools/secondary = hub or profile.
+3. Aggregate numbers → Statistics; at-a-glance numbers → their entity screen.
+4. Mobile nav is always visible (bottom bar / top tabs), never hamburger/left-menu.
+5. Hero ≤ ~25% viewport; content above the fold.
+
+## Open decisions (for review before build)
+
+- Fermentation J3: ship a minimal manual log, or gate the marketing claim?
+- Does Scan-as-FAB change the demo Communauté slot logic?
+- Académie + Tools merge name and exact placement.

--- a/docs/design/ux-refonte/03-uml-refresh-plan.md
+++ b/docs/design/ux-refonte/03-uml-refresh-plan.md
@@ -3,7 +3,8 @@
 The refonte changes the information architecture, so the UML must be refreshed
 **before** implementation (project rule: conception precedes code). This lists
 which diagrams to create or update, per the UML conventions
-(`docs/architecture/diagrams/<feature>/<NN>-<type>.md`, Mermaid, six types).
+(`docs/architecture/diagrams/<feature>/<NN>[a/b]-<type>[-<scope>].md`, e.g. the
+existing `scan/01a-use-case-barcode.md`; Mermaid, six types).
 
 UML orthodoxy reminder: use cases are **actor-initiated goals**; group them by
 **domain**, never by backend package; the Mobile/API split lives only in the

--- a/docs/design/ux-refonte/03-uml-refresh-plan.md
+++ b/docs/design/ux-refonte/03-uml-refresh-plan.md
@@ -1,0 +1,51 @@
+# Phase 3 — UML refresh plan
+
+The refonte changes the information architecture, so the UML must be refreshed
+**before** implementation (project rule: conception precedes code). This lists
+which diagrams to create or update, per the UML conventions
+(`docs/architecture/diagrams/<feature>/<NN>-<type>.md`, Mermaid, six types).
+
+UML orthodoxy reminder: use cases are **actor-initiated goals**; group them by
+**domain**, never by backend package; the Mobile/API split lives only in the
+component diagram.
+
+## Guiding rule for this refresh
+
+The IA refonte does **not** invent new product capabilities — it relocates and
+consolidates existing ones. So most use-case *content* is stable; what changes
+is **navigation/flow** (sequence + component) and two **consolidations**
+(Statistics, Profile hub) that deserve their own use-case views.
+
+## Diagrams to create / update
+
+| Domain / feature | Diagram(s) | Action | Why |
+|------------------|-----------|--------|-----|
+| **Navigation / IA** (new folder `navigation/`) | component + state | **Create** | Document the 5-tab bar + central Scan, and the demoted-items map (Académie+Outils hub, Profil hub). The bottom-bar IA has never been modelled; #611 ("unify 3 nav layers") is the related issue. |
+| **Statistics** (new `statistics/`) | use-case + data-flow | **Create** | New consolidated destination. UC: "Consult my brewing statistics", "Filter stats by period". Data-flow: where each metric is sourced (batches, recipes). Ties to #646, #829. |
+| **Account / Profile** (`account/`) | use-case | **Update** | Profile becomes a hub. Add UC: "Manage my equipment", "Open settings (units/language)", "Open statistics", "Browse shop". Existing auth UCs unchanged. Ties to #644, #645, #836. |
+| **Recipes** (`recipes/`) | sequence | **Update** | Recipe detail navigation changes (top segmented control / scroll, not left menu). Update the "consult a recipe" sequence; use cases unchanged. Flagship of #1082. |
+| **Batches / brewing** (`batches/`) | use-case + state | **Update** | Make the *fermentation-follow* use case first-class (today demo-only). Add the bottling/label entry from a finished batch. State diagram: batch lifecycle incl. fermentation + bottled. Ties to #595, journey 3 & 4 gaps. |
+| **Scan** (`scan/`) | — | **No change** | Already modelled (01a barcode, 01b panoramic). Scan only gains visual prominence (nav), not new UCs. |
+
+## User-story alignment
+
+After the diagrams are refreshed, reconcile the product backlog
+(`docs/product-backlog/product-backlog.md`) so every new/relocated use case has
+a matching user story in the right epic:
+
+- **E08 Dashboard & Navigation** — add stories for the 5-tab IA + central Scan
+  (relocate Académie/Outils/Équipement/Boutique). (#611, #829)
+- **New "Statistics" grouping** (or fold into E08) — stories for the unified
+  Statistics screen + period filter. (#646)
+- **E01 Account & Profile** — stories for the profile hub sections. (#644, #645)
+- **E04 Batch Tracking** — promote the fermentation-follow story out of demo-only;
+  add bottling/label entry-from-batch. (journey 3 & 4)
+- **E02 Recipes** — story for the recipe-detail layout change (segmented control). (#1082 flagship)
+
+## Order of work (conception → build)
+
+1. Draft the `navigation/` component + state diagrams (the IA backbone).
+2. Draft `statistics/` use-case + data-flow; update `account/` use-case.
+3. Update `batches/` (fermentation first-class) + `recipes/` sequence.
+4. Reconcile user stories in the product backlog.
+5. Get the diagrams validated, then open implementation issues ([04](04-implementation-backlog.md)).

--- a/docs/design/ux-refonte/04-implementation-backlog.md
+++ b/docs/design/ux-refonte/04-implementation-backlog.md
@@ -1,0 +1,85 @@
+# Phase 4 — Implementation backlog (#1082)
+
+Phased breakdown of the refonte into reviewable chunks, KISS/YAGNI, to open as
+sub-issues of **epic #1082** once the UML ([03](03-uml-refresh-plan.md)) is
+refreshed and validated. **Implementation is post-soutenance** (2026-05-27).
+
+Each chunk is sized to land as one PR, respecting the Clean Architecture
+(domain/application/data/presentation) and the Definition of Done (tests, no
+`any`, theme tokens, no inline styles).
+
+## Sequencing principle
+
+Ship the IA backbone first (navigation + homes), then the per-screen patterns,
+then the consolidations. Each step leaves the app shippable.
+
+## R1 — Navigation backbone (5 tabs + central Scan)
+
+- Rework `NavigationFooter` + `app/(app)/_layout.tsx` to 5 destinations
+  (Accueil, Recettes, Scan-centre, Brassins, Profil); elevate Scan visually.
+- Relocate hidden routes per the target map ([02](02-target-ia.md)).
+- **Done when**: bottom bar has 5 items, Scan is the central action, no route is
+  orphaned, longest-prefix active-state still correct, tests updated.
+- Refs: #611, #1082. Pattern guard: no hamburger, no left menu.
+
+## R2 — Profile hub
+
+- Promote `ProfileScreen` into a hub: identity + Mon matériel (Equipment) +
+  Boutique (Shop) + Réglages (settings stub) + Statistiques entry + logout.
+- Move Equipment/Shop entry points here (they leave the implicit hidden tier).
+- **Done when**: every previously-hidden secondary destination has a visible
+  home in Profil; account fields unchanged.
+- Refs: #644, #645, #836.
+
+## R3 — "Apprendre & outils" hub
+
+- Merge Académie + Tools (calculators) into one discoverable hub (entered from
+  Accueil/Profil), since education + calculators belong together.
+- **Done when**: calculators and academy topics live under one hub; no duplicate
+  entry points.
+
+## R4 — Unified Statistics (v0 = brewing + per-batch)
+
+- New `statistics` feature (domain/application/presentation) + screen, entered
+  from Accueil and Profil. v0: brewing totals + per-batch progress. Period
+  filter (#646) gets its home. Recipes/period aggregation = v0.2.
+- Keep contextual at-a-glance numbers on their entity screens (don't remove).
+- **Done when**: one Statistics screen aggregates across batches; the dashboard
+  KPI numbers reference it; period filter works.
+- Refs: #646, #829.
+
+## R5 — Recipe detail layout (flagship)
+
+- Replace the left-side menu with a sticky top segmented control (Aperçu ·
+  Ingrédients · Brassage · Eau · Notes) or single scroll; compact the hero
+  (≤ ~25% viewport).
+- **Done when**: recipe detail has no left menu, hero is compact, all sections
+  reachable, content above the fold.
+- Refs: #740, #1082 (named flagship).
+
+## R6 — Compact-hero pass (consistency)
+
+- Apply the compact-hero pattern to scan result + celebration, matching recipe
+  detail. (Brand-header compaction already shipped in PR #1093.)
+- **Done when**: no hero exceeds ~25% of the viewport across detail screens.
+
+## R7 — Fermentation made first-class (journey 3)
+
+- Surface the fermentation-follow journey in production (today demo-only).
+  Minimal manual log if live sensor data isn't available yet (decision in
+  [02](02-target-ia.md) open questions).
+- **Done when**: a non-demo user can follow a batch's fermentation. Depends on
+  the batch-tracking rewrite (#595 and the #808–#814 series) — coordinate.
+
+## Cross-cutting
+
+- Each R-chunk updates the relevant UML diagram first (per [03](03-uml-refresh-plan.md)).
+- Each R-chunk adds tests (happy/sad/edge) and reconciles its user stories.
+- Harmonisation rules ([02](02-target-ia.md)) become a review checklist.
+
+## Out of scope of #1082 (tracked elsewhere)
+
+Recipe write CRUD (#410–#420), panoramic craft scan (#751), BeerXML I/O
+(#865/#778/#881), community beer-duel (#1050), IoT, shop commerce, AI label.
+These are product features, not IA/UX consistency — see the prioritized roadmap
+(`docs/product-backlog/prioritized-roadmap.md`).

--- a/docs/design/ux-refonte/README.md
+++ b/docs/design/ux-refonte/README.md
@@ -1,0 +1,50 @@
+# UX/IA Refonte Study — Brasse-Bouillon mobile app
+
+Design dossier for the information-architecture (IA) and UX modernization of the
+mobile app, tracked under **epic #1082** ("UX/UI optimisation pass — density,
+layout, consistency"). **Design-led and UML-first**: this study precedes
+implementation. Implementation lands **after the 2026-05-27 soutenance**, in
+phased PRs, respecting the existing Clean Architecture and KISS / YAGNI.
+
+## Why
+
+Live testing on an emulator (2026-05-24) surfaced recurring UX debt: a brand
+header that ate the top of every screen (fixed pre-study in PR #1093), an
+overloaded bottom bar (6–7 tabs), oversized hero cards that hide content,
+a recipe detail with a left-side menu (a desktop anti-pattern on mobile),
+statistics scattered across 6+ screens, a thin profile, and journeys that are
+buried or demo-only. Rather than improvise fixes screen-by-screen, this dossier
+maps the current state, defines a target IA grounded in mobile UX heuristics,
+and sequences the work.
+
+## Scope
+
+In scope: information architecture (navigation, where journeys live), screen
+density/layout patterns, a unified Statistics feature, profile, menu/feature
+harmonization. Out of scope: new product features, backend changes beyond what
+an IA change strictly requires.
+
+## Documents
+
+| # | Document | Phase |
+|---|----------|-------|
+| 00 | [Current-state inventory](00-current-state-inventory.md) | Factual map of routes, nav, features, stats, journeys |
+| 01 | [Journey ↔ menu gap analysis](01-journey-menu-gap-analysis.md) | Where journeys are buried / duplicated / unreachable |
+| 02 | [Target information architecture](02-target-ia.md) | Proposed nav, profile, unified Statistics, harmonization rules |
+| 03 | [UML refresh plan](03-uml-refresh-plan.md) | Which diagrams to update per use case / user story |
+| 04 | [Implementation backlog](04-implementation-backlog.md) | Phased #1082 sub-issues, KISS/YAGNI |
+
+## Design principles applied
+
+- **Brand hierarchy** — biggest on auth, discreet elsewhere (already shipped, PR #1093).
+- **Visible primary navigation** — bottom bar of 3–5 destinations; no hamburger, no
+  left-side menu for primary nav (both reduce discoverability on mobile).
+- **Content over chrome** — vertical space above the fold goes to content.
+- **One home per concept** — a capability lives in exactly one place; no duplicate entry points that drift.
+- **KISS / YAGNI** — ship the minimal coherent IA; defer richness explicitly.
+
+## Status
+
+- Phase 0: **done** (this dossier).
+- Phases 1–4: drafted here, to be reviewed before implementation.
+- Implementation: not started; gated on soutenance + UML refresh (see 03).

--- a/docs/product-backlog/prioritized-roadmap.md
+++ b/docs/product-backlog/prioritized-roadmap.md
@@ -53,7 +53,7 @@ The biggest product hole; needed by all personas.
 
 | Need | Persona(s) | Covered by | Tier | Status |
 |------|-----------|------------|------|--------|
-| Scan a beer (barcode) | Léa | UC barcode (01a), #594 | P-done | done |
+| Scan a beer (barcode) | Léa | UC barcode (01a), #594 | done | done |
 | Scan craft label (panoramic) | Léa, Claire | UC panoramic (01b), #751 | P3 | open |
 | Find / browse recipes | all | E02 read, #408/#409 | done | done |
 | **Create / edit recipes** | Claire, Nicolas | #410–#417, #420 | **P1** | **open** |

--- a/docs/product-backlog/prioritized-roadmap.md
+++ b/docs/product-backlog/prioritized-roadmap.md
@@ -1,0 +1,83 @@
+# Prioritized roadmap — Brasse-Bouillon
+
+Single source of **sequencing** for what we build next, grounded in the project's
+own artifacts: personas (`docs/personas/user_personas.md`), use-case diagrams
+(`docs/architecture/diagrams/`), user stories (`docs/product-backlog/product-backlog.md`),
+and the GitHub backlog. It does not replace those — it orders them.
+
+**Context:** soutenance **2026-05-27**. There are **16 open demo-blockers**, and
+the central **recipe write CRUD (#410–#420) is entirely open**. The UX/IA refonte
+is studied under epic #1082 (`docs/design/ux-refonte/`) and implemented after the
+soutenance, UML-first.
+
+## Personas (recap)
+
+| Persona | Level | Tier | Core need |
+|---------|-------|------|-----------|
+| **Léa** la curieuse | beginner (0) | free | "Yuka for beer": scan → find a clone → succeed at batch 1, guided |
+| **Nicolas** le débutant | 1–2 yrs | premium | repeatable process, understand calcs, fermentation journal |
+| **Claire** la créative | 3–7 yrs | pro | recipe versioning, custom labels, document experiments |
+| **Marc** l'expert | 8–15 yrs | pro | BeerXML I/O, IoT sensors, FR water chemistry, no lock-in |
+| **Zoé** l'éco | beg–int | premium | reduce footprint (reserve persona) |
+
+## Priority tiers
+
+### P0 — Soutenance demo (≤ 2026-05-27) — the 16 demo-blockers
+Goal: Léa's end-to-end guided journey is demo-credible. Pivot personas: Léa, Claire.
+
+- **Batches / pilotage**: #595 detail rewrite, #605 data model, #606 layout, #607 inline measurements, #608 step status, #781 brewing assistance (timers/tips).
+- **Demo catalog content**: #779 mini-catalog, #780 25 BrewDog DIY Dog recipes, #884 5–10 signature recipes.
+- **Dashboard**: #829 home rewrite + Statistiques screen.
+- **Account**: #644 merge settings into Profil.
+- **Labels**: #629 export. **Scan**: #777 shopping list. **Demo**: #642 assets, #702 script, #776 spent-grain (drêches).
+
+### P1 — Core functional gaps (immediately post-soutenance)
+The biggest product hole; needed by all personas.
+
+- **Recipe write CRUD**: #410 create, #411 edit, #412 delete, #413 hops, #414 fermentables, #415 yeast, #417 steps, #420 auto-calc IBU/ABV.
+- **Ingredients CRUD + custom**: #624, #915 (Strategy B — ad-hoc ingredients).
+- **Fermentation in production** (journey 3, today demo-only) — Nicolas, Marc.
+
+### P2 — UX/IA refonte (epic #1082) — see `docs/design/ux-refonte/`
+- 5-tab nav + central Scan; compact hero (flagship recipe detail); recipe-detail segmented control (no left menu); **unified Statistics** feature; **Profile hub**; menu harmonisation.
+
+### P3 — Strategic differentiators
+- **Panoramic craft-label scan** (#751 + ~24 issues) — the "recognise → clone" wedge (Léa + craft audience).
+- **Community clone-recipes**, credited & versioned (#883, #739, #882 cloneOf).
+- **BeerXML/BeerJSON import/export** (#865/#778/#881) — capture migrants (Marc, Claire).
+
+### P4 — Later / v0.2+
+- Community beer-duel (#1050); IoT Tilt/iSpindel (Marc); eco/carbon (Zoé); shop/commerce (#650+); AI label (#834); n8n competitive watch (#825).
+
+## Persona × need coverage (completeness check)
+
+| Need | Persona(s) | Covered by | Tier | Status |
+|------|-----------|------------|------|--------|
+| Scan a beer (barcode) | Léa | UC barcode (01a), #594 | P-done | done |
+| Scan craft label (panoramic) | Léa, Claire | UC panoramic (01b), #751 | P3 | open |
+| Find / browse recipes | all | E02 read, #408/#409 | done | done |
+| **Create / edit recipes** | Claire, Nicolas | #410–#417, #420 | **P1** | **open** |
+| Recipe versioning / clone | Claire, Marc | #883, #739, #882 | P3 | open |
+| Brew step-by-step (guided) | Léa, Nicolas | E04, #595, #781 | P0 | open |
+| **Follow fermentation** | Nicolas, Marc | batches #811/#812, journey 3 | **P0/P1** | **demo-only** |
+| Bottle + custom label | Claire | E07, #629 | P0 | partial |
+| Calculators | Nicolas, Marc | E03 (#421–#430) | done | done |
+| Ingredient library + custom | all, Marc | E05 done; #624/#915 | P1 | read done |
+| Academy / learn | Léa | E06 (#443–#447) | done | done |
+| Statistics (cross-entity) | Nicolas, Marc | #646, #829, refonte P2 | P0/P2 | open |
+| Profile / settings / equipment | all | #644/#645/#836 | P0/P2 | open |
+| Community sharing / ratings | Claire | E09 done; beer-duel #1050 | P4 | base done |
+| BeerXML I/O (migration) | Marc, Claire | #865/#778/#881 | P3 | open |
+| IoT sensors | Marc | — | P4 | not started |
+| Eco / carbon footprint | Zoé | — | P4 | not modelled |
+
+### Gaps to confirm with the team
+- **Fermentation (journey 3)** is production-invisible — promote to P0/P1 or gate the marketing claim.
+- **Recipe write CRUD** is the central open gap; not in the demo-blocker set — confirm whether the demo relies on pre-seeded recipes only (P0 catalog) and CRUD is genuinely P1.
+- **IoT (Marc)** and **eco (Zoé)** have no use-case diagram yet — model before committing.
+
+## How to use this doc
+
+- Re-prioritise at backlog grooming; keep tiers P0–P4 in sync with GitHub labels
+  (`priority:*`, `demo-blocker`) and milestones.
+- Every tier item must satisfy the Definition of Ready before it enters a sprint.


### PR DESCRIPTION
## Summary

Design dossier for the mobile-app UX/IA refonte (epic #1082) plus a prioritized
product roadmap. **Documentation only — no code.** Design-led and UML-first;
implementation is deferred to after the 2026-05-27 soutenance.

- `docs/design/ux-refonte/` — README + Phase 0 (current-state IA inventory),
  Phase 1 (journey↔menu gap analysis), Phase 2 (target IA: 5-tab nav + central
  Scan, unified Statistics, Profile hub, harmonisation rules; no hamburger / no
  left-side menu), Phase 3 (UML refresh plan), Phase 4 (phased implementation
  backlog).
- `docs/product-backlog/prioritized-roadmap.md` — P0–P4 sequencing tied to the
  5 personas, use-case diagrams and GitHub issues, with a persona×need coverage
  matrix and the open gaps to confirm (fermentation journey is production-only in
  demo, recipe write CRUD #410–#420 open, IoT/eco not yet modelled in UML).

## Context

Grounded in the project's own artifacts: `docs/personas/user_personas.md` (Léa,
Nicolas, Claire, Marc, Zoé), `docs/architecture/diagrams/` (scan, beer-duel,
feedback use cases), `docs/product-backlog/product-backlog.md` (US-####), and the
live GitHub backlog (16 open demo-blockers for the soutenance). Builds on the
brand-header + background refresh already shipped in #1093.

Part of #1082.

## Checklist

- [x] Documentation only — no code, no config changes
- [x] English (internal artefact)
- [x] Grounded in existing personas / use cases / user stories (nothing invented)
- [x] Implementation explicitly deferred post-soutenance, UML-first