### PR TITLE
feat(website): lead the journey with scan→clone (5 steps)

### DIFF
--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -165,10 +165,18 @@
       <section class="section-block" id="journeyFr">
         <p class="section-eyebrow">Le parcours</p>
         <h2 class="section-title">De la recette à la <em>dégustation</em></h2>
-        <p class="section-intro">Quatre étapes, un copilote à chaque moment. Tu n’es jamais seul devant tes cuves.</p>
+        <p class="section-intro">Tu as goûté une bière que tu as adorée ? Tout commence par un scan. Cinq étapes, un copilote à chaque moment — tu n’es jamais seul devant tes cuves.</p>
         <ol class="journey-grid">
           <li class="journey-step">
             <span class="journey-num" aria-hidden="true">01</span>
+            <div class="journey-screenshot">
+              <img src="screenshots/feature-scan-recognition.webp?v=20260522" alt="Capture de l’écran « Bière reconnue » : une bière scannée est identifiée avec son style, sa couleur et son amertume, prête à être clonée" loading="lazy" width="320" height="640">
+            </div>
+            <h3>Scanne ta bière coup de cœur</h3>
+            <p>Une bière que tu as adorée ? Scanne-la : l’app la reconnaît et te propose des recettes-clones à brasser.</p>
+          </li>
+          <li class="journey-step">
+            <span class="journey-num" aria-hidden="true">02</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-1-catalog.webp?v=20260522" alt="Catalogue de recettes de l’app : liste de recettes publiques avec leurs indicateurs IBU, ABV et volume" loading="lazy" width="320" height="640">
             </div>
@@ -176,7 +184,7 @@
             <p>Un catalogue calibré pour réussir dès le premier brassin — sans jargon, sans surprise.</p>
           </li>
           <li class="journey-step">
-            <span class="journey-num" aria-hidden="true">02</span>
+            <span class="journey-num" aria-hidden="true">03</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-2-brewing.webp?v=20260525" alt="Capture de l’écran de pilotage du brassin pendant l’empâtage à 67°C, avec timer et étapes" loading="lazy" width="320" height="640">
             </div>
@@ -184,7 +192,7 @@
             <p>L’app te dit quoi faire, quand, et pourquoi — empâtage, ébullition, refroidissement.</p>
           </li>
           <li class="journey-step">
-            <span class="journey-num" aria-hidden="true">03</span>
+            <span class="journey-num" aria-hidden="true">04</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-3-fermenting.webp?v=20260522" alt="Capture de l’écran de fermentation avec la barre de progression jour 5 sur 14 et la densité actuelle" loading="lazy" width="320" height="640">
             </div>
@@ -192,7 +200,7 @@
             <p>Jours, densité, température. Un coup d’œil et tu sais où tu en es.</p>
           </li>
           <li class="journey-step">
-            <span class="journey-num" aria-hidden="true">04</span>
+            <span class="journey-num" aria-hidden="true">05</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-4-deguste.webp?v=20260524" alt="Capture de l’écran de célébration « brassin terminé » avec la bouteille et l’étiquette personnalisée" loading="lazy" width="320" height="640">
             </div>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -164,7 +164,7 @@
 
       <section class="section-block" id="journeyFr">
         <p class="section-eyebrow">Le parcours</p>
-        <h2 class="section-title">De la recette à la <em>dégustation</em></h2>
+        <h2 class="section-title">Du scan à la <em>dégustation</em></h2>
         <p class="section-intro">Tu as goûté une bière que tu as adorée ? Tout commence par un scan. Cinq étapes, un copilote à chaque moment — tu n’es jamais seul devant tes cuves.</p>
         <ol class="journey-grid">
           <li class="journey-step">

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -181,7 +181,7 @@
               <img src="screenshots/journey-1-catalog.webp?v=20260522" alt="Catalogue de recettes de l’app : liste de recettes publiques avec leurs indicateurs IBU, ABV et volume" loading="lazy" width="320" height="640">
             </div>
             <h3>Choisis ta recette</h3>
-            <p>Un catalogue calibré pour réussir dès le premier brassin — sans jargon, sans surprise.</p>
+            <p>Compare les recettes-clones de la communauté, notées et éprouvées, et adopte celle qui te tente. Sans jargon.</p>
           </li>
           <li class="journey-step">
             <span class="journey-num" aria-hidden="true">03</span>
@@ -189,7 +189,7 @@
               <img src="screenshots/journey-2-brewing.webp?v=20260525" alt="Capture de l’écran de pilotage du brassin pendant l’empâtage à 67°C, avec timer et étapes" loading="lazy" width="320" height="640">
             </div>
             <h3>Brasse pas à pas</h3>
-            <p>L’app te dit quoi faire, quand, et pourquoi — empâtage, ébullition, refroidissement.</p>
+            <p>Minuteurs, températures et le pourquoi de chaque geste : l’app te guide à chaque étape — empâtage, ébullition, refroidissement.</p>
           </li>
           <li class="journey-step">
             <span class="journey-num" aria-hidden="true">04</span>


### PR DESCRIPTION
## Summary

Reframes the homepage "Le parcours" section to **start with the scan** — the product's differentiating wedge and the true start of the user story ("you loved a beer → can I brew it?"). The journey was starting at "Choisis ta recette" and omitted the scan entirely.

## Changes (FR `index.html` only)

- New **step 01 — « Scanne ta bière coup de cœur »**, reusing the existing `feature-scan-recognition.webp` (no new asset).
- Renumbered to **5 steps**: Scan → Choisis → Brasse → Suis la fermentation → Mets en bouteille.
- Intro reworked around the scan hook + a light persona flavour ("Tu as goûté une bière que tu as adorée ? Tout commence par un scan.").

## Notes

- `.journey-grid` uses `auto-fit` → 5 cards reflow with no CSS change.
- `index-en.html` has no journey section → FR-only change, no EN parity needed.
- Header "Parcours" link + hero CTA already point at `#journeyFr` — unchanged.
- Website quality gate passes.

Keeps the journey universal (not narrowed to a beginner persona) while leading with the clone-community wedge from the marketing needs study.