### PR TITLE
docs(adr): ADR-0010/0011/0012 from the conception sweep

### DIFF
--- a/docs/architecture/decisions/0010-recipe-step-type-nine-phase.md
+++ b/docs/architecture/decisions/0010-recipe-step-type-nine-phase.md
@@ -45,9 +45,10 @@ conditioning_packaging`.
 - **Optional phases** (`sparge` for BIAB, `whirlpool`, `dry_hop`) appear only
   when the recipe carries the matching data — the step list is recipe-derived,
   never a fixed 9.
-- **Migration is additive**: existing rows keep `mash/boil/whirlpool/fermentation/
-  packaging`; a data migration maps legacy `fermentation → primary_fermentation`
-  and `packaging → conditioning_packaging`. No row is dropped.
+- **Migration is additive**: existing rows keep their legacy values (`mash`,
+  `boil`, `whirlpool`, `fermentation`, `packaging`); a data migration maps legacy
+  `fermentation → primary_fermentation` and `packaging → conditioning_packaging`.
+  No row is dropped.
 - **BeerXML/BeerJSON mapping (#866)** is the translation layer: BeerJSON's
   explicit boil/whirlpool steps and sparge-as-mash-step map onto these phases;
   the mapping table lives with #866, not duplicated here.

--- a/docs/architecture/decisions/0010-recipe-step-type-nine-phase.md
+++ b/docs/architecture/decisions/0010-recipe-step-type-nine-phase.md
@@ -1,0 +1,96 @@
+# ADR-0010 — Extend `RecipeStepType` to the 9-phase brewing set
+
+**Status**  Proposed
+**Date**    2026-05-25
+**Owners**  @benoit-bremaud
+
+> Records decision **D1** surfaced by the brewing-session conception
+> ([`docs/architecture/specs/brewing-session.md`](../specs/brewing-session.md),
+> PR #1096). Gates the guided-brewing implementation (#781) and recipe steps
+> (#410–#420). Sibling of the BeerXML/BeerJSON mapping epic #866.
+
+---
+
+## Context
+
+A recipe's ordered steps **are** the brewing process. Today `RecipeStepType`
+(both `packages/api/src/recipe/domain/enums/recipe-step-type.enum.ts` and the
+mobile `recipe.types.ts`) has **5 values**: `MASH, BOIL, WHIRLPOOL,
+FERMENTATION, PACKAGING`.
+
+The guided-brewing assistant (#781/#868) and the standard all-grain workflow
+(grounded in BeerXML 1.0, BeerJSON 1.0, BrewDog DIY Dog — see the brewing-session
+spec) need a finer **9-phase** sequence to drive per-phase timers, temperatures
+and pedagogical tips:
+
+`mash → sparge → boil → whirlpool → cool → pitch → primary_fermentation →
+dry_hop → conditioning_packaging`.
+
+The 5-value enum cannot express sparge, cool, pitch, or the split of
+"fermentation" into primary / dry-hop / conditioning. The choice crosses three
+surfaces — the **API enum + entity**, the **mobile domain types**, and the
+**BeerXML/BeerJSON import/export mapping** (#866) — so it must be decided before
+the assistant is built, not discovered mid-implementation.
+
+---
+
+## Decision
+
+**Extend `RecipeStepType` to the 9-phase `BrewPhase` set**, applied consistently
+in the API enum, the API `recipe_steps` rows, and the mobile domain type:
+
+`mash, sparge, boil, whirlpool, cool, pitch, primary_fermentation, dry_hop,
+conditioning_packaging`.
+
+- **Optional phases** (`sparge` for BIAB, `whirlpool`, `dry_hop`) appear only
+  when the recipe carries the matching data — the step list is recipe-derived,
+  never a fixed 9.
+- **Migration is additive**: existing rows keep `mash/boil/whirlpool/fermentation/
+  packaging`; a data migration maps legacy `fermentation → primary_fermentation`
+  and `packaging → conditioning_packaging`. No row is dropped.
+- **BeerXML/BeerJSON mapping (#866)** is the translation layer: BeerJSON's
+  explicit boil/whirlpool steps and sparge-as-mash-step map onto these phases;
+  the mapping table lives with #866, not duplicated here.
+- The guided assistant reads the **snapshot** of these steps copied onto the
+  batch at session start (per the brewing-session conception), so a later recipe
+  edit never mutates an in-flight batch.
+
+---
+
+## Consequences
+
+### Positive
+
+- The assistant can drive correct per-phase timers/temps/tips (the #781 goal).
+- One vocabulary shared by recipes, batches and the BeerXML mapping — no
+  per-feature ad-hoc step lists.
+- Additive migration → no data loss, backward-compatible reads during rollout.
+
+### Trade-offs
+
+- A coordinated change across API enum + entity + migration + mobile types +
+  the #866 mapping; must land together to avoid a split-brain enum.
+- `whirlpool` already exists as a 5-set value **and** appears in the 9-set —
+  confirm it is not double-counted when mapping (decision **D2**, see below).
+
+### Rejected alternatives
+
+- **Keep 5 values, encode sub-phases in free text** — unparseable, defeats
+  timers/tips; rejected.
+- **A separate `BrewPhase` enum only on the batch side** — would desync recipe
+  authoring from execution and duplicate the mapping; rejected in favour of one
+  shared enum.
+
+### Open follow-ups
+
+- **D2** — whirlpool as its own phase vs a boil sub-step (BeerJSON makes it
+  explicit; #781 folds it into boil/cool). Resolve when wiring the mapping.
+
+---
+
+## References
+
+- Spec [`docs/architecture/specs/brewing-session.md`](../specs/brewing-session.md) (§ canonical phases, D1).
+- Brewing-session UML [`docs/architecture/diagrams/brewing-session/`](../diagrams/brewing-session/) (class `BrewPhase`).
+- Recipes UML [`docs/architecture/diagrams/recipes/`](../diagrams/recipes/).
+- Epics #868 (guided session), #781 (assistance), #866 (BeerXML/BeerJSON mapping), #605/#608 (batch model + step state).

--- a/docs/architecture/decisions/0011-creator-role-above-admin.md
+++ b/docs/architecture/decisions/0011-creator-role-above-admin.md
@@ -27,14 +27,18 @@ owner. A distinct top role makes "who can manage admins" unambiguous.
 **Add a `CREATOR` role as the highest privilege, held by exactly one account,
 seeded once.**
 
-- Enum becomes `USER < MODERATOR < ADMIN < CREATOR` (monotonic privilege order).
+- `UserRole` stays a **string enum**; privilege order is expressed by an explicit
+  rank map, not by comparing the strings. Define `ROLE_RANK = { user: 0,
+  moderator: 1, admin: 2, creator: 3 }` and a helper
+  `hasAtLeast(role, min) => ROLE_RANK[role] >= ROLE_RANK[min]`.
 - **Single-holder invariant**: at most one `CREATOR` exists, created by a
   one-time seed; the role is **not** grantable through the normal role-assignment
   UI/endpoint. Enforced in application code + a DB uniqueness guard.
 - `CREATOR` inherits all `ADMIN` capabilities and additionally may assign/revoke
   `ADMIN`/`MODERATOR`.
-- Authorization checks compare on the privilege order, not on equality, so new
-  admin-or-above checks read `role >= ADMIN`.
+- Authorization checks use the rank helper, so an admin-or-above check is
+  `hasAtLeast(user.role, UserRole.ADMIN)` — never a raw `role === 'admin'` or a
+  string `>=`.
 
 ---
 
@@ -49,8 +53,8 @@ seeded once.**
 
 - The single-holder invariant must be enforced in **two** places (app guard + DB
   constraint) and covered by tests — a uniqueness rule, not just data.
-- Existing role checks that used `=== ADMIN` must migrate to `>= ADMIN` to avoid
-  accidentally excluding `CREATOR`.
+- Existing role checks that used `=== ADMIN` must migrate to
+  `hasAtLeast(role, ADMIN)` to avoid accidentally excluding `CREATOR`.
 
 ### Rejected alternatives
 

--- a/docs/architecture/decisions/0011-creator-role-above-admin.md
+++ b/docs/architecture/decisions/0011-creator-role-above-admin.md
@@ -1,0 +1,67 @@
+# ADR-0011 — Introduce a single-holder `CREATOR` role above `ADMIN`
+
+**Status**  Proposed
+**Date**    2026-05-25
+**Owners**  @benoit-bremaud
+
+> Records the RBAC decision surfaced by the account/profile conception
+> (PR #1100) and tracked by epic #821.
+
+---
+
+## Context
+
+The API role enum (`packages/api/src/common/enums/role.enum.ts`) today has three
+values: `USER`, `MODERATOR`, `ADMIN`. The product needs a **supreme owner** role
+above `ADMIN` — the founder/super-admin who can do everything an admin can plus
+manage admins themselves (grant/revoke `ADMIN`, hold ownership of the platform
+account, seed-once operations).
+
+Reusing `ADMIN` for this is unsafe: any admin could then demote/lock out the
+owner. A distinct top role makes "who can manage admins" unambiguous.
+
+---
+
+## Decision
+
+**Add a `CREATOR` role as the highest privilege, held by exactly one account,
+seeded once.**
+
+- Enum becomes `USER < MODERATOR < ADMIN < CREATOR` (monotonic privilege order).
+- **Single-holder invariant**: at most one `CREATOR` exists, created by a
+  one-time seed; the role is **not** grantable through the normal role-assignment
+  UI/endpoint. Enforced in application code + a DB uniqueness guard.
+- `CREATOR` inherits all `ADMIN` capabilities and additionally may assign/revoke
+  `ADMIN`/`MODERATOR`.
+- Authorization checks compare on the privilege order, not on equality, so new
+  admin-or-above checks read `role >= ADMIN`.
+
+---
+
+## Consequences
+
+### Positive
+
+- Unambiguous platform ownership; admins cannot lock out the owner.
+- Seed-once + non-grantable closes the privilege-escalation path to the top role.
+
+### Trade-offs
+
+- The single-holder invariant must be enforced in **two** places (app guard + DB
+  constraint) and covered by tests — a uniqueness rule, not just data.
+- Existing role checks that used `=== ADMIN` must migrate to `>= ADMIN` to avoid
+  accidentally excluding `CREATOR`.
+
+### Rejected alternatives
+
+- **Reuse `ADMIN`** — no protection against an admin demoting the owner.
+- **A boolean `isOwner` flag on `users`** — splits authorization across an enum
+  and a flag; the ordered enum keeps one source of truth for privilege.
+
+---
+
+## References
+
+- Account/profile UML [`docs/architecture/diagrams/account/`](../diagrams/account/) (class `Role`).
+- Epic #821 (CREATOR role). Role enum `packages/api/src/common/enums/role.enum.ts`.
+- [ADR-0002](0002-centralized-nestjs-backend.md) — auth/authz owned by NestJS.

--- a/docs/architecture/decisions/0012-rgpd-anonymize-authored-public-content.md
+++ b/docs/architecture/decisions/0012-rgpd-anonymize-authored-public-content.md
@@ -1,0 +1,77 @@
+# ADR-0012 — On account deletion, anonymize authored public content (don't hard-delete)
+
+**Status**  Proposed
+**Date**    2026-05-25
+**Owners**  @benoit-bremaud
+
+> Records the RGPD decision surfaced by the account/profile data-flow conception
+> (PR #1100, `account/06-data-flow.md`) and epic #645.
+
+---
+
+## Context
+
+A user may exercise their RGPD right to erasure (art. 17). But a user can also
+author **public** content others depend on: published recipes that other brewers
+have **cloned** (clone → a new private root with `importedFromRecipeId` provenance,
+per the recipes conception). Hard-deleting an account that authored public
+recipes would either break those clones' provenance/lineage or cascade-delete
+content other users legitimately reuse.
+
+We must reconcile the user's erasure right with the integrity of content the
+community has built on.
+
+---
+
+## Decision
+
+**On account deletion, erase personal data but anonymize authored *public*
+content rather than hard-deleting it.**
+
+- **Erase**: identity + PII (email, names, avatar, preferences, sessions),
+  private recipes/batches/labels the user did not publish, and the link from
+  public content to the personal identity.
+- **Anonymize, keep**: published (public) recipes the user authored are
+  re-attributed to an `"Auteur supprimé"` / anonymized owner — the **content and
+  its lineage survive** (clones keep working, provenance stays valid) but carry
+  no PII.
+- **Export (art. 20)** returns the full personal bundle (incl. the user's own
+  recipes/batches) to the app, which writes the file locally (the API does not
+  write it) — per the data-flow diagram.
+- Deletion + anonymization run server-side in one transaction; the operation is
+  idempotent and logged (without PII) for audit.
+
+---
+
+## Consequences
+
+### Positive
+
+- Honours erasure (no PII remains) **and** preserves community content + clone
+  lineage — no orphaned/broken provenance.
+- Public recipes don't vanish from under other users who cloned/brew them.
+
+### Trade-offs
+
+- "Anonymize vs erase" is a per-entity policy the deletion service must encode
+  (private → erase, authored-public → anonymize); needs tests per entity type.
+- An anonymized author is a tombstone identity that must never be reused or
+  re-personalised.
+
+### Rejected alternatives
+
+- **Hard-delete everything the user authored** — breaks clones' provenance and
+  removes content others rely on; also risks referential dangling.
+- **Refuse deletion while the user has public content** — violates the erasure
+  right; not acceptable.
+- **Keep the author name but drop the account** — leaves PII (the name) in public
+  content; fails erasure.
+
+---
+
+## References
+
+- Account/profile data-flow [`docs/architecture/diagrams/account/06-data-flow.md`](../diagrams/account/06-data-flow.md).
+- Recipes UML [`docs/architecture/diagrams/recipes/`](../diagrams/recipes/) (clone/version lineage, provenance).
+- [ADR-0003](0003-consent-single-source-of-truth.md) — consent SSOT.
+- Epic #645 (profile completion incl. RGPD export + delete).

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -47,6 +47,9 @@ Every ADR follows the same skeleton (inspired by Michael Nygard's template):
 | [0004](0004-data-locality-hybrid-principle.md) | Data locality: hybrid principle | Accepted | 2026-04-24 |
 | [0005](0005-backend-split-encyclopedia-vs-product.md) | Backend split: encyclopedia vs product | Accepted | 2026-05-02 |
 | [0009](0009-beer-duel-preference-data-ownership.md) | Beer-duel preference data ownership | Accepted | 2026-05-21 |
+| [0010](0010-recipe-step-type-nine-phase.md) | Extend `RecipeStepType` to the 9-phase brewing set | Proposed | 2026-05-25 |
+| [0011](0011-creator-role-above-admin.md) | Single-holder `CREATOR` role above `ADMIN` | Proposed | 2026-05-25 |
+| [0012](0012-rgpd-anonymize-authored-public-content.md) | RGPD: anonymize authored public content on deletion | Proposed | 2026-05-25 |
 
 > **Numbers 0006–0008 are reserved** (not yet drafted) for decisions already
 > referenced by open epics: 0006 — private journal vs. social product (#833),


### PR DESCRIPTION
## Summary

Three ADRs formalising the structural decisions surfaced by the UML conception
sweep (#1094–#1104). **Status: Proposed** — flip to Accepted on your approval.

- **ADR-0010** — extend `RecipeStepType` from 5 to the **9-phase** brewing set
  (D1). Gates the guided-brewing assistant (#781) and recipe steps (#410–#420);
  sibling of the BeerXML/BeerJSON mapping (#866).
- **ADR-0011** — single-holder **`CREATOR`** role above `ADMIN` (#821).
- **ADR-0012** — **RGPD**: on account deletion, erase PII but **anonymize**
  authored public content (keep clones' lineage working) (#645).

Indexed in `docs/architecture/decisions/README.md`.

## Checklist

- [x] Documentation only — no code
- [x] MADR-aligned (Context / Decision / Consequences / References)
- [x] Each ADR cites the conception diagrams + the epics it decides
- [ ] Owner accepts (Proposed → Accepted) — your call on merge