### PR TITLE
docs(tools-academy/architecture): UML deliverables for tools & academy

### DIFF
--- a/docs/architecture/diagrams/tools-academy/01-use-case.md
+++ b/docs/architecture/diagrams/tools-academy/01-use-case.md
@@ -1,0 +1,60 @@
+# Use-case diagram — tools & academy — calculators & learning
+
+> **Feature**: brewing calculators (E03, shipped) + academy/glossary (E06,
+> shipped); enrichments #657 (save/history), #783/#914 (glossary tooltips→API),
+> #660 (unit i18n), #892 (BJCP styles).
+> **Refonte**: ux-refonte merges these into one "Apprendre & outils" hub.
+> **Personas**: Léa (learn the why), Nicolas/Marc (compute precisely).
+
+## Context
+
+Tools (8 calculators) and Academy (educational topics + glossary) are one feature
+module — learning and computing belong together. Who uses them and for what.
+Calculators are stateless compute; academy is read + glossary lookup. Grouped by
+domain.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer — Léa / Nicolas / Marc"))
+
+  subgraph SYSTEM ["Brasse-Bouillon — Apprendre & outils"]
+    subgraph Tools ["Calculators"]
+      UC1(("Run a calculator (color / IBU / ABV / water / …)"))
+      UC2(("Switch units (metric / imperial)"))
+      UC3(("Save / recall a calculation"))
+      UC4(("Apply a water profile (style preset / location)"))
+    end
+    subgraph Academy ["Academy"]
+      UC5(("Browse academy topics"))
+      UC6(("Read a topic"))
+      UC7(("Look up a glossary term"))
+      UC8(("Open the calculator for a topic"))
+    end
+  end
+
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+  Brewer --> UC7
+  Brewer --> UC8
+```
+
+## Notes / suggestions
+
+- **Shipped**: UC1 (8 calculators), UC4 (water profiles), UC5/UC6 (topics, some
+  "coming-soon"). **Open enrichments**: UC2 unit i18n (#660), UC3 save/history
+  (#657), UC7 glossary tooltips backed by an API (#783/#914), UC8 topic→calculator
+  link.
+- **The 8 calculators**: Couleur (EBC), Houblons (IBU), Fermentescibles, Levures,
+  Eau (water salts), Rendement (efficiency), Carbonatation (CO₂), Avancés.
+- **Suggestion (gap)**: calculators are isolated today — **feed a recipe** from a
+  calculation (e.g. "use this IBU result in my recipe") would close the loop with
+  the recipes domain; currently absent. Also **save/recall (UC3)** needs a home —
+  the profile or a per-recipe scratch pad.
+- **Glossary (UC7)**: #914 moves the glossary to the API so terms are shared with
+  recipe/brewing tips (cross-link to brewing-session pedagogical tips).

--- a/docs/architecture/diagrams/tools-academy/01-use-case.md
+++ b/docs/architecture/diagrams/tools-academy/01-use-case.md
@@ -1,8 +1,8 @@
 # Use-case diagram — tools & academy — calculators & learning
 
-> **Feature**: brewing calculators (E03, shipped) + academy/glossary (E06,
-> shipped); enrichments #657 (save/history), #783/#914 (glossary tooltips→API),
-> #660 (unit i18n), #892 (BJCP styles).
+> **Feature**: brewing calculators (E03, shipped) + academy topics (E06; the
+> `glossaire` topic itself is still `status: "coming-soon"`); enrichments #657
+> (save/history), #783/#914 (glossary tooltips→API), #660 (unit i18n), #892 (BJCP).
 > **Refonte**: ux-refonte merges these into one "Apprendre & outils" hub.
 > **Personas**: Léa (learn the why), Nicolas/Marc (compute precisely).
 

--- a/docs/architecture/diagrams/tools-academy/02-sequence-calculator.md
+++ b/docs/architecture/diagrams/tools-academy/02-sequence-calculator.md
@@ -34,16 +34,16 @@ sequenceDiagram
   participant S as "Mobile — topic / tip with term"
   participant UC as "Mobile — glossary.use-cases"
   participant HTTP as "core/http/http-client"
-  participant API as "API — glossary (#914)"
+  participant API as "API — academy glossary (#914)"
 
-  B->>S: Tap a highlighted term
+  B->>S: Long-press a highlighted term (#783)
   S->>UC: getGlossaryTerm(slug)
   alt cached / bundled
     UC-->>S: term + definition (local)
   else API-backed
-    UC->>HTTP: GET /glossary/:slug
+    UC->>HTTP: GET /academy/glossary (list, then resolve slug) — #914
     HTTP->>API: forward
-    API-->>S: term + definition
+    API-->>S: terms + definitions
   end
   S-->>B: tooltip / modal
 ```

--- a/docs/architecture/diagrams/tools-academy/02-sequence-calculator.md
+++ b/docs/architecture/diagrams/tools-academy/02-sequence-calculator.md
@@ -1,0 +1,59 @@
+# Sequence diagram — tools & academy — run a calculator & glossary lookup
+
+> **Feature**: calculators E03; glossary tooltip #783/#914.
+
+## Context
+
+The two interactions: running a calculator (live, local, stateless) and looking
+up a glossary term from a topic/tip. Calculators need no network; the glossary
+becomes API-backed (#914) shared across the app.
+
+## Run a calculator
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant S as "Mobile — <X>CalculatorScreen"
+  participant Calc as "core/brewing-calculations (pure)"
+
+  B->>S: Enter inputs (weights, times, %, volume)
+  S->>Calc: compute(inputs)
+  Calc-->>S: result (e.g. IBU = 42)
+  S-->>B: live output (no network)
+  opt Save (#657)
+    B->>S: Tap "Enregistrer"
+    S->>S: persist SavedCalculation (local / profile)
+  end
+```
+
+## Glossary lookup
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant S as "Mobile — topic / tip with term"
+  participant UC as "Mobile — glossary.use-cases"
+  participant HTTP as "core/http/http-client"
+  participant API as "API — glossary (#914)"
+
+  B->>S: Tap a highlighted term
+  S->>UC: getGlossaryTerm(slug)
+  alt cached / bundled
+    UC-->>S: term + definition (local)
+  else API-backed
+    UC->>HTTP: GET /glossary/:slug
+    HTTP->>API: forward
+    API-->>S: term + definition
+  end
+  S-->>B: tooltip / modal
+```
+
+## Notes / suggestions
+
+- **Calculators stay client-side** (pure functions) — fast, offline, testable in
+  isolation (existing tests). No state diagram applies (stateless).
+- **Glossary**: ship bundled for v0 (offline), move to API (#914) when it must be
+  shared/edited centrally — **one glossary** feeding tools + brewing tips + recipe
+  tooltips (suggestion).
+- **Save (#657)** is optional persistence; until built, calculators are
+  ephemeral — that's fine (KISS).

--- a/docs/architecture/diagrams/tools-academy/04-class.md
+++ b/docs/architecture/diagrams/tools-academy/04-class.md
@@ -33,16 +33,23 @@ classDiagram
   }
   class WaterStylePreset {
     +WaterStylePresetId id
-    +IonRange calcium
-    +IonRange sulfate
-    +IonRange chloride
+    +string name
+    +string description
+    +IonRange ca
+    +IonRange mg
+    +IonRange na
+    +IonRange so4
+    +IonRange cl
+    +IonRange hco3
   }
   class AcademyTopic {
     +string slug
     +string title
     +AcademyTopicStatus status
-    +AcademyMascotVariant mascot
-    +CalculatorSlug calculator
+    +AcademyMascotVariant mascotVariant
+    +string mascotAlt
+    +string calculatorDescription
+    +int calculatorOrder
   }
   class GlossaryTerm {
     +string term
@@ -51,7 +58,7 @@ classDiagram
 
   Calculator ..> CalculationResult : produces
   SavedCalculation ..> CalculationResult : stores
-  AcademyTopic ..> Calculator : links (optional)
+  AcademyTopic ..> Calculator : links by slug (calculatorOrder/Description)
   AcademyTopic ..> GlossaryTerm : references
 
   class CalculatorSlug {
@@ -77,8 +84,11 @@ classDiagram
 - **Calculators are pure** (`@/core/brewing-calculations`): inputs → result, no
   state. `SavedCalculation` (#657) is the only persistence, and only if save is
   built — KISS/YAGNI until then.
-- **`AcademyTopic.calculator`** already links a topic to its calculator (UC8) —
-  the learn→compute bridge exists in the type.
+- **`AcademyTopic`** has no direct `calculator` field; it carries
+  `calculatorDescription` + `calculatorOrder` and links to a calculator **by slug
+  convention** (the learn→compute bridge). `AcademyTopicStatus` literals are
+  `"ready"` / `"coming-soon"` (rendered `coming_soon` in the enum — Mermaid avoids
+  the hyphen).
 - **`GlossaryTerm`** is content; **suggestion** — back it by the API (#914) and
   reuse it for the brewing-session pedagogical tips + recipe term tooltips, so
   there is **one glossary** across the app rather than three.

--- a/docs/architecture/diagrams/tools-academy/04-class.md
+++ b/docs/architecture/diagrams/tools-academy/04-class.md
@@ -1,0 +1,86 @@
+# Class diagram — tools & academy — calculators, topics, glossary
+
+> **Feature**: calculators E03; academy E06; save/history #657; glossary #914.
+> **Source**: `features/tools/domain/academy.types.ts`, `water-profiles.ts`,
+> `@/core/brewing-calculations`.
+
+## Context
+
+The model behind calculators and academy. Calculators are pure functions over
+typed inputs (no persistence unless a calculation is saved — #657). Academy topics
+and glossary terms are content. Reflects existing types; `SavedCalculation` and
+the API-backed `GlossaryTerm` are flagged additions.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class Calculator {
+    +CalculatorSlug slug
+    +compute(inputs) CalculationResult
+  }
+  class CalculationResult {
+    +string metric
+    +float value
+    +string unit
+  }
+  class SavedCalculation {
+    +UUID id
+    +CalculatorSlug slug
+    +json inputs
+    +CalculationResult result
+    +Date savedAt
+  }
+  class WaterStylePreset {
+    +WaterStylePresetId id
+    +IonRange calcium
+    +IonRange sulfate
+    +IonRange chloride
+  }
+  class AcademyTopic {
+    +string slug
+    +string title
+    +AcademyTopicStatus status
+    +AcademyMascotVariant mascot
+    +CalculatorSlug calculator
+  }
+  class GlossaryTerm {
+    +string term
+    +string definition
+  }
+
+  Calculator ..> CalculationResult : produces
+  SavedCalculation ..> CalculationResult : stores
+  AcademyTopic ..> Calculator : links (optional)
+  AcademyTopic ..> GlossaryTerm : references
+
+  class CalculatorSlug {
+    <<enumeration>>
+    couleur
+    houblons
+    fermentescibles
+    levures
+    eau
+    rendement
+    carbonatation
+    avances
+  }
+  class AcademyTopicStatus {
+    <<enumeration>>
+    ready
+    coming_soon
+  }
+```
+
+## Notes / suggestions
+
+- **Calculators are pure** (`@/core/brewing-calculations`): inputs → result, no
+  state. `SavedCalculation` (#657) is the only persistence, and only if save is
+  built — KISS/YAGNI until then.
+- **`AcademyTopic.calculator`** already links a topic to its calculator (UC8) —
+  the learn→compute bridge exists in the type.
+- **`GlossaryTerm`** is content; **suggestion** — back it by the API (#914) and
+  reuse it for the brewing-session pedagogical tips + recipe term tooltips, so
+  there is **one glossary** across the app rather than three.
+- **Unit i18n (#660)**: a `UnitSystem` (see account `Profile`) should drive
+  calculator display units — cross-link so units are a single preference.


### PR DESCRIPTION
## Summary

Conception for the **calculators + academy/glossary** domain (one module; the
ux-refonte "Apprendre & outils" hub). Documentation only, UML-first.

- `docs/architecture/diagrams/tools-academy/` — 01 use-case, 02 sequence (run a
  calculator + glossary lookup), 04 class (8 calculators + saved calc + academy
  topic + glossary term).

## Context

Calculators (E03) and academy (E06) are shipped at read/MVP level; open items are
enrichments (save/history #657, unit i18n #660, glossary→API #914, BJCP #892).
State/component diagrams omitted with justification (stateless pure functions).
Suggestions embedded: feed a recipe from a calculation, one shared glossary across
tools/tips/recipes, single unit-preference source.

Refs #657, #660, #783, #892, #914.

## Checklist

- [x] Documentation only — no code
- [x] UML 2.5 conventions; skipped diagram types justified