### PR TITLE
docs(equipment-shop/architecture): UML deliverables for equipment & shop

### DIFF
--- a/docs/architecture/diagrams/equipment-shop/01-use-case.md
+++ b/docs/architecture/diagrams/equipment-shop/01-use-case.md
@@ -1,0 +1,61 @@
+# Use-case diagram — equipment & shop — gear, catalog & shopping list
+
+> **Feature**: equipment "L'Office" CRUD #621; shop catalog (E10, read);
+> local cart/shopping list #653; affiliate links #650.
+> **Refonte**: equipment + shop are reached from the Profile hub (ux-refonte).
+> **Personas**: all (need gear + ingredients); Léa (what to buy for batch 1).
+
+## Context
+
+Who manages brewing gear and shops for ingredients/equipment, and how the
+shopping list ties the app together (a recipe's ingredients → things to buy).
+Grouped by domain. The cart is **local** (a shopping list), not a checkout —
+purchase happens at a partner (#650).
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer — all personas"))
+
+  subgraph SYSTEM ["Brasse-Bouillon — Equipment & Shop"]
+    subgraph Equip ["My equipment (L'Office)"]
+      UC1(("Add / edit / delete my equipment"))
+      UC2(("Search my equipment"))
+    end
+    subgraph Shop ["Shop"]
+      UC3(("Browse the shop by category"))
+      UC4(("View a product"))
+      UC5(("Open a partner link to buy"))
+    end
+    subgraph List ["Shopping list"]
+      UC6(("Add ingredients/equipment to my shopping list"))
+      UC7(("Adjust quantities"))
+      UC8(("View / share my shopping list"))
+    end
+  end
+
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+  Brewer --> UC7
+  Brewer --> UC8
+```
+
+## Notes / suggestions
+
+- **Status**: shop browse/product (UC3/UC4) shipped (read); equipment is read
+  today, CRUD is #621; the **local cart concept exists in recipe detail but is
+  never visible** (#653) — UC6–UC8 surface it.
+- **UC6 cross-domain**: the shopping list is fed from a recipe's ingredients
+  (recipes domain) and from a scan's "what to buy" (#777) — it is the connective
+  tissue between recipe → purchase. **Suggestion**: a single shopping list,
+  reachable from the Profile hub, that aggregates items from any recipe/scan.
+- **UC5 affiliate (#650)**: deep-link to a partner e-commerce (commission); the
+  app does not process payment. **Suggestion** — flag affiliate links clearly
+  (transparency) and keep prices labelled "indicatif".
+- **`LocalCartItem.source`** distinguishes `ingredient` vs `equipment`, so the
+  list groups buy-now ingredients from durable gear.

--- a/docs/architecture/diagrams/equipment-shop/02-sequence-shopping-list.md
+++ b/docs/architecture/diagrams/equipment-shop/02-sequence-shopping-list.md
@@ -1,0 +1,45 @@
+# Sequence diagram — equipment & shop — build & share a shopping list
+
+> **Feature**: local cart/shopping list #653; recipe → buy bridge.
+
+## Context
+
+How the shopping list is built from a recipe's ingredients (the cross-domain
+bridge) and then viewed/shared. The list is local; buying is a partner deep-link.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant R as "Mobile — RecipeDetails (Ingredients tab)"
+  participant UC as "Mobile — cart.use-cases"
+  participant Store as "Local store (persisted)"
+  participant L as "Mobile — ShoppingListScreen"
+
+  B->>R: "Ajouter au panier" (bulk or per-ingredient)
+  R->>UC: addItems(ingredients[])
+  UC->>Store: upsert LocalCartItem[] (source=ingredient)
+  Store-->>UC: ok
+  B->>L: Open shopping list (from Profile hub)
+  L->>UC: getShoppingList()
+  UC->>Store: read
+  Store-->>L: items grouped by category
+  B->>L: Adjust quantities
+  B->>L: "Partager" → OS share (text list)
+  opt Buy
+    B->>L: Tap a partner link
+    L-->>B: open partner e-commerce (deep-link, #650)
+  end
+```
+
+## Notes / suggestions
+
+- **Local & persisted**: the list lives client-side (AsyncStorage), survives app
+  restarts. No server order. **Suggestion** — one list per user, appended to from
+  any recipe or scan (#777), not a per-recipe ephemeral cart.
+- **Grouping**: items group by `ShopCategory` (malts / hops / yeast / equipment)
+  so the brewer shops efficiently.
+- **Share** is text today (parity with labels share) — a richer export (checklist
+  PDF) is a later enhancement.
+- **Demo mode**: the list reads/writes the in-memory demo store.

--- a/docs/architecture/diagrams/equipment-shop/02-sequence-shopping-list.md
+++ b/docs/architecture/diagrams/equipment-shop/02-sequence-shopping-list.md
@@ -38,7 +38,7 @@ sequenceDiagram
 - **Local & persisted**: the list lives client-side (AsyncStorage), survives app
   restarts. No server order. **Suggestion** — one list per user, appended to from
   any recipe or scan (#777), not a per-recipe ephemeral cart.
-- **Grouping**: items group by `ShopCategory` (malts / hops / yeast / equipment)
+- **Grouping**: items group by `ShopCategory` (malts / houblons / levures / materiel / accessoires / kits)
   so the brewer shops efficiently.
 - **Share** is text today (parity with labels share) — a richer export (checklist
   PDF) is a later enhancement.

--- a/docs/architecture/diagrams/equipment-shop/04-class.md
+++ b/docs/architecture/diagrams/equipment-shop/04-class.md
@@ -33,10 +33,13 @@ classDiagram
     +LocalCartItem[] items
   }
   class LocalCartItem {
-    +string refId
+    +string key
     +LocalCartItemSource source
+    +string refId
+    +string name
     +ShopCategory category
     +int quantity
+    +string unit
   }
 
   ShoppingList "1" o-- "0..*" LocalCartItem
@@ -45,18 +48,19 @@ classDiagram
 
   class ShopCategory {
     <<enumeration>>
-    malt
-    hop
-    yeast
-    equipment
-    consumable
+    malts
+    houblons
+    levures
+    materiel
+    accessoires
+    kits
   }
   class PriceUnit {
     <<enumeration>>
-    eur_per_kg
-    eur_per_100g
-    eur_per_sachet
-    eur_per_piece
+    eurPerKg
+    eurPer100g
+    eurPerSachet
+    eurPerPiece
   }
   class LocalCartItemSource {
     <<enumeration>>
@@ -67,9 +71,12 @@ classDiagram
 
 ## Notes / suggestions
 
-- **Existing**: `Product` (price/priceUnit/category), `LocalCartItem`
-  (source/quantity), `ShopCategory`, `PriceUnit` are real. `Equipment` fields +
-  `EquipmentType` are the #621 CRUD addition (today equipment is read-only demo).
+- **Existing & real values**: `ShopCategory` = `malts / houblons / levures /
+  materiel / accessoires / kits` (French, `shop.types.ts`); `PriceUnit` literals
+  are `"€/kg" | "€/100g" | "€/sachet" | "€/pièce"` (shown as `eurPerKg`… in the
+  enum — Mermaid avoids `€` and `/`). `LocalCartItem` = `key/source/refId/name/
+  category/quantity/unit` (`cart.types.ts`). `Equipment` fields + `EquipmentType`
+  are the #621 CRUD addition (today equipment is read-only demo).
 - **`ShoppingList` is local** (the "cart" that was never surfaced, #653) — not a
   server order. **Suggestion**: persist it per user (so it survives reinstall)
   and let any recipe/scan append to the *same* list.

--- a/docs/architecture/diagrams/equipment-shop/04-class.md
+++ b/docs/architecture/diagrams/equipment-shop/04-class.md
@@ -1,0 +1,80 @@
+# Class diagram — equipment & shop — gear, products, shopping list
+
+> **Feature**: equipment CRUD #621; shop catalog E10; local cart #653.
+> **Source**: `features/shop/domain/shop.types.ts`, `cart.types.ts`.
+
+## Context
+
+The model for owned equipment, the shop product catalog, and the local shopping
+list that links recipes/scans to purchases. Reflects the existing shop/cart types;
+`Equipment` CRUD fields are the #621 addition.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class Equipment {
+    +UUID id
+    +UUID ownerId
+    +string name
+    +EquipmentType type
+    +float volumeL
+    +string notes
+  }
+  class Product {
+    +UUID id
+    +string name
+    +float price
+    +PriceUnit priceUnit
+    +ShopCategory category
+  }
+  class ShoppingList {
+    +UUID ownerId
+    +LocalCartItem[] items
+  }
+  class LocalCartItem {
+    +string refId
+    +LocalCartItemSource source
+    +ShopCategory category
+    +int quantity
+  }
+
+  ShoppingList "1" o-- "0..*" LocalCartItem
+  LocalCartItem "0..*" ..> "0..1" Product : may reference
+  LocalCartItem "0..*" ..> "0..1" Equipment : may reference
+
+  class ShopCategory {
+    <<enumeration>>
+    malt
+    hop
+    yeast
+    equipment
+    consumable
+  }
+  class PriceUnit {
+    <<enumeration>>
+    eur_per_kg
+    eur_per_100g
+    eur_per_sachet
+    eur_per_piece
+  }
+  class LocalCartItemSource {
+    <<enumeration>>
+    ingredient
+    equipment
+  }
+```
+
+## Notes / suggestions
+
+- **Existing**: `Product` (price/priceUnit/category), `LocalCartItem`
+  (source/quantity), `ShopCategory`, `PriceUnit` are real. `Equipment` fields +
+  `EquipmentType` are the #621 CRUD addition (today equipment is read-only demo).
+- **`ShoppingList` is local** (the "cart" that was never surfaced, #653) — not a
+  server order. **Suggestion**: persist it per user (so it survives reinstall)
+  and let any recipe/scan append to the *same* list.
+- **Item → catalog link is optional**: a custom ingredient (Strategy B) added to
+  the list may not map to a `Product` — keep `refId` generic so off-catalog items
+  are listable (name + quantity).
+- **No payment/order entity**: purchase is a partner deep-link (#650) — out of
+  the model on purpose.

--- a/docs/architecture/diagrams/equipment-shop/05-state-shopping-list.md
+++ b/docs/architecture/diagrams/equipment-shop/05-state-shopping-list.md
@@ -1,0 +1,33 @@
+# State diagram — equipment & shop — shopping list lifecycle
+
+> **Feature**: local cart/shopping list #653.
+
+## Context
+
+The local shopping list's lifecycle. Light, but worth naming so "empty" vs
+"has items" drives the UI (empty state vs list + share), and clearing is explicit.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> Empty
+  Empty --> HasItems: add item(s) from recipe / scan / shop
+  HasItems --> HasItems: adjust quantities / add more
+  HasItems --> Empty: remove last item / clear
+  HasItems --> HasItems: share (does not clear)
+  HasItems --> Empty: "Marquer comme achetée" (clear)
+```
+
+## Notes / suggestions
+
+- **Share does not clear** the list (you may share and keep shopping). Only an
+  explicit clear or "marquer comme achetée" empties it.
+- **Empty state** is a real UI concern (#621 mentions empty states for equipment
+  too) — the screen shows guidance ("ajoute des ingrédients depuis une recette")
+  rather than a blank list.
+- **Equipment ("L'Office")** has no list lifecycle — it is a managed collection
+  (CRUD), so no state machine; only the shopping list has one.
+- **Suggestion**: a "purchased history" (what I bought, when) could grow from the
+  clear action later — out of scope now (YAGNI), but the clear transition is the
+  natural hook.


### PR DESCRIPTION
## Summary

Conception for **equipment ("L'Office")**, the **shop catalog**, and the **local
shopping list** — the recipe→buy bridge. Documentation only, UML-first. This
completes the domain conception sweep.

- `docs/architecture/diagrams/equipment-shop/` — 01 use-case, 02 sequence (build &
  share a shopping list), 04 class (equipment + product + shopping list), 05 state
  (shopping list lifecycle).

## Context

Shop browse is shipped (read); equipment CRUD is #621; the local cart concept
exists in recipe detail but was never surfaced (#653). Grounded in
`features/shop/domain`. Suggestions: one persisted shopping list per user fed by
any recipe/scan (#777), off-catalog custom items listable, affiliate transparency
(#650). Purchase is a partner deep-link — no payment entity.

Refs #621, #650, #653.

## Checklist

- [x] Documentation only — no code
- [x] UML 2.5 conventions; cross-domain shopping-list bridge made explicit