### PR TITLE
feat(api/batches): Measurement entity + table (#605 slice 1)

### DIFF
--- a/packages/api/src/batch/batch.module.ts
+++ b/packages/api/src/batch/batch.module.ts
@@ -7,6 +7,7 @@ import { BatchController } from './controllers/batch.controller';
 import { BatchReminderOrmEntity } from './entities/batch-reminder.orm.entity';
 import { BatchOrmEntity } from './entities/batch.orm.entity';
 import { BatchStepOrmEntity } from './entities/batch-step.orm.entity';
+import { MeasurementOrmEntity } from './entities/measurement.orm.entity';
 import { BatchService } from './services/batch.service';
 
 @Module({
@@ -15,6 +16,7 @@ import { BatchService } from './services/batch.service';
       BatchOrmEntity,
       BatchStepOrmEntity,
       BatchReminderOrmEntity,
+      MeasurementOrmEntity,
     ]),
     RecipeModule,
   ],

--- a/packages/api/src/batch/domain/enums/measurement-type.enum.ts
+++ b/packages/api/src/batch/domain/enums/measurement-type.enum.ts
@@ -1,0 +1,22 @@
+/**
+ * Kinds of measurement a brewer records against a batch (#605).
+ *
+ * - `og` / `fg` — original / final specific gravity (one per batch, typically).
+ * - `sg_spot` — a spot specific-gravity reading taken mid-fermentation.
+ * - `temperature` — fermentation / mash temperature in °C.
+ * - `ph` — wort / mash pH.
+ */
+export enum MeasurementType {
+  OG = 'og',
+  FG = 'fg',
+  SG_SPOT = 'sg_spot',
+  TEMPERATURE = 'temperature',
+  PH = 'ph',
+}
+
+/** Specific-gravity-family types share the same plausible range + unitless reading. */
+export const GRAVITY_MEASUREMENT_TYPES: readonly MeasurementType[] = [
+  MeasurementType.OG,
+  MeasurementType.FG,
+  MeasurementType.SG_SPOT,
+] as const;

--- a/packages/api/src/batch/domain/measurement.factory.spec.ts
+++ b/packages/api/src/batch/domain/measurement.factory.spec.ts
@@ -1,0 +1,98 @@
+import {
+  createMeasurement,
+  MeasurementValidationError,
+} from './measurement.factory';
+import { MeasurementType } from './enums/measurement-type.enum';
+
+describe('createMeasurement', () => {
+  // Happy path
+  it('builds a normalised measurement for a valid gravity reading', () => {
+    const takenAt = new Date('2026-05-20T10:00:00.000Z');
+    const m = createMeasurement({
+      batchId: 'b-1',
+      type: MeasurementType.OG,
+      value: 1.048,
+      stepOrder: 2,
+      unit: 'SG',
+      takenAt,
+    });
+
+    expect(m).toEqual({
+      batchId: 'b-1',
+      type: MeasurementType.OG,
+      value: 1.048,
+      stepOrder: 2,
+      unit: 'SG',
+      takenAt,
+    });
+  });
+
+  // Happy path: optional fields default
+  it('defaults stepOrder/unit to null and takenAt to now', () => {
+    const before = Date.now();
+    const m = createMeasurement({
+      batchId: 'b-1',
+      type: MeasurementType.TEMPERATURE,
+      value: 19,
+    });
+
+    expect(m.stepOrder).toBeNull();
+    expect(m.unit).toBeNull();
+    expect(m.takenAt.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  // Sad path: missing batch
+  it('rejects an empty batchId', () => {
+    expect(() =>
+      createMeasurement({
+        batchId: ' ',
+        type: MeasurementType.FG,
+        value: 1.01,
+      }),
+    ).toThrow(MeasurementValidationError);
+  });
+
+  // Sad path: non-finite value
+  it('rejects a non-finite value', () => {
+    expect(() =>
+      createMeasurement({
+        batchId: 'b-1',
+        type: MeasurementType.PH,
+        value: Number.NaN,
+      }),
+    ).toThrow(/finite/);
+  });
+
+  // Edge: out-of-range per type
+  it.each([
+    [MeasurementType.OG, 1.5], // gravity too high
+    [MeasurementType.TEMPERATURE, 200], // temp too high
+    [MeasurementType.PH, 15], // pH out of 0..14
+  ])('rejects %s value %p as out of range', (type, value) => {
+    expect(() => createMeasurement({ batchId: 'b-1', type, value })).toThrow(
+      /out of range/,
+    );
+  });
+
+  // Edge: negative / non-integer stepOrder
+  it('rejects a negative or non-integer stepOrder', () => {
+    expect(() =>
+      createMeasurement({
+        batchId: 'b-1',
+        type: MeasurementType.FG,
+        value: 1.012,
+        stepOrder: -1,
+      }),
+    ).toThrow(/stepOrder/);
+  });
+
+  // Edge: gravity boundary is accepted
+  it('accepts the gravity lower boundary', () => {
+    const m = createMeasurement({
+      batchId: 'b-1',
+      type: MeasurementType.SG_SPOT,
+      value: 0.99,
+    });
+    expect(m.value).toBe(0.99);
+  });
+});

--- a/packages/api/src/batch/domain/measurement.factory.ts
+++ b/packages/api/src/batch/domain/measurement.factory.ts
@@ -1,0 +1,95 @@
+import {
+  GRAVITY_MEASUREMENT_TYPES,
+  MeasurementType,
+} from './enums/measurement-type.enum';
+
+/** Raw input for a new measurement, before validation/normalisation. */
+export interface MeasurementInput {
+  batchId: string;
+  type: MeasurementType;
+  value: number;
+  stepOrder?: number | null;
+  unit?: string | null;
+  takenAt?: Date;
+}
+
+/** A validated, normalised measurement (the shape the service persists). */
+export interface Measurement {
+  batchId: string;
+  type: MeasurementType;
+  value: number;
+  stepOrder: number | null;
+  unit: string | null;
+  takenAt: Date;
+}
+
+/** Raised when a measurement violates a domain invariant (#605). */
+export class MeasurementValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MeasurementValidationError';
+  }
+}
+
+// Plausible physical ranges — reject obvious garbage (typos, wrong unit) early.
+const GRAVITY_MIN = 0.99;
+const GRAVITY_MAX = 1.2;
+const TEMPERATURE_MIN_C = -10;
+const TEMPERATURE_MAX_C = 120;
+const PH_MIN = 0;
+const PH_MAX = 14;
+
+function rangeFor(type: MeasurementType): { min: number; max: number } {
+  if (GRAVITY_MEASUREMENT_TYPES.includes(type)) {
+    return { min: GRAVITY_MIN, max: GRAVITY_MAX };
+  }
+  if (type === MeasurementType.TEMPERATURE) {
+    return { min: TEMPERATURE_MIN_C, max: TEMPERATURE_MAX_C };
+  }
+  return { min: PH_MIN, max: PH_MAX }; // pH
+}
+
+/**
+ * Validate + normalise a measurement against its domain invariants (#605):
+ * non-empty batch, finite value within the plausible range for its type, and a
+ * non-negative integer step order when provided. Returns the normalised value
+ * object or throws `MeasurementValidationError`.
+ */
+export function createMeasurement(input: MeasurementInput): Measurement {
+  if (!input.batchId || input.batchId.trim().length === 0) {
+    throw new MeasurementValidationError('batchId is required');
+  }
+  if (!Object.values(MeasurementType).includes(input.type)) {
+    throw new MeasurementValidationError(
+      `unknown measurement type: ${input.type}`,
+    );
+  }
+  if (!Number.isFinite(input.value)) {
+    throw new MeasurementValidationError('value must be a finite number');
+  }
+
+  const { min, max } = rangeFor(input.type);
+  if (input.value < min || input.value > max) {
+    throw new MeasurementValidationError(
+      `${input.type} value ${input.value} is out of range [${min}, ${max}]`,
+    );
+  }
+
+  if (
+    input.stepOrder != null &&
+    (!Number.isInteger(input.stepOrder) || input.stepOrder < 0)
+  ) {
+    throw new MeasurementValidationError(
+      'stepOrder must be a non-negative integer',
+    );
+  }
+
+  return {
+    batchId: input.batchId,
+    type: input.type,
+    value: input.value,
+    stepOrder: input.stepOrder ?? null,
+    unit: input.unit ?? null,
+    takenAt: input.takenAt ?? new Date(),
+  };
+}

--- a/packages/api/src/batch/entities/measurement.orm.entity.ts
+++ b/packages/api/src/batch/entities/measurement.orm.entity.ts
@@ -1,0 +1,53 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryColumn,
+} from 'typeorm';
+
+import { MeasurementType } from '../domain/enums/measurement-type.enum';
+
+/**
+ * A single measurement recorded against a batch (#605) — OG/FG/SG spot,
+ * temperature or pH. Belongs to a `Batch` (the aggregate root, per the batches
+ * class diagram); `step_order` optionally pins it to the batch step it was
+ * taken during (the `batch_steps` row is identified by `batch_id` + `step_order`).
+ *
+ * SQLite-friendly column types (no JSONB): `real` for the value, `datetime`
+ * for timestamps, `varchar` + CHECK for the enum.
+ */
+@Entity('batch_measurements')
+@Index(['batch_id'])
+export class MeasurementOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  batch_id: string;
+
+  /** Step the reading belongs to (nullable — some readings are batch-level). */
+  @Column({ type: 'integer', nullable: true })
+  step_order?: number | null;
+
+  @Column({
+    type: 'varchar',
+    length: 20,
+    enum: MeasurementType,
+    nullable: false,
+  })
+  type: MeasurementType;
+
+  @Column({ type: 'real', nullable: false })
+  value: number;
+
+  /** e.g. "°C", "SG", "pH" — free-form, optional. */
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  unit?: string | null;
+
+  @Column({ type: 'datetime', nullable: false })
+  taken_at: Date;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+}

--- a/packages/api/src/database/migrations/1796000000000-AddBatchMeasurementsTable.ts
+++ b/packages/api/src/database/migrations/1796000000000-AddBatchMeasurementsTable.ts
@@ -24,7 +24,8 @@ export class AddBatchMeasurementsTable1796000000000 implements MigrationInterfac
         "unit" varchar(20),
         "taken_at" datetime NOT NULL,
         "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
-        CONSTRAINT "CHK_batch_measurements_type" CHECK ("type" IN ('og', 'fg', 'sg_spot', 'temperature', 'ph'))
+        CONSTRAINT "CHK_batch_measurements_type" CHECK ("type" IN ('og', 'fg', 'sg_spot', 'temperature', 'ph')),
+        CONSTRAINT "FK_batch_measurements_batch_id" FOREIGN KEY ("batch_id") REFERENCES "batches" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
       )
     `);
     await queryRunner.query(

--- a/packages/api/src/database/migrations/1796000000000-AddBatchMeasurementsTable.ts
+++ b/packages/api/src/database/migrations/1796000000000-AddBatchMeasurementsTable.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `batch_measurements` table (#605, first slice of the Mes Brassins
+ * data-model extension #595).
+ *
+ * One row per reading a brewer records against a batch — OG/FG/SG-spot,
+ * temperature or pH. Belongs to a batch (`batch_id`); `step_order` optionally
+ * pins it to the batch step it was taken during. SQLite-friendly types
+ * (`real`, `datetime`, `varchar` + CHECK). Indexed on `batch_id` for the
+ * detail-screen measurements section (#606/#607).
+ */
+export class AddBatchMeasurementsTable1796000000000 implements MigrationInterface {
+  name = 'AddBatchMeasurementsTable1796000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "batch_measurements" (
+        "id" varchar PRIMARY KEY NOT NULL,
+        "batch_id" varchar NOT NULL,
+        "step_order" integer,
+        "type" varchar(20) NOT NULL,
+        "value" real NOT NULL,
+        "unit" varchar(20),
+        "taken_at" datetime NOT NULL,
+        "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        CONSTRAINT "CHK_batch_measurements_type" CHECK ("type" IN ('og', 'fg', 'sg_spot', 'temperature', 'ph'))
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_batch_measurements_batch_id" ON "batch_measurements" ("batch_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_batch_measurements_batch_id"`);
+    await queryRunner.query(`DROP TABLE "batch_measurements"`);
+  }
+}

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -16,6 +16,7 @@ import { HopOrmEntity } from '../catalog/hop/entities/hop.orm.entity';
 import { LabelDraftOrmEntity } from '../label/entities/label-draft.orm.entity';
 import { MashProfileOrmEntity } from '../catalog/mash/entities/mash-profile.orm.entity';
 import { MashStepOrmEntity } from '../catalog/mash/entities/mash-step.orm.entity';
+import { MeasurementOrmEntity } from '../batch/entities/measurement.orm.entity';
 import { MiscTemplateDistributorOrmEntity } from '../catalog/misc/entities/misc-template-distributor.orm.entity';
 import { MiscTemplateOrmEntity } from '../catalog/misc/entities/misc-template.orm.entity';
 import { ProducerOrmEntity } from '../catalog/producer/entities/producer.orm.entity';
@@ -46,6 +47,7 @@ export const ormEntities = [
   BatchOrmEntity,
   BatchStepOrmEntity,
   BatchReminderOrmEntity,
+  MeasurementOrmEntity,
   RecipeOrmEntity,
   RecipeStepOrmEntity,
   RecipeFermentableOrmEntity,


### PR DESCRIPTION
## Summary

First slice of the Mes Brassins data-model extension (**#605**, epic **#595**): the `batch_measurements` table that holds the readings a brewer records against a batch — OG/FG/SG-spot, temperature, pH.

## Changes (API, backend-only)

- `MeasurementType` enum (`og`/`fg`/`sg_spot`/`temperature`/`ph`).
- `MeasurementOrmEntity` — SQLite-friendly (`real`/`datetime`/`varchar`+CHECK), indexed on `batch_id`, optional `step_order` link to the batch step.
- `createMeasurement` domain factory enforcing invariants (non-empty batch, finite value within the plausible per-type range, non-negative integer `stepOrder`) — **H/S/E unit tests** (9 cases).
- Migration `AddBatchMeasurementsTable1796000000000` (rollback-able); entity registered in `typeorm.config` + `BatchModule`.

## Why this slice

Aligns with the post-UML build order (assistant-first, journey step 3 = fermentation tracking) and the dependency-first principle (data model before the inline-entry UI). Matches the batches/brewing-session UML class diagrams.

## Scope / follow-ups

This slice is **only** the Measurement table + domain guard. Deferred to later #605/#607 slices: response/create DTOs + endpoint (#607 inline entry), and the Observation / Alert entities + Batch-metadata columns.

## Verification

- `lint:check` clean, `build` ok.
- Unit: 691 passed. **e2e: 14 passed — the migration applies cleanly against in-memory SQLite.**
- Backend-only → no impact on the demo (demo mode reads mocked data).

Part of #605 · epic #595.