### PR TITLE
docs(recipes/architecture): UML deliverables for the recipes domain

### DIFF
--- a/docs/architecture/diagrams/recipes/01-use-case.md
+++ b/docs/architecture/diagrams/recipes/01-use-case.md
@@ -60,15 +60,17 @@ flowchart LR
 
 ## Notes
 
-- **Status today** (see `06-status` note in PR): UC7–UC12 (read/list/scale/clone/
-  start) are implemented; **UC1–UC6 (write CRUD + fork) have backend endpoints
-  but no mobile UI** — the central open gap (#410–#420). UC13/UC14 (BeerXML) are
-  planned (#778/#865/#881).
+- **Status today**: UC7–UC12 (read/list/scale/clone/start) are implemented.
+  **UC1–UC5 (create/edit/delete + ingredients/steps)** have backend **create/update/
+  delete** endpoints (steps are GET + PATCH today) but **no mobile UI** — the
+  central open gap (#410–#420). **UC6 fork** has no REST route yet (pure domain
+  service only, #882/#883). UC13/UC14 (BeerXML) are planned (#778/#865/#881).
 - **Clone vs fork** are distinct goals: UC11 *clone a community recipe* deep-copies
   a public recipe into a **new private root** (own lineage, provenance kept); UC6
   *fork* creates a **new version within my own lineage** (`version+1`,
   `parentRecipeId` → source). Both reuse the same versioning model (class diagram).
 - **UC12 (start a session)** is the hand-off to the brewing-session feature — its
-  own use-case set lives in `diagrams/brewing-session/`.
+  own use-case set is the sibling conception PR #1096 (merges into
+  `docs/architecture/diagrams/brewing-session/`).
 - **No `Beer` actor/entity**: recipes are the core unit; the old "Recipe.cloneOf →
   Beer.id" note is superseded by the root/parent versioning model.

--- a/docs/architecture/diagrams/recipes/01-use-case.md
+++ b/docs/architecture/diagrams/recipes/01-use-case.md
@@ -1,0 +1,74 @@
+# Use-case diagram — recipes — author, discover, clone & version
+
+> **Feature**: epic #740 (Mes Recettes hub + detail); recipe write CRUD
+> #410–#420; community clone/version #739 #882 #883; BeerXML I/O #778 #865 #881.
+> **Personas**: Claire (creative — versioning/forks), Nicolas (repeatable),
+> Léa (discover/clone), Marc (BeerXML migration).
+
+## Context
+
+Who interacts with recipes and to do what. Goals are actor-initiated (UML 2.5).
+Grouped by domain (Recipes), with sub-groups: Author (own recipes), Discover
+(catalog + clone), Interop (BeerXML). The Mobile/API split is in `03-component.md`,
+not here. Read paths exist today; write CRUD + clone-UX + BeerXML are the open
+goals this models so implementation has a target.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer — Claire / Nicolas / Léa / Marc"))
+
+  subgraph SYSTEM ["Brasse-Bouillon — Recipes"]
+    subgraph Author ["Author my recipes"]
+      UC1(("Create a recipe"))
+      UC2(("Edit a recipe (metadata + targets)"))
+      UC3(("Add / remove ingredients (hops, fermentables, yeast, water)"))
+      UC4(("Define / order brewing steps"))
+      UC5(("Delete a recipe"))
+      UC6(("Save a variant as a new version (fork)"))
+    end
+    subgraph Discover ["Discover & reuse"]
+      UC7(("Browse my recipes"))
+      UC8(("Browse the public catalog"))
+      UC9(("Consult a recipe (5-tab detail)"))
+      UC10(("Scale a recipe to my target volume"))
+      UC11(("Clone a community recipe into my recipes"))
+      UC12(("Start a brewing session from a recipe"))
+    end
+    subgraph Interop ["Interop"]
+      UC13(("Import a recipe from BeerXML / BeerJSON"))
+      UC14(("Export a recipe to BeerXML / BeerJSON"))
+    end
+  end
+
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+  Brewer --> UC7
+  Brewer --> UC8
+  Brewer --> UC9
+  Brewer --> UC10
+  Brewer --> UC11
+  Brewer --> UC12
+  Brewer --> UC13
+  Brewer --> UC14
+```
+
+## Notes
+
+- **Status today** (see `06-status` note in PR): UC7–UC12 (read/list/scale/clone/
+  start) are implemented; **UC1–UC6 (write CRUD + fork) have backend endpoints
+  but no mobile UI** — the central open gap (#410–#420). UC13/UC14 (BeerXML) are
+  planned (#778/#865/#881).
+- **Clone vs fork** are distinct goals: UC11 *clone a community recipe* deep-copies
+  a public recipe into a **new private root** (own lineage, provenance kept); UC6
+  *fork* creates a **new version within my own lineage** (`version+1`,
+  `parentRecipeId` → source). Both reuse the same versioning model (class diagram).
+- **UC12 (start a session)** is the hand-off to the brewing-session feature — its
+  own use-case set lives in `diagrams/brewing-session/`.
+- **No `Beer` actor/entity**: recipes are the core unit; the old "Recipe.cloneOf →
+  Beer.id" note is superseded by the root/parent versioning model.

--- a/docs/architecture/diagrams/recipes/02-sequence-create-and-fork.md
+++ b/docs/architecture/diagrams/recipes/02-sequence-create-and-fork.md
@@ -1,0 +1,77 @@
+# Sequence diagram — recipes — create a recipe & fork a version
+
+> **Feature**: write CRUD #410–#420; fork/versioning #882 #883.
+> **Source**: `recipes.use-cases.ts`, `recipes.api.ts`, `recipe.service.ts`.
+
+## Context
+
+The write path the mobile app is missing today: create a recipe then populate
+its ingredients/steps, and fork an existing recipe into a new version. Backend
+endpoints already exist (POST/PATCH/DELETE) — this models the mobile use-cases +
+egress to add. Read/scale/clone-from-community already work and are not repeated
+here.
+
+## Create & populate a recipe
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant S as "Mobile — RecipeEditorScreen"
+  participant UC as "Mobile — recipes.use-cases (NEW)"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — recipe.controller"
+  participant DB as "DB"
+
+  B->>S: Fill name, style, targets (OG/IBU/volume)
+  B->>S: Tap "Créer"
+  S->>UC: createRecipe(draft)
+  UC->>HTTP: POST /recipes
+  HTTP->>API: forward
+  API->>DB: insert Recipe (version=1, rootRecipeId=self, visibility=private)
+  API-->>S: 201 { recipe }
+
+  loop Add ingredients / steps
+    B->>S: Add hop / fermentable / yeast / step
+    S->>UC: addIngredient(recipeId, item) / addStep(recipeId, step)
+    UC->>HTTP: POST /recipes/:id/{hops|fermentables|yeasts|steps}
+    HTTP->>API: forward
+    API->>DB: insert satellite (recipe_id FK)
+    API-->>S: 201
+  end
+
+  S-->>B: render the 5-tab detail (live-scaled stats)
+```
+
+## Fork a recipe into a new version
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant S as "Mobile — RecipeDetailsScreen"
+  participant UC as "Mobile — recipes.use-cases (NEW)"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — recipe.controller"
+  participant DB as "DB"
+
+  B->>S: Tap "Enregistrer comme nouvelle version"
+  S->>UC: forkRecipe(sourceId)
+  UC->>HTTP: POST /recipes/:id/fork
+  HTTP->>API: forward
+  API->>DB: deep-copy satellites; new Recipe (version+1, same rootRecipeId, parentRecipeId=source)
+  API-->>S: 201 { recipe }
+  S-->>B: open the new version in the editor
+```
+
+## Notes
+
+- **Egress rule**: screen → use-case → `core/http/http-client`; never a direct
+  `fetch` (project rule; see `03-component.md`).
+- **Demo mode**: the new write use-cases must branch on `dataSource.useDemoData`
+  and mutate the in-memory demo recipes (existing pattern) so the demo works
+  offline.
+- **Clone-from-community** (#601, already implemented) is a sibling of *fork*: it
+  deep-copies a *public* recipe into a **new private root**, whereas *fork* stays
+  within the user's lineage (`version+1`). Both land on the same satellite
+  deep-copy logic server-side.
+- **Validation**: targets (OG/FG/IBU/volume) validated client + server; a recipe
+  with no fermentable cannot be marked brewable (acceptance criterion for #410).

--- a/docs/architecture/diagrams/recipes/02-sequence-create-and-fork.md
+++ b/docs/architecture/diagrams/recipes/02-sequence-create-and-fork.md
@@ -19,7 +19,7 @@ sequenceDiagram
   participant S as "Mobile — RecipeEditorScreen"
   participant UC as "Mobile — recipes.use-cases (NEW)"
   participant HTTP as "core/http/http-client"
-  participant API as "API — recipe.controller"
+  participant API as "API — RecipeController (src/recipe)"
   participant DB as "DB"
 
   B->>S: Fill name, style, targets (OG/IBU/volume)
@@ -30,10 +30,10 @@ sequenceDiagram
   API->>DB: insert Recipe (version=1, rootRecipeId=self, visibility=private)
   API-->>S: 201 { recipe }
 
-  loop Add ingredients / steps
+  loop Add ingredients / steps (endpoints to ADD — see note)
     B->>S: Add hop / fermentable / yeast / step
     S->>UC: addIngredient(recipeId, item) / addStep(recipeId, step)
-    UC->>HTTP: POST /recipes/:id/{hops|fermentables|yeasts|steps}
+    UC->>HTTP: POST /recipes/:id/{hops|fermentables|yeasts|steps} (planned)
     HTTP->>API: forward
     API->>DB: insert satellite (recipe_id FK)
     API-->>S: 201
@@ -42,7 +42,10 @@ sequenceDiagram
   S-->>B: render the 5-tab detail (live-scaled stats)
 ```
 
-## Fork a recipe into a new version
+## Fork a recipe into a new version (PLANNED — no REST route yet)
+
+> Fork exists only as a pure domain service today (#882/#883); the
+> `POST /recipes/:id/fork` route + mobile use-case below are the target to build.
 
 ```mermaid
 sequenceDiagram
@@ -50,12 +53,12 @@ sequenceDiagram
   participant S as "Mobile — RecipeDetailsScreen"
   participant UC as "Mobile — recipes.use-cases (NEW)"
   participant HTTP as "core/http/http-client"
-  participant API as "API — recipe.controller"
+  participant API as "API — RecipeController (src/recipe)"
   participant DB as "DB"
 
   B->>S: Tap "Enregistrer comme nouvelle version"
   S->>UC: forkRecipe(sourceId)
-  UC->>HTTP: POST /recipes/:id/fork
+  UC->>HTTP: POST /recipes/:id/fork (planned)
   HTTP->>API: forward
   API->>DB: deep-copy satellites; new Recipe (version+1, same rootRecipeId, parentRecipeId=source)
   API-->>S: 201 { recipe }

--- a/docs/architecture/diagrams/recipes/03-component.md
+++ b/docs/architecture/diagrams/recipes/03-component.md
@@ -29,16 +29,16 @@ flowchart LR
     Data --> HTTP
   end
 
-  subgraph API ["packages/api — recipe module"]
+  subgraph API ["packages/api/src/recipe — recipe module"]
     direction TB
-    Ctrl["recipe.controller (REST: CRUD, steps, ingredients, import-from-community, fork)"]
-    Svc["recipe.service (versioning, deep-copy, provenance)"]
+    Ctrl["RecipeController (REST: CRUD, GET/PATCH steps, ingredients, import-from-community)"]
+    Svc["RecipeService (versioning, deep-copy, provenance) — fork = domain service, not yet exposed"]
     Ent["entities: Recipe + Step/Hop/Fermentable/Yeast/Additive/Water (TypeORM)"]
     Ctrl --> Svc
     Svc --> Ent
   end
 
-  DB[("PostgreSQL")]
+  DB[("SQLite (better-sqlite3, TypeORM)")]
 
   HTTP -->|"HTTPS REST"| Ctrl
   Ent --> DB
@@ -49,8 +49,10 @@ flowchart LR
 - **Egress**: all recipe network calls go through `data/recipes.api` →
   `core/http/http-client`. No direct `fetch` in screens.
 - **Gap made visible**: the mobile `application` + `presentation` write path
-  (create/edit/delete/fork + RecipeEditorScreen) is the missing layer — backend
-  controller/service/entities already expose it.
+  (create/edit/delete + RecipeEditorScreen) is the missing layer — the backend
+  already exposes **create/update/delete + GET/PATCH steps + import-from-community**.
+  **Fork is not yet a REST route** (only a pure domain service today, #882/#883) —
+  it needs both an endpoint and the mobile UI.
 - **ADR-0005**: recipe data is product data → `packages/api`, never the
   beer-encyclopedia service. The encyclopedia only feeds *scan* matching (a
   recipe's `style` tag is used there, read-only).

--- a/docs/architecture/diagrams/recipes/03-component.md
+++ b/docs/architecture/diagrams/recipes/03-component.md
@@ -1,0 +1,58 @@
+# Component diagram — recipes — structure & boundaries
+
+> **Feature**: epic #740; write CRUD #410–#420.
+> **ADRs**: ADR-0002 (centralized NestJS backend), ADR-0005 (recipes are product
+> data → product API, not the encyclopedia).
+
+## Context
+
+How the recipes feature is structured across packages and layers. Confirms the
+single network egress and the Clean Architecture layering. Same shape as the
+brewing-session component diagram (consistency is intentional).
+
+## Diagram
+
+```mermaid
+flowchart LR
+  subgraph Mobile ["packages/mobile-app — features/recipes"]
+    direction TB
+    Screens["presentation/ (RecipesScreen, RecipeDetailsScreen + 5 tabs, RecipeEditorScreen NEW)"]
+    UCs["application/recipes.use-cases (list/get/scale/import done; create/edit/delete/fork NEW)"]
+    Domain["domain/recipe.types (Recipe, RecipeStep, stats, ingredient refs)"]
+    Data["data/recipes.api"]
+    HTTP["core/http/http-client (sole egress)"]
+    DataSrc["core/data/data-source (demo toggle)"]
+    Screens --> UCs
+    UCs --> Domain
+    UCs --> DataSrc
+    UCs --> Data
+    Data --> HTTP
+  end
+
+  subgraph API ["packages/api — recipe module"]
+    direction TB
+    Ctrl["recipe.controller (REST: CRUD, steps, ingredients, import-from-community, fork)"]
+    Svc["recipe.service (versioning, deep-copy, provenance)"]
+    Ent["entities: Recipe + Step/Hop/Fermentable/Yeast/Additive/Water (TypeORM)"]
+    Ctrl --> Svc
+    Svc --> Ent
+  end
+
+  DB[("PostgreSQL")]
+
+  HTTP -->|"HTTPS REST"| Ctrl
+  Ent --> DB
+```
+
+## Notes
+
+- **Egress**: all recipe network calls go through `data/recipes.api` →
+  `core/http/http-client`. No direct `fetch` in screens.
+- **Gap made visible**: the mobile `application` + `presentation` write path
+  (create/edit/delete/fork + RecipeEditorScreen) is the missing layer — backend
+  controller/service/entities already expose it.
+- **ADR-0005**: recipe data is product data → `packages/api`, never the
+  beer-encyclopedia service. The encyclopedia only feeds *scan* matching (a
+  recipe's `style` tag is used there, read-only).
+- **Demo toggle** mirrors every other feature: use-cases short-circuit to
+  `demoRecipes` when `useDemoData`.

--- a/docs/architecture/diagrams/recipes/04-class.md
+++ b/docs/architecture/diagrams/recipes/04-class.md
@@ -38,6 +38,9 @@ classDiagram
     +int brewCount
     +float avgRating
     +bool isOfficial
+    +Date lastBrewedAt
+    +Date createdAt
+    +Date updatedAt
   }
   class RecipeStep {
     +UUID recipeId
@@ -87,6 +90,7 @@ classDiagram
     +float mashTemperatureC
     +float spargeTemperatureC
     +float calciumPpm
+    +float magnesiumPpm
     +float sulfatePpm
     +float chloridePpm
     +float phTarget
@@ -136,5 +140,6 @@ classDiagram
 - **Ingredient satellites** are one-to-many by `recipeId` FK; `RecipeWater` is
   0..1 (one water profile per recipe). Enums shown are the load-bearing ones;
   fermentable/yeast/additive type enums omitted for space (exist in the API).
-- **`RecipeStepType` (5 values)** is shared with the brewing session; its 9-phase
-  extension is brewing-session **D1** (ADR before build), not decided here.
+- **`RecipeStepType` (5 values)** is shared with the brewing session; its planned
+  9-phase extension (decision **D1**, tracked in #781/#866 and the sibling
+  brewing-session conception PR #1096) needs an ADR before build — not decided here.

--- a/docs/architecture/diagrams/recipes/04-class.md
+++ b/docs/architecture/diagrams/recipes/04-class.md
@@ -1,0 +1,140 @@
+# Class diagram — recipes — domain model & versioning
+
+> **Feature**: epic #740; versioning #882 #883; write CRUD #410–#420.
+> **Source**: `packages/api/src/recipe/entities/*` and
+> `packages/mobile-app/src/features/recipes/domain/recipe.types.ts`.
+
+## Context
+
+The recipe aggregate and its ingredient/step satellites, plus the
+root/parent/version lineage that powers clone and fork. Reflects the **existing**
+schema (not a proposal) so the write-CRUD UI maps onto real tables. The 9-phase
+`RecipeStepType` extension is the brewing-session decision D1, not made here.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class Recipe {
+    +UUID id
+    +UUID ownerId
+    +string name
+    +string description
+    +RecipeVisibility visibility
+    +int version
+    +UUID rootRecipeId
+    +UUID parentRecipeId
+    +float batchSizeL
+    +int boilTimeMin
+    +float ogTarget
+    +float fgTarget
+    +float abvEstimated
+    +float ibuTarget
+    +float ebcTarget
+    +float efficiencyTarget
+    +string style
+    +UUID importedFromRecipeId
+    +string importProvenance
+    +int brewCount
+    +float avgRating
+    +bool isOfficial
+  }
+  class RecipeStep {
+    +UUID recipeId
+    +int stepOrder
+    +RecipeStepType type
+    +string label
+    +string description
+  }
+  class RecipeHop {
+    +UUID recipeId
+    +string variety
+    +RecipeHopType type
+    +float weightG
+    +float alphaAcidPercent
+    +RecipeHopAdditionStage additionStage
+    +int additionTimeMin
+  }
+  class RecipeFermentable {
+    +UUID recipeId
+    +string name
+    +RecipeFermentableType type
+    +float weightG
+    +float potentialGravity
+    +float colorEbc
+  }
+  class RecipeYeast {
+    +UUID recipeId
+    +string name
+    +RecipeYeastType type
+    +float amountG
+    +float attenuationPercent
+    +float temperatureMinC
+    +float temperatureMaxC
+  }
+  class RecipeAdditive {
+    +UUID recipeId
+    +string name
+    +RecipeAdditiveType type
+    +float amountG
+    +RecipeStepType additionStep
+    +int additionTimeMin
+  }
+  class RecipeWater {
+    +UUID recipeId
+    +float mashVolumeL
+    +float spargeVolumeL
+    +float mashTemperatureC
+    +float spargeTemperatureC
+    +float calciumPpm
+    +float sulfatePpm
+    +float chloridePpm
+    +float phTarget
+  }
+
+  Recipe "1" o-- "0..*" RecipeStep
+  Recipe "1" o-- "0..*" RecipeHop
+  Recipe "1" o-- "0..*" RecipeFermentable
+  Recipe "1" o-- "0..*" RecipeYeast
+  Recipe "1" o-- "0..*" RecipeAdditive
+  Recipe "1" o-- "0..1" RecipeWater
+  Recipe "1" --> "0..1" Recipe : parentRecipeId (fork)
+  Recipe "1" --> "1" Recipe : rootRecipeId (lineage)
+
+  class RecipeVisibility {
+    <<enumeration>>
+    private
+    unlisted
+    public
+  }
+  class RecipeHopAdditionStage {
+    <<enumeration>>
+    first_wort
+    boil
+    whirlpool
+    dry_hop
+  }
+  class RecipeStepType {
+    <<enumeration>>
+    mash
+    boil
+    whirlpool
+    fermentation
+    packaging
+  }
+```
+
+## Notes
+
+- **Versioning** is the two self-references: `rootRecipeId` (first recipe of the
+  lineage, immutable) + `parentRecipeId` (direct parent). A fork = new Recipe,
+  `version+1`, same `rootRecipeId`, `parentRecipeId` = source. No mutation of the
+  source — variants are first-class rows.
+- **Clone from community** (#601, implemented): deep-copies all satellites into a
+  **new private root** (`rootRecipeId = newId`, `parentRecipeId = null`,
+  `version = 1`); provenance kept in `importedFromRecipeId` + `importProvenance`.
+- **Ingredient satellites** are one-to-many by `recipeId` FK; `RecipeWater` is
+  0..1 (one water profile per recipe). Enums shown are the load-bearing ones;
+  fermentable/yeast/additive type enums omitted for space (exist in the API).
+- **`RecipeStepType` (5 values)** is shared with the brewing session; its 9-phase
+  extension is brewing-session **D1** (ADR before build), not decided here.

--- a/docs/architecture/diagrams/recipes/05-state-recipe-lifecycle.md
+++ b/docs/architecture/diagrams/recipes/05-state-recipe-lifecycle.md
@@ -1,0 +1,49 @@
+# State diagram — recipes — visibility & version lineage
+
+> **Feature**: epic #740; visibility model (existing); fork/versioning #882 #883.
+
+## Context
+
+A recipe's two orthogonal lifecycles: its **visibility** (who can see it) and its
+**version lineage** (how variants relate). Recipes have no heavy state machine
+beyond these; capturing them prevents accidental mutation-in-place of shared
+recipes.
+
+## Visibility
+
+```mermaid
+stateDiagram-v2
+  [*] --> private: Create
+  private --> unlisted: Share by link
+  unlisted --> public: Publish to catalog
+  public --> unlisted: Unpublish
+  unlisted --> private: Make private
+  private --> [*]: Delete
+  public --> [*]: Delete (owner)
+```
+
+## Version lineage (fork)
+
+```mermaid
+stateDiagram-v2
+  [*] --> v1: Create (rootRecipeId = self, version = 1)
+  v1 --> v2: Fork (version+1, parent = v1, same root)
+  v2 --> v3: Fork (version+1, parent = v2, same root)
+  note right of v2
+    Each version is a new immutable Recipe row.
+    Forking never mutates the parent.
+    Clone-from-community starts a NEW root (own v1).
+  end note
+```
+
+## Notes
+
+- **Visibility transitions** are owner-initiated; publishing to `public` is what
+  makes a recipe clonable by others (clone → a new private root for the cloner).
+- **Versions are append-only rows**, not in-place edits of a shared recipe — this
+  is the guarantee that a public recipe others have cloned cannot change under
+  them. Editing your *own* private recipe is a normal PATCH (not a fork); a fork
+  is an explicit "save as new version".
+- **Delete**: removing a recipe cascades to its satellites; deleting a `root`
+  with descendants is a product decision (block, or re-root children) — flag as
+  an open question for the write-CRUD epic (#420).


### PR DESCRIPTION
## Summary

Conception for the **recipes** domain (no UML existed). Documentation only, UML-first.

- `docs/architecture/diagrams/recipes/` — 01 use-case (author / discover / clone /
  version / BeerXML interop), 02 sequence (create-and-populate + fork — the
  missing mobile write path), 03 component (Clean Architecture, single egress,
  ADR-0005), 04 class (existing Recipe schema + satellites + root/parent/version
  lineage), 05 state (visibility + append-only version lineage).

## Context

Read/list/scale/clone-from-community are implemented; the **write CRUD
(#410–#420) has backend endpoints but no mobile UI** — the central open gap this
models. Clone (new private root, provenance) vs fork (new version in lineage) are
distinguished. Grounded in `packages/api/src/recipe/*` and the mobile recipes
domain.

Refs #740, #410, #882, #883.

## Checklist

- [x] Documentation only — no code
- [x] English; FR only in quoted UI labels
- [x] UML 2.5 conventions (actor goals; use-case ≠ component; grouped by domain)
- [x] Reflects the existing schema (not a proposal); open questions flagged