### PR TITLE
feat(api/batches): Alert entity + table (#605 slice 3)

### DIFF
--- a/packages/api/src/batch/batch.module.ts
+++ b/packages/api/src/batch/batch.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { RecipeModule } from '../recipe/recipe.module';
 
+import { AlertOrmEntity } from './entities/alert.orm.entity';
 import { BatchController } from './controllers/batch.controller';
 import { BatchReminderOrmEntity } from './entities/batch-reminder.orm.entity';
 import { BatchOrmEntity } from './entities/batch.orm.entity';
@@ -19,6 +20,7 @@ import { BatchService } from './services/batch.service';
       BatchReminderOrmEntity,
       MeasurementOrmEntity,
       ObservationOrmEntity,
+      AlertOrmEntity,
     ]),
     RecipeModule,
   ],

--- a/packages/api/src/batch/domain/alert.factory.spec.ts
+++ b/packages/api/src/batch/domain/alert.factory.spec.ts
@@ -1,0 +1,104 @@
+import { createAlert, AlertValidationError } from './alert.factory';
+import { AlertSeverity } from './enums/alert-severity.enum';
+import { AlertTrigger } from './enums/alert-trigger.enum';
+
+describe('createAlert', () => {
+  // Happy path
+  it('builds a normalised alert with all fields', () => {
+    const triggeredAt = new Date('2026-05-20T08:00:00.000Z');
+    const dismissedAt = new Date('2026-05-20T09:00:00.000Z');
+    const a = createAlert({
+      batchId: 'b-1',
+      trigger: AlertTrigger.OVERDUE,
+      severity: AlertSeverity.WARNING,
+      stepOrder: 1,
+      message: '  Empâtage en retard  ',
+      triggeredAt,
+      dismissedAt,
+    });
+
+    expect(a).toEqual({
+      batchId: 'b-1',
+      trigger: AlertTrigger.OVERDUE,
+      severity: AlertSeverity.WARNING,
+      stepOrder: 1,
+      message: 'Empâtage en retard', // trimmed
+      triggeredAt,
+      dismissedAt,
+    });
+  });
+
+  // Happy path: optional fields default
+  it('defaults stepOrder/message/dismissedAt to null and triggeredAt to now', () => {
+    const before = Date.now();
+    const a = createAlert({
+      batchId: 'b-1',
+      trigger: AlertTrigger.THRESHOLD,
+      severity: AlertSeverity.CRITICAL,
+    });
+
+    expect(a.stepOrder).toBeNull();
+    expect(a.message).toBeNull();
+    expect(a.dismissedAt).toBeNull();
+    expect(a.triggeredAt.getTime()).toBeGreaterThanOrEqual(before);
+  });
+
+  // Sad path: missing batch
+  it('rejects an empty batchId', () => {
+    expect(() =>
+      createAlert({
+        batchId: '',
+        trigger: AlertTrigger.OVERDUE,
+        severity: AlertSeverity.INFO,
+      }),
+    ).toThrow(AlertValidationError);
+  });
+
+  // Sad path: unknown enum values
+  it('rejects an unknown trigger', () => {
+    expect(() =>
+      createAlert({
+        batchId: 'b-1',
+        trigger: 'boom' as AlertTrigger,
+        severity: AlertSeverity.INFO,
+      }),
+    ).toThrow(/trigger/);
+  });
+
+  it('rejects an unknown severity', () => {
+    expect(() =>
+      createAlert({
+        batchId: 'b-1',
+        trigger: AlertTrigger.OVERDUE,
+        severity: 'meh' as AlertSeverity,
+      }),
+    ).toThrow(/severity/);
+  });
+
+  // Edge: dismissal before trigger
+  it('rejects a dismissedAt that predates triggeredAt', () => {
+    const triggeredAt = new Date('2026-05-20T10:00:00.000Z');
+    const dismissedAt = new Date('2026-05-20T09:00:00.000Z');
+    expect(() =>
+      createAlert({
+        batchId: 'b-1',
+        trigger: AlertTrigger.THRESHOLD,
+        severity: AlertSeverity.WARNING,
+        triggeredAt,
+        dismissedAt,
+      }),
+    ).toThrow(/dismissedAt/);
+  });
+
+  // Edge: negative stepOrder
+  it('rejects a negative stepOrder', () => {
+    expect(() =>
+      createAlert({
+        batchId: 'b-1',
+        trigger: AlertTrigger.OVERDUE,
+        severity: AlertSeverity.INFO,
+        stepOrder: -1,
+      }),
+    ).toThrow(/stepOrder/);
+  });
+});

--- a/packages/api/src/batch/domain/alert.factory.spec.ts
+++ b/packages/api/src/batch/domain/alert.factory.spec.ts
@@ -90,15 +90,18 @@ describe('createAlert', () => {
     ).toThrow(/dismissedAt/);
   });
 
-  // Edge: negative stepOrder
-  it('rejects a negative stepOrder', () => {
-    expect(() =>
-      createAlert({
-        batchId: 'b-1',
-        trigger: AlertTrigger.OVERDUE,
-        severity: AlertSeverity.INFO,
-        stepOrder: -1,
-      }),
-    ).toThrow(/stepOrder/);
-  });
+  // Edge: negative or non-integer stepOrder
+  it.each([-1, 2.5])(
+    'rejects a negative or non-integer stepOrder %p',
+    (stepOrder) => {
+      expect(() =>
+        createAlert({
+          batchId: 'b-1',
+          trigger: AlertTrigger.OVERDUE,
+          severity: AlertSeverity.INFO,
+          stepOrder,
+        }),
+      ).toThrow(/stepOrder/);
+    },
+  );
 });

--- a/packages/api/src/batch/domain/alert.factory.ts
+++ b/packages/api/src/batch/domain/alert.factory.ts
@@ -1,0 +1,74 @@
+import { AlertSeverity } from './enums/alert-severity.enum';
+import { AlertTrigger } from './enums/alert-trigger.enum';
+
+/** Raw input for a new alert, before validation/normalisation. */
+export interface AlertInput {
+  batchId: string;
+  trigger: AlertTrigger;
+  severity: AlertSeverity;
+  stepOrder?: number | null;
+  message?: string | null;
+  triggeredAt?: Date;
+  dismissedAt?: Date | null;
+}
+
+/** A validated, normalised alert (the shape the service persists). */
+export interface Alert {
+  batchId: string;
+  trigger: AlertTrigger;
+  severity: AlertSeverity;
+  stepOrder: number | null;
+  message: string | null;
+  triggeredAt: Date;
+  dismissedAt: Date | null;
+}
+
+/** Raised when an alert violates a domain invariant (#605). */
+export class AlertValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AlertValidationError';
+  }
+}
+
+/**
+ * Validate + normalise an alert against its domain invariants (#605):
+ * non-empty batch, known trigger + severity, non-negative integer step order,
+ * and a dismissal that cannot predate the trigger. Returns the normalised
+ * value object or throws.
+ */
+export function createAlert(input: AlertInput): Alert {
+  if (!input.batchId || input.batchId.trim().length === 0) {
+    throw new AlertValidationError('batchId is required');
+  }
+  if (!Object.values(AlertTrigger).includes(input.trigger)) {
+    throw new AlertValidationError(`unknown trigger: ${input.trigger}`);
+  }
+  if (!Object.values(AlertSeverity).includes(input.severity)) {
+    throw new AlertValidationError(`unknown severity: ${input.severity}`);
+  }
+  if (
+    input.stepOrder != null &&
+    (!Number.isInteger(input.stepOrder) || input.stepOrder < 0)
+  ) {
+    throw new AlertValidationError('stepOrder must be a non-negative integer');
+  }
+
+  const triggeredAt = input.triggeredAt ?? new Date();
+  const dismissedAt = input.dismissedAt ?? null;
+  if (dismissedAt != null && dismissedAt.getTime() < triggeredAt.getTime()) {
+    throw new AlertValidationError('dismissedAt cannot predate triggeredAt');
+  }
+
+  const message = input.message?.trim() ?? '';
+
+  return {
+    batchId: input.batchId,
+    trigger: input.trigger,
+    severity: input.severity,
+    stepOrder: input.stepOrder ?? null,
+    message: message.length > 0 ? message : null,
+    triggeredAt,
+    dismissedAt,
+  };
+}

--- a/packages/api/src/batch/domain/enums/alert-severity.enum.ts
+++ b/packages/api/src/batch/domain/enums/alert-severity.enum.ts
@@ -1,0 +1,6 @@
+/** How urgent a batch alert is (#605, slice 3). */
+export enum AlertSeverity {
+  INFO = 'info',
+  WARNING = 'warning',
+  CRITICAL = 'critical',
+}

--- a/packages/api/src/batch/domain/enums/alert-trigger.enum.ts
+++ b/packages/api/src/batch/domain/enums/alert-trigger.enum.ts
@@ -1,0 +1,10 @@
+/**
+ * What raised an alert on a batch (#605, slice 3).
+ *
+ * - `overdue` — a step's planned end passed without completion.
+ * - `threshold` — a measurement crossed a configured bound (temp/pH/gravity).
+ */
+export enum AlertTrigger {
+  OVERDUE = 'overdue',
+  THRESHOLD = 'threshold',
+}

--- a/packages/api/src/batch/entities/alert.orm.entity.ts
+++ b/packages/api/src/batch/entities/alert.orm.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryColumn,
+} from 'typeorm';
+
+import { AlertSeverity } from '../domain/enums/alert-severity.enum';
+import { AlertTrigger } from '../domain/enums/alert-trigger.enum';
+
+/**
+ * An alert raised on a batch (#605, slice 3) — an overdue step or a measurement
+ * crossing a threshold. Belongs to a `Batch`; `step_order` optionally pins it to
+ * the step concerned. `dismissed_at` is set once the brewer acknowledges it.
+ *
+ * SQLite-friendly types: `varchar` + CHECK for the enums, `datetime` for
+ * timestamps, `text` for the human message.
+ */
+@Entity('batch_alerts')
+@Index(['batch_id'])
+export class AlertOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  batch_id: string;
+
+  @Column({ type: 'integer', nullable: true })
+  step_order?: number | null;
+
+  @Column({ type: 'varchar', length: 20, enum: AlertTrigger, nullable: false })
+  trigger: AlertTrigger;
+
+  @Column({ type: 'varchar', length: 20, enum: AlertSeverity, nullable: false })
+  severity: AlertSeverity;
+
+  @Column({ type: 'text', nullable: true })
+  message?: string | null;
+
+  @Column({ type: 'datetime', nullable: false })
+  triggered_at: Date;
+
+  /** Set when the brewer acknowledges the alert; null while active. */
+  @Column({ type: 'datetime', nullable: true })
+  dismissed_at?: Date | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+}

--- a/packages/api/src/database/migrations/1798000000000-AddBatchAlertsTable.ts
+++ b/packages/api/src/database/migrations/1798000000000-AddBatchAlertsTable.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `batch_alerts` table (#605 slice 3, epic #595).
+ *
+ * Alerts raised on a batch — an overdue step or a measurement crossing a
+ * threshold. Belongs to a batch (`batch_id`, FK CASCADE like batch_steps);
+ * `step_order` optionally pins it to a step; `dismissed_at` is set on
+ * acknowledgement. SQLite-friendly: `varchar` + CHECK for the trigger/severity
+ * enums, `text` message, `datetime` timestamps. Indexed on `batch_id`.
+ */
+export class AddBatchAlertsTable1798000000000 implements MigrationInterface {
+  name = 'AddBatchAlertsTable1798000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "batch_alerts" (
+        "id" varchar PRIMARY KEY NOT NULL,
+        "batch_id" varchar NOT NULL,
+        "step_order" integer,
+        "trigger" varchar(20) NOT NULL,
+        "severity" varchar(20) NOT NULL,
+        "message" text,
+        "triggered_at" datetime NOT NULL,
+        "dismissed_at" datetime,
+        "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        CONSTRAINT "CHK_batch_alerts_trigger" CHECK ("trigger" IN ('overdue', 'threshold')),
+        CONSTRAINT "CHK_batch_alerts_severity" CHECK ("severity" IN ('info', 'warning', 'critical')),
+        CONSTRAINT "FK_batch_alerts_batch_id" FOREIGN KEY ("batch_id") REFERENCES "batches" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "IDX_batch_alerts_batch_id" ON "batch_alerts" ("batch_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_batch_alerts_batch_id"`);
+    await queryRunner.query(`DROP TABLE "batch_alerts"`);
+  }
+}

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 
+import { AlertOrmEntity } from '../batch/entities/alert.orm.entity';
 import { BatchOrmEntity } from '../batch/entities/batch.orm.entity';
 import { BatchReminderOrmEntity } from '../batch/entities/batch-reminder.orm.entity';
 import { BatchStepOrmEntity } from '../batch/entities/batch-step.orm.entity';
@@ -50,6 +51,7 @@ export const ormEntities = [
   BatchReminderOrmEntity,
   MeasurementOrmEntity,
   ObservationOrmEntity,
+  AlertOrmEntity,
   RecipeOrmEntity,
   RecipeStepOrmEntity,
   RecipeFermentableOrmEntity,


### PR DESCRIPTION
Third slice of the Mes Brassins data-model extension (**#605**, epic **#595**): the `batch_alerts` table (overdue-step / threshold alerts, severity, dismissal).

- `AlertTrigger`/`AlertSeverity` enums; `AlertOrmEntity` (varchar+CHECK, datetime, text), indexed on `batch_id`, FK to `batches(id)` ON DELETE CASCADE.
- `createAlert` domain factory + **H/S/E tests** (7 cases): known trigger/severity, non-negative stepOrder, dismissal not before trigger.
- Migration `AddBatchAlertsTable1798000000000` (FK CASCADE + enum CHECKs).

Verification: lint/build clean, factory 7/7, **e2e 14 (migration applies)**. Backend-only, demo-safe. Part of #605 · epic #595.