### PR TITLE
feat(scan): recognize six physical demo bottles in the offline catalogue

### DIFF
--- a/packages/mobile-app/src/features/scan/presentation/__tests__/ScanScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/ScanScreen.test.tsx
@@ -490,9 +490,10 @@ describe("ScanScreen", () => {
       fireEvent(helpButton, "longPress");
 
       // The override menu lists seeded beers — Punk IPA appears
-      // twice (UK 0,5L canonical EAN + DE 0,33L physical alias —
-      // Issue #807), so assert via findAllByText.
-      expect(await screen.findAllByText("Punk IPA")).toHaveLength(2);
+      // three times (UK 0,5L canonical EAN + DE 0,33L physical alias,
+      // Issue #807, + UK 0,33L physical alias for the 2026-05-27
+      // soutenance), so assert via findAllByText.
+      expect(await screen.findAllByText("Punk IPA")).toHaveLength(3);
       // The regular guide modal must NOT be shown.
       expect(screen.queryByText("How barcode verification works")).toBeNull();
     });
@@ -508,7 +509,7 @@ describe("ScanScreen", () => {
       fireEvent(helpButton, "longPress");
       fireEvent.press(helpButton);
 
-      expect(await screen.findAllByText("Punk IPA")).toHaveLength(2);
+      expect(await screen.findAllByText("Punk IPA")).toHaveLength(3);
       expect(screen.queryByText("How barcode verification works")).toBeNull();
     });
 
@@ -531,9 +532,11 @@ describe("ScanScreen", () => {
       await waitForReadyState();
 
       fireEvent(screen.getByLabelText("Open scan guide"), "longPress");
-      // Punk IPA — two EAN variants in the menu (UK 0,5L canonical
-      // 5060277380019 + DE 0,33L physical alias 4260649360279,
-      // Issue #807). Tap the first row (canonical UK EAN).
+      // Punk IPA — three EAN variants in the menu (UK 0,5L canonical
+      // 5060277380019 + DE 0,33L alias 4260649360279, Issue #807,
+      // + UK 0,33L alias 5056025440494). Rows are sorted by name and
+      // ties keep insertion order, so the first row is the canonical
+      // UK 0,5L EAN.
       const punkRows = await screen.findAllByLabelText(/Forcer Punk IPA/i);
       fireEvent.press(punkRows[0]);
 

--- a/packages/mobile-app/src/features/scan/presentation/components/DemoOverrideMenu.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/components/DemoOverrideMenu.tsx
@@ -65,6 +65,11 @@ export function DemoOverrideMenu({ visible, onClose, onSelectBeer }: Props) {
           <FlatList
             data={beers}
             keyExtractor={(item) => item.barcode}
+            // Render every seeded beer up-front. The list is short (a
+            // dozen-odd demo bottles) and this is a stage-emergency
+            // menu — the speaker must be able to reach any beer, and
+            // virtualisation windowing would otherwise hide the tail.
+            initialNumToRender={beers.length}
             ItemSeparatorComponent={() => <View style={styles.separator} />}
             renderItem={({ item }) => (
               <Pressable

--- a/packages/mobile-app/src/features/scan/presentation/components/__tests__/DemoOverrideMenu.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/components/__tests__/DemoOverrideMenu.test.tsx
@@ -9,16 +9,24 @@ describe("DemoOverrideMenu (Issue #642 — soutenance backup)", () => {
       <DemoOverrideMenu visible onClose={jest.fn()} onSelectBeer={jest.fn()} />,
     );
 
-    // Sample assertions on a few well-known seeds. Punk IPA has two
-    // EAN variants (UK 0,5L canonical + DE 0,33L physical alias —
-    // Issue #807) so it appears twice; the menu is per-EAN by
-    // design so the speaker can force the exact bottle they have.
-    expect(screen.getAllByText("Punk IPA")).toHaveLength(2);
-    expect(screen.getByText("La Chouffe")).toBeTruthy();
+    // Sample assertions on a few well-known seeds. Punk IPA has three
+    // EAN variants (UK 0,5L canonical + DE 0,33L alias, Issue #807, +
+    // UK 0,33L alias for the 2026-05-27 soutenance) so it appears
+    // three times; the menu is per-EAN by design so the speaker can
+    // force the exact bottle they have.
+    expect(screen.getAllByText("Punk IPA")).toHaveLength(3);
+    // La Chouffe also has two EAN variants now (canonical + 0,33L
+    // physical alias 5410769100081).
+    expect(screen.getAllByText("La Chouffe")).toHaveLength(2);
     expect(screen.getByText("Rochefort 10")).toBeTruthy();
     // Issue #804 — these 5 entries were API-only until the sync.
     // Asserting on one of them guards against future drift.
     expect(screen.getByText("Karmeliet Tripel")).toBeTruthy();
+    // Physical bottles wired for the 2026-05-27 soutenance — guard
+    // that the new seeds reach the override menu too.
+    expect(screen.getByText("Bush Caractère")).toBeTruthy();
+    expect(screen.getByText("Pauwel Kwak")).toBeTruthy();
+    expect(screen.getByText("Wingman")).toBeTruthy();
     expect(screen.getByText(/Démo — bières seedées/i)).toBeTruthy();
   });
 
@@ -72,9 +80,10 @@ describe("DemoOverrideMenu (Issue #642 — soutenance backup)", () => {
       <DemoOverrideMenu visible onClose={jest.fn()} onSelectBeer={jest.fn()} />,
     );
 
-    // Punk IPA: BrewDog · IPA · 5.4 % — appears on both EAN
-    // variants (UK 0,5L + DE 0,33L alias, Issue #807).
-    expect(screen.getAllByText(/BrewDog · IPA · 5\.4 %/i)).toHaveLength(2);
+    // Punk IPA: BrewDog · IPA · 5.4 % — appears on all three EAN
+    // variants (UK 0,5L + DE 0,33L alias, Issue #807, + UK 0,33L
+    // alias). Wingman is a separate "Session IPA" line, not matched.
+    expect(screen.getAllByText(/BrewDog · IPA · 5\.4 %/i)).toHaveLength(3);
   });
 
   it("shows the EAN-13 barcode on each row (so the speaker can sanity-check it)", () => {

--- a/packages/mobile-app/src/mocks/__tests__/demo-data.test.ts
+++ b/packages/mobile-app/src/mocks/__tests__/demo-data.test.ts
@@ -8,6 +8,20 @@ const PUNK_IPA_BARCODE = "5060277380019";
 // DE 0,33L bottle EAN alias for the same beer (Issue #807 — physical
 // verification before soutenance blanche).
 const PUNK_IPA_BARCODE_DE_ALIAS = "4260649360279";
+// UK 0,33L bottle EAN — 3rd physical Punk IPA SKU scanned for the
+// 2026-05-27 soutenance. Same beer → same official clone + equivalents.
+const PUNK_IPA_BARCODE_UK_ALIAS = "5056025440494";
+
+// Physical bottles scanned for the 2026-05-27 soutenance, identified
+// via our OpenFoodFacts client and wired into the demo catalogue so the
+// scan flow surfaces a beer card + equivalent recipes offline.
+const SCANNED_DEMO_BARCODES_NO_OFFICIAL = [
+  "5410769100081", // La Chouffe 0,33L alias
+  "5411551300818", // Bush Caractère
+  "3770012913076", // À la fût IPA
+  "54050051", // Pauwel Kwak
+  "5056025475885", // BrewDog Wingman
+];
 
 describe("demoEquivalentRecipes (Issue #911)", () => {
   describe("Punk IPA — 🏆 Recette officielle + 🧪 Équivalentes split", () => {
@@ -65,6 +79,7 @@ describe("demoEquivalentRecipes (Issue #911)", () => {
       const punkIpaBarcodes = new Set([
         PUNK_IPA_BARCODE,
         PUNK_IPA_BARCODE_DE_ALIAS,
+        PUNK_IPA_BARCODE_UK_ALIAS,
       ]);
       const otherBarcodes = Object.keys(demoEquivalentRecipes).filter(
         (b) => !punkIpaBarcodes.has(b),
@@ -92,6 +107,44 @@ describe("demoEquivalentRecipes (Issue #911)", () => {
       expect(alias.find((m) => m.isOfficial === true)?.name).toBe(
         "BrewDog DIY Dog Punk IPA",
       );
+    });
+
+    it("routes the UK 0,33L bottle EAN to the same matches as the canonical EAN", () => {
+      // 3rd physical Punk IPA SKU scanned for the 2026-05-27 soutenance.
+      const canonical = getDemoEquivalentRecipes(PUNK_IPA_BARCODE);
+      const alias = getDemoEquivalentRecipes(PUNK_IPA_BARCODE_UK_ALIAS);
+      expect(alias).toEqual(canonical);
+      expect(alias.find((m) => m.isOfficial === true)?.name).toBe(
+        "BrewDog DIY Dog Punk IPA",
+      );
+    });
+  });
+
+  describe("scanned demo bottles (soutenance 2026-05-27)", () => {
+    it.each(SCANNED_DEMO_BARCODES_NO_OFFICIAL)(
+      "surfaces 3 selectable equivalents and no official clone for %s",
+      (barcode) => {
+        // These beers carry no official BrewDog DIY Dog clone — the
+        // scan flow must still propose 3 community equivalents the user
+        // can open, never an empty "🏆 Recette officielle" section.
+        const matches = getDemoEquivalentRecipes(barcode);
+
+        expect(matches).toHaveLength(3);
+        expect(matches.filter((m) => m.isOfficial === true)).toHaveLength(0);
+        matches.forEach((m) => expect(m.recipeId).toBeTruthy());
+      },
+    );
+
+    it("links every equivalent recipe to a resolvable demoRecipes row", () => {
+      // Guards the import CTA: tapping an equivalent must land on a real
+      // recipe, not a dangling id.
+      const recipeIds = new Set(demoRecipes.map((r) => r.id));
+
+      for (const barcode of SCANNED_DEMO_BARCODES_NO_OFFICIAL) {
+        for (const match of getDemoEquivalentRecipes(barcode)) {
+          expect(recipeIds.has(match.recipeId)).toBe(true);
+        }
+      }
     });
   });
 });

--- a/packages/mobile-app/src/mocks/__tests__/demo-data.test.ts
+++ b/packages/mobile-app/src/mocks/__tests__/demo-data.test.ts
@@ -1,6 +1,7 @@
 import {
   demoEquivalentRecipes,
   demoRecipes,
+  demoScanCatalog,
   getDemoEquivalentRecipes,
 } from "@/mocks/demo-data";
 
@@ -146,5 +147,43 @@ describe("demoEquivalentRecipes (Issue #911)", () => {
         }
       }
     });
+  });
+});
+
+describe("demoScanCatalog — offline lookup for scanned bottles", () => {
+  const ALL_SCANNED_BARCODES = [
+    PUNK_IPA_BARCODE_UK_ALIAS,
+    ...SCANNED_DEMO_BARCODES_NO_OFFICIAL,
+  ];
+
+  it.each(ALL_SCANNED_BARCODES)(
+    "resolves %s to a catalogue entry so the demo lookup succeeds offline",
+    (barcode) => {
+      // demoScanCatalog is the only source the demo-mode lookup reads
+      // (no backend). Each scanned bottle must resolve here or the scan
+      // shows "not in catalogue".
+      const item = demoScanCatalog[barcode];
+
+      expect(item).toBeDefined();
+      expect(item.barcode).toBe(barcode);
+      expect(item.name.length).toBeGreaterThan(0);
+    },
+  );
+
+  it("flags IBU and EBC as estimated when they are style-based guesses", () => {
+    // notesSource on these entries states IBU/EBC are estimates — the
+    // technical-sheet UI badge relies on isIbuEstimated / isColorEbcEstimated.
+    const estimatedBottles = [
+      "5411551300818", // Bush Caractère
+      "3770012913076", // À la fût IPA
+      "54050051", // Pauwel Kwak
+      "5056025475885", // BrewDog Wingman
+    ];
+
+    for (const barcode of estimatedBottles) {
+      const item = demoScanCatalog[barcode];
+      expect(item.isIbuEstimated).toBe(true);
+      expect(item.isColorEbcEstimated).toBe(true);
+    }
   });
 });

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2726,6 +2726,8 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     abv: 12.0,
     ibu: 24,
     colorEbc: 35,
+    isIbuEstimated: true,
+    isColorEbcEstimated: true,
     aromaticTags: "caramel, dried fruit, toffee, warming alcohol",
     notesSource:
       "OpenFoodFacts 2026-05-27 + Dubuisson datasheet (IBU/EBC estimated)",
@@ -2741,6 +2743,8 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     abv: null,
     ibu: 50,
     colorEbc: 14,
+    isIbuEstimated: true,
+    isColorEbcEstimated: true,
     aromaticTags: "citrus, resinous hops, grapefruit",
     notesSource: "OpenFoodFacts 2026-05-27 (ABV/IBU/EBC estimated)",
   }),
@@ -2755,6 +2759,8 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     abv: 8.4,
     ibu: 18,
     colorEbc: 30,
+    isIbuEstimated: true,
+    isColorEbcEstimated: true,
     aromaticTags: "banana, caramel, ripe fruit, spice",
     notesSource:
       "OpenFoodFacts 2026-05-27 + Bosteels datasheet (IBU/EBC estimated)",
@@ -2771,6 +2777,8 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     abv: 4.3,
     ibu: 40,
     colorEbc: 12,
+    isIbuEstimated: true,
+    isColorEbcEstimated: true,
     aromaticTags: "tropical, citrus, light body",
     notesSource:
       "OpenFoodFacts 2026-05-27 (Wingman session IPA; IBU/EBC estimated)",

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2680,6 +2680,101 @@ export const demoScanCatalog: Record<string, ScanCatalogItem> = {
     notesSource:
       "Brasserie de Lancelot public datasheet (56460 Le Roc-Saint-André, Bretagne)",
   }),
+  // --- Physical bottles scanned for the 2026-05-27 soutenance demo.
+  // Identities resolved through our own OpenFoodFacts client
+  // (packages/api/src/scan/services/openfoodfacts.client.ts). OFF only
+  // carries name/brand/ABV, so style/IBU/EBC are style-based estimates
+  // (flagged via buildDemoScanCatalogItem's isXxxEstimated defaults). ---
+
+  // Punk IPA — UK 0,33L bottle EAN, a 3rd physical SKU of the same beer
+  // already keyed under 5060277380019 (UK 0,5L) + 4260649360279 (DE
+  // 0,33L). Routes to the canonical Punk IPA values + official clone.
+  "5056025440494": buildDemoScanCatalogItem({
+    id: "demo-scan-punk-ipa-uk-033",
+    barcode: "5056025440494",
+    name: "Punk IPA",
+    brewery: "BrewDog",
+    style: "IPA",
+    abv: 5.4,
+    ibu: 35,
+    colorEbc: 14,
+    aromaticTags: "tropical, citrus, pine",
+    notesSource: "BrewDog DIY Dog 2019 (open-source recipe book)",
+  }),
+  // La Chouffe — 0,33L bottle EAN alias (OFF "BIERE BLONDE CHOUFFE 8%").
+  // Same beer as the canonical 5410702000133 entry.
+  "5410769100081": buildDemoScanCatalogItem({
+    id: "demo-scan-la-chouffe-033",
+    barcode: "5410769100081",
+    name: "La Chouffe",
+    brewery: "Brasserie d Achouffe",
+    style: "Belgian Strong Pale Ale",
+    abv: 8.0,
+    ibu: 20,
+    colorEbc: 14,
+    aromaticTags: "banana, clove, coriander",
+    notesSource: "Brasserie d'Achouffe — official datasheet",
+  }),
+  // Bush Caractère — Brasserie Dubuisson. OFF: amber strong Belgian.
+  // ABV 12% (brewery); IBU/EBC style-based estimates.
+  "5411551300818": buildDemoScanCatalogItem({
+    id: "demo-scan-bush-caractere",
+    barcode: "5411551300818",
+    name: "Bush Caractère",
+    brewery: "Brasserie Dubuisson",
+    style: "Belgian Strong Amber Ale",
+    abv: 12.0,
+    ibu: 24,
+    colorEbc: 35,
+    aromaticTags: "caramel, dried fruit, toffee, warming alcohol",
+    notesSource:
+      "OpenFoodFacts 2026-05-27 + Dubuisson datasheet (IBU/EBC estimated)",
+  }),
+  // Bière À la fût IPA — OFF lists no brand; organic French IPA. ABV
+  // absent on OFF → left null (flagged estimated by the builder).
+  "3770012913076": buildDemoScanCatalogItem({
+    id: "demo-scan-a-la-fut-ipa",
+    barcode: "3770012913076",
+    name: "À la fût IPA",
+    brewery: "Brasserie À la fût",
+    style: "IPA",
+    abv: null,
+    ibu: 50,
+    colorEbc: 14,
+    aromaticTags: "citrus, resinous hops, grapefruit",
+    notesSource: "OpenFoodFacts 2026-05-27 (ABV/IBU/EBC estimated)",
+  }),
+  // Pauwel Kwak — Brouwerij Bosteels. OFF brand "PAUWEL", strong
+  // Belgian. ABV 8.4 (brewery); IBU/EBC estimates. EAN-8 SKU.
+  "54050051": buildDemoScanCatalogItem({
+    id: "demo-scan-pauwel-kwak",
+    barcode: "54050051",
+    name: "Pauwel Kwak",
+    brewery: "Brouwerij Bosteels",
+    style: "Belgian Strong Amber Ale",
+    abv: 8.4,
+    ibu: 18,
+    colorEbc: 30,
+    aromaticTags: "banana, caramel, ripe fruit, spice",
+    notesSource:
+      "OpenFoodFacts 2026-05-27 + Bosteels datasheet (IBU/EBC estimated)",
+  }),
+  // BrewDog Wingman — 0,33L bottle (distinct from the 0,5L can
+  // 5056025476097). Session IPA 4.3% (OFF category "session-ipa").
+  // IBU/EBC estimated. No official DIY Dog clone wired (only Punk IPA).
+  "5056025475885": buildDemoScanCatalogItem({
+    id: "demo-scan-brewdog-wingman",
+    barcode: "5056025475885",
+    name: "Wingman",
+    brewery: "BrewDog",
+    style: "Session IPA",
+    abv: 4.3,
+    ibu: 40,
+    colorEbc: 12,
+    aromaticTags: "tropical, citrus, light body",
+    notesSource:
+      "OpenFoodFacts 2026-05-27 (Wingman session IPA; IBU/EBC estimated)",
+  }),
 };
 
 /**
@@ -2752,6 +2847,77 @@ const PUNK_IPA_RECIPE_MATCHES: ScanRecipeMatch[] = [
   },
 ];
 
+// IPA-family equivalents (no official clone) — reused for scanned IPAs
+// that are not the BrewDog Punk IPA: the À la fût IPA and the Wingman
+// session IPA. Same 3 community picks as the Punk IPA equivalents,
+// minus the official DIY Dog row.
+const IPA_EQUIVALENT_MATCHES: ScanRecipeMatch[] =
+  PUNK_IPA_RECIPE_MATCHES.filter((match) => match.isOfficial !== true);
+
+// La Chouffe neighbours — shared by both the canonical 5410702000133
+// entry and the 5410769100081 physical-bottle alias.
+const LA_CHOUFFE_RECIPE_MATCHES: ScanRecipeMatch[] = [
+  {
+    recipeId: "r-demo-6",
+    publicRecipeId: "00000000-0000-4000-8000-000000000004",
+    name: "Belgian Tripel",
+    brewer: "Caroline",
+    rating: 4.8,
+    brewedCount: 31,
+    score: 0.93,
+  },
+  {
+    recipeId: "r-demo-9",
+    publicRecipeId: "00000000-0000-4000-8000-000000000005",
+    name: "Saison Farmhouse",
+    brewer: "Hugo",
+    rating: 4.6,
+    brewedCount: 19,
+    score: 0.86,
+  },
+  {
+    recipeId: "r-demo-2",
+    publicRecipeId: "00000000-0000-4000-8000-000000000006",
+    name: "Witbier Orange",
+    brewer: "Sophie",
+    rating: 4.2,
+    brewedCount: 9,
+    score: 0.74,
+  },
+];
+
+// Strong Belgian amber neighbours — shared by the scanned Bush
+// Caractère (12%) and Pauwel Kwak (8.4%) bottles. Malty, strong picks.
+const BELGIAN_STRONG_RECIPE_MATCHES: ScanRecipeMatch[] = [
+  {
+    recipeId: "r-demo-6",
+    publicRecipeId: "00000000-0000-4000-8000-000000000004",
+    name: "Belgian Tripel",
+    brewer: "Caroline",
+    rating: 4.8,
+    brewedCount: 31,
+    score: 0.9,
+  },
+  {
+    recipeId: "r-demo-15",
+    publicRecipeId: "00000000-0000-4000-8000-000000000007",
+    name: "Scotch Ale Wee Heavy",
+    brewer: "Pierre",
+    rating: 4.9,
+    brewedCount: 27,
+    score: 0.83,
+  },
+  {
+    recipeId: "r-demo-9",
+    publicRecipeId: "00000000-0000-4000-8000-000000000005",
+    name: "Saison Farmhouse",
+    brewer: "Hugo",
+    rating: 4.6,
+    brewedCount: 19,
+    score: 0.71,
+  },
+];
+
 export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
   // Punk IPA — UK 0,5L bottle EAN (canonical seed entry).
   "5060277380019": PUNK_IPA_RECIPE_MATCHES,
@@ -2759,36 +2925,13 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
   // verification before soutenance blanche). Same beer, different
   // SKU — both bottles route to the same matches.
   "4260649360279": PUNK_IPA_RECIPE_MATCHES,
-  // La Chouffe — Belgian Strong Pale Ale neighbours.
-  "5410702000133": [
-    {
-      recipeId: "r-demo-6",
-      publicRecipeId: "00000000-0000-4000-8000-000000000004",
-      name: "Belgian Tripel",
-      brewer: "Caroline",
-      rating: 4.8,
-      brewedCount: 31,
-      score: 0.93,
-    },
-    {
-      recipeId: "r-demo-9",
-      publicRecipeId: "00000000-0000-4000-8000-000000000005",
-      name: "Saison Farmhouse",
-      brewer: "Hugo",
-      rating: 4.6,
-      brewedCount: 19,
-      score: 0.86,
-    },
-    {
-      recipeId: "r-demo-2",
-      publicRecipeId: "00000000-0000-4000-8000-000000000006",
-      name: "Witbier Orange",
-      brewer: "Sophie",
-      rating: 4.2,
-      brewedCount: 9,
-      score: 0.74,
-    },
-  ],
+  // Punk IPA — UK 0,33L bottle EAN (3rd physical SKU, soutenance
+  // 2026-05-27). Same beer → same official clone + 3 equivalents.
+  "5056025440494": PUNK_IPA_RECIPE_MATCHES,
+  // La Chouffe — Belgian Strong Pale Ale neighbours. The canonical EAN
+  // and the 5410769100081 physical-bottle alias share the same matches.
+  "5410702000133": LA_CHOUFFE_RECIPE_MATCHES,
+  "5410769100081": LA_CHOUFFE_RECIPE_MATCHES,
   // Rochefort 10 — strong dark ale neighbours.
   "5410799000115": [
     {
@@ -2850,6 +2993,14 @@ export const demoEquivalentRecipes: Record<string, ScanRecipeMatch[]> = {
       score: 0.76,
     },
   ],
+  // Bush Caractère (Dubuisson, strong amber) — malty strong neighbours.
+  "5411551300818": BELGIAN_STRONG_RECIPE_MATCHES,
+  // À la fût IPA — IPA family equivalents (no official clone).
+  "3770012913076": IPA_EQUIVALENT_MATCHES,
+  // Pauwel Kwak (Bosteels, strong amber) — same strong Belgian picks.
+  "54050051": BELGIAN_STRONG_RECIPE_MATCHES,
+  // BrewDog Wingman (session IPA) — IPA family equivalents.
+  "5056025475885": IPA_EQUIVALENT_MATCHES,
 };
 
 /**


### PR DESCRIPTION
## Summary

Wire six real bottles scanned for the soutenance into the **demo scan catalogue** so the offline scan flow surfaces a beer card + selectable equivalent recipes for them. Identities were resolved through the project's own OpenFoodFacts client.

| Barcode | Beer | Catalogue | Equivalent recipes |
|---|---|---|---|
| `5056025440494` | Punk IPA (UK 0,33L) | alias | official DIY Dog clone + 3 |
| `5410769100081` | La Chouffe (0,33L) | alias | 3 |
| `5411551300818` | Bush Caractère (Dubuisson) | new | 3 |
| `3770012913076` | À la fût IPA | new | 3 |
| `54050051` | Pauwel Kwak | new | 3 |
| `5056025475885` | BrewDog Wingman (0,33L) | new | 3 |

## Context

These physical bottles carry SKUs absent from the curated 10-beer demo catalogue, so they showed "not in catalogue" in demo (offline) mode. OpenFoodFacts only carries name/brand/ABV, so style/IBU/EBC are style-based estimates (flagged via the builder defaults). The scan → beer card → equivalent recipes → official clone flow already existed (Issue #911); only the data was wired. Shared match lists extracted to consts (DRY).

## Checklist

- [x] Tests added (H/S/E): new aliases + scanned bottles, equivalents resolve to real recipes
- [x] `npm run typecheck` + `prettier --check` pass
- [x] Lint clean on changed files
- [x] No `any`, named exports only, demo data stays in `src/mocks/`