### PR TITLE
docs(brewing-session/architecture): brewing process spec + UML deliverables

### DIFF
--- a/docs/architecture/diagrams/brewing-session/01-use-case.md
+++ b/docs/architecture/diagrams/brewing-session/01-use-case.md
@@ -1,0 +1,67 @@
+# Use-case diagram — brewing-session — guided live brewing
+
+> **Feature**: epic #868 — guided live brewing session; assistance #781.
+> **Source spec**: `docs/architecture/specs/brewing-session.md`
+> **Related**: #605 (data model), #608 (step state machine), #595 (detail rewrite).
+
+## Context
+
+Who interacts with the guided brewing session, and to do what. Goals are
+actor-initiated (UML 2.5): the brewer drives each step; the app's timers and
+alerts are triggers, reframed as the action the brewer takes (e.g. *review* an
+alert, *resume* a paused step). The Mobile/API split is **not** here — see
+`03-component.md`. Grouped by domain (single domain: Brewing session, with a
+Journal sub-group for live data capture).
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer — personas Léa (beginner) / Nicolas (repeatable)"))
+
+  subgraph SYSTEM ["Brasse-Bouillon — Brewing session"]
+    subgraph Run ["Run the session"]
+      UC1(("Start a guided session from a recipe"))
+      UC2(("Start the current step"))
+      UC3(("Complete the current step"))
+      UC4(("Pause / resume the current step"))
+      UC5(("Skip an optional step (with reason)"))
+      UC6(("Consult the step countdown timer"))
+      UC7(("Read a phase's pedagogical tip"))
+    end
+    subgraph Journal ["Live journal"]
+      UC8(("Record a measurement (OG / FG / temp / pH)"))
+      UC9(("Log an observation (note / photo)"))
+      UC10(("Review a batch alert (overdue / threshold)"))
+    end
+    subgraph Close ["Finish"]
+      UC11(("Follow fermentation progress"))
+      UC12(("Finish and package the batch"))
+    end
+  end
+
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+  Brewer --> UC7
+  Brewer --> UC8
+  Brewer --> UC9
+  Brewer --> UC10
+  Brewer --> UC11
+  Brewer --> UC12
+```
+
+## Notes
+
+- **Triggers reframed as goals**: a countdown reaching zero or an overdue alert
+  is a system event, not a use case. The use cases are the brewer's actions —
+  *consult the timer* (UC6), *review an alert* (UC10) — never "be notified".
+- **Optional phases** (whirlpool, dry hop): UC5 (skip with reason) covers
+  recipes that don't have them; the step list is recipe-derived (see spec).
+- **Single actor**: only the Brewer here. Maintainer/admin curation of recipe
+  step data lives in the recipes/catalog domain, not this feature.
+- **Out of scope v0.1** (per #781): full-screen "Brew Day" mode, push
+  notifications, per-step photos — deferred to v0.2.

--- a/docs/architecture/diagrams/brewing-session/02-sequence-guided-step.md
+++ b/docs/architecture/diagrams/brewing-session/02-sequence-guided-step.md
@@ -19,7 +19,7 @@ sequenceDiagram
   participant S as "Mobile — BrewingSessionScreen"
   participant UC as "Mobile — step.use-cases"
   participant HTTP as "core/http/http-client"
-  participant API as "API — batches controller"
+  participant API as "API — BatchController (src/batch)"
   participant DB as "DB"
 
   Note over S: current step = in_progress (recipe-derived)

--- a/docs/architecture/diagrams/brewing-session/02-sequence-guided-step.md
+++ b/docs/architecture/diagrams/brewing-session/02-sequence-guided-step.md
@@ -1,0 +1,70 @@
+# Sequence diagram — brewing-session — execute a guided step
+
+> **Feature**: epic #868; step state machine #608; assistance #781.
+> **Source spec**: `docs/architecture/specs/brewing-session.md`
+
+## Context
+
+What happens in time when the brewer runs one phase of the session: start the
+step (persist timestamp, launch the countdown), optionally record a measurement,
+read the tip, then complete and advance. Shows the mobile ↔ API boundary and the
+offline-resilient timer. Does not cover session creation (recipe → batch steps
+snapshot) — that precedes this loop.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant S as "Mobile — BrewingSessionScreen"
+  participant UC as "Mobile — step.use-cases"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — batches controller"
+  participant DB as "DB"
+
+  Note over S: current step = in_progress (recipe-derived)
+  B->>S: Tap "Démarrer l'étape"
+  S->>UC: startStep(batchId, stepId)
+  UC->>HTTP: POST /batches/:id/steps/:stepId/start
+  HTTP->>API: forward
+  API->>DB: set actualStart, status=in_progress
+  API-->>S: 200 { step }
+  S->>S: persist actualStart locally, start countdown
+
+  opt Record a measurement
+    B->>S: Enter OG / temp value
+    S->>UC: recordMeasurement(stepId, type, value)
+    UC->>HTTP: POST /batches/:id/steps/:stepId/measurements
+    HTTP->>API: forward
+    API->>DB: insert Measurement
+    API-->>S: 201 { measurement }
+  end
+
+  opt Read the tip
+    B->>S: Tap ⓘ
+    S-->>B: show pedagogical tip (local, from step snapshot)
+  end
+
+  Note over S: countdown reaches target → visual shift (trigger, not a transition)
+  B->>S: Tap "Terminer l'étape" (confirm)
+  S->>UC: completeStep(batchId, stepId)
+  UC->>HTTP: POST /batches/:id/steps/:stepId/complete
+  HTTP->>API: forward
+  API->>DB: set actualEnd, status=completed; advance currentStepOrder
+  API-->>S: 200 { batch }
+  S-->>B: render next step (or celebration if last)
+```
+
+## Notes
+
+- **Egress is explicit**: the screen calls a use-case, which calls
+  `core/http/http-client` — never a direct `fetch` (ADR / project rule). The
+  component diagram (`03-component.md`) makes this boundary structural.
+- **Offline-resilient timer**: `actualStart` is persisted locally on Start so
+  the countdown is recomputed on reopen even before the API round-trip resolves;
+  the API call reconciles the server timestamp.
+- **Confirm on Complete**: irreversible transition → confirmation modal (#608).
+- **Tip is local**: read from the step snapshot (no network), so it works mid-brew
+  without signal.
+- **Demo mode**: the same use-cases branch on `dataSource.useDemoData` and mutate
+  the in-memory demo batch instead of calling the API (existing pattern).

--- a/docs/architecture/diagrams/brewing-session/03-component.md
+++ b/docs/architecture/diagrams/brewing-session/03-component.md
@@ -1,0 +1,65 @@
+# Component diagram — brewing-session — structure & boundaries
+
+> **Feature**: epic #868; data model #605; step state machine #608.
+> **Source spec**: `docs/architecture/specs/brewing-session.md`
+> **ADRs**: ADR-0002 (centralized NestJS backend), ADR-0005 (backend split —
+> batch/product data lives in the product API, not the encyclopedia).
+
+## Context
+
+How the feature is structured across packages and layers, and where the single
+network egress point is. Answers "how is it built?", not "who wants what?"
+(that's `01-use-case.md`). Confirms the Clean Architecture layering the project
+mandates: presentation → application (use-cases) → data (http-client) → API.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  subgraph Mobile ["packages/mobile-app — features/batches"]
+    direction TB
+    Screen["presentation/BrewingSessionScreen + step components"]
+    UCs["application/step.use-cases (start/complete/pause/skip, measurement)"]
+    Domain["domain/batch.types (Batch, BatchStep, Measurement...)"]
+    HTTP["core/http/http-client (sole egress)"]
+    DataSrc["core/data/data-source (demo toggle)"]
+    Screen --> UCs
+    UCs --> Domain
+    UCs --> DataSrc
+    UCs --> HTTP
+  end
+
+  subgraph API ["packages/api — batches module"]
+    direction TB
+    Ctrl["batches.controller (REST: steps start/complete/...)"]
+    Svc["batches.service (state machine, alert eval)"]
+    Ent["domain entities + TypeORM (Batch, BatchStep, Measurement, Observation, Alert)"]
+    Ctrl --> Svc
+    Svc --> Ent
+  end
+
+  subgraph Recipes ["packages/api — recipe module"]
+    RStep["RecipeStep (source of the step list)"]
+  end
+
+  DB[("PostgreSQL")]
+
+  HTTP -->|"HTTPS REST"| Ctrl
+  Ent --> DB
+  Svc -->|"snapshot steps on session start"| RStep
+```
+
+## Notes
+
+- **Single egress**: all network calls go through `core/http/http-client`; the
+  screen never calls `fetch` directly (project rule). This diagram makes a
+  bypass visible.
+- **Demo toggle**: `core/data/data-source` lets the use-cases short-circuit to
+  the in-memory demo batch — the demo path does not hit the API.
+- **Recipe-derived**: `batches.service` reads `RecipeStep` from the recipe module
+  to seed the batch step list at session start (snapshot), then never depends on
+  it again — keeps an in-flight batch stable if the recipe changes.
+- **ADR-0005**: batch/session data is product data → lives in `packages/api`
+  (the product backend), never in the beer-encyclopedia service.
+- New entities (Measurement/Observation/Alert) are the #605 deliverable; their
+  TypeORM migrations are part of that issue, not this diagram.

--- a/docs/architecture/diagrams/brewing-session/03-component.md
+++ b/docs/architecture/diagrams/brewing-session/03-component.md
@@ -29,20 +29,20 @@ flowchart LR
     UCs --> HTTP
   end
 
-  subgraph API ["packages/api — batches module"]
+  subgraph API ["packages/api/src/batch — batch module"]
     direction TB
-    Ctrl["batches.controller (REST: steps start/complete/...)"]
-    Svc["batches.service (state machine, alert eval)"]
+    Ctrl["BatchController (REST: steps start/complete/...)"]
+    Svc["BatchService (state machine, alert eval)"]
     Ent["domain entities + TypeORM (Batch, BatchStep, Measurement, Observation, Alert)"]
     Ctrl --> Svc
     Svc --> Ent
   end
 
-  subgraph Recipes ["packages/api — recipe module"]
+  subgraph Recipes ["packages/api/src/recipe — recipe module"]
     RStep["RecipeStep (source of the step list)"]
   end
 
-  DB[("PostgreSQL")]
+  DB[("SQLite (better-sqlite3, TypeORM)")]
 
   HTTP -->|"HTTPS REST"| Ctrl
   Ent --> DB
@@ -56,7 +56,7 @@ flowchart LR
   bypass visible.
 - **Demo toggle**: `core/data/data-source` lets the use-cases short-circuit to
   the in-memory demo batch — the demo path does not hit the API.
-- **Recipe-derived**: `batches.service` reads `RecipeStep` from the recipe module
+- **Recipe-derived**: `BatchService` reads `RecipeStep` from the recipe module
   to seed the batch step list at session start (snapshot), then never depends on
   it again — keeps an in-flight batch stable if the recipe changes.
 - **ADR-0005**: batch/session data is product data → lives in `packages/api`

--- a/docs/architecture/diagrams/brewing-session/04-class.md
+++ b/docs/architecture/diagrams/brewing-session/04-class.md
@@ -1,0 +1,134 @@
+# Class diagram — brewing-session — domain model
+
+> **Feature**: epic #868; data model #605.
+> **Source spec**: `docs/architecture/specs/brewing-session.md`
+
+## Context
+
+The domain entities a guided session needs and their relations. Captures the
+#605 extension (Measurement / Observation / Alert + batch metadata + step
+timestamps) and the recipe link that makes the step list **recipe-derived**.
+This is the conceptual model (cross-package); the persistence mapping (TypeORM
+entities) and the API/mobile split live in `03-component.md`.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class Batch {
+    +UUID id
+    +UUID ownerId
+    +UUID recipeId
+    +BatchStatus status
+    +int currentStepOrder
+    +Date plannedDate
+    +Date actualStartDate
+    +float targetVolume
+    +float realVolume
+    +Date completedAt
+  }
+  class BatchStep {
+    +UUID batchId
+    +int stepOrder
+    +BrewPhase type
+    +string label
+    +string description
+    +string pedagogicalTip
+    +int plannedDurationMin
+    +BatchStepStatus status
+    +Date plannedStart
+    +Date actualStart
+    +Date plannedEnd
+    +Date actualEnd
+    +string skipReason
+  }
+  class Measurement {
+    +UUID id
+    +MeasurementType type
+    +float value
+    +string unit
+    +Date timestamp
+  }
+  class Observation {
+    +UUID id
+    +string freeText
+    +string[] photoRefs
+    +int moodScore
+    +Date timestamp
+  }
+  class Alert {
+    +UUID id
+    +AlertTrigger trigger
+    +AlertSeverity severity
+    +Date createdAt
+    +Date dismissedAt
+  }
+  class RecipeStep {
+    +UUID recipeId
+    +int order
+    +BrewPhase type
+    +float stepTemp
+    +int stepTime
+  }
+
+  Batch "1" o-- "1..*" BatchStep : derived from recipe
+  BatchStep "1" o-- "0..*" Measurement
+  BatchStep "1" o-- "0..*" Observation
+  BatchStep "1" o-- "0..*" Alert
+  RecipeStep "1" ..> "1" BatchStep : seeds (recipe-derived)
+
+  class BatchStatus {
+    <<enumeration>>
+    in_progress
+    completed
+  }
+  class BatchStepStatus {
+    <<enumeration>>
+    pending
+    in_progress
+    paused
+    completed
+    skipped
+  }
+  class BrewPhase {
+    <<enumeration>>
+    mash
+    sparge
+    boil
+    whirlpool
+    cool
+    pitch
+    primary_fermentation
+    dry_hop
+    conditioning_packaging
+  }
+  class MeasurementType {
+    <<enumeration>>
+    OG
+    FG
+    temperature
+    pH
+    SG_spot
+  }
+  class AlertSeverity {
+    <<enumeration>>
+    info
+    warning
+    critical
+  }
+```
+
+## Notes
+
+- **`BrewPhase`** is the 9-phase set from the spec — it **extends** today's API
+  `RecipeStepType` (5 values) and the mobile `BatchStepType` (5 values). This is
+  decision **D1** (ADR needed before build) — flagged here so the model is not
+  silently committed.
+- **Recipe-derived steps**: `RecipeStep ..> BatchStep` — starting a session
+  copies the recipe's ordered steps into batch steps (snapshot), so editing the
+  recipe later does not mutate an in-flight batch.
+- **`pedagogicalTip` + `plannedDurationMin`** live on `BatchStep` (snapshot from
+  recipe/phase defaults) so the timer and ⓘ tip work offline without re-reading
+  the recipe.
+- New entities (`Measurement`, `Observation`, `Alert`) are #605; they compose
+  under `BatchStep` (cascade delete with the batch).

--- a/docs/architecture/diagrams/brewing-session/04-class.md
+++ b/docs/architecture/diagrams/brewing-session/04-class.md
@@ -6,8 +6,9 @@
 ## Context
 
 The domain entities a guided session needs and their relations. Captures the
-#605 extension (Measurement / Observation / Alert + batch metadata + step
-timestamps) and the recipe link that makes the step list **recipe-derived**.
+data-model extension from #605 (Measurement / Observation / Alert + batch
+metadata + step timestamps) and the recipe link that makes the step list
+**recipe-derived**.
 This is the conceptual model (cross-package); the persistence mapping (TypeORM
 entities) and the API/mobile split live in `03-component.md`.
 
@@ -75,7 +76,7 @@ classDiagram
   BatchStep "1" o-- "0..*" Measurement
   BatchStep "1" o-- "0..*" Observation
   BatchStep "1" o-- "0..*" Alert
-  RecipeStep "1" ..> "1" BatchStep : seeds (recipe-derived)
+  RecipeStep "1" ..> "0..*" BatchStep : seeds (one step → many batch steps)
 
   class BatchStatus {
     <<enumeration>>

--- a/docs/architecture/diagrams/brewing-session/05-state-batch-step.md
+++ b/docs/architecture/diagrams/brewing-session/05-state-batch-step.md
@@ -1,0 +1,49 @@
+# State diagram — brewing-session — step & batch lifecycle
+
+> **Feature**: step state machine #608; epic #868.
+> **Source spec**: `docs/architecture/specs/brewing-session.md` § Step lifecycle.
+
+## Context
+
+The lifecycle of a single `BatchStep` (the #608 state machine) and, below it,
+the batch lifecycle it drives. Transitions persist real timestamps and feed the
+dashboard alerts. Irreversible transitions (Complete, Skip) require a
+confirmation modal.
+
+## Step lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending
+  pending --> in_progress: Start (sets actualStart, starts timer)
+  in_progress --> paused: Pause
+  paused --> in_progress: Resume
+  in_progress --> completed: Complete (sets actualEnd) — confirm
+  pending --> skipped: Skip (reason) — confirm, optional phases only
+  in_progress --> skipped: Skip (reason) — confirm
+  completed --> [*]
+  skipped --> [*]
+```
+
+## Batch lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> in_progress: Start guided session (first step Start)
+  in_progress --> in_progress: advance steps
+  in_progress --> completed: last step Complete (Packaging)
+  completed --> [*]
+```
+
+## Notes
+
+- **Timer** runs only in `in_progress`; `actualStart` is persisted so the
+  countdown survives app close/reopen (spec). `paused` freezes it.
+- **Skip** is allowed for optional phases (whirlpool, dry hop) and always
+  records a reason; the use-case diagram models it as UC5.
+- **Alerts** are derived state, not transitions: an *overdue* alert is raised
+  when `now > plannedEnd` while still `in_progress` — handled by the alert
+  evaluator, reviewed by the brewer (UC10), not a step transition.
+- `currentStepOrder` on the batch points at the single `in_progress` step;
+  completing the last phase (Packaging) moves the batch to `completed` (which is
+  what opens the celebration screen — see existing `BatchFinishedScreen`).

--- a/docs/architecture/specs/brewing-session.md
+++ b/docs/architecture/specs/brewing-session.md
@@ -31,9 +31,9 @@ typical for an all-grain ale.
 | # | Phase (FR) | Typ. temp | Typ. duration | Derived from (recipe data) | Optional |
 |---|-----------|-----------|---------------|----------------------------|----------|
 | 1 | **Empâtage** (Mash) | ~65–67 °C | 60 min | mash step(s) `type=infusion/temperature` | no |
-| 2 | **Rinçage** (Sparge / mash-out) | ~75–77 °C | 10–30 min | mash-out + sparge (BeerJSON: sparge = mash step) | no (BIAB may skip) |
+| 2 | **Rinçage** (Sparge / mash-out) | ~75–77 °C | 10–30 min | mash-out + sparge (BeerJSON: sparge = mash step) | optional (BIAB skips) |
 | 3 | **Ébullition** (Boil) | 100 °C | 60–90 min (`boil_time`) | boil step + hop schedule (60/30/15/5/flameout) | no |
-| 4 | **Whirlpool / hop-stand** | ~80 °C | 10–20 min | aroma/whirlpool hop additions | optional |
+| 4 | **Whirlpool / hop-stand** | ~80 °C | 10–20 min | aroma/whirlpool hop additions | optional (see D2) |
 | 5 | **Refroidissement** (Cool/Chill) | → 18–22 °C | 20–60 min | cool step to pitch temp | no |
 | 6 | **Levurage** (Pitch) | 18–22 °C | instant | yeast + pitch temp | no |
 | 7 | **Fermentation primaire** | yeast temp (~18–20 °C ale) | 7–14 days (`primary_age`) | fermentation stage 1 | no |
@@ -41,9 +41,12 @@ typical for an all-grain ale.
 | 9 | **Garde + conditionnement** (Cold crash / Packaging) | < 4 °C crash; then carbonation | 1–2 h active + 2–3 wks bottle conditioning | packaging + `carbonation`/`age` | no |
 
 Mapping to the current API `RecipeStepType` enum (MASH, BOIL, WHIRLPOOL,
-FERMENTATION, PACKAGING — 5 values): **#781 extends it** toward the 9-phase set
-(add SPARGE, COOL, PITCH, split FERMENTATION into PRIMARY/DRY_HOP/CONDITION).
-This extension is a schema decision → to be ratified in an ADR before build.
+FERMENTATION, PACKAGING — 5 values): **#781 extends it** toward the 9-phase
+`BrewPhase` set used in the class diagram — `mash, sparge, boil, whirlpool, cool,
+pitch, primary_fermentation, dry_hop, conditioning_packaging` (adds SPARGE, COOL,
+PITCH; splits FERMENTATION into `primary_fermentation` + `dry_hop`; PACKAGING
+becomes `conditioning_packaging`). This extension is a schema decision (D1) → to
+be ratified in an ADR before build.
 
 ## Pedagogical tips (the "why", vulgarized FR)
 
@@ -75,7 +78,8 @@ During a session the brewer records, per step:
 
 `pending → in_progress → completed`, plus `paused` (resumable) and `skipped`
 (with reason, for optional phases). Transitions persist real timestamps
-(`actual_start`, `actual_end`). Countdown timers run on the `in_progress` step
+(`actualStart`, `actualEnd` in the domain model; `actual_start` / `actual_end`
+as TypeORM snake_case columns). Countdown timers run on the `in_progress` step
 from its planned duration; the start timestamp is persisted so the timer
 survives app close/reopen. Long phases (fermentation 7+ days) display in
 days/hours, not seconds.

--- a/docs/architecture/specs/brewing-session.md
+++ b/docs/architecture/specs/brewing-session.md
@@ -1,0 +1,94 @@
+# Brewing session — process reference
+
+> **Feature**: epic #868 — guided live brewing session ("I brew with the
+> Brasse-Bouillon assistant"); assistance epic #781 (step structure + timers +
+> tips); data model #605; step state machine #608.
+> **Sibling**: epic #866 — BeerXML/BeerJSON schema & mapping (format side).
+> **Personas**: Léa (beginner, needs guidance) · Nicolas (repeatable process).
+
+## Context
+
+This is the **source of truth** for the brewing process the app guides a user
+through. It exists because the brassins/brewing domain had no spec or UML. The
+process below is grounded in the BeerXML 1.0 schema, the BeerJSON 1.0 model, the
+standard all-grain brew-day procedure, and the BrewDog DIY Dog recipe format
+(the 25 recipes seeded by #780). The UML diagrams in
+`docs/architecture/diagrams/brewing-session/` are the visual index of this spec —
+they do not restate it.
+
+**Key insight (epic #868):** a recipe record *is* the process — its mash
+schedule, hop schedule and fermentation stages encode the ordered operations.
+The guided session **derives its steps from recipe data**, it does not hardcode
+them.
+
+## Canonical phases (9, recipe-derived)
+
+Phases are derived from the recipe's steps; optional phases appear only when the
+recipe has the matching data (e.g. dry hop only if the recipe has dry-hop
+additions). Durations/temperatures are recipe values; the defaults below are
+typical for an all-grain ale.
+
+| # | Phase (FR) | Typ. temp | Typ. duration | Derived from (recipe data) | Optional |
+|---|-----------|-----------|---------------|----------------------------|----------|
+| 1 | **Empâtage** (Mash) | ~65–67 °C | 60 min | mash step(s) `type=infusion/temperature` | no |
+| 2 | **Rinçage** (Sparge / mash-out) | ~75–77 °C | 10–30 min | mash-out + sparge (BeerJSON: sparge = mash step) | no (BIAB may skip) |
+| 3 | **Ébullition** (Boil) | 100 °C | 60–90 min (`boil_time`) | boil step + hop schedule (60/30/15/5/flameout) | no |
+| 4 | **Whirlpool / hop-stand** | ~80 °C | 10–20 min | aroma/whirlpool hop additions | optional |
+| 5 | **Refroidissement** (Cool/Chill) | → 18–22 °C | 20–60 min | cool step to pitch temp | no |
+| 6 | **Levurage** (Pitch) | 18–22 °C | instant | yeast + pitch temp | no |
+| 7 | **Fermentation primaire** | yeast temp (~18–20 °C ale) | 7–14 days (`primary_age`) | fermentation stage 1 | no |
+| 8 | **Houblonnage à cru** (Dry hop) | ~14 °C | 3–5 days | hop additions `use=dry hop` | optional |
+| 9 | **Garde + conditionnement** (Cold crash / Packaging) | < 4 °C crash; then carbonation | 1–2 h active + 2–3 wks bottle conditioning | packaging + `carbonation`/`age` | no |
+
+Mapping to the current API `RecipeStepType` enum (MASH, BOIL, WHIRLPOOL,
+FERMENTATION, PACKAGING — 5 values): **#781 extends it** toward the 9-phase set
+(add SPARGE, COOL, PITCH, split FERMENTATION into PRIMARY/DRY_HOP/CONDITION).
+This extension is a schema decision → to be ratified in an ADR before build.
+
+## Pedagogical tips (the "why", vulgarized FR)
+
+Each phase carries one tip (BrewDog DIY Dog "Brewer's Tip" style), surfaced via
+an ⓘ icon. Examples (validated against the research sources):
+
+- **Empâtage 67 °C** — *« À cette température l'alpha-amylase convertit l'amidon
+  en sucres fermentescibles ; plus chaud = corps + sucres non fermentescibles,
+  plus froid = bière plus sèche. »*
+- **Ébullition** — *« L'ébullition stérilise le moût, isomérise les acides alpha
+  du houblon (création de l'amertume) et concentre les sucres. »*
+- **Levurage** — *« Verser la levure à 18–22 °C ; au-delà elle stresse et produit
+  des esters/phénols indésirables. »*
+- **Houblonnage à cru** — *« Le dry hop infuse les huiles aromatiques sans
+  amertume (pas d'isomérisation à froid). BrewDog : ~14 °C, 5 jours, profil le
+  plus aromatique. »*
+
+## Live tracking data (#605)
+
+During a session the brewer records, per step:
+
+- **Measurement** — typed reading: OG / FG / temperature / pH / SG-spot, with
+  value + unit + timestamp + step link.
+- **Observation** — free text + optional photos + mood score.
+- **Alert** — overdue (planned vs actual time) or threshold (e.g. temp out of
+  range), with severity, dismissible.
+
+## Step lifecycle (#608)
+
+`pending → in_progress → completed`, plus `paused` (resumable) and `skipped`
+(with reason, for optional phases). Transitions persist real timestamps
+(`actual_start`, `actual_end`). Countdown timers run on the `in_progress` step
+from its planned duration; the start timestamp is persisted so the timer
+survives app close/reopen. Long phases (fermentation 7+ days) display in
+days/hours, not seconds.
+
+## Sources
+
+- BeerXML 1.0 schema — <https://www.beerxml.com/beerxml.htm>
+- BeerJSON 1.0 — <https://beerjson.github.io/beerjson/> · <https://github.com/beerjson/beerjson>
+- All-grain brew day (AHA) — <https://homebrewersassociation.org/tutorials/all-grain-batch-sparge-homebrewing/all-grain-batch-sparge-homebrewing/>
+- BrewDog DIY Dog / Punk IPA method + Brewer's Tip — <https://byo.com/recipes/brewdog-punk-ipa-clone/>
+
+## Open decisions (ratify before build)
+
+- **D1** — extend `RecipeStepType` to the 9-phase set (ADR needed; touches API + mobile + BeerXML mapping #866).
+- **D2** — whirlpool: own phase or boil sub-step? (BeerJSON makes it explicit; #781 folds it into boil/cool.)
+- **D3** — fermentation surfaced in production (today demo-only) — minimal manual log vs sensor data (cross-ref ux-refonte journey-3 gap).


### PR DESCRIPTION
## Summary

Conception for the previously-unmodelled **brassins / brewing** domain.
Documentation only — UML-first, conception precedes code.

- `docs/architecture/specs/brewing-session.md` — process **source of truth**:
  the 9 recipe-derived phases (mash → sparge → boil → whirlpool → cool → pitch →
  primary fermentation → dry hop → conditioning/packaging) with typical
  temps/durations, pedagogical tips, live tracking (Measurement / Observation /
  Alert), step lifecycle, and the mapping to BeerXML 1.0 / BeerJSON 1.0 + the
  BrewDog DIY Dog format. Open decisions **D1–D3** flagged.
- `docs/architecture/diagrams/brewing-session/` — 01 use-case (brewer goals,
  triggers reframed), 02 sequence (execute a guided step, mobile↔API, offline
  timer), 03 component (Clean Architecture layers, single http egress, ADR-0005),
  04 class (domain model incl. #605 entities + 9-phase `BrewPhase` enum), 05 state
  (step #608 + batch lifecycle).

## Context

The brewing domain had no spec or UML (only scan / beer-duel / feedback were
modelled). Grounded in beerxml.com, beerjson.github.io, the AHA all-grain
tutorial, and BrewDog DIY Dog. **D1** (extend `RecipeStepType` from 5 → 9 phases)
crosses API + mobile + BeerXML mapping #866 → needs an ADR before implementation.

Refs #868, #781, #605, #608.

## Checklist

- [x] Documentation only — no code
- [x] English (internal artefact); FR only in quoted UI tips/labels
- [x] UML 2.5 conventions (use cases = actor goals; use-case ≠ component; grouped by domain)
- [x] Cross-links spec + ADR-0002/0005; open decisions flagged (not silently committed)