### PR TITLE
chore(mobile): add EAS preview-demo profile and exclude local native dirs

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -71,6 +71,13 @@
 /packages/mobile-app/dist/
 /packages/mobile-app/coverage/
 
+# Local prebuild output (gitignored, created locally on 2026-05-24). Uploading
+# these flips EAS into the bare workflow, which rejects the appVersion
+# runtimeVersion policy and breaks the build. The committed project is managed
+# (no native dirs tracked), matching the May 2026 APKs — keep it that way.
+/packages/mobile-app/android/
+/packages/mobile-app/ios/
+
 # Anywhere-in-the-tree dependency caches and build outputs
 **/.venv/
 **/venv/

--- a/packages/mobile-app/.easignore
+++ b/packages/mobile-app/.easignore
@@ -33,6 +33,13 @@ node_modules/
 **/venv/
 **/__pycache__/
 
+# Local prebuild output — keep the build on the managed workflow (continuous
+# native generation), matching the May 2026 APKs. These dirs are gitignored
+# local artifacts; uploading them flips EAS into the bare workflow and breaks
+# the appVersion runtimeVersion policy. Anchored to the package root.
+/android/
+/ios/
+
 # Local artifacts (can appear in either workspace or package)
 .expo/
 coverage/

--- a/packages/mobile-app/eas.json
+++ b/packages/mobile-app/eas.json
@@ -20,6 +20,17 @@
         "EXPO_PUBLIC_USE_DEMO_DATA": "false"
       }
     },
+    "preview-demo": {
+      "distribution": "internal",
+      "channel": "preview-demo",
+      "android": {
+        "buildType": "apk"
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://brasse-bouillon-api.fly.dev",
+        "EXPO_PUBLIC_USE_DEMO_DATA": "true"
+      }
+    },
     "production": {
       "autoIncrement": true,
       "channel": "production"


### PR DESCRIPTION
## Summary

Adds a dedicated EAS build profile that ships the mobile app in **offline demo mode**, and fixes a build break caused by a locally generated native directory.

- `eas.json`: new `preview-demo` profile (internal distribution, Android `apk`, channel `preview-demo`) with `EXPO_PUBLIC_USE_DEMO_DATA=true`. The existing `preview` profile stays live-mode and is untouched.
- `.easignore` (root + package): exclude `packages/mobile-app/android` and `ios`.

## Context

A locally generated prebuild (`packages/mobile-app/android/`, gitignored) was being uploaded in the EAS tarball, flipping the build into the **bare workflow**, which rejects the `appVersion` runtimeVersion policy and aborted the build. The committed project is managed (no native dirs tracked) — excluding these dirs restores the managed workflow used by the May 2026 APKs.

## Checklist

- [x] No app/runtime code changed (build config only)
- [x] `preview` profile unchanged
- [x] Demo APK built successfully from this profile