### PR TITLE
docs(ingredients/architecture): UML deliverables for the ingredients domain

### DIFF
--- a/docs/architecture/diagrams/ingredients/01-use-case.md
+++ b/docs/architecture/diagrams/ingredients/01-use-case.md
@@ -1,0 +1,65 @@
+# Use-case diagram — ingredients — catalog & custom ingredients
+
+> **Feature**: ingredient library (E05, read paths shipped); catalog expansion +
+> custom user ingredients Strategy B #915; ingredient CRUD/personalisation #624.
+> **Personas**: all (browse specs); Claire / Marc (author custom/exotic ingredients).
+
+## Context
+
+Who interacts with the ingredient library and to do what. Two parallel needs
+(#915): the **curated catalog** (read-only reference, datasheet specs) and
+**user-created custom ingredients** (partial metadata, BeerSmith/Brewfather
+pattern) so a brewer can author a recipe even when an exotic ingredient isn't in
+the catalog. A Maintainer grows the curated catalog (separate goal). Grouped by
+domain; Mobile/API split is in the component view.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer — all personas"))
+  Maintainer(("Maintainer"))
+
+  subgraph SYSTEM ["Brasse-Bouillon — Ingredients"]
+    subgraph Browse ["Browse the catalog"]
+      UC1(("Browse ingredients by category (malt / hop / yeast / …)"))
+      UC2(("Filter / search a category"))
+      UC3(("Consult an ingredient datasheet (specs)"))
+    end
+    subgraph Custom ["My custom ingredients"]
+      UC4(("Create a custom ingredient (partial metadata)"))
+      UC5(("Edit / delete my custom ingredient"))
+    end
+    subgraph Use ["Use"]
+      UC6(("Add an ingredient to a recipe"))
+      UC7(("Add an ingredient to the shopping list"))
+    end
+    subgraph Curate ["Curate (maintainer)"]
+      UC8(("Add / enrich a curated catalog entry"))
+    end
+  end
+
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+  Brewer --> UC7
+  Maintainer --> UC8
+```
+
+## Notes
+
+- **Status**: UC1–UC3 (browse/filter/datasheet) are shipped (E05, read-only).
+  UC4–UC5 (custom ingredients, Strategy B) are the open #915/#624 target this
+  models. UC6 hands off to the recipes domain (RecipeIngredientRef). UC7 hands
+  off to the shop/shopping-list feature.
+- **Custom vs curated** (UC4): a custom ingredient is private to its owner
+  (`isCustom` + `ownerId`) with possibly-partial specs; it never appears in
+  another user's catalog unless a Maintainer promotes it (UC8).
+- **Maintainer (UC8)** grows the curated catalog from references (BrewDog DIY
+  Dog, canonical BeerXML fixtures) — an admin/curation goal, distinct from the
+  brewer's authoring.
+- **Categories** today: malt / hop / yeast (mobile); the API also has
+  fermentable / water / misc / style / equipment catalogs (component/class view).

--- a/docs/architecture/diagrams/ingredients/02-sequence-custom-ingredient.md
+++ b/docs/architecture/diagrams/ingredients/02-sequence-custom-ingredient.md
@@ -1,0 +1,46 @@
+# Sequence diagram — ingredients — create a custom ingredient & use it
+
+> **Feature**: custom ingredients Strategy B #915 / #624.
+> **Source**: mobile `features/ingredients` + API `catalog` module.
+
+## Context
+
+The Strategy-B flow: a brewer authoring a recipe hits a missing exotic
+ingredient, creates a custom one with partial metadata, and references it
+immediately. This is the open #915/#624 path; browsing/filtering the curated
+catalog already works and is not repeated.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant R as "Mobile — RecipeEditor / ingredient picker"
+  participant S as "Mobile — CustomIngredientForm"
+  participant UC as "Mobile — ingredients.use-cases (NEW)"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — catalog controller"
+  participant DB as "DB"
+
+  B->>R: Search "Nelson Sauvin" — not in catalog
+  R->>S: Open "Créer un ingrédient" (category=hop)
+  B->>S: Enter name + known specs (alpha % only)
+  S->>UC: createCustomIngredient(category, partialSpecs)
+  UC->>HTTP: POST /catalog/custom-ingredients
+  HTTP->>API: forward
+  API->>DB: insert ingredient (isCustom=true, ownerId=user, partial specs)
+  API-->>S: 201 { ingredient }
+  S-->>R: return to picker, new ingredient selected
+  R->>R: add RecipeIngredientRef(ingredientId, amount, unit) to the recipe
+```
+
+## Notes
+
+- **Egress**: screen → use-case → `core/http/http-client`; no direct `fetch`.
+- **Partial metadata**: the form requires only `name` + `category`; specs are
+  optional so the brewer is never blocked. Missing specs degrade gracefully
+  (recipe calculators use defaults / flag low-confidence).
+- **Scoping**: the created ingredient is private (`ownerId`); it appears only in
+  the owner's picker/catalog, never in others' — until a Maintainer promotes it.
+- **Demo mode**: use-cases mutate the in-memory custom-ingredient list (existing
+  data-source toggle).

--- a/docs/architecture/diagrams/ingredients/02-sequence-custom-ingredient.md
+++ b/docs/architecture/diagrams/ingredients/02-sequence-custom-ingredient.md
@@ -17,16 +17,16 @@ sequenceDiagram
   actor B as Brewer
   participant R as "Mobile — RecipeEditor / ingredient picker"
   participant S as "Mobile — CustomIngredientForm"
-  participant UC as "Mobile — ingredients.use-cases (NEW)"
+  participant UC as "Mobile — ingredients.use-cases (add createCustomIngredient)"
   participant HTTP as "core/http/http-client"
-  participant API as "API — catalog controller"
+  participant API as "API — catalog controller (per-category routes)"
   participant DB as "DB"
 
   B->>R: Search "Nelson Sauvin" — not in catalog
   R->>S: Open "Créer un ingrédient" (category=hop)
   B->>S: Enter name + known specs (alpha % only)
   S->>UC: createCustomIngredient(category, partialSpecs)
-  UC->>HTTP: POST /catalog/custom-ingredients
+  UC->>HTTP: POST /catalog/hops (or /malts | /yeasts), isCustom=true (PLANNED route)
   HTTP->>API: forward
   API->>DB: insert ingredient (isCustom=true, ownerId=user, partial specs)
   API-->>S: 201 { ingredient }
@@ -42,5 +42,9 @@ sequenceDiagram
   (recipe calculators use defaults / flag low-confidence).
 - **Scoping**: the created ingredient is private (`ownerId`); it appears only in
   the owner's picker/catalog, never in others' — until a Maintainer promotes it.
-- **Demo mode**: use-cases mutate the in-memory custom-ingredient list (existing
-  data-source toggle).
+- **Demo mode**: today the demo catalog is sourced from exported constants
+  (`demoIngredients`); the custom-create path would branch on the data-source
+  toggle to add to an in-memory/persisted custom list (to build with #915).
+- **Route shape**: the custom-create endpoint is **planned** — the existing
+  catalog API exposes per-category read routes (`GET /catalog/hops`, …); #915 adds
+  the writable custom-ingredient path.

--- a/docs/architecture/diagrams/ingredients/04-class.md
+++ b/docs/architecture/diagrams/ingredients/04-class.md
@@ -1,0 +1,96 @@
+# Class diagram — ingredients — catalog model & custom ingredients
+
+> **Feature**: ingredient library E05; custom ingredients Strategy B #915 #624.
+> **Source**: `packages/mobile-app/src/features/ingredients/domain/*` and
+> `packages/api/src/catalog/*`.
+
+## Context
+
+The ingredient model: a category-discriminated hierarchy with datasheet specs,
+the `isCustom`/`ownerId` extension for user-created ingredients (Strategy B), and
+how a recipe references an ingredient. Reflects the existing mobile types and the
+API catalog shape; the `isCustom`/`ownerId` columns are the #915 addition (flag
+before migration).
+
+## Diagram
+
+```mermaid
+classDiagram
+  class Ingredient {
+    <<abstract>>
+    +UUID id
+    +string name
+    +IngredientCategory category
+    +bool isCustom
+    +UUID ownerId
+  }
+  class Malt {
+    +float colorEbc
+    +float potentialGravity
+    +float moisturePercent
+  }
+  class Hop {
+    +float alphaAcidPercent
+    +HopType type
+    +string flavorProfile
+  }
+  class Yeast {
+    +float attenuationPercent
+    +float temperatureMinC
+    +float temperatureMaxC
+  }
+  class SpecGroup {
+    +string title
+    +SpecRow[] rows
+  }
+  class SpecRow {
+    +string label
+    +string value
+    +string unit
+  }
+  class RecipeIngredientRef {
+    +UUID ingredientId
+    +float amount
+    +RecipeIngredientUnit unit
+    +string timing
+  }
+
+  Ingredient <|-- Malt
+  Ingredient <|-- Hop
+  Ingredient <|-- Yeast
+  Ingredient "1" o-- "0..*" SpecGroup
+  SpecGroup "1" o-- "1..*" SpecRow
+  RecipeIngredientRef "0..*" --> "1" Ingredient : references
+
+  class IngredientCategory {
+    <<enumeration>>
+    malt
+    hop
+    yeast
+  }
+  class RecipeIngredientUnit {
+    <<enumeration>>
+    kg
+    g
+    l
+    ml
+    unit
+  }
+```
+
+## Notes
+
+- **`isCustom` + `ownerId`** (Strategy B, #915): a curated catalog entry has
+  `isCustom = false`, `ownerId = null`; a user-created one is `isCustom = true`,
+  scoped to its owner. Custom entries allow **partial** specs (SpecGroups may be
+  sparse) so a recipe can reference an exotic ingredient not yet curated.
+- **Datasheet** = `SpecGroup`/`SpecRow` (the mobile spec-group structure), e.g.
+  Malt → "Color 6 EBC", "Extract 80%". Curated entries are rich; custom ones may
+  have just a name + the one or two specs the brewer knows.
+- **API catalog** has more categories than the mobile union (fermentable / water
+  / misc / style / equipment / producer / distributor) — those are read-only
+  reference tables (intentionally parallel, see the repo's CPD exclusions). The
+  mobile union (malt/hop/yeast) is the user-facing subset; extend as needed.
+- **Recipe link**: `RecipeIngredientRef.ingredientId` points at either a curated
+  or a custom ingredient — uniform reference, so the recipe editor treats both
+  identically.

--- a/docs/architecture/diagrams/ingredients/04-class.md
+++ b/docs/architecture/diagrams/ingredients/04-class.md
@@ -22,7 +22,7 @@ classDiagram
     +string name
     +IngredientCategory category
     +bool isCustom
-    +UUID ownerId
+    +UUID ownerId «nullable — null if curated»
   }
   class Malt {
     +float colorEbc
@@ -46,7 +46,7 @@ classDiagram
   class SpecRow {
     +string label
     +string value
-    +string unit
+    +string unit «optional»
   }
   class RecipeIngredientRef {
     +UUID ingredientId

--- a/docs/architecture/diagrams/ingredients/04-class.md
+++ b/docs/architecture/diagrams/ingredients/04-class.md
@@ -22,7 +22,7 @@ classDiagram
     +string name
     +IngredientCategory category
     +bool isCustom
-    +UUID ownerId «nullable — null if curated»
+    +UUID ownerId
   }
   class Malt {
     +float colorEbc
@@ -46,7 +46,7 @@ classDiagram
   class SpecRow {
     +string label
     +string value
-    +string unit «optional»
+    +string unit
   }
   class RecipeIngredientRef {
     +UUID ingredientId
@@ -86,7 +86,9 @@ classDiagram
   sparse) so a recipe can reference an exotic ingredient not yet curated.
 - **Datasheet** = `SpecGroup`/`SpecRow` (the mobile spec-group structure), e.g.
   Malt → "Color 6 EBC", "Extract 80%". Curated entries are rich; custom ones may
-  have just a name + the one or two specs the brewer knows.
+  have just a name + the one or two specs the brewer knows. `ownerId` is
+  **nullable** (null when curated); `SpecRow.unit` is **optional** (matches
+  `Malt/Hop/YeastSpecRow`).
 - **API catalog** has more categories than the mobile union (fermentable / water
   / misc / style / equipment / producer / distributor) — those are read-only
   reference tables (intentionally parallel, see the repo's CPD exclusions). The

--- a/docs/architecture/diagrams/ingredients/05-state-ingredient-provenance.md
+++ b/docs/architecture/diagrams/ingredients/05-state-ingredient-provenance.md
@@ -13,12 +13,12 @@ users' catalogs and documents the (optional) promotion path.
 
 ```mermaid
 stateDiagram-v2
-  [*] --> custom_private: Brewer creates (isCustom=true, ownerId set)
-  custom_private --> custom_private: Brewer edits specs
-  custom_private --> curated: Maintainer promotes (isCustom=false, ownerId cleared)
-  custom_private --> [*]: Brewer deletes
-  [*] --> curated: Maintainer adds from reference (BrewDog DIY Dog, BeerXML fixtures)
-  curated --> [*]: Maintainer retires
+  [*] --> CustomPrivate: Brewer creates (isCustom=true, ownerId set)
+  CustomPrivate --> CustomPrivate: Brewer edits specs
+  CustomPrivate --> Curated: Maintainer promotes (isCustom=false, ownerId cleared)
+  CustomPrivate --> [*]: Brewer deletes
+  [*] --> Curated: Maintainer adds from reference (BrewDog DIY Dog, BeerXML fixtures)
+  Curated --> [*]: Maintainer retires
 ```
 
 ## Notes

--- a/docs/architecture/diagrams/ingredients/05-state-ingredient-provenance.md
+++ b/docs/architecture/diagrams/ingredients/05-state-ingredient-provenance.md
@@ -1,0 +1,34 @@
+# State diagram — ingredients — provenance & promotion
+
+> **Feature**: custom ingredients Strategy B #915.
+
+## Context
+
+An ingredient's provenance lifecycle: a user-created custom entry can stay
+private, or be promoted by a Maintainer into the curated catalog. Curated entries
+are stable reference data. This guards against custom entries leaking into other
+users' catalogs and documents the (optional) promotion path.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> custom_private: Brewer creates (isCustom=true, ownerId set)
+  custom_private --> custom_private: Brewer edits specs
+  custom_private --> curated: Maintainer promotes (isCustom=false, ownerId cleared)
+  custom_private --> [*]: Brewer deletes
+  [*] --> curated: Maintainer adds from reference (BrewDog DIY Dog, BeerXML fixtures)
+  curated --> [*]: Maintainer retires
+```
+
+## Notes
+
+- **Promotion is maintainer-only** and one-way: a private custom ingredient
+  becomes shared reference data (`isCustom=false`); the reverse (un-curate) is a
+  retire, not a downgrade to someone's private entry.
+- **Delete safety**: deleting a custom ingredient that a recipe already
+  references is a product decision (block, or keep a denormalized snapshot on the
+  RecipeIngredientRef) — flag for the #624 CRUD epic.
+- **No approval queue in v0.1**: promotion is a manual maintainer action; a
+  community-suggestion workflow (like the scan BeerDataSuggestion) is out of scope
+  here.


### PR DESCRIPTION
## Summary

Conception for the **ingredients** domain: the curated catalog (read-only,
datasheet specs) and user-created **custom ingredients** (Strategy B — partial
metadata, `isCustom`/`ownerId`). Documentation only, UML-first.

- `docs/architecture/diagrams/ingredients/` — 01 use-case, 02 sequence (create a
  custom ingredient + use it), 04 class (category hierarchy + specs + custom flag
  + recipe link), 05 state (provenance: custom_private → curated via maintainer).

## Context

Browse/filter/datasheet are shipped (E05). The open target is custom ingredients
(#915/#624) so a brewer can author a recipe with an exotic ingredient not yet in
the catalog (BeerSmith/Brewfather pattern). Grounded in the mobile ingredients
domain types + the API catalog module.

Refs #915, #624.

## Checklist

- [x] Documentation only — no code
- [x] UML 2.5 conventions; curated vs custom provenance made explicit
- [x] Recipe link uniform across curated/custom ingredients