### PR TITLE
docs(dashboard/architecture): UML deliverables for dashboard + statistics

### DIFF
--- a/docs/architecture/diagrams/dashboard/01-use-case.md
+++ b/docs/architecture/diagrams/dashboard/01-use-case.md
@@ -1,0 +1,54 @@
+# Use-case diagram — dashboard — overview & unified statistics
+
+> **Feature**: home rewrite #829; unified Statistics screen #646; nav unify #611.
+> **Refonte**: `docs/design/ux-refonte/02-target-ia.md` (Accueil + Statistiques).
+> **Personas**: Léa (clear next action), Nicolas/Marc (track & compare).
+
+## Context
+
+What the brewer does from the home dashboard and the statistics screen. The
+dashboard is the **launchpad** (status at a glance + next action into a journey);
+Statistics is the **consolidation** of numbers scattered across the app today
+(ux-refonte). Grouped by domain. Contextual at-a-glance numbers stay on their
+own screens — Statistics aggregates *across* entities.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer — Léa / Nicolas / Marc"))
+
+  subgraph SYSTEM ["Brasse-Bouillon — Dashboard & Statistics"]
+    subgraph Home ["Dashboard (Accueil)"]
+      UC1(("Consult my brewing status at a glance (KPIs)"))
+      UC2(("Resume an active batch"))
+      UC3(("Review due actions & alerts"))
+      UC4(("Start a journey (scan / choose recipe / brew)"))
+    end
+    subgraph Stats ["Statistics"]
+      UC5(("Consult my brewing statistics"))
+      UC6(("Filter statistics by period (year / 90d / 30d)"))
+    end
+  end
+
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+```
+
+## Notes / suggestions
+
+- **UC1 KPIs** today: active batches, actions-due-24h, critical alerts. **UC5
+  Statistics** consolidates brewing totals, per-batch adherence, recipe counts —
+  the place the pinned "Période d'analyse" filter (#646, today stuck on "year")
+  finally lives (UC6).
+- **UC2/UC4 are launchpad hand-offs** (to batches / scan / recipes / brewing-session)
+  — not owned here; the dashboard surfaces the entry point.
+- **Triggers reframed**: alerts are events; UC3 is *review* (brewer pulls).
+- **Suggestion (gap)**: define what counts as a "due action" precisely (overdue
+  step? fermentation check?) — currently implicit in the demo. Worth a small
+  spec so the KPI is not hand-wavy. Also consider a **"set a brewing goal"**
+  use case (e.g. L brewed/month) for Statistics v0.2 — absent today.

--- a/docs/architecture/diagrams/dashboard/01-use-case.md
+++ b/docs/architecture/diagrams/dashboard/01-use-case.md
@@ -1,7 +1,8 @@
 # Use-case diagram — dashboard — overview & unified statistics
 
 > **Feature**: home rewrite #829; unified Statistics screen #646; nav unify #611.
-> **Refonte**: `docs/design/ux-refonte/02-target-ia.md` (Accueil + Statistiques).
+> **Refonte**: sibling PR #1094 → `docs/design/ux-refonte/02-target-ia.md`
+> (Accueil + Statistiques), once merged.
 > **Personas**: Léa (clear next action), Nicolas/Marc (track & compare).
 
 ## Context

--- a/docs/architecture/diagrams/dashboard/02-sequence-load-and-stats.md
+++ b/docs/architecture/diagrams/dashboard/02-sequence-load-and-stats.md
@@ -20,10 +20,10 @@ sequenceDiagram
 
   B->>S: Open Accueil
   S->>UC: getDashboardViewModel()
-  UC->>HTTP: GET /batches?status=active
+  UC->>HTTP: GET /batches (no status param today)
   HTTP->>API: forward
-  API-->>UC: active batches (+ steps, alerts)
-  UC->>UC: derive KPIs (active count, due actions, critical alerts)
+  API-->>UC: batches (+ steps, alerts)
+  UC->>UC: filter active + derive KPIs (active count, due actions, critical alerts)
   UC-->>S: DashboardViewModel
   S-->>B: render KPIs + alerts + active batches + journey entries
 ```
@@ -40,12 +40,12 @@ sequenceDiagram
 
   B->>S: Open Statistiques (default period = year)
   S->>UC: getStatistics(period)
-  UC->>HTTP: GET /batches + /recipes (period-filtered)
+  UC->>HTTP: GET /batches + /recipes (no period param — filter client-side)
   HTTP->>API: forward
   API-->>UC: rows
-  UC->>UC: aggregate (brewed, in-progress, success rate, volume, signed recipes)
+  UC->>UC: filter by period + aggregate (brewed, in-progress, success rate, volume, authored recipes)
   UC-->>S: StatisticsViewModel
-  B->>S: Change period (30d / 90d / all)
+  B->>S: Change period (year / 90d / 30d)
   S->>UC: getStatistics(newPeriod)
   UC-->>S: recomputed StatisticsViewModel
 ```

--- a/docs/architecture/diagrams/dashboard/02-sequence-load-and-stats.md
+++ b/docs/architecture/diagrams/dashboard/02-sequence-load-and-stats.md
@@ -1,0 +1,62 @@
+# Sequence diagram — dashboard — load overview & open statistics
+
+> **Feature**: home rewrite #829; unified Statistics + period filter #646.
+
+## Context
+
+How the dashboard assembles its KPIs/alerts on open, and how the statistics
+screen recomputes when the period changes. Both are read/aggregation flows over
+batches + recipes.
+
+## Load the dashboard
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant S as "Mobile — DashboardScreen"
+  participant UC as "Mobile — dashboard.use-cases"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — batches / recipes"
+
+  B->>S: Open Accueil
+  S->>UC: getDashboardViewModel()
+  UC->>HTTP: GET /batches?status=active
+  HTTP->>API: forward
+  API-->>UC: active batches (+ steps, alerts)
+  UC->>UC: derive KPIs (active count, due actions, critical alerts)
+  UC-->>S: DashboardViewModel
+  S-->>B: render KPIs + alerts + active batches + journey entries
+```
+
+## Open statistics & change period
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant S as "Mobile — StatisticsScreen"
+  participant UC as "Mobile — statistics.use-cases"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — batches / recipes"
+
+  B->>S: Open Statistiques (default period = year)
+  S->>UC: getStatistics(period)
+  UC->>HTTP: GET /batches + /recipes (period-filtered)
+  HTTP->>API: forward
+  API-->>UC: rows
+  UC->>UC: aggregate (brewed, in-progress, success rate, volume, signed recipes)
+  UC-->>S: StatisticsViewModel
+  B->>S: Change period (30d / 90d / all)
+  S->>UC: getStatistics(newPeriod)
+  UC-->>S: recomputed StatisticsViewModel
+```
+
+## Notes / suggestions
+
+- **Aggregation locus**: shown client-side over API rows (KISS for v0). **Suggestion**
+  — if datasets grow, move aggregation to a dedicated API endpoint
+  (`GET /statistics?period=`) so the mobile doesn't pull all rows; flag as the
+  scaling path (don't build yet — YAGNI).
+- **Egress**: via `core/http/http-client`; demo mode aggregates the in-memory
+  demo batches/recipes.
+- **Period filter (#646)** currently exists but is pinned to "year" — this
+  sequence is what unpins it.

--- a/docs/architecture/diagrams/dashboard/03-component.md
+++ b/docs/architecture/diagrams/dashboard/03-component.md
@@ -1,7 +1,9 @@
 # Component diagram — dashboard — structure & boundaries
 
 > **Feature**: home rewrite #829; unified Statistics #646.
-> **ADRs**: ADR-0002 (centralized backend), ADR-0005 (product data in the API).
+> **Related ADRs**: [ADR-0002](../../decisions/0002-centralized-nestjs-backend.md)
+> (centralized backend), [ADR-0005](../../decisions/0005-backend-split-encyclopedia-vs-product.md)
+> (product data in the API).
 
 ## Context
 
@@ -34,8 +36,8 @@ flowchart LR
     Recipes["recipe module"]
   end
 
-  HTTP -->|"GET active batches"| Batches
-  HTTP -->|"GET recipes / counts"| Recipes
+  HTTP -->|"GET /batches"| Batches
+  HTTP -->|"GET /recipes"| Recipes
 ```
 
 ## Notes / suggestions

--- a/docs/architecture/diagrams/dashboard/03-component.md
+++ b/docs/architecture/diagrams/dashboard/03-component.md
@@ -1,0 +1,51 @@
+# Component diagram — dashboard — structure & boundaries
+
+> **Feature**: home rewrite #829; unified Statistics #646.
+> **ADRs**: ADR-0002 (centralized backend), ADR-0005 (product data in the API).
+
+## Context
+
+How the dashboard + statistics are structured. They are **read aggregators** over
+the batches and recipes features — no new backend domain in v0. Confirms the
+single egress and that aggregation is a use-case concern, not a screen one.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  subgraph Mobile ["packages/mobile-app"]
+    direction TB
+    Dash["features/dashboard — DashboardScreen"]
+    Stats["features/statistics — StatisticsScreen (NEW)"]
+    DUC["dashboard.use-cases (derive KPIs)"]
+    SUC["statistics.use-cases (aggregate by period)"]
+    HTTP["core/http/http-client (sole egress)"]
+    DataSrc["core/data/data-source (demo toggle)"]
+    Dash --> DUC
+    Stats --> SUC
+    DUC --> HTTP
+    SUC --> HTTP
+    DUC --> DataSrc
+    SUC --> DataSrc
+  end
+
+  subgraph API ["packages/api"]
+    Batches["batches module"]
+    Recipes["recipe module"]
+  end
+
+  HTTP -->|"GET active batches"| Batches
+  HTTP -->|"GET recipes / counts"| Recipes
+```
+
+## Notes / suggestions
+
+- **No new backend module for v0**: dashboard/statistics read from batches +
+  recipes. **Suggestion** — add a thin `statistics` API endpoint only if
+  client-side aggregation becomes a perf problem (the scaling path).
+- **`features/statistics` is new on mobile** (the consolidation target of the
+  ux-refonte); `features/dashboard` exists and is rewritten (#829).
+- **Egress rule** holds: screens → use-cases → `core/http/http-client`.
+- **Reuse, don't duplicate**: KPIs/alerts derive from the same batch data the
+  batches feature already fetches — share the use-case/query layer where possible
+  to avoid two divergent derivations of "active batch".

--- a/docs/architecture/diagrams/dashboard/04-class.md
+++ b/docs/architecture/diagrams/dashboard/04-class.md
@@ -34,7 +34,7 @@ classDiagram
     +int batchesInProgress
     +float successRate
     +float volumeBrewedL
-    +int recipesSigned
+    +int recipesAuthored
   }
   class StatisticsSnapshot {
     +UUID userId
@@ -47,10 +47,9 @@ classDiagram
 
   class Period {
     <<enumeration>>
-    last_30d
-    last_90d
     year
-    all
+    90d
+    30d
   }
   class AlertSeverity {
     <<enumeration>>
@@ -63,7 +62,12 @@ classDiagram
 ## Notes / suggestions
 
 - **Derived, not stored**: both view-models are computed from `Batch`/`Recipe`
-  (see batches/recipes class diagrams). No new core entity is required for v0.
+  (see the sibling batches/recipes conception PRs #1098/#1097). No new core entity
+  is required for v0.
+- **`Period`** mirrors the existing mobile `PeriodKey` = `"year" | "90d" | "30d"`
+  (`DashboardScreen.tsx`); there is no `all` option.
+- **`recipesAuthored`** = recipes created/owned by the user (renamed from the
+  ambiguous "recipesSigned").
 - **`StatisticsSnapshot` is optional**: only worth persisting if aggregation
   over many batches becomes slow. **Suggestion** — start with on-the-fly compute
   (KISS); add the snapshot cache only if profiling shows a need (YAGNI).

--- a/docs/architecture/diagrams/dashboard/04-class.md
+++ b/docs/architecture/diagrams/dashboard/04-class.md
@@ -1,0 +1,73 @@
+# Class diagram — dashboard — view-models & statistics aggregates
+
+> **Feature**: home rewrite #829; unified Statistics #646.
+
+## Context
+
+The dashboard and statistics are **read/derived views** over existing entities
+(batches, recipes), not new persisted tables. This models the view-models the
+screens consume so the rewrite has a clear contract. The only candidate new
+persistence is an optional cached `StatisticsSnapshot` (flagged, not assumed).
+
+## Diagram
+
+```mermaid
+classDiagram
+  class DashboardViewModel {
+    +int activeBatchCount
+    +int actionsDueCount
+    +int criticalAlertCount
+    +BatchSummary[] activeBatches
+    +AlertItem[] alerts
+  }
+  class AlertItem {
+    +UUID batchId
+    +string batchName
+    +string currentStep
+    +string nextStep
+    +Date dueAt
+    +AlertSeverity severity
+  }
+  class StatisticsViewModel {
+    +Period period
+    +int batchesBrewed
+    +int batchesInProgress
+    +float successRate
+    +float volumeBrewedL
+    +int recipesSigned
+  }
+  class StatisticsSnapshot {
+    +UUID userId
+    +Period period
+    +Date computedAt
+  }
+
+  DashboardViewModel "1" o-- "0..*" AlertItem
+  StatisticsViewModel ..> StatisticsSnapshot : may cache
+
+  class Period {
+    <<enumeration>>
+    last_30d
+    last_90d
+    year
+    all
+  }
+  class AlertSeverity {
+    <<enumeration>>
+    info
+    warning
+    critical
+  }
+```
+
+## Notes / suggestions
+
+- **Derived, not stored**: both view-models are computed from `Batch`/`Recipe`
+  (see batches/recipes class diagrams). No new core entity is required for v0.
+- **`StatisticsSnapshot` is optional**: only worth persisting if aggregation
+  over many batches becomes slow. **Suggestion** — start with on-the-fly compute
+  (KISS); add the snapshot cache only if profiling shows a need (YAGNI).
+- **`AlertSeverity` is shared** with the batches/brewing-session `Alert` entity —
+  reuse the same enum, don't fork it.
+- **Suggestion (gap)**: `successRate` needs a definition (e.g. batches that hit
+  target FG ± tolerance) — specify in #646 before building, else it's arbitrary.


### PR DESCRIPTION
## Summary

Conception for the **dashboard (home rewrite #829)** + the **unified Statistics
screen (#646)**. Documentation only, UML-first.

- `docs/architecture/diagrams/dashboard/` — 01 use-case, 02 sequence (load + stats
  period filter), 03 component (read aggregators over batches+recipes), 04 class
  (derived view-models + optional snapshot cache).

## Context

Both screens are read/derived views over existing batch + recipe data — no new
backend domain for v0. The pinned "Période d'analyse" filter (#646) gets its home.
State diagram intentionally omitted (no lifecycle). Proactive suggestions embedded
(precise definitions for "due action" / "success rate"; server-side aggregation
as the scaling path; snapshot cache only if profiling demands it).

Refs #829, #646, #611.

## Checklist

- [x] Documentation only — no code
- [x] UML 2.5 conventions; skipped state diagram justified
- [x] Reuses existing batch/recipe data (no divergent "active batch" logic)