### PR TITLE
docs(account/architecture): UML deliverables for the account/profile domain

### DIFF
--- a/docs/architecture/diagrams/account/01-use-case.md
+++ b/docs/architecture/diagrams/account/01-use-case.md
@@ -1,0 +1,70 @@
+# Use-case diagram — account — auth, profile hub & RGPD
+
+> **Feature**: identifier-first sign-in #1081; profile completion #645 #836;
+> settings merge #644; RBAC CREATOR role #821.
+> **Personas**: all (every user has an account); Léa (first sign-up must be easy).
+
+## Context
+
+Who interacts with account/identity and to do what: authenticate, manage the
+profile hub, control privacy (RGPD). The profile becomes a hub (ux-refonte) so
+secondary destinations (equipment, shop, stats, settings) are reached from here.
+Grouped by domain; Mobile/API split in the component view; PII flows in
+`06-data-flow.md`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  User(("User — all personas"))
+  Admin(("Administrator / Creator"))
+
+  subgraph SYSTEM ["Brasse-Bouillon — Account"]
+    subgraph Auth ["Authenticate"]
+      UC1(("Sign in (identifier-first: email → continue)"))
+      UC2(("Create an account"))
+      UC3(("Reset a forgotten password"))
+      UC4(("Sign out"))
+    end
+    subgraph Profile ["Manage my profile"]
+      UC5(("Edit identity (name, username, avatar)"))
+      UC6(("Change my password"))
+      UC7(("Set preferences (units, language)"))
+      UC8(("Open my equipment / shop / statistics"))
+    end
+    subgraph Privacy ["Privacy (RGPD)"]
+      UC9(("Export my data"))
+      UC10(("Delete my account"))
+    end
+    subgraph Admin_ ["Administration"]
+      UC11(("Assign roles (RBAC)"))
+    end
+  end
+
+  User --> UC1
+  User --> UC2
+  User --> UC3
+  User --> UC4
+  User --> UC5
+  User --> UC6
+  User --> UC7
+  User --> UC8
+  User --> UC9
+  User --> UC10
+  Admin --> UC11
+```
+
+## Notes
+
+- **UC1 identifier-first (#1081)**: the user enters email, taps "Continuer", and
+  the app routes to password (account exists) or create-password (new). Removes
+  the Connexion/Inscription tabs. The "exists?" check must be **enumeration-safe**
+  (see `02-sequence`).
+- **Profile hub (UC8)**: equipment / shop / statistics are reached *from* the
+  profile (ux-refonte target); they are separate domains, linked here.
+- **RGPD (UC9/UC10)**: data export + account deletion are first-class user
+  rights (#645) — see the data-flow diagram for the PII involved.
+- **RBAC (UC11)**: roles are USER / ADMIN / CREATOR (#821, CREATOR single-holder
+  above ADMIN). Role assignment is an admin goal, distinct from self-service.
+- **Demo mode**: typing the reserved demo credentials on UC1 enters demo mode
+  (existing `isDemoTriggerCredentials`), not a real auth — a separate path.

--- a/docs/architecture/diagrams/account/01-use-case.md
+++ b/docs/architecture/diagrams/account/01-use-case.md
@@ -64,7 +64,9 @@ flowchart LR
   profile (ux-refonte target); they are separate domains, linked here.
 - **RGPD (UC9/UC10)**: data export + account deletion are first-class user
   rights (#645) — see the data-flow diagram for the PII involved.
-- **RBAC (UC11)**: roles are USER / ADMIN / CREATOR (#821, CREATOR single-holder
-  above ADMIN). Role assignment is an admin goal, distinct from self-service.
+- **RBAC (UC11)**: roles today are USER / MODERATOR / ADMIN
+  (`role.enum.ts`); **CREATOR is planned (#821**, single-holder above ADMIN).
+  Role assignment is an admin goal, distinct from self-service.
 - **Demo mode**: typing the reserved demo credentials on UC1 enters demo mode
-  (existing `isDemoTriggerCredentials`), not a real auth — a separate path.
+  (checked in `core/auth/auth-context`, `isDemoTriggerCredentials`), not a real
+  auth — a separate path.

--- a/docs/architecture/diagrams/account/02-sequence-identifier-first.md
+++ b/docs/architecture/diagrams/account/02-sequence-identifier-first.md
@@ -17,34 +17,35 @@ that bypasses real auth.
 sequenceDiagram
   actor U as User
   participant S as "Mobile — LoginScreen"
-  participant UC as "Mobile — auth.use-cases"
+  participant Ctx as "core/auth/auth-context (useAuth)"
   participant HTTP as "core/http/http-client"
   participant API as "API — auth controller"
 
   U->>S: Enter email, tap "Continuer"
-  alt demo trigger credentials
-    S->>S: isDemoTriggerCredentials(email,pwd) → enter demo mode
-  else real account
-    S->>UC: checkIdentifier(email)
-    UC->>HTTP: POST /auth/identifier
-    HTTP->>API: forward
-    Note over API: enumeration-safe — same shape + timing whether or not the email exists
-    API-->>S: 200 { nextStep: "password" | "create" }
-    alt nextStep = password
-      U->>S: Enter password, tap "Se connecter"
-      S->>UC: signIn(email, password)
-      UC->>HTTP: POST /auth/login
+  S->>Ctx: checkIdentifier(email)
+  Ctx->>HTTP: POST /auth/identifier
+  HTTP->>API: forward
+  Note over API: enumeration-safe — same shape + timing whether or not the email exists
+  API-->>S: 200 { nextStep: "password" | "create" }
+  alt nextStep = password
+    U->>S: Enter password, tap "Se connecter"
+    S->>Ctx: signIn(email, password)
+    Note over Ctx: isDemoTriggerCredentials(email, password) checked HERE (needs both) → demo mode
+    alt demo trigger credentials
+      Ctx-->>S: enter demo mode (no API call)
+    else real account
+      Ctx->>HTTP: POST /auth/login
       HTTP->>API: forward
       API-->>S: 200 { user, accessToken }
       S->>S: persist token (session.ts), redirect to app
-    else nextStep = create
-      U->>S: Set a password, tap "Créer mon compte"
-      S->>UC: register(email, password)
-      UC->>HTTP: POST /auth/register
-      HTTP->>API: forward
-      API-->>S: 201 { user, accessToken }
-      S->>S: persist token, redirect to app
     end
+  else nextStep = create
+    U->>S: Set a password, tap "Créer mon compte"
+    S->>Ctx: register(email, password)
+    Ctx->>HTTP: POST /auth/register
+    HTTP->>API: forward
+    API-->>S: 201 { user, accessToken }
+    S->>S: persist token, redirect to app
   end
 ```
 

--- a/docs/architecture/diagrams/account/02-sequence-identifier-first.md
+++ b/docs/architecture/diagrams/account/02-sequence-identifier-first.md
@@ -1,0 +1,65 @@
+# Sequence diagram — account — identifier-first sign-in
+
+> **Feature**: identifier-first sign-in #1081.
+> **Source**: `LoginScreen.tsx`, `auth.api.ts`, `core/auth/session.ts`.
+
+## Context
+
+The #1081 "email d'abord" flow: the user enters an email, taps Continuer, and the
+app routes to password (account exists) or create-password (new) — **without
+leaking whether the email is registered** (enumeration-safe). Replaces the
+tabs/Google/demo clutter. The demo-credentials shortcut is shown as the branch
+that bypasses real auth.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor U as User
+  participant S as "Mobile — LoginScreen"
+  participant UC as "Mobile — auth.use-cases"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — auth controller"
+
+  U->>S: Enter email, tap "Continuer"
+  alt demo trigger credentials
+    S->>S: isDemoTriggerCredentials(email,pwd) → enter demo mode
+  else real account
+    S->>UC: checkIdentifier(email)
+    UC->>HTTP: POST /auth/identifier
+    HTTP->>API: forward
+    Note over API: enumeration-safe — same shape + timing whether or not the email exists
+    API-->>S: 200 { nextStep: "password" | "create" }
+    alt nextStep = password
+      U->>S: Enter password, tap "Se connecter"
+      S->>UC: signIn(email, password)
+      UC->>HTTP: POST /auth/login
+      HTTP->>API: forward
+      API-->>S: 200 { user, accessToken }
+      S->>S: persist token (session.ts), redirect to app
+    else nextStep = create
+      U->>S: Set a password, tap "Créer mon compte"
+      S->>UC: register(email, password)
+      UC->>HTTP: POST /auth/register
+      HTTP->>API: forward
+      API-->>S: 201 { user, accessToken }
+      S->>S: persist token, redirect to app
+    end
+  end
+```
+
+## Notes / suggestions
+
+- **Enumeration safety is the load-bearing requirement** (#1081): `/auth/identifier`
+  must return an identical response shape **and** comparable timing for existing
+  vs non-existing emails, otherwise it becomes an account-enumeration oracle. The
+  routing decision (password vs create) is the only signal, and it is unavoidable
+  for the UX — mitigate with rate-limiting + CAPTCHA-on-abuse rather than hiding
+  it. **Suggested addition**: model the rate-limit/abuse path explicitly (a new
+  use case "throttle repeated identifier checks") — currently absent.
+- **Token storage**: `session.ts` persists the access token; **suggestion** —
+  the diagram does not yet cover **refresh tokens / expiry**; if the API issues
+  short-lived tokens, add a refresh sequence (see `05-state` note).
+- **Demo branch** never calls the API — keep it strictly client-side.
+- **OAuth (Google)**: currently cosmetic (#765). If it becomes real, it is a
+  distinct sequence (provider redirect) — out of scope of #1081's first cut.

--- a/docs/architecture/diagrams/account/04-class.md
+++ b/docs/architecture/diagrams/account/04-class.md
@@ -18,10 +18,15 @@ classDiagram
     +string email
     +string username
     +string firstName
+    +string lastName
     +Role role
+    +bool isActive
+    +Date createdAt
+    +Date updatedAt
   }
   class Session {
     +string accessToken
+    +User user
     +Date expiresAt
   }
   class Profile {
@@ -44,6 +49,7 @@ classDiagram
   class Role {
     <<enumeration>>
     USER
+    MODERATOR
     ADMIN
     CREATOR
   }
@@ -61,13 +67,15 @@ classDiagram
 
 ## Notes / suggestions
 
-- **Today** the `User` has `id/email/username/firstName/role` (role is a
-  `string`); `Session` has only `accessToken`. Everything else (`Profile`,
-  `Consent`, `expiresAt`, the enums) is the **#645/#836 addition** — flagged, not
-  assumed.
-- **`Role` enum (#821)**: promote the current `string` role to a typed enum with
-  CREATOR above ADMIN (single-holder, seeded once). **Suggestion**: capture the
-  CREATOR-uniqueness invariant in an ADR — it is a structural rule, not just data.
+- **Today** (`features/auth/domain/auth.types.ts`) the `User` is
+  `id/email/username/firstName?/lastName?/role:string/isActive/createdAt/updatedAt`;
+  `AuthSession` = `accessToken` + `user`. `Profile`, `Consent`, `expiresAt`, and
+  the typed enums are the **#645/#836 additions** — flagged, not assumed.
+- **`Role` enum**: the API enum today is `USER / MODERATOR / ADMIN`
+  (`packages/api/src/common/enums/role.enum.ts`); **`CREATOR` is planned (#821)**,
+  not yet in the enum. Promote the mobile `string` role to the typed enum.
+  **Suggestion**: capture the CREATOR-uniqueness invariant (single-holder above
+  ADMIN) in an ADR — a structural rule, not just data.
 - **`Locale` ties to the bilingual FR/EN epic** (#512): the language preference
   here is the per-user override of the app default — coordinate with the i18n
   chantier so there is one source of truth for locale.

--- a/docs/architecture/diagrams/account/04-class.md
+++ b/docs/architecture/diagrams/account/04-class.md
@@ -1,0 +1,76 @@
+# Class diagram — account — identity, session, preferences, consent
+
+> **Feature**: profile completion #645 #836; RBAC #821; identifier-first #1081.
+> **Source**: `features/auth/domain/auth.types.ts`, `core/auth/session.ts`.
+
+## Context
+
+The identity model: User + Session (today), extended with the profile/preferences
+and RGPD-consent the completion epics add (#645/#836). Fields beyond today's
+`User` are flagged as additions to confirm before migration.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class User {
+    +UUID id
+    +string email
+    +string username
+    +string firstName
+    +Role role
+  }
+  class Session {
+    +string accessToken
+    +Date expiresAt
+  }
+  class Profile {
+    +UUID userId
+    +string avatarUrl
+    +UnitSystem units
+    +Locale language
+  }
+  class Consent {
+    +UUID userId
+    +bool analytics
+    +bool marketing
+    +Date updatedAt
+  }
+
+  User "1" --> "0..1" Session : authenticated
+  User "1" --> "1" Profile
+  User "1" --> "1" Consent
+
+  class Role {
+    <<enumeration>>
+    USER
+    ADMIN
+    CREATOR
+  }
+  class UnitSystem {
+    <<enumeration>>
+    metric
+    imperial
+  }
+  class Locale {
+    <<enumeration>>
+    fr
+    en
+  }
+```
+
+## Notes / suggestions
+
+- **Today** the `User` has `id/email/username/firstName/role` (role is a
+  `string`); `Session` has only `accessToken`. Everything else (`Profile`,
+  `Consent`, `expiresAt`, the enums) is the **#645/#836 addition** — flagged, not
+  assumed.
+- **`Role` enum (#821)**: promote the current `string` role to a typed enum with
+  CREATOR above ADMIN (single-holder, seeded once). **Suggestion**: capture the
+  CREATOR-uniqueness invariant in an ADR — it is a structural rule, not just data.
+- **`Locale` ties to the bilingual FR/EN epic** (#512): the language preference
+  here is the per-user override of the app default — coordinate with the i18n
+  chantier so there is one source of truth for locale.
+- **`Consent`** is the RGPD backbone (cookie/analytics/marketing opt-ins). The
+  website already gates analytics on consent; **suggestion** — align the mobile
+  consent model with the website's so a user's choice is coherent across surfaces.

--- a/docs/architecture/diagrams/account/05-state-session.md
+++ b/docs/architecture/diagrams/account/05-state-session.md
@@ -1,0 +1,39 @@
+# State diagram — account — session lifecycle
+
+> **Feature**: auth/session (`core/auth/session.ts`); identifier-first #1081.
+
+## Context
+
+The app's authentication state, from anonymous to authenticated, including the
+demo-mode branch and token expiry. Drives the `(auth)` vs `(app)` route guard in
+`app/_layout.tsx`.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> Anonymous
+  Anonymous --> CheckingIdentifier: enter email + Continuer
+  CheckingIdentifier --> EnteringPassword: account exists
+  CheckingIdentifier --> CreatingAccount: new email
+  EnteringPassword --> Authenticated: login ok (token persisted)
+  CreatingAccount --> Authenticated: register ok (token persisted)
+  EnteringPassword --> Anonymous: cancel / wrong password (retry)
+  Anonymous --> DemoMode: demo trigger credentials
+  Authenticated --> Anonymous: sign out (token cleared)
+  Authenticated --> Expired: token expires
+  Expired --> Anonymous: re-auth required
+  DemoMode --> Anonymous: exit demo
+```
+
+## Notes / suggestions
+
+- **Route guard**: `Anonymous`/`Expired` → `(auth)/login`; `Authenticated`/
+  `DemoMode` → `(app)`. The guard already exists; this names the states it keys on.
+- **`Expired` is a suggested addition**: today `session.ts` persists a token with
+  no modelled expiry. **Suggestion** — if the API issues short-lived JWTs, add a
+  silent-refresh transition (`Authenticated → Refreshing → Authenticated`) and a
+  fallback to `Expired`; if tokens are long-lived, document that explicitly so the
+  absence of refresh is a decision, not an oversight.
+- **DemoMode** is a parallel, token-less state — it must never hit authenticated
+  API routes (it reads demo data via the data-source toggle).

--- a/docs/architecture/diagrams/account/05-state-session.md
+++ b/docs/architecture/diagrams/account/05-state-session.md
@@ -5,8 +5,8 @@
 ## Context
 
 The app's authentication state, from anonymous to authenticated, including the
-demo-mode branch and token expiry. Drives the `(auth)` vs `(app)` route guard in
-`app/_layout.tsx`.
+demo-mode branch and token expiry. Drives the `(auth)` vs `(app)` route guard
+(redirects in `app/(auth)/_layout.tsx` and `app/(app)/_layout.tsx`).
 
 ## Diagram
 

--- a/docs/architecture/diagrams/account/06-data-flow.md
+++ b/docs/architecture/diagrams/account/06-data-flow.md
@@ -1,0 +1,51 @@
+# Data-flow diagram — account — PII & RGPD
+
+> **Feature**: profile + RGPD export/delete #645 #836.
+> **Related**: ADR/privacy policy; website consent model (parity).
+
+## Context
+
+Where personal data flows in the account domain, so a privacy review cannot be
+skipped. Every PII-bearing edge is annotated. Covers sign-in, profile edit, and
+the RGPD export/delete rights.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  User((User))
+  App["Mobile app"]
+  API["API — auth/account"]
+  DB[("DB")]
+  Export(["Exported file (user-owned)"])
+
+  User -->|"PII: email, password"| App
+  App -->|"PII: email, password (TLS)"| API
+  API -->|"PII: email, hashed password, profile"| DB
+  App -->|"PII: name, username, avatar, prefs"| API
+  User -->|"Request export"| App
+  App -->|"GET /account/export"| API
+  API -->|"PII: full account bundle"| Export
+  Export -.->|"shared via OS by the user"| User
+  User -->|"Request deletion"| App
+  App -->|"DELETE /account"| API
+  API -->|"erase / anonymize PII"| DB
+```
+
+## Notes / suggestions
+
+- **Passwords**: never stored in clear — hashed server-side (annotate the DB edge
+  as `hashed`). The app holds the password only transiently during sign-in.
+- **Export (RGPD art. 20 portability)**: the bundle is PII — it must be delivered
+  over an authenticated channel and is then user-owned (OS share). **Suggestion**:
+  define the export format (JSON?) and whether it includes recipes/batches (likely
+  yes — user content) in the #645 spec; currently unspecified.
+- **Deletion (RGPD art. 17)**: decide **erase vs anonymize** for content the user
+  authored that others may have cloned (public recipes). **Suggestion** —
+  anonymize authored public recipes (keep the lineage, drop the identity) rather
+  than hard-delete, to avoid breaking others' clones; capture this in an ADR.
+- **Consent parity**: the website gates analytics on consent (PR #817 removed
+  GA4). **Suggestion** — the mobile `Consent` model should mirror the website's
+  categories so a user's privacy choices are coherent across surfaces.
+- **No third-party PII egress** in scope: no analytics/marketing SDK receives PII
+  unless consent is granted (and none is wired today).

--- a/docs/architecture/diagrams/account/06-data-flow.md
+++ b/docs/architecture/diagrams/account/06-data-flow.md
@@ -25,7 +25,8 @@ flowchart LR
   App -->|"PII: name, username, avatar, prefs"| API
   User -->|"Request export"| App
   App -->|"GET /account/export"| API
-  API -->|"PII: full account bundle"| Export
+  API -->|"PII: full account bundle (response)"| App
+  App -->|"writes export file (local)"| Export
   Export -.->|"shared via OS by the user"| User
   User -->|"Request deletion"| App
   App -->|"DELETE /account"| API


### PR DESCRIPTION
## Summary

Conception for the **account / profile** domain: identifier-first authentication,
the profile hub, and RGPD. Documentation only, UML-first. Includes a **data-flow**
diagram (PII/RGPD) since this domain processes personal data.

- `docs/architecture/diagrams/account/` — 01 use-case, 02 sequence
  (identifier-first, enumeration-safe), 04 class (identity/session/profile/consent),
  05 state (session lifecycle), 06 data-flow (PII + RGPD export/delete).

## Context

Grounded in `features/auth` + `core/auth/session.ts`. Surfaces the #1081
enumeration-safety requirement and the #645/#836 profile/RGPD additions
(flagged as additions, not assumed). Several proactive suggestions are embedded
in the diagram notes (rate-limit on identifier check, token refresh/expiry,
export format, erase-vs-anonymize on deletion, consent parity with the website).

Refs #1081, #645, #836, #644, #821.

## Checklist

- [x] Documentation only — no code
- [x] UML 2.5 conventions; PII edges annotated (privacy review)
- [x] Enumeration-safety + RGPD decisions flagged for ADR