### PR TITLE
feat(api/batches): Observation entity + table (#605 slice 2)

### DIFF
--- a/packages/api/src/batch/batch.module.ts
+++ b/packages/api/src/batch/batch.module.ts
@@ -8,6 +8,7 @@ import { BatchReminderOrmEntity } from './entities/batch-reminder.orm.entity';
 import { BatchOrmEntity } from './entities/batch.orm.entity';
 import { BatchStepOrmEntity } from './entities/batch-step.orm.entity';
 import { MeasurementOrmEntity } from './entities/measurement.orm.entity';
+import { ObservationOrmEntity } from './entities/observation.orm.entity';
 import { BatchService } from './services/batch.service';
 
 @Module({
@@ -17,6 +18,7 @@ import { BatchService } from './services/batch.service';
       BatchStepOrmEntity,
       BatchReminderOrmEntity,
       MeasurementOrmEntity,
+      ObservationOrmEntity,
     ]),
     RecipeModule,
   ],

--- a/packages/api/src/batch/domain/observation.factory.spec.ts
+++ b/packages/api/src/batch/domain/observation.factory.spec.ts
@@ -1,0 +1,78 @@
+import {
+  createObservation,
+  ObservationValidationError,
+} from './observation.factory';
+
+describe('createObservation', () => {
+  // Happy path
+  it('builds a normalised observation with all fields', () => {
+    const observedAt = new Date('2026-05-20T18:00:00.000Z');
+    const o = createObservation({
+      batchId: 'b-1',
+      freeText: '  Krausen bien formé, odeur fruitée  ',
+      stepOrder: 3,
+      photoRefs: ['photos/1.jpg'],
+      moodScore: 4,
+      observedAt,
+    });
+
+    expect(o).toEqual({
+      batchId: 'b-1',
+      freeText: 'Krausen bien formé, odeur fruitée', // trimmed
+      stepOrder: 3,
+      photoRefs: ['photos/1.jpg'],
+      moodScore: 4,
+      observedAt,
+    });
+  });
+
+  // Happy path: optional fields default
+  it('defaults stepOrder/moodScore to null, photoRefs to [], observedAt to now', () => {
+    const before = Date.now();
+    const o = createObservation({ batchId: 'b-1', freeText: 'note' });
+
+    expect(o.stepOrder).toBeNull();
+    expect(o.moodScore).toBeNull();
+    expect(o.photoRefs).toEqual([]);
+    expect(o.observedAt.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  // Sad path: empty free text
+  it('rejects empty free text', () => {
+    expect(() =>
+      createObservation({ batchId: 'b-1', freeText: '   ' }),
+    ).toThrow(ObservationValidationError);
+  });
+
+  // Sad path: missing batch
+  it('rejects an empty batchId', () => {
+    expect(() => createObservation({ batchId: '', freeText: 'note' })).toThrow(
+      /batchId/,
+    );
+  });
+
+  // Edge: mood score out of range
+  it.each([0, 6, 2.5])('rejects mood score %p', (moodScore) => {
+    expect(() =>
+      createObservation({ batchId: 'b-1', freeText: 'note', moodScore }),
+    ).toThrow(/moodScore/);
+  });
+
+  // Edge: blank photo ref
+  it('rejects a blank photo ref', () => {
+    expect(() =>
+      createObservation({
+        batchId: 'b-1',
+        freeText: 'note',
+        photoRefs: ['ok', '  '],
+      }),
+    ).toThrow(/photoRefs/);
+  });
+
+  // Edge: negative stepOrder
+  it('rejects a negative stepOrder', () => {
+    expect(() =>
+      createObservation({ batchId: 'b-1', freeText: 'note', stepOrder: -2 }),
+    ).toThrow(/stepOrder/);
+  });
+});

--- a/packages/api/src/batch/domain/observation.factory.ts
+++ b/packages/api/src/batch/domain/observation.factory.ts
@@ -1,0 +1,87 @@
+/** Raw input for a new observation, before validation/normalisation. */
+export interface ObservationInput {
+  batchId: string;
+  freeText: string;
+  stepOrder?: number | null;
+  photoRefs?: string[] | null;
+  moodScore?: number | null;
+  observedAt?: Date;
+}
+
+/** A validated, normalised observation (the shape the service persists). */
+export interface Observation {
+  batchId: string;
+  freeText: string;
+  stepOrder: number | null;
+  photoRefs: string[];
+  moodScore: number | null;
+  observedAt: Date;
+}
+
+/** Raised when an observation violates a domain invariant (#605). */
+export class ObservationValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ObservationValidationError';
+  }
+}
+
+export const MOOD_SCORE_MIN = 1;
+export const MOOD_SCORE_MAX = 5;
+const FREE_TEXT_MAX = 2000;
+
+/**
+ * Validate + normalise an observation against its domain invariants (#605):
+ * non-empty batch, non-empty free text within a sane length, a non-negative
+ * integer step order, an optional 1–5 integer mood score, and string photo
+ * refs. Returns the normalised value object or throws.
+ */
+export function createObservation(input: ObservationInput): Observation {
+  if (!input.batchId || input.batchId.trim().length === 0) {
+    throw new ObservationValidationError('batchId is required');
+  }
+
+  const freeText = input.freeText?.trim() ?? '';
+  if (freeText.length === 0) {
+    throw new ObservationValidationError('freeText is required');
+  }
+  if (freeText.length > FREE_TEXT_MAX) {
+    throw new ObservationValidationError(
+      `freeText exceeds ${FREE_TEXT_MAX} characters`,
+    );
+  }
+
+  if (
+    input.stepOrder != null &&
+    (!Number.isInteger(input.stepOrder) || input.stepOrder < 0)
+  ) {
+    throw new ObservationValidationError(
+      'stepOrder must be a non-negative integer',
+    );
+  }
+
+  if (
+    input.moodScore != null &&
+    (!Number.isInteger(input.moodScore) ||
+      input.moodScore < MOOD_SCORE_MIN ||
+      input.moodScore > MOOD_SCORE_MAX)
+  ) {
+    throw new ObservationValidationError(
+      `moodScore must be an integer in [${MOOD_SCORE_MIN}, ${MOOD_SCORE_MAX}]`,
+    );
+  }
+
+  const photoRefs = input.photoRefs ?? [];
+  if (photoRefs.some((ref) => typeof ref !== 'string' || ref.trim() === '')) {
+    throw new ObservationValidationError('photoRefs must be non-empty strings');
+  }
+
+  return {
+    batchId: input.batchId,
+    freeText,
+    stepOrder: input.stepOrder ?? null,
+    photoRefs,
+    moodScore: input.moodScore ?? null,
+    observedAt: input.observedAt ?? new Date(),
+  };
+}

--- a/packages/api/src/batch/entities/observation.orm.entity.ts
+++ b/packages/api/src/batch/entities/observation.orm.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryColumn,
+} from 'typeorm';
+
+/**
+ * A free-text observation a brewer logs against a batch (#605, slice 2) — the
+ * "Notes" section of the Mes Brassins detail (#606). Belongs to a `Batch`;
+ * `step_order` optionally pins it to the step it was taken during.
+ *
+ * SQLite-friendly types: `text` for the note, `simple-array` (stored as a
+ * comma-joined `text`) for photo references, `integer` for the optional
+ * 1–5 mood score, `datetime` for timestamps.
+ */
+@Entity('batch_observations')
+@Index(['batch_id'])
+export class ObservationOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  batch_id: string;
+
+  /** Step the note belongs to (nullable — some notes are batch-level). */
+  @Column({ type: 'integer', nullable: true })
+  step_order?: number | null;
+
+  @Column({ type: 'text', nullable: false })
+  free_text: string;
+
+  /** Opaque references to attached photos (storage keys / URIs). */
+  @Column({ type: 'simple-array', nullable: true })
+  photo_refs?: string[] | null;
+
+  /** Optional subjective 1–5 mood/confidence score for the reading. */
+  @Column({ type: 'integer', nullable: true })
+  mood_score?: number | null;
+
+  @Column({ type: 'datetime', nullable: false })
+  observed_at: Date;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+}

--- a/packages/api/src/database/migrations/1797000000000-AddBatchObservationsTable.ts
+++ b/packages/api/src/database/migrations/1797000000000-AddBatchObservationsTable.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `batch_observations` table (#605 slice 2, epic #595).
+ *
+ * Free-text notes a brewer logs against a batch — the "Notes" section of the
+ * Mes Brassins detail (#606). Belongs to a batch (`batch_id`, FK CASCADE like
+ * batch_steps); `step_order` optionally pins it to a step. SQLite-friendly:
+ * `text` note, `text` for the comma-joined photo refs (TypeORM simple-array),
+ * `integer` 1–5 mood score (CHECK-guarded). Indexed on `batch_id`.
+ */
+export class AddBatchObservationsTable1797000000000 implements MigrationInterface {
+  name = 'AddBatchObservationsTable1797000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "batch_observations" (
+        "id" varchar PRIMARY KEY NOT NULL,
+        "batch_id" varchar NOT NULL,
+        "step_order" integer,
+        "free_text" text NOT NULL,
+        "photo_refs" text,
+        "mood_score" integer,
+        "observed_at" datetime NOT NULL,
+        "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        CONSTRAINT "CHK_batch_observations_mood" CHECK ("mood_score" IS NULL OR ("mood_score" >= 1 AND "mood_score" <= 5)),
+        CONSTRAINT "FK_batch_observations_batch_id" FOREIGN KEY ("batch_id") REFERENCES "batches" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_batch_observations_batch_id" ON "batch_observations" ("batch_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_batch_observations_batch_id"`);
+    await queryRunner.query(`DROP TABLE "batch_observations"`);
+  }
+}

--- a/packages/api/src/database/migrations/1797000000000-AddBatchObservationsTable.ts
+++ b/packages/api/src/database/migrations/1797000000000-AddBatchObservationsTable.ts
@@ -23,7 +23,7 @@ export class AddBatchObservationsTable1797000000000 implements MigrationInterfac
         "mood_score" integer,
         "observed_at" datetime NOT NULL,
         "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
-        CONSTRAINT "CHK_batch_observations_mood" CHECK ("mood_score" IS NULL OR ("mood_score" >= 1 AND "mood_score" <= 5)),
+        CONSTRAINT "CHK_batch_observations_mood" CHECK ("mood_score" IS NULL OR ("mood_score" >= 1 AND "mood_score" <= 5 AND "mood_score" = CAST("mood_score" AS INTEGER))),
         CONSTRAINT "FK_batch_observations_batch_id" FOREIGN KEY ("batch_id") REFERENCES "batches" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
       )
     `);

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -19,6 +19,7 @@ import { MashStepOrmEntity } from '../catalog/mash/entities/mash-step.orm.entity
 import { MeasurementOrmEntity } from '../batch/entities/measurement.orm.entity';
 import { MiscTemplateDistributorOrmEntity } from '../catalog/misc/entities/misc-template-distributor.orm.entity';
 import { MiscTemplateOrmEntity } from '../catalog/misc/entities/misc-template.orm.entity';
+import { ObservationOrmEntity } from '../batch/entities/observation.orm.entity';
 import { ProducerOrmEntity } from '../catalog/producer/entities/producer.orm.entity';
 import { RecipeAdditiveOrmEntity } from '../recipe/entities/recipe-additive.orm.entity';
 import { RecipeFermentableOrmEntity } from '../recipe/entities/recipe-fermentable.orm.entity';
@@ -48,6 +49,7 @@ export const ormEntities = [
   BatchStepOrmEntity,
   BatchReminderOrmEntity,
   MeasurementOrmEntity,
+  ObservationOrmEntity,
   RecipeOrmEntity,
   RecipeStepOrmEntity,
   RecipeFermentableOrmEntity,


### PR DESCRIPTION
## Summary

Second slice of the Mes Brassins data-model extension (**#605**, epic **#595**): the `batch_observations` table — the brewer's free-text notes (the "Notes" section of the detail screen #606).

## Changes (API, backend-only)

- `ObservationOrmEntity` — `free_text`, optional `photo_refs` (simple-array), optional 1–5 `mood_score`, optional `step_order`; indexed on `batch_id`, FK to `batches(id)` **ON DELETE CASCADE** (matching slice 1 / batch_steps).
- `createObservation` domain factory enforcing invariants (non-empty batch + free text, ≤2000 chars, 1–5 integer mood, non-negative integer stepOrder, non-empty string photo refs) — **H/S/E unit tests** (9 cases).
- Migration `AddBatchObservationsTable1797000000000` (FK CASCADE + mood CHECK, rollback-able); entity registered in `typeorm.config` + `BatchModule`.

## Verification

- `lint:check` clean, `build` ok, factory tests 9/9.
- **e2e 14 passed — migration applies cleanly** against in-memory SQLite.
- Backend-only → demo-safe.

Part of #605 · epic #595. Follows slice 1 (#1112). Next: Alert entity (slice 3), then DTO + inline-entry endpoint (#607).