### PR TITLE
docs(labels/architecture): UML deliverables for the labels domain

### DIFF
--- a/docs/architecture/diagrams/labels/01-use-case.md
+++ b/docs/architecture/diagrams/labels/01-use-case.md
@@ -1,0 +1,67 @@
+# Use-case diagram — labels — design, comply & export
+
+> **Feature**: label designer (shipped to draft); export PDF/Print/Share #629.
+> **Journey**: journey 4 "bottle & taste" (ux-refonte flags it as buried today).
+> **Personas**: Claire (custom labelled creations), Léa (proud first bottle).
+
+## Context
+
+Who designs a bottle label and to do what, from autofilled draft to a printable
+sheet. Today the flow stops at the draft detail (only Modify/Delete); #629 adds
+the export/print/share that completes the journey. Grouped by domain. Compliance
+(Loi Évin mention) is a constraint surfaced as a use case ("apply the legal
+mention"), not an afterthought.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer — Claire / Léa"))
+
+  subgraph SYSTEM ["Brasse-Bouillon — Labels"]
+    subgraph Design ["Design"]
+      UC1(("Create a label from a finished batch (autofill)"))
+      UC2(("Customize (template, palette, icon, name, style)"))
+      UC3(("Preview the label"))
+      UC4(("Apply the mandatory legal mention (Loi Évin)"))
+    end
+    subgraph Output ["Output (#629)"]
+      UC5(("Export as PDF (N per A4 sheet, cut marks)"))
+      UC6(("Export as PNG (single)"))
+      UC7(("Print via the OS print sheet"))
+      UC8(("Share the label"))
+      UC9(("Choose the quantity (e.g. 24 bottles → 24 labels)"))
+    end
+    subgraph Manage ["Manage"]
+      UC10(("Browse my labels"))
+      UC11(("Delete a label"))
+    end
+  end
+
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+  Brewer --> UC7
+  Brewer --> UC8
+  Brewer --> UC9
+  Brewer --> UC10
+  Brewer --> UC11
+```
+
+## Notes / suggestions
+
+- **Status**: UC1–UC3 + UC10/UC11 are shipped (design to draft + text-only share);
+  **UC5–UC9 (#629)** are the open export pipeline. UC4 is partly shipped (the
+  `DEFAULT_LABEL_LEGAL_HINT` constant exists).
+- **UC1 autofill** pulls name/style/ABV/volume/brewer/brew-date from the batch +
+  recipe — the entry point should be **from the finished batch** (journey 4),
+  which the ux-refonte fixes (today it is buried under "Voir plus").
+- **UC4 compliance (Loi Évin, art. L.3323-4)**: the sanitary mention is
+  mandatory on every alcohol label. **Suggestion** — make it non-removable in the
+  editor (render it always), and consider other mandatory mentions (ABV, volume,
+  allergens e.g. "contient de l'orge/gluten") — currently only the health mention
+  is modelled; allergens are a likely legal gap to confirm.
+- **Out of scope**: bulk/varied labels per bottle, NFC/QR on label — v0.2.

--- a/docs/architecture/diagrams/labels/02-sequence-create-and-export.md
+++ b/docs/architecture/diagrams/labels/02-sequence-create-and-export.md
@@ -19,17 +19,17 @@ sequenceDiagram
   participant EX as "Export (expo-print / pdf-lib)"
 
   B->>Bd: "Créer l'étiquette" (from finished batch)
-  Bd->>UC: buildAutofill(batchId)
-  UC-->>E: LabelDraft (autofill: name/style/ABV/volume/brewer/date)
-  B->>E: Pick template / palette / icon, adjust name
-  E->>E: live preview (legal mention always rendered)
+  Bd->>UC: createLabelDraftFromBatch(batchId)
+  UC-->>E: LabelDraft (autofillFields: beerName/style/abv/volumeLiters/breweryName/brewDateIso)
+  B->>E: Pick template / palette / icon, adjust name + subtitle
+  E->>E: live preview (legalHint always rendered)
   B->>E: Save draft
-  E->>UC: saveLabelDraft(draft)
+  E->>UC: updateLabelDraft(draft)
 
   rect rgb(245,245,245)
-    note over B,EX: Export (#629)
+    note over B,EX: Export — PLANNED (#629, not yet implemented)
     B->>E: Tap "Exporter", choose format + quantity
-    E->>UC: exportLabel(draftId, format, quantity)
+    E->>UC: exportLabel(draftId, format, quantity) (to build)
     UC->>EX: render (PDF A4 N-up + cut marks / PNG / print)
     EX-->>UC: file / print job
     UC-->>B: OS share/print sheet

--- a/docs/architecture/diagrams/labels/02-sequence-create-and-export.md
+++ b/docs/architecture/diagrams/labels/02-sequence-create-and-export.md
@@ -1,0 +1,49 @@
+# Sequence diagram — labels — create from batch & export
+
+> **Feature**: label designer; export pipeline #629.
+
+## Context
+
+The journey-4 flow: from a finished batch, create a label (autofilled), customize
+it, then export/print/share (#629). Today the chain stops after save (text-only
+share); this models the export pipeline to add.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant Bd as "Mobile — BatchFinishedScreen / Labels"
+  participant E as "Mobile — LabelEditorScreen"
+  participant UC as "Mobile — labels.use-cases"
+  participant EX as "Export (expo-print / pdf-lib)"
+
+  B->>Bd: "Créer l'étiquette" (from finished batch)
+  Bd->>UC: buildAutofill(batchId)
+  UC-->>E: LabelDraft (autofill: name/style/ABV/volume/brewer/date)
+  B->>E: Pick template / palette / icon, adjust name
+  E->>E: live preview (legal mention always rendered)
+  B->>E: Save draft
+  E->>UC: saveLabelDraft(draft)
+
+  rect rgb(245,245,245)
+    note over B,EX: Export (#629)
+    B->>E: Tap "Exporter", choose format + quantity
+    E->>UC: exportLabel(draftId, format, quantity)
+    UC->>EX: render (PDF A4 N-up + cut marks / PNG / print)
+    EX-->>UC: file / print job
+    UC-->>B: OS share/print sheet
+  end
+```
+
+## Notes / suggestions
+
+- **Autofill at creation** binds the label to the batch's real data; later batch
+  edits do **not** retro-change a saved label (snapshot) — confirm this is the
+  desired behaviour for #629.
+- **Export library**: #629 suggests `expo-print` or `pdf-lib`. **Suggestion** —
+  PDF A4 packing needs correct physical dimensions per bottle format (33/44/75 cl)
+  with bleed + cut marks; spec the mm dimensions before building so labels print
+  to size.
+- **No network needed** for export (local render) — works offline.
+- **Demo mode**: autofill reads the demo batch; export still produces a real file.

--- a/docs/architecture/diagrams/labels/04-class.md
+++ b/docs/architecture/diagrams/labels/04-class.md
@@ -1,0 +1,99 @@
+# Class diagram — labels — draft model & export
+
+> **Feature**: label designer; export #629.
+> **Source**: `features/labels/domain/label.types.ts` + `label.constants.ts`.
+
+## Context
+
+The label draft model as it exists, plus the export target (#629). Autofilled
+fields (from batch/recipe) and editable design fields are separated, matching the
+code. The mandatory legal mention is a domain constant, not an editable field.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class LabelDraft {
+    +UUID id
+    +UUID batchId
+    +UUID recipeId
+    +LabelDraftStatus status
+    +LabelBottleFormat bottleFormat
+    +LabelAutofillFields autofill
+    +LabelEditableFields editable
+    +Date createdAt
+  }
+  class LabelAutofillFields {
+    +string beerName
+    +string style
+    +float abv
+    +float volumeLiters
+    +string brewer
+    +Date brewDate
+  }
+  class LabelEditableFields {
+    +string name
+    +string style
+    +LabelTemplateId templateId
+    +LabelPaletteId paletteId
+    +LabelIconId iconId
+  }
+  class LabelExport {
+    +ExportFormat format
+    +int quantity
+  }
+  class LegalMention {
+    +string text
+  }
+
+  LabelDraft "1" o-- "1" LabelAutofillFields
+  LabelDraft "1" o-- "1" LabelEditableFields
+  LabelDraft "1" ..> "1" LegalMention : always rendered (Loi Évin)
+  LabelDraft "1" ..> "0..*" LabelExport : produces
+
+  class LabelDraftStatus {
+    <<enumeration>>
+    draft
+    exported
+  }
+  class LabelBottleFormat {
+    <<enumeration>>
+    cl33
+    cl44
+    cl75
+  }
+  class LabelTemplateId {
+    <<enumeration>>
+    template_1
+    template_2
+    template_3
+  }
+  class LabelPaletteId {
+    <<enumeration>>
+    sunset_amber
+    hop_garden
+    midnight_stout
+  }
+  class ExportFormat {
+    <<enumeration>>
+    pdf_a4_sheet
+    png_single
+    os_print
+    share
+  }
+```
+
+## Notes / suggestions
+
+- **Today**: `LabelDraftStatus` only has `draft`; `exported` is the #629 addition
+  (so a label can show "exported"/"ready to print"). Bottle formats, templates,
+  palettes, icons match the existing constants.
+- **`LegalMention`** = `DEFAULT_LABEL_LEGAL_HINT` (Loi Évin) — always rendered,
+  not user-editable. **Suggestion** — model additional mandatory mentions (ABV,
+  net volume, allergens) as required fields rendered on every template, so
+  compliance is structural not optional.
+- **`LabelExport`** is transient (a render action), not necessarily persisted; the
+  PDF A4 sheet packs `quantity` labels with cut marks/bleed per format (#629).
+- **Autofill vs editable**: autofill is the truth from the batch; editable lets
+  the brewer override display name/style + pick the visual — keep them separate so
+  re-autofill never clobbers the brewer's design choices.

--- a/docs/architecture/diagrams/labels/04-class.md
+++ b/docs/architecture/diagrams/labels/04-class.md
@@ -14,29 +14,33 @@ code. The mandatory legal mention is a domain constant, not an editable field.
 ```mermaid
 classDiagram
   class LabelDraft {
-    +UUID id
-    +UUID batchId
-    +UUID recipeId
-    +LabelDraftStatus status
+    +string id
+    +string batchId
     +LabelBottleFormat bottleFormat
-    +LabelAutofillFields autofill
-    +LabelEditableFields editable
-    +Date createdAt
+    +LabelTemplateId templateId
+    +LabelEditableFields editableFields
+    +LabelAutofillFields autofillFields
+    +LabelPreviewSnapshot previewSnapshot
+    +LabelDraftStatus status
+    +string updatedAt
   }
   class LabelAutofillFields {
     +string beerName
     +string style
     +float abv
     +float volumeLiters
-    +string brewer
-    +Date brewDate
+    +string breweryName
+    +string brewDateIso
   }
   class LabelEditableFields {
     +string name
-    +string style
-    +LabelTemplateId templateId
+    +string subtitle
     +LabelPaletteId paletteId
     +LabelIconId iconId
+  }
+  class LabelPreviewSnapshot {
+    +string title
+    +string legalHint
   }
   class LabelExport {
     +ExportFormat format
@@ -48,8 +52,9 @@ classDiagram
 
   LabelDraft "1" o-- "1" LabelAutofillFields
   LabelDraft "1" o-- "1" LabelEditableFields
-  LabelDraft "1" ..> "1" LegalMention : always rendered (Loi Évin)
-  LabelDraft "1" ..> "0..*" LabelExport : produces
+  LabelDraft "1" o-- "1" LabelPreviewSnapshot
+  LabelPreviewSnapshot "1" ..> "1" LegalMention : legalHint (Loi Évin)
+  LabelDraft "1" ..> "0..*" LabelExport : produces (planned #629)
 
   class LabelDraftStatus {
     <<enumeration>>
@@ -58,9 +63,8 @@ classDiagram
   }
   class LabelBottleFormat {
     <<enumeration>>
-    cl33
-    cl44
-    cl75
+    33cl_long_neck
+    75cl_champenoise
   }
   class LabelTemplateId {
     <<enumeration>>

--- a/docs/architecture/diagrams/labels/05-state-label.md
+++ b/docs/architecture/diagrams/labels/05-state-label.md
@@ -1,0 +1,31 @@
+# State diagram — labels — draft lifecycle
+
+> **Feature**: label designer; export #629.
+
+## Context
+
+A label's lifecycle, from creation to export. Today only `draft` exists; #629
+adds the `exported` outcome so the UI can show a label as ready/printed.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> draft: Create from batch (autofill)
+  draft --> draft: Edit (template / palette / name)
+  draft --> exported: Export (PDF / PNG / print / share)
+  exported --> draft: Re-edit
+  draft --> [*]: Delete
+  exported --> [*]: Delete
+```
+
+## Notes / suggestions
+
+- **`exported` is non-terminal**: re-editing an exported label returns it to
+  `draft` (a new export supersedes the old) — keeps the model honest about
+  reprints after a tweak.
+- **No "published/shared-to-community" state** in scope: labels are private
+  artefacts; a community label gallery (#832 creator gallery) would add a
+  `published` state later — out of scope here.
+- **Legal mention** is invariant across every state (always rendered) — it is not
+  a state, it is a rendering rule (see class diagram).


### PR DESCRIPTION
## Summary

Conception for the **bottle-label designer + export** (#629) — journey 4 "bottle
& taste". Documentation only, UML-first.

- `docs/architecture/diagrams/labels/` — 01 use-case, 02 sequence (create from
  batch + export), 04 class (draft model + Loi Évin legal mention + export
  formats), 05 state (draft → exported).

## Context

Design-to-draft is shipped (text-only share today); #629 adds PDF A4 (N-up + cut
marks) / PNG / OS print / share. Grounded in `features/labels/domain`. Compliance
(Loi Évin sanitary mention) is modelled as a structural rendering rule. Proactive
suggestions: model all mandatory mentions (ABV/volume/allergens), spec physical
PDF dimensions per format, snapshot autofill at creation.

Refs #629.

## Checklist

- [x] Documentation only — no code
- [x] UML 2.5 conventions; legal compliance surfaced (Loi Évin) + flagged gaps