### PR TITLE
docs(batches/architecture): UML deliverables for the Mes Brassins journal

### DIFF
--- a/docs/architecture/diagrams/batches/01-use-case.md
+++ b/docs/architecture/diagrams/batches/01-use-case.md
@@ -1,0 +1,65 @@
+# Use-case diagram — batches — "Mes Brassins" journal
+
+> **Feature**: epic #595 (Mes Brassins detail rewrite); #605 (data model),
+> #606 (5-section detail), #607 (measurement/observation entry), #608 (step state).
+> **Related**: the live guided execution is `diagrams/brewing-session/` — this
+> feature is the **journal / management** around batches.
+> **Personas**: Nicolas (track & compare batches), Claire (document experiments).
+
+## Context
+
+Who manages brewing batches and to do what. This is the brewer's **journal**:
+browse batches, read the 5-section detail, record measurements/observations
+(including after the fact), review alerts, and close out. The live step-by-step
+execution (start/complete/pause a step, timers, tips) is a distinct feature
+(`brewing-session/01-use-case.md`) reached via UC "Start a guided session".
+Grouped by domain (Batches). Mobile/API split is not here.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer — Nicolas / Claire"))
+
+  subgraph SYSTEM ["Brasse-Bouillon — Mes Brassins"]
+    subgraph Browse ["Browse"]
+      UC1(("Browse my batches (by status)"))
+      UC2(("Open a batch detail (5 sections)"))
+      UC3(("Open the linked recipe"))
+    end
+    subgraph Journal ["Journal"]
+      UC4(("Record a measurement (OG / FG / temp / pH)"))
+      UC5(("Log an observation (note / photo)"))
+      UC6(("Review a batch alert (overdue / threshold)"))
+    end
+    subgraph Lifecycle ["Lifecycle"]
+      UC7(("Start a guided brewing session"))
+      UC8(("View the finished-batch celebration"))
+      UC9(("Archive / delete a batch"))
+    end
+  end
+
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+  Brewer --> UC7
+  Brewer --> UC8
+  Brewer --> UC9
+```
+
+## Notes
+
+- **Boundary with brewing-session**: UC7 hands off to the guided-execution
+  feature (its own use cases). UC4/UC5 here are *journal* entries — recordable
+  any time (retrospective logging), whereas the same data captured *during* a
+  live step is modelled in `brewing-session/02-sequence`.
+- **5-section detail (UC2, #606)**: Identity / Plan / Live-history / Measurements
+  / Notes — a presentation grouping over the batch aggregate (class diagram).
+- **UC8 celebration** is the existing `BatchFinishedScreen`, reached when the
+  batch reaches `completed` (today demo-gated; production surfacing is the
+  journey-3/4 gap from the ux-refonte study).
+- **Triggers reframed**: an overdue/threshold alert is a system event; the use
+  case is UC6 *review* an alert (brewer pulls), not "be notified".

--- a/docs/architecture/diagrams/batches/01-use-case.md
+++ b/docs/architecture/diagrams/batches/01-use-case.md
@@ -2,8 +2,8 @@
 
 > **Feature**: epic #595 (Mes Brassins detail rewrite); #605 (data model),
 > #606 (5-section detail), #607 (measurement/observation entry), #608 (step state).
-> **Related**: the live guided execution is `diagrams/brewing-session/` — this
-> feature is the **journal / management** around batches.
+> **Related**: the live guided execution is the sibling brewing-session
+> conception (PR #1096) — this feature is the **journal / management** around batches.
 > **Personas**: Nicolas (track & compare batches), Claire (document experiments).
 
 ## Context

--- a/docs/architecture/diagrams/batches/02-sequence-detail-and-measurement.md
+++ b/docs/architecture/diagrams/batches/02-sequence-detail-and-measurement.md
@@ -1,0 +1,62 @@
+# Sequence diagram — batches — open detail & record a measurement
+
+> **Feature**: 5-section detail #606; measurement entry #607.
+> **Source**: mobile `features/batches` + API `batches` module.
+
+## Context
+
+Two journal interactions: loading the 5-section batch detail, and recording a
+measurement from the Measurements section (retrospective entry, any time — not
+necessarily mid-live-step). The live-step start/complete flow is in
+`brewing-session/02-sequence`.
+
+## Open the 5-section detail
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant L as "Mobile — BatchesScreen (list)"
+  participant S as "Mobile — BatchDetailsScreen"
+  participant UC as "Mobile — batches.use-cases"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — batches controller"
+
+  B->>L: Tap a batch
+  L->>S: navigate(batchId)
+  S->>UC: getBatchDetailsViewModel(batchId)
+  UC->>HTTP: GET /batches/:id (steps, measurements, observations, alerts)
+  HTTP->>API: forward
+  API-->>S: 200 { batch, steps, measurements, observations, alerts }
+  S-->>B: render Identity / Plan / Live / Measurements / Notes
+```
+
+## Record a measurement
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant S as "Mobile — Measurements section"
+  participant UC as "Mobile — batches.use-cases"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — batches controller"
+  participant DB as "DB"
+
+  B->>S: Tap "Ajouter une mesure", pick type (OG/temp/pH), enter value
+  S->>UC: recordMeasurement(batchId, stepId?, type, value, unit)
+  UC->>HTTP: POST /batches/:id/measurements
+  HTTP->>API: forward
+  API->>DB: insert Measurement (timestamp = now)
+  API->>API: re-evaluate threshold alerts
+  API-->>S: 201 { measurement, alerts? }
+  S-->>B: append row to the Measurements table (+ alert badge if raised)
+```
+
+## Notes
+
+- **Egress**: screen → use-case → `core/http/http-client`; no direct `fetch`.
+- **`getBatchDetailsViewModel`** already exists (assembles recipe name + steps);
+  the rewrite extends it to also fetch measurements/observations/alerts for the
+  5 sections.
+- **Alert re-evaluation** happens server-side on measurement insert (threshold
+  breach) — the brewer then *reviews* it (use-case UC6), it is not pushed.
+- **Demo mode**: use-cases mutate the in-memory demo batch (existing pattern).

--- a/docs/architecture/diagrams/batches/02-sequence-detail-and-measurement.md
+++ b/docs/architecture/diagrams/batches/02-sequence-detail-and-measurement.md
@@ -7,8 +7,8 @@
 
 Two journal interactions: loading the 5-section batch detail, and recording a
 measurement from the Measurements section (retrospective entry, any time — not
-necessarily mid-live-step). The live-step start/complete flow is in
-`brewing-session/02-sequence`.
+necessarily mid-live-step). The live-step start/complete flow is in the sibling
+brewing-session conception (PR #1096).
 
 ## Open the 5-section detail
 
@@ -42,10 +42,10 @@ sequenceDiagram
   participant DB as "DB"
 
   B->>S: Tap "Ajouter une mesure", pick type (OG/temp/pH), enter value
-  S->>UC: recordMeasurement(batchId, stepId?, type, value, unit)
-  UC->>HTTP: POST /batches/:id/measurements
+  S->>UC: recordMeasurement(batchId, stepId?, type, value, unit, takenAt=client now)
+  UC->>HTTP: POST /batches/:id/measurements (client timestamp in payload, #607)
   HTTP->>API: forward
-  API->>DB: insert Measurement (timestamp = now)
+  API->>DB: insert Measurement (persist client takenAt)
   API->>API: re-evaluate threshold alerts
   API-->>S: 201 { measurement, alerts? }
   S-->>B: append row to the Measurements table (+ alert badge if raised)

--- a/docs/architecture/diagrams/batches/04-class.md
+++ b/docs/architecture/diagrams/batches/04-class.md
@@ -2,7 +2,9 @@
 
 > **Feature**: epic #595; data model #605; 5-section detail #606.
 > **Shared entities**: `Measurement`, `Observation`, `Alert`, `BatchStep` are
-> detailed in `diagrams/brewing-session/04-class.md` — not redrawn here.
+> detailed in the sibling brewing-session conception (PR #1096 →
+> `docs/architecture/diagrams/brewing-session/04-class.md` once merged) — not
+> redrawn here.
 
 ## Context
 
@@ -59,8 +61,10 @@ classDiagram
 
   class BatchStatus {
     <<enumeration>>
+    planned
     in_progress
     completed
+    archived
   }
 ```
 
@@ -72,7 +76,9 @@ classDiagram
 - **`recipeId` is a snapshot link**: the batch references the recipe it was
   started from, but its step list is copied at start (see brewing-session) so a
   later recipe edit/fork does not mutate a recorded batch.
-- **`archivedAt`** is the only field this journal adds beyond #605 (for UC9
-  archive); confirm with the data-model issue before migration.
+- **`BatchStatus`** today is only `in_progress`/`completed` (mobile
+  `batch.types.ts`); **`planned` + `archived` are the #595/#605 additions** that
+  the lifecycle (`05-state`) introduces — flagged, confirm before migration.
+  `archivedAt` is the matching new timestamp (for UC9 archive).
 - **Entity field detail** (Measurement/Observation/Alert columns, enums) lives in
-  `brewing-session/04-class.md` — single source, cross-referenced.
+  the sibling brewing-session class diagram (PR #1096) — single source, cross-referenced.

--- a/docs/architecture/diagrams/batches/04-class.md
+++ b/docs/architecture/diagrams/batches/04-class.md
@@ -1,0 +1,78 @@
+# Class diagram — batches — the batch aggregate & 5-section view
+
+> **Feature**: epic #595; data model #605; 5-section detail #606.
+> **Shared entities**: `Measurement`, `Observation`, `Alert`, `BatchStep` are
+> detailed in `diagrams/brewing-session/04-class.md` — not redrawn here.
+
+## Context
+
+The Batch aggregate as the journal sees it, and how the 5 detail sections (#606)
+project over it. The live-execution entities (steps, measurements, observations,
+alerts) are owned by the brewing-session class diagram; this one shows the batch
+root, its recipe link, and the section grouping so the detail-screen rewrite has
+a structural map.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class Batch {
+    +UUID id
+    +UUID ownerId
+    +UUID recipeId
+    +BatchStatus status
+    +int currentStepOrder
+    +Date plannedDate
+    +Date actualStartDate
+    +float targetVolume
+    +float realVolume
+    +Date completedAt
+    +Date archivedAt
+  }
+  class Recipe {
+    +UUID id
+    +string name
+    +int version
+  }
+  class BatchStep {
+    +int stepOrder
+    +BatchStepStatus status
+  }
+  class Measurement {
+    +MeasurementType type
+    +float value
+  }
+  class Observation {
+    +string freeText
+  }
+  class Alert {
+    +AlertSeverity severity
+  }
+
+  Batch "1" --> "1" Recipe : recipeId (snapshot link)
+  Batch "1" o-- "1..*" BatchStep
+  Batch "1" o-- "0..*" Measurement
+  Batch "1" o-- "0..*" Observation
+  Batch "1" o-- "0..*" Alert
+
+  note for Batch "5-section detail (#606) is a VIEW over this aggregate:\n1 Identity = Batch + Recipe link\n2 Plan = Recipe ingredients/equipment\n3 Live/History = BatchStep[]\n4 Measurements = Measurement[]\n5 Notes = Observation[]"
+
+  class BatchStatus {
+    <<enumeration>>
+    in_progress
+    completed
+  }
+```
+
+## Notes
+
+- **The 5 sections are presentation, not new entities** — the `note` maps each
+  section to the underlying data. Keeping that explicit prevents the rewrite
+  from inventing parallel models.
+- **`recipeId` is a snapshot link**: the batch references the recipe it was
+  started from, but its step list is copied at start (see brewing-session) so a
+  later recipe edit/fork does not mutate a recorded batch.
+- **`archivedAt`** is the only field this journal adds beyond #605 (for UC9
+  archive); confirm with the data-model issue before migration.
+- **Entity field detail** (Measurement/Observation/Alert columns, enums) lives in
+  `brewing-session/04-class.md` — single source, cross-referenced.

--- a/docs/architecture/diagrams/batches/05-state-batch-lifecycle.md
+++ b/docs/architecture/diagrams/batches/05-state-batch-lifecycle.md
@@ -1,0 +1,38 @@
+# State diagram — batches — batch lifecycle (journal view)
+
+> **Feature**: epic #595; status model (#605).
+> **Related**: the per-step state machine is `brewing-session/05-state-batch-step.md`.
+
+## Context
+
+The batch's overall lifecycle as the journal tracks it, from planned to archived.
+This is coarser than the per-step machine (which drives the live execution); it
+is what the list status badge and the Identity-section status reflect.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> planned: Create batch from recipe
+  planned --> in_progress: Start guided session (first step)
+  in_progress --> in_progress: advance steps / record measurements
+  in_progress --> completed: last step (Packaging) complete
+  completed --> archived: Archive
+  planned --> archived: Abandon (archive without brewing)
+  archived --> [*]
+  completed --> [*]
+```
+
+## Notes
+
+- **`planned`** is a journal state (a batch created/scheduled but not started);
+  today's model collapses to `in_progress`/`completed` — adding `planned` +
+  `archived` is the #595/#605 enrichment, confirm at migration.
+- **`completed`** opens the celebration (`BatchFinishedScreen`) and unlocks
+  bottling/label (journey 4). The transition is driven by the last step
+  completing (see per-step machine).
+- **`archived`** (UC9) hides a batch from the active list without deleting its
+  journal — distinct from hard delete (which cascades satellites).
+- The fine-grained `paused`/`skipped` step states are NOT batch states — they
+  live on `BatchStep` (`brewing-session/05`). Keeping the two levels separate
+  avoids conflating "this step is paused" with "this batch is in progress".

--- a/docs/architecture/diagrams/batches/05-state-batch-lifecycle.md
+++ b/docs/architecture/diagrams/batches/05-state-batch-lifecycle.md
@@ -1,7 +1,8 @@
 # State diagram — batches — batch lifecycle (journal view)
 
 > **Feature**: epic #595; status model (#605).
-> **Related**: the per-step state machine is `brewing-session/05-state-batch-step.md`.
+> **Related**: the per-step state machine is the sibling brewing-session
+> conception (PR #1096 → `diagrams/brewing-session/05-state-batch-step.md`).
 
 ## Context
 
@@ -19,8 +20,8 @@ stateDiagram-v2
   in_progress --> completed: last step (Packaging) complete
   completed --> archived: Archive
   planned --> archived: Abandon (archive without brewing)
-  archived --> [*]
-  completed --> [*]
+  archived --> [*]: end of tracking
+  completed --> [*]: end of tracking (kept in history)
 ```
 
 ## Notes


### PR DESCRIPTION
## Summary

Conception for the **batches journal** ("Mes Brassins") — browsing, the
5-section detail, retrospective measurement/observation logging, alerts review,
and the batch lifecycle. Complements `diagrams/brewing-session/` (the live guided
execution), cross-referenced rather than duplicated. Documentation only, UML-first.

- `docs/architecture/diagrams/batches/` — 01 use-case, 02 sequence (detail +
  measurement), 04 class (Batch aggregate + 5-section view mapping), 05 state
  (batch lifecycle).

## Context

Grounded in epic #595 and sub-issues #605/#606/#607/#608 and the existing mobile
batches feature. Shared entities (Measurement/Observation/Alert, per-step state
machine) are owned by the brewing-session conception and linked, not redrawn.

Refs #595, #605, #606, #607.

## Checklist

- [x] Documentation only — no code
- [x] UML 2.5 conventions; boundary with brewing-session made explicit
- [x] Cross-links brewing-session for shared entities (single source)