### PR TITLE
fix(website): journey back to 4 steps (scan only in 'La reconnaissance')

### DIFF
--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -164,19 +164,11 @@
 
       <section class="section-block" id="journeyFr">
         <p class="section-eyebrow">Le parcours</p>
-        <h2 class="section-title">Du scan à la <em>dégustation</em></h2>
-        <p class="section-intro">Tu as goûté une bière que tu as adorée ? Tout commence par un scan. Cinq étapes, un copilote à chaque moment — tu n’es jamais seul devant tes cuves.</p>
+        <h2 class="section-title">De la recette à la <em>dégustation</em></h2>
+        <p class="section-intro">Quatre étapes, un copilote à chaque moment. Tu n’es jamais seul devant tes cuves.</p>
         <ol class="journey-grid">
           <li class="journey-step">
             <span class="journey-num" aria-hidden="true">01</span>
-            <div class="journey-screenshot">
-              <img src="screenshots/feature-scan-recognition.webp?v=20260522" alt="Capture de l’écran « Bière reconnue » : une bière scannée est identifiée avec son style, sa couleur et son amertume, prête à être clonée" loading="lazy" width="320" height="640">
-            </div>
-            <h3>Scanne ta bière coup de cœur</h3>
-            <p>Une bière que tu as adorée ? Scanne-la : l’app la reconnaît et te propose des recettes-clones à brasser.</p>
-          </li>
-          <li class="journey-step">
-            <span class="journey-num" aria-hidden="true">02</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-1-catalog.webp?v=20260522" alt="Catalogue de recettes de l’app : liste de recettes publiques avec leurs indicateurs IBU, ABV et volume" loading="lazy" width="320" height="640">
             </div>
@@ -184,7 +176,7 @@
             <p>Compare les recettes-clones de la communauté, notées et éprouvées, et adopte celle qui te tente. Sans jargon.</p>
           </li>
           <li class="journey-step">
-            <span class="journey-num" aria-hidden="true">03</span>
+            <span class="journey-num" aria-hidden="true">02</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-2-brewing.webp?v=20260525" alt="Capture de l’écran de pilotage du brassin pendant l’empâtage à 67°C, avec timer et étapes" loading="lazy" width="320" height="640">
             </div>
@@ -192,7 +184,7 @@
             <p>Minuteurs, températures et le pourquoi de chaque geste : l’app te guide à chaque étape — empâtage, ébullition, refroidissement.</p>
           </li>
           <li class="journey-step">
-            <span class="journey-num" aria-hidden="true">04</span>
+            <span class="journey-num" aria-hidden="true">03</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-3-fermenting.webp?v=20260522" alt="Capture de l’écran de fermentation avec la barre de progression jour 5 sur 14 et la densité actuelle" loading="lazy" width="320" height="640">
             </div>
@@ -200,7 +192,7 @@
             <p>Jours, densité, température. Un coup d’œil et tu sais où tu en es.</p>
           </li>
           <li class="journey-step">
-            <span class="journey-num" aria-hidden="true">05</span>
+            <span class="journey-num" aria-hidden="true">04</span>
             <div class="journey-screenshot">
               <img src="screenshots/journey-4-deguste.webp?v=20260524" alt="Capture de l’écran de célébration « brassin terminé » avec la bouteille et l’étiquette personnalisée" loading="lazy" width="320" height="640">
             </div>


### PR DESCRIPTION
## Summary

#1109 promoted scan to journey step 01, but the scan feature is already showcased in its own **« La reconnaissance »** section — so the homepage presented scan **twice**. This reverts the journey to its 4 steps and keeps scan in its dedicated section only.

## Changes (FR `index.html`)

- Journey back to **4 steps**: Choisis ta recette → Brasse pas à pas → Suis la fermentation → Mets en bouteille, savoure.
- Title/intro restored to « De la recette à la dégustation » / « Quatre étapes… ».
- Removed the scan step + its `feature-scan-recognition.webp` use from the journey (still used in « La reconnaissance »).
- **Kept** the sharpened step captions from #1109 (community-clone wedge, guided timer) — they don't mention scan.

## Notes

- `index-en.html` has no journey section → FR-only.
- Website quality gate passes.