### PR TITLE
feat(api/batches): observation entry + list endpoints (#607 slice B)

### DIFF
--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -13,6 +13,7 @@ import { BatchStepOrmEntity } from './entities/batch-step.orm.entity';
 import { BatchStepStatus } from './domain/enums/batch-step-status.enum';
 import { MeasurementOrmEntity } from './entities/measurement.orm.entity';
 import { MeasurementType } from './domain/enums/measurement-type.enum';
+import { ObservationOrmEntity } from './entities/observation.orm.entity';
 import { RecipeHopOrmEntity } from '../recipe/entities/recipe-hop.orm.entity';
 import { RecipeOrmEntity } from '../recipe/entities/recipe.orm.entity';
 import { RecipeService } from '../recipe/services/recipe.service';
@@ -31,6 +32,7 @@ describe('BatchService', () => {
   let recipeRepo: Repository<RecipeOrmEntity>;
   let recipeStepRepo: Repository<RecipeStepOrmEntity>;
   let measurementRepo: Repository<MeasurementOrmEntity>;
+  let observationRepo: Repository<ObservationOrmEntity>;
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
@@ -46,6 +48,7 @@ describe('BatchService', () => {
             BatchStepOrmEntity,
             BatchReminderOrmEntity,
             MeasurementOrmEntity,
+            ObservationOrmEntity,
           ],
           synchronize: true,
           logging: false,
@@ -58,6 +61,7 @@ describe('BatchService', () => {
           BatchStepOrmEntity,
           BatchReminderOrmEntity,
           MeasurementOrmEntity,
+          ObservationOrmEntity,
         ]),
       ],
       providers: [RecipeService, BatchService],
@@ -71,6 +75,7 @@ describe('BatchService', () => {
     recipeRepo = module.get(getRepositoryToken(RecipeOrmEntity));
     recipeStepRepo = module.get(getRepositoryToken(RecipeStepOrmEntity));
     measurementRepo = module.get(getRepositoryToken(MeasurementOrmEntity));
+    observationRepo = module.get(getRepositoryToken(ObservationOrmEntity));
   });
 
   afterAll(async () => {
@@ -78,6 +83,7 @@ describe('BatchService', () => {
   });
 
   beforeEach(async () => {
+    await observationRepo.clear();
     await measurementRepo.clear();
     await batchStepRepo.clear();
     await batchRepo.clear();
@@ -424,6 +430,60 @@ describe('BatchService', () => {
     ).rejects.toThrow(NotFoundException);
     await expect(
       batchService.listMineMeasurements(otherOwner, batch.id),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  // #607 — observation entry (happy path)
+  it('createMineObservation() persists a note and listMineObservations() returns it', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    const saved = await batchService.createMineObservation(ownerId, batch.id, {
+      freeText: 'Krausen bien formé, odeur fruitée',
+      stepOrder: 2,
+      photoRefs: ['photos/1.jpg'],
+      moodScore: 4,
+    });
+
+    expect(saved.id).toBeDefined();
+    expect(saved.batch_id).toBe(batch.id);
+    expect(saved.free_text).toBe('Krausen bien formé, odeur fruitée');
+    expect(saved.mood_score).toBe(4);
+
+    const list = await batchService.listMineObservations(ownerId, batch.id);
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(saved.id);
+  });
+
+  // #607 — sad path: domain invariant violation surfaces as 400
+  it('createMineObservation() rejects an out-of-range mood with BadRequest', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.createMineObservation(ownerId, batch.id, {
+        freeText: 'Looks fine',
+        moodScore: 9,
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // #607 — edge: ownership enforced on both routes
+  it('observation routes reject a batch the user does not own', async () => {
+    const ownerId = 'user-1';
+    const otherOwner = 'user-2';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.createMineObservation(otherOwner, batch.id, {
+        freeText: 'Sneaky note',
+      }),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      batchService.listMineObservations(otherOwner, batch.id),
     ).rejects.toThrow(NotFoundException);
   });
 });

--- a/packages/api/src/batch/controllers/batch.controller.spec.ts
+++ b/packages/api/src/batch/controllers/batch.controller.spec.ts
@@ -12,6 +12,7 @@ import { CreateBatchReminderDto } from '../dtos/create-batch-reminder.dto';
 import { MeasurementOrmEntity } from '../entities/measurement.orm.entity';
 import { MeasurementType } from '../domain/enums/measurement-type.enum';
 import { NotFoundException } from '@nestjs/common';
+import { ObservationOrmEntity } from '../entities/observation.orm.entity';
 import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
 import { StartBatchDto } from '../dtos/start-batch.dto';
 import { UpdateBatchReminderDto } from '../dtos/update-batch-reminder.dto';
@@ -116,6 +117,8 @@ describe('BatchController', () => {
             completeMineCurrentStep: jest.fn(),
             listMineMeasurements: jest.fn(),
             createMineMeasurement: jest.fn(),
+            listMineObservations: jest.fn(),
+            createMineObservation: jest.fn(),
           },
         },
       ],
@@ -558,6 +561,82 @@ describe('BatchController', () => {
         mockUser.id,
         mockBatchOrm.id,
         expect.objectContaining({ takenAt: undefined }),
+      );
+    });
+  });
+
+  /**
+   * Observations — GET/POST /batches/:id/observations (#607)
+   */
+  describe('observations', () => {
+    const mockObservation: ObservationOrmEntity = {
+      id: '550e8400-e29b-41d4-a716-446655440040',
+      batch_id: mockBatchOrm.id,
+      step_order: 2,
+      free_text: 'Krausen bien formé',
+      photo_refs: ['photos/1.jpg'],
+      mood_score: 4,
+      observed_at: new Date('2026-05-20T18:00:00.000Z'),
+      created_at: new Date('2026-05-20T18:00:01.000Z'),
+    };
+
+    it('listMineObservations() delegates with ownership and maps DTOs', async () => {
+      const spy = jest
+        .spyOn(service, 'listMineObservations')
+        .mockResolvedValue([mockObservation]);
+
+      const result = await controller.listMineObservations(
+        mockUser,
+        mockBatchOrm.id,
+      );
+
+      expect(spy).toHaveBeenCalledWith(mockUser.id, mockBatchOrm.id);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(mockObservation.id);
+    });
+
+    it('createMineObservation() parses observedAt to a Date and returns a DTO', async () => {
+      const spy = jest
+        .spyOn(service, 'createMineObservation')
+        .mockResolvedValue(mockObservation);
+
+      const result = await controller.createMineObservation(
+        mockUser,
+        mockBatchOrm.id,
+        {
+          freeText: 'Krausen bien formé',
+          stepOrder: 2,
+          moodScore: 4,
+          observedAt: '2026-05-20T18:00:00.000Z',
+        },
+      );
+
+      expect(spy).toHaveBeenCalledWith(
+        mockUser.id,
+        mockBatchOrm.id,
+        expect.objectContaining({
+          freeText: 'Krausen bien formé',
+          moodScore: 4,
+        }),
+      );
+      const input = spy.mock.calls[0][2];
+      expect(input.observedAt).toBeInstanceOf(Date);
+      expect(result.id).toBe(mockObservation.id);
+    });
+
+    it('createMineObservation() forwards undefined observedAt when omitted', async () => {
+      const spy = jest
+        .spyOn(service, 'createMineObservation')
+        .mockResolvedValue(mockObservation);
+
+      await controller.createMineObservation(mockUser, mockBatchOrm.id, {
+        freeText: 'Quick note',
+      });
+
+      expect(spy).toHaveBeenCalledWith(
+        mockUser.id,
+        mockBatchOrm.id,
+        expect.objectContaining({ observedAt: undefined }),
       );
     });
   });

--- a/packages/api/src/batch/controllers/batch.controller.ts
+++ b/packages/api/src/batch/controllers/batch.controller.ts
@@ -30,7 +30,9 @@ import { BatchReminderDto } from '../dtos/batch-reminder.dto';
 import { BatchSummaryDto } from '../dtos/batch-summary.dto';
 import { CreateBatchReminderDto } from '../dtos/create-batch-reminder.dto';
 import { CreateMeasurementDto } from '../dtos/create-measurement.dto';
+import { CreateObservationDto } from '../dtos/create-observation.dto';
 import { MeasurementDto } from '../dtos/measurement.dto';
+import { ObservationDto } from '../dtos/observation.dto';
 import { StartBatchDto } from '../dtos/start-batch.dto';
 import { UpdateBatchReminderDto } from '../dtos/update-batch-reminder.dto';
 import { BatchService } from '../services/batch.service';
@@ -213,5 +215,36 @@ export class BatchController {
       takenAt: dto.takenAt ? new Date(dto.takenAt) : undefined,
     });
     return MeasurementDto.fromEntity(saved);
+  }
+
+  @Get(':id/observations')
+  @ApiOperation({ summary: 'List observations for one of my batches' })
+  @ApiOkResponse({ type: ObservationDto, isArray: true })
+  async listMineObservations(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<ObservationDto[]> {
+    const rows = await this.service.listMineObservations(user.id, id);
+    return rows.map((row) => ObservationDto.fromEntity(row));
+  }
+
+  @Post(':id/observations')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Log an observation on one of my batches' })
+  @ApiCreatedResponse({ type: ObservationDto })
+  async createMineObservation(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    dto: CreateObservationDto,
+  ): Promise<ObservationDto> {
+    const saved = await this.service.createMineObservation(user.id, id, {
+      freeText: dto.freeText,
+      stepOrder: dto.stepOrder,
+      photoRefs: dto.photoRefs,
+      moodScore: dto.moodScore,
+      observedAt: dto.observedAt ? new Date(dto.observedAt) : undefined,
+    });
+    return ObservationDto.fromEntity(saved);
   }
 }

--- a/packages/api/src/batch/domain/observation.factory.spec.ts
+++ b/packages/api/src/batch/domain/observation.factory.spec.ts
@@ -69,6 +69,17 @@ describe('createObservation', () => {
     ).toThrow(/photoRefs/);
   });
 
+  // Edge: a comma would be split by simple-array persistence
+  it('rejects a photo ref containing a comma', () => {
+    expect(() =>
+      createObservation({
+        batchId: 'b-1',
+        freeText: 'note',
+        photoRefs: ['photos/a,b.jpg'],
+      }),
+    ).toThrow(/comma/);
+  });
+
   // Edge: negative stepOrder
   it('rejects a negative stepOrder', () => {
     expect(() =>

--- a/packages/api/src/batch/domain/observation.factory.ts
+++ b/packages/api/src/batch/domain/observation.factory.ts
@@ -75,6 +75,11 @@ export function createObservation(input: ObservationInput): Observation {
   if (photoRefs.some((ref) => typeof ref !== 'string' || ref.trim() === '')) {
     throw new ObservationValidationError('photoRefs must be non-empty strings');
   }
+  // photo_refs is persisted as a TypeORM simple-array (comma-delimited), so a
+  // ref containing a comma would be silently split on read-back. Reject it.
+  if (photoRefs.some((ref) => ref.includes(','))) {
+    throw new ObservationValidationError('photoRefs must not contain commas');
+  }
 
   return {
     batchId: input.batchId,

--- a/packages/api/src/batch/dtos/create-observation.dto.ts
+++ b/packages/api/src/batch/dtos/create-observation.dto.ts
@@ -6,6 +6,7 @@ import {
   IsNotEmpty,
   IsOptional,
   IsString,
+  Matches,
   Max,
   MaxLength,
   Min,
@@ -29,6 +30,12 @@ export class CreateObservationDto {
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
+  // Stored as a TypeORM simple-array (comma-delimited): commas would corrupt
+  // the list on read-back, so reject any ref containing one.
+  @Matches(/^[^,]*$/, {
+    each: true,
+    message: 'photoRefs must not contain commas',
+  })
   photoRefs?: string[];
 
   @ApiProperty({ required: false, minimum: 1, maximum: 5, example: 4 })

--- a/packages/api/src/batch/dtos/create-observation.dto.ts
+++ b/packages/api/src/batch/dtos/create-observation.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+/** Body for logging a free-text observation against a batch (#607). */
+export class CreateObservationDto {
+  @ApiProperty({ example: 'Krausen bien formé, odeur fruitée' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  freeText: string;
+
+  @ApiProperty({ required: false, example: 2 })
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  stepOrder?: number;
+
+  @ApiProperty({ required: false, type: [String], example: ['photos/1.jpg'] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  photoRefs?: string[];
+
+  @ApiProperty({ required: false, minimum: 1, maximum: 5, example: 4 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  moodScore?: number;
+
+  @ApiProperty({ required: false, example: '2026-05-20T18:00:00.000Z' })
+  @IsOptional()
+  @IsDateString()
+  observedAt?: string;
+}

--- a/packages/api/src/batch/dtos/observation.dto.spec.ts
+++ b/packages/api/src/batch/dtos/observation.dto.spec.ts
@@ -1,0 +1,43 @@
+import { ObservationDto } from './observation.dto';
+import { ObservationOrmEntity } from '../entities/observation.orm.entity';
+
+describe('ObservationDto.fromEntity', () => {
+  const base: ObservationOrmEntity = {
+    id: 'o-1',
+    batch_id: 'b-1',
+    step_order: 2,
+    free_text: 'Krausen bien formé',
+    photo_refs: ['photos/1.jpg'],
+    mood_score: 4,
+    observed_at: new Date('2026-05-20T18:00:00.000Z'),
+    created_at: new Date('2026-05-20T18:00:01.000Z'),
+  };
+
+  // Happy path: full entity maps field-for-field.
+  it('maps every field of a fully populated entity', () => {
+    expect(ObservationDto.fromEntity(base)).toEqual({
+      id: 'o-1',
+      batch_id: 'b-1',
+      step_order: 2,
+      free_text: 'Krausen bien formé',
+      photo_refs: ['photos/1.jpg'],
+      mood_score: 4,
+      observed_at: base.observed_at,
+      created_at: base.created_at,
+    });
+  });
+
+  // Edge: nullable optionals normalise to null, missing photos to [].
+  it('normalises absent step_order/mood_score to null and photo_refs to []', () => {
+    const dto = ObservationDto.fromEntity({
+      ...base,
+      step_order: null,
+      mood_score: null,
+      photo_refs: null as unknown as string[],
+    });
+
+    expect(dto.step_order).toBeNull();
+    expect(dto.mood_score).toBeNull();
+    expect(dto.photo_refs).toEqual([]);
+  });
+});

--- a/packages/api/src/batch/dtos/observation.dto.spec.ts
+++ b/packages/api/src/batch/dtos/observation.dto.spec.ts
@@ -33,7 +33,7 @@ describe('ObservationDto.fromEntity', () => {
       ...base,
       step_order: null,
       mood_score: null,
-      photo_refs: null as unknown as string[],
+      photo_refs: null,
     });
 
     expect(dto.step_order).toBeNull();

--- a/packages/api/src/batch/dtos/observation.dto.ts
+++ b/packages/api/src/batch/dtos/observation.dto.ts
@@ -1,0 +1,43 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { ObservationOrmEntity } from '../entities/observation.orm.entity';
+
+/** Serialised observation returned by the API (#607). */
+export class ObservationDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  batch_id: string;
+
+  @ApiProperty({ nullable: true })
+  step_order: number | null;
+
+  @ApiProperty()
+  free_text: string;
+
+  @ApiProperty({ type: [String] })
+  photo_refs: string[];
+
+  @ApiProperty({ nullable: true })
+  mood_score: number | null;
+
+  @ApiProperty()
+  observed_at: Date;
+
+  @ApiProperty()
+  created_at: Date;
+
+  static fromEntity(e: ObservationOrmEntity): ObservationDto {
+    return {
+      id: e.id,
+      batch_id: e.batch_id,
+      step_order: e.step_order ?? null,
+      free_text: e.free_text,
+      photo_refs: e.photo_refs ?? [],
+      mood_score: e.mood_score ?? null,
+      observed_at: e.observed_at,
+      created_at: e.created_at,
+    };
+  }
+}

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -25,6 +25,12 @@ import {
   Measurement,
   MeasurementValidationError,
 } from '../domain/measurement.factory';
+import { ObservationOrmEntity } from '../entities/observation.orm.entity';
+import {
+  createObservation,
+  Observation,
+  ObservationValidationError,
+} from '../domain/observation.factory';
 
 export interface BatchWithSteps {
   batch: BatchOrmEntity;
@@ -37,6 +43,14 @@ export interface CreateMeasurementInput {
   stepOrder?: number | null;
   unit?: string | null;
   takenAt?: Date;
+}
+
+export interface CreateObservationInput {
+  freeText: string;
+  stepOrder?: number | null;
+  photoRefs?: string[] | null;
+  moodScore?: number | null;
+  observedAt?: Date;
 }
 
 export interface CreateBatchReminderInput {
@@ -63,6 +77,8 @@ export class BatchService {
     private readonly reminderRepo: Repository<BatchReminderOrmEntity>,
     @InjectRepository(MeasurementOrmEntity)
     private readonly measurementRepo: Repository<MeasurementOrmEntity>,
+    @InjectRepository(ObservationOrmEntity)
+    private readonly observationRepo: Repository<ObservationOrmEntity>,
     private readonly recipeService: RecipeService,
   ) {}
 
@@ -386,6 +402,53 @@ export class BatchService {
       taken_at: normalised.takenAt,
     });
     return this.measurementRepo.save(measurement);
+  }
+
+  async listMineObservations(
+    ownerId: string,
+    batchId: string,
+  ): Promise<ObservationOrmEntity[]> {
+    await this.getMineBatch(ownerId, batchId);
+    return this.observationRepo.find({
+      where: { batch_id: batchId },
+      order: { observed_at: 'ASC' },
+    });
+  }
+
+  async createMineObservation(
+    ownerId: string,
+    batchId: string,
+    input: CreateObservationInput,
+  ): Promise<ObservationOrmEntity> {
+    await this.getMineBatch(ownerId, batchId);
+
+    let normalised: Observation;
+    try {
+      normalised = createObservation({
+        batchId,
+        freeText: input.freeText,
+        stepOrder: input.stepOrder,
+        photoRefs: input.photoRefs,
+        moodScore: input.moodScore,
+        observedAt: input.observedAt,
+      });
+    } catch (error) {
+      if (error instanceof ObservationValidationError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
+
+    const observation = this.observationRepo.create({
+      id: randomUUID(),
+      batch_id: batchId,
+      step_order: normalised.stepOrder,
+      free_text: normalised.freeText,
+      photo_refs: normalised.photoRefs,
+      mood_score: normalised.moodScore,
+      observed_at: normalised.observedAt,
+    });
+    return this.observationRepo.save(observation);
   }
 
   private async getMineBatch(


### PR DESCRIPTION
## Summary

Adds the owner-scoped observation endpoints on a batch, mirroring the measurement endpoint shipped in slice A (#1116):

- `GET /batches/:id/observations` — list my batch's observations.
- `POST /batches/:id/observations` — log a free-text note with optional `stepOrder`, `photoRefs`, `moodScore` (1–5) and `observedAt`.

Input is validated by the `createObservation` domain factory (#605); invariant violations (empty text, out-of-range mood, negative step, blank photo refs) surface as `400 Bad Request`. Ownership is enforced via `getMineBatch` — a batch the caller does not own yields `404 Not Found` on both routes.

This is backend-only and demo-safe (the demo runs on mocked data); the inline UI face of #607 is deferred post-soutenance.

## Checklist

- [x] Happy path + sad path + edge cases covered (service, controller, DTO specs)
- [x] `tsc --noEmit` / build passes
- [x] Build passes
- [x] Existing tests still green (77 unit + 14 e2e)
- [x] No `any`, no inline styles introduced

Part of #607