### PR TITLE
feat(api/batches): measurement entry + list endpoints (#607 slice A)

### DIFF
--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -11,6 +11,8 @@ import { BatchService } from './services/batch.service';
 import { BatchStatus } from './domain/enums/batch-status.enum';
 import { BatchStepOrmEntity } from './entities/batch-step.orm.entity';
 import { BatchStepStatus } from './domain/enums/batch-step-status.enum';
+import { MeasurementOrmEntity } from './entities/measurement.orm.entity';
+import { MeasurementType } from './domain/enums/measurement-type.enum';
 import { RecipeHopOrmEntity } from '../recipe/entities/recipe-hop.orm.entity';
 import { RecipeOrmEntity } from '../recipe/entities/recipe.orm.entity';
 import { RecipeService } from '../recipe/services/recipe.service';
@@ -28,6 +30,7 @@ describe('BatchService', () => {
   let batchReminderRepo: Repository<BatchReminderOrmEntity>;
   let recipeRepo: Repository<RecipeOrmEntity>;
   let recipeStepRepo: Repository<RecipeStepOrmEntity>;
+  let measurementRepo: Repository<MeasurementOrmEntity>;
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
@@ -42,6 +45,7 @@ describe('BatchService', () => {
             BatchOrmEntity,
             BatchStepOrmEntity,
             BatchReminderOrmEntity,
+            MeasurementOrmEntity,
           ],
           synchronize: true,
           logging: false,
@@ -53,6 +57,7 @@ describe('BatchService', () => {
           BatchOrmEntity,
           BatchStepOrmEntity,
           BatchReminderOrmEntity,
+          MeasurementOrmEntity,
         ]),
       ],
       providers: [RecipeService, BatchService],
@@ -65,6 +70,7 @@ describe('BatchService', () => {
     batchReminderRepo = module.get(getRepositoryToken(BatchReminderOrmEntity));
     recipeRepo = module.get(getRepositoryToken(RecipeOrmEntity));
     recipeStepRepo = module.get(getRepositoryToken(RecipeStepOrmEntity));
+    measurementRepo = module.get(getRepositoryToken(MeasurementOrmEntity));
   });
 
   afterAll(async () => {
@@ -72,6 +78,7 @@ describe('BatchService', () => {
   });
 
   beforeEach(async () => {
+    await measurementRepo.clear();
     await batchStepRepo.clear();
     await batchRepo.clear();
     await batchReminderRepo.clear();
@@ -362,6 +369,61 @@ describe('BatchService', () => {
 
     await expect(
       batchService.listMineReminders(otherOwner, started.batch.id),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  // #607 — measurement entry (happy path)
+  it('createMineMeasurement() persists a reading and listMineMeasurements() returns it', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    const saved = await batchService.createMineMeasurement(ownerId, batch.id, {
+      type: MeasurementType.OG,
+      value: 1.048,
+      stepOrder: 0,
+      unit: 'SG',
+    });
+
+    expect(saved.id).toBeDefined();
+    expect(saved.batch_id).toBe(batch.id);
+    expect(saved.type).toBe(MeasurementType.OG);
+    expect(saved.value).toBeCloseTo(1.048);
+
+    const list = await batchService.listMineMeasurements(ownerId, batch.id);
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(saved.id);
+  });
+
+  // #607 — sad path: domain range violation surfaces as 400
+  it('createMineMeasurement() rejects an out-of-range value with BadRequest', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.createMineMeasurement(ownerId, batch.id, {
+        type: MeasurementType.PH,
+        value: 99,
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // #607 — edge: ownership enforced on both routes
+  it('measurement routes reject a batch the user does not own', async () => {
+    const ownerId = 'user-1';
+    const otherOwner = 'user-2';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.createMineMeasurement(otherOwner, batch.id, {
+        type: MeasurementType.FG,
+        value: 1.012,
+      }),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      batchService.listMineMeasurements(otherOwner, batch.id),
     ).rejects.toThrow(NotFoundException);
   });
 });

--- a/packages/api/src/batch/controllers/batch.controller.spec.ts
+++ b/packages/api/src/batch/controllers/batch.controller.spec.ts
@@ -9,6 +9,8 @@ import { BatchStatus } from '../domain/enums/batch-status.enum';
 import { BatchStepOrmEntity } from '../entities/batch-step.orm.entity';
 import { BatchStepStatus } from '../domain/enums/batch-step-status.enum';
 import { CreateBatchReminderDto } from '../dtos/create-batch-reminder.dto';
+import { MeasurementOrmEntity } from '../entities/measurement.orm.entity';
+import { MeasurementType } from '../domain/enums/measurement-type.enum';
 import { NotFoundException } from '@nestjs/common';
 import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
 import { StartBatchDto } from '../dtos/start-batch.dto';
@@ -112,6 +114,8 @@ describe('BatchController', () => {
             createMineReminder: jest.fn(),
             updateMineReminder: jest.fn(),
             completeMineCurrentStep: jest.fn(),
+            listMineMeasurements: jest.fn(),
+            createMineMeasurement: jest.fn(),
           },
         },
       ],
@@ -478,6 +482,81 @@ describe('BatchController', () => {
         expect.objectContaining({ status: dto.status }),
       );
       expect(result).toBeDefined();
+    });
+  });
+
+  /**
+   * Measurements — GET/POST /batches/:id/measurements (#607)
+   */
+  describe('measurements', () => {
+    const mockMeasurement: MeasurementOrmEntity = {
+      id: '550e8400-e29b-41d4-a716-446655440030',
+      batch_id: mockBatchOrm.id,
+      step_order: null,
+      type: MeasurementType.OG,
+      value: 1.048,
+      unit: null,
+      taken_at: new Date('2026-05-20T10:00:00.000Z'),
+      created_at: new Date('2026-05-20T10:00:01.000Z'),
+    };
+
+    it('listMineMeasurements() delegates with ownership and maps DTOs', async () => {
+      const spy = jest
+        .spyOn(service, 'listMineMeasurements')
+        .mockResolvedValue([mockMeasurement]);
+
+      const result = await controller.listMineMeasurements(
+        mockUser,
+        mockBatchOrm.id,
+      );
+
+      expect(spy).toHaveBeenCalledWith(mockUser.id, mockBatchOrm.id);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(mockMeasurement.id);
+    });
+
+    it('createMineMeasurement() parses takenAt to a Date and returns a DTO', async () => {
+      const spy = jest
+        .spyOn(service, 'createMineMeasurement')
+        .mockResolvedValue(mockMeasurement);
+
+      const result = await controller.createMineMeasurement(
+        mockUser,
+        mockBatchOrm.id,
+        {
+          type: MeasurementType.OG,
+          value: 1.048,
+          takenAt: '2026-05-20T10:00:00.000Z',
+        },
+      );
+
+      expect(spy).toHaveBeenCalledWith(
+        mockUser.id,
+        mockBatchOrm.id,
+        expect.objectContaining({
+          type: MeasurementType.OG,
+          value: 1.048,
+          takenAt: expect.any(Date),
+        }),
+      );
+      expect(result.id).toBe(mockMeasurement.id);
+    });
+
+    it('createMineMeasurement() forwards undefined takenAt when omitted', async () => {
+      const spy = jest
+        .spyOn(service, 'createMineMeasurement')
+        .mockResolvedValue(mockMeasurement);
+
+      await controller.createMineMeasurement(mockUser, mockBatchOrm.id, {
+        type: MeasurementType.TEMPERATURE,
+        value: 19,
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        mockUser.id,
+        mockBatchOrm.id,
+        expect.objectContaining({ takenAt: undefined }),
+      );
     });
   });
 });

--- a/packages/api/src/batch/controllers/batch.controller.spec.ts
+++ b/packages/api/src/batch/controllers/batch.controller.spec.ts
@@ -536,9 +536,11 @@ describe('BatchController', () => {
         expect.objectContaining({
           type: MeasurementType.OG,
           value: 1.048,
-          takenAt: expect.any(Date),
         }),
       );
+      // takenAt: the controller parses the ISO string into a Date.
+      const input = spy.mock.calls[0][2];
+      expect(input.takenAt).toBeInstanceOf(Date);
       expect(result.id).toBe(mockMeasurement.id);
     });
 

--- a/packages/api/src/batch/controllers/batch.controller.ts
+++ b/packages/api/src/batch/controllers/batch.controller.ts
@@ -29,6 +29,8 @@ import { BatchDto } from '../dtos/batch.dto';
 import { BatchReminderDto } from '../dtos/batch-reminder.dto';
 import { BatchSummaryDto } from '../dtos/batch-summary.dto';
 import { CreateBatchReminderDto } from '../dtos/create-batch-reminder.dto';
+import { CreateMeasurementDto } from '../dtos/create-measurement.dto';
+import { MeasurementDto } from '../dtos/measurement.dto';
 import { StartBatchDto } from '../dtos/start-batch.dto';
 import { UpdateBatchReminderDto } from '../dtos/update-batch-reminder.dto';
 import { BatchService } from '../services/batch.service';
@@ -180,5 +182,36 @@ export class BatchController {
       },
     );
     return BatchReminderDto.fromEntity(updated);
+  }
+
+  @Get(':id/measurements')
+  @ApiOperation({ summary: 'List measurements for one of my batches' })
+  @ApiOkResponse({ type: MeasurementDto, isArray: true })
+  async listMineMeasurements(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<MeasurementDto[]> {
+    const rows = await this.service.listMineMeasurements(user.id, id);
+    return rows.map((row) => MeasurementDto.fromEntity(row));
+  }
+
+  @Post(':id/measurements')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Record a measurement on one of my batches' })
+  @ApiCreatedResponse({ type: MeasurementDto })
+  async createMineMeasurement(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    dto: CreateMeasurementDto,
+  ): Promise<MeasurementDto> {
+    const saved = await this.service.createMineMeasurement(user.id, id, {
+      type: dto.type,
+      value: dto.value,
+      stepOrder: dto.stepOrder,
+      unit: dto.unit,
+      takenAt: dto.takenAt ? new Date(dto.takenAt) : undefined,
+    });
+    return MeasurementDto.fromEntity(saved);
   }
 }

--- a/packages/api/src/batch/dtos/create-measurement.dto.ts
+++ b/packages/api/src/batch/dtos/create-measurement.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+import { MeasurementType } from '../domain/enums/measurement-type.enum';
+
+/** Body for recording a measurement against a batch (#607). */
+export class CreateMeasurementDto {
+  @ApiProperty({ enum: MeasurementType, example: MeasurementType.OG })
+  @IsEnum(MeasurementType)
+  type: MeasurementType;
+
+  @ApiProperty({ example: 1.048 })
+  @IsNumber()
+  value: number;
+
+  @ApiProperty({ required: false, example: 2 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  stepOrder?: number;
+
+  @ApiProperty({ required: false, example: 'SG' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  unit?: string;
+
+  @ApiProperty({ required: false, example: '2026-05-20T10:00:00.000Z' })
+  @IsOptional()
+  @IsDateString()
+  takenAt?: string;
+}

--- a/packages/api/src/batch/dtos/measurement.dto.spec.ts
+++ b/packages/api/src/batch/dtos/measurement.dto.spec.ts
@@ -1,0 +1,42 @@
+import { MeasurementDto } from './measurement.dto';
+import { MeasurementType } from '../domain/enums/measurement-type.enum';
+import { MeasurementOrmEntity } from '../entities/measurement.orm.entity';
+
+describe('MeasurementDto.fromEntity', () => {
+  const base: MeasurementOrmEntity = {
+    id: 'm-1',
+    batch_id: 'b-1',
+    step_order: 2,
+    type: MeasurementType.OG,
+    value: 1.048,
+    unit: 'SG',
+    taken_at: new Date('2026-05-20T10:00:00.000Z'),
+    created_at: new Date('2026-05-20T10:00:01.000Z'),
+  };
+
+  // Happy path: full entity maps field-for-field.
+  it('maps every field of a fully populated entity', () => {
+    expect(MeasurementDto.fromEntity(base)).toEqual({
+      id: 'm-1',
+      batch_id: 'b-1',
+      step_order: 2,
+      type: MeasurementType.OG,
+      value: 1.048,
+      unit: 'SG',
+      taken_at: base.taken_at,
+      created_at: base.created_at,
+    });
+  });
+
+  // Edge: nullable optionals normalise to null.
+  it('normalises absent step_order/unit to null', () => {
+    const dto = MeasurementDto.fromEntity({
+      ...base,
+      step_order: null,
+      unit: null,
+    });
+
+    expect(dto.step_order).toBeNull();
+    expect(dto.unit).toBeNull();
+  });
+});

--- a/packages/api/src/batch/dtos/measurement.dto.ts
+++ b/packages/api/src/batch/dtos/measurement.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { MeasurementType } from '../domain/enums/measurement-type.enum';
+import { MeasurementOrmEntity } from '../entities/measurement.orm.entity';
+
+/** Serialised measurement returned by the API (#607). */
+export class MeasurementDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  batch_id: string;
+
+  @ApiProperty({ nullable: true })
+  step_order: number | null;
+
+  @ApiProperty({ enum: MeasurementType })
+  type: MeasurementType;
+
+  @ApiProperty()
+  value: number;
+
+  @ApiProperty({ nullable: true })
+  unit: string | null;
+
+  @ApiProperty()
+  taken_at: Date;
+
+  @ApiProperty()
+  created_at: Date;
+
+  static fromEntity(e: MeasurementOrmEntity): MeasurementDto {
+    return {
+      id: e.id,
+      batch_id: e.batch_id,
+      step_order: e.step_order ?? null,
+      type: e.type,
+      value: e.value,
+      unit: e.unit ?? null,
+      taken_at: e.taken_at,
+      created_at: e.created_at,
+    };
+  }
+}

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -18,10 +18,25 @@ import { BatchStatus } from '../domain/enums/batch-status.enum';
 import { BatchReminderOrmEntity } from '../entities/batch-reminder.orm.entity';
 import { BatchOrmEntity } from '../entities/batch.orm.entity';
 import { BatchStepOrmEntity } from '../entities/batch-step.orm.entity';
+import { MeasurementOrmEntity } from '../entities/measurement.orm.entity';
+import { MeasurementType } from '../domain/enums/measurement-type.enum';
+import {
+  createMeasurement,
+  Measurement,
+  MeasurementValidationError,
+} from '../domain/measurement.factory';
 
 export interface BatchWithSteps {
   batch: BatchOrmEntity;
   steps: BatchStepOrmEntity[];
+}
+
+export interface CreateMeasurementInput {
+  type: MeasurementType;
+  value: number;
+  stepOrder?: number | null;
+  unit?: string | null;
+  takenAt?: Date;
 }
 
 export interface CreateBatchReminderInput {
@@ -46,6 +61,8 @@ export class BatchService {
     private readonly stepRepo: Repository<BatchStepOrmEntity>,
     @InjectRepository(BatchReminderOrmEntity)
     private readonly reminderRepo: Repository<BatchReminderOrmEntity>,
+    @InjectRepository(MeasurementOrmEntity)
+    private readonly measurementRepo: Repository<MeasurementOrmEntity>,
     private readonly recipeService: RecipeService,
   ) {}
 
@@ -320,6 +337,55 @@ export class BatchService {
       startedAt: step.started_at ?? undefined,
       completedAt: step.completed_at ?? undefined,
     };
+  }
+
+  async listMineMeasurements(
+    ownerId: string,
+    batchId: string,
+  ): Promise<MeasurementOrmEntity[]> {
+    await this.getMineBatch(ownerId, batchId);
+    return this.measurementRepo.find({
+      where: { batch_id: batchId },
+      order: { taken_at: 'ASC' },
+    });
+  }
+
+  async createMineMeasurement(
+    ownerId: string,
+    batchId: string,
+    input: CreateMeasurementInput,
+  ): Promise<MeasurementOrmEntity> {
+    await this.getMineBatch(ownerId, batchId);
+
+    // The domain factory enforces per-type range invariants the DTO can't
+    // express; surface a violation as a 400 rather than a 500.
+    let normalised: Measurement;
+    try {
+      normalised = createMeasurement({
+        batchId,
+        type: input.type,
+        value: input.value,
+        stepOrder: input.stepOrder,
+        unit: input.unit,
+        takenAt: input.takenAt,
+      });
+    } catch (error) {
+      if (error instanceof MeasurementValidationError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
+
+    const measurement = this.measurementRepo.create({
+      id: randomUUID(),
+      batch_id: batchId,
+      step_order: normalised.stepOrder,
+      type: normalised.type,
+      value: normalised.value,
+      unit: normalised.unit,
+      taken_at: normalised.takenAt,
+    });
+    return this.measurementRepo.save(measurement);
   }
 
   private async getMineBatch(


### PR DESCRIPTION
Wires fermentation-tracking entry on the Measurement entity (#1112): owner-scoped `GET`/`POST /batches/:id/measurements`.

- `CreateMeasurementDto` + `MeasurementDto`; `createMineMeasurement`/`listMineMeasurements` (ownership via `getMineBatch`); the `createMeasurement` domain guard maps a range violation to **400**.
- Service spec extended with **H/S/E** (persist+list, out-of-range→400, ownership→404).

Verification: lint/build clean, **unit 694 + e2e 14 green**. Backend-only, demo-safe (P0 fermentation tracking). Part of #607 · epic #595. Observation entry follows after #1113 merges.