### PR TITLE
docs(marketing): interview-recruitment page for the needs-study

### DIFF
--- a/docs/marketing/needs-study/.vitepress/config.mjs
+++ b/docs/marketing/needs-study/.vitepress/config.mjs
@@ -40,6 +40,7 @@ const sidebarFr = [
     collapsed: false,
     items: [
       { text: "Guide d'entretien", link: "/05-interview-guide" },
+      { text: "Recrutement entretiens", link: "/c-recrutement-entretiens" },
       { text: "Sondage (questionnaire)", link: "/c-sondage" },
       { text: "Kit de diffusion", link: "/c-diffusion" },
       { text: "Résultats", link: "/c-resultats" }
@@ -84,6 +85,7 @@ const sidebarEn = [
     collapsed: false,
     items: [
       { text: "Interview guide", link: "/en/05-interview-guide" },
+      { text: "Interview recruitment", link: "/en/c-interview-recruitment" },
       { text: "Survey (questionnaire)", link: "/en/c-survey" },
       { text: "Distribution kit", link: "/en/c-distribution" },
       { text: "Results", link: "/en/c-resultats" }

--- a/docs/marketing/needs-study/c-recrutement-entretiens.md
+++ b/docs/marketing/needs-study/c-recrutement-entretiens.md
@@ -1,0 +1,112 @@
+# C · Recrutement pour les entretiens
+
+Posts et messages **prêts à coller** pour recruter des participants aux
+[entretiens](/05-interview-guide) (recherche qualitative). Complémentaire du
+[kit de diffusion du sondage](/c-diffusion) : le sondage donne la **largeur**
+(les chiffres), les entretiens donnent la **profondeur** (le pourquoi, les mots
+exacts).
+
+::: tip Principes (mêmes règles que pour le sondage)
+- **Cadrage « débutant qui apprend »**, jamais « teste mon app » — et on ne
+  propose **aucune solution** pendant l'entretien (sinon on biaise les réponses).
+- **Lire les règles** de chaque communauté ; demander aux **modérateurs** en cas
+  de doute (r/Homebrewing restreint le recrutement).
+- **Contribuer un peu d'abord** (réponses utiles), puis poster.
+- **Promettre de partager la synthèse** → forte hausse de bienveillance.
+- Ne pas spammer plusieurs endroits le même jour.
+:::
+
+## Cible et volume
+
+Brasseurs **réguliers / intermédiaires** (cf. Q0 du [guide](/05-interview-guide) :
+ni tout-débutants, ni pros mono-outil). **Filtre doux** dans le post public, **tri
+réel en privé** avant l'appel. Viser **10-15 entretiens**, mix FR/EN, jusqu'à
+**saturation** (quand les nouveaux entretiens n'apportent plus rien de neuf).
+
+## 1 · Forum brassageamateur.com (FR)
+
+**Titre :** Débutant : comment gérez-vous vos recettes ? J'aimerais en discuter 30 min
+
+```
+Bonjour à tous,
+
+Vous brassez depuis bien plus longtemps que moi, et j'aimerais apprendre
+de votre façon de gérer vos recettes au quotidien : où vous les notez, ce
+qui vous agace, et comment vous adaptez celles des autres à votre matériel.
+
+J'aimerais en discuter de vive voix avec quelques-uns d'entre vous — un
+échange détendu de 25-30 min, en visio, au tél, ou autour d'une bière si
+on est dans le coin. Juste pour vous écouter raconter votre façon de faire.
+Rien à installer, rien à vendre.
+
+Je partagerai bien sûr une synthèse de ce que j'apprends, ici même, pour
+que ça serve à tout le monde.
+
+Si vous brassez régulièrement et que ça vous tente, laissez un commentaire
+ou envoyez-moi un message — je m'adapte à vos dispos. Merci beaucoup pour
+votre temps !
+```
+
+## 2 · r/Homebrewing (EN)
+
+::: warning Règles
+Lire les règles du sub **avant** de poster ; beaucoup restreignent le recrutement.
+Proposer aux modérateurs un fil dédié au besoin. Ici c'est un **appel**, pas un
+lien de sondage — donc pas bloqué par l'absence de formulaire EN.
+:::
+
+**Title:** New to brewing — could I chat with a few of you about how you manage your recipes? (~30 min)
+
+```
+Hi all,
+
+You've been brewing far longer than me, and I'd love to learn from how you
+manage your recipes day to day: where you keep them, what's annoying about
+it, and how you adapt other people's recipes to your own setup.
+
+I'd love to talk it through with a few of you — a relaxed 25-30 min chat
+over video, a call, or a beer if you're nearby. Just to hear how you
+actually do it. Nothing to install, nothing to sell.
+
+I'll share a summary of what I learn back here, of course.
+
+If you brew regularly and you're up for it, drop a comment or DM me and
+I'll work around your schedule. Mods — happy to move this to a dedicated
+thread if you prefer. Thanks for your time!
+```
+
+## 3 · Canal bonus — contacts opt-in du sondage
+
+Le [sondage](/c-sondage) propose un **contact optionnel** en fin de questionnaire
+(« uniquement si vous acceptez un échange »). Ces répondants sont ta **première
+liste de candidats** aux entretiens : recontacte-les avec le message de cadrage
+ci-dessous. C'est l'**entonnoir sondage → entretiens** (méthodes mixtes).
+
+## 4 · Message privé de cadrage (avant l'appel)
+
+À envoyer une fois la personne partante, pour caler le créneau **et recueillir le
+consentement d'enregistrement**.
+
+```
+Bonjour [prénom], merci beaucoup d'avoir accepté !
+
+Ça te dirait [créneau 1] ou [créneau 2] ? L'échange dure 25-30 min, en
+visio, au tél ou en personne si on est proches — comme tu préfères.
+
+Pour ne rien rater de ce que tu me dis, j'aimerais enregistrer et
+transcrire notre échange (avec un petit dictaphone) : c'est uniquement
+pour mes notes, les citations seront anonymisées et l'enregistrement ne
+sera jamais partagé. C'est OK pour toi ?
+
+À très vite, et merci encore !
+```
+
+## 5 · Captation (PLAUD) & RGPD
+
+- Enregistrement via **PLAUD** (dictaphone qui transcrit automatiquement) →
+  transcript **verbatim**, idéal pour remplir la fiche de capture du
+  [guide](/05-interview-guide) mot pour mot.
+- **Consentement obligatoire** avant d'enregistrer (cf. message ci-dessus) ;
+  préciser que l'audio est **transcrit** (traitement cloud).
+- **Anonymiser** les citations dans l'étude ; **ne jamais partager** l'audio brut ;
+  supprimer l'enregistrement après transcription.

--- a/docs/marketing/needs-study/c-recrutement-entretiens.md
+++ b/docs/marketing/needs-study/c-recrutement-entretiens.md
@@ -94,9 +94,10 @@ Bonjour [prénom], merci beaucoup d'avoir accepté !
 visio, au tél ou en personne si on est proches — comme tu préfères.
 
 Pour ne rien rater de ce que tu me dis, j'aimerais enregistrer et
-transcrire notre échange (avec un petit dictaphone) : c'est uniquement
-pour mes notes, les citations seront anonymisées et l'enregistrement ne
-sera jamais partagé. C'est OK pour toi ?
+transcrire notre échange (avec un petit dictaphone dont la transcription
+passe par un service en ligne) : c'est uniquement pour mes notes, les
+citations seront anonymisées et l'enregistrement ne sera jamais partagé.
+C'est OK pour toi ?
 
 À très vite, et merci encore !
 ```

--- a/docs/marketing/needs-study/en/c-interview-recruitment.md
+++ b/docs/marketing/needs-study/en/c-interview-recruitment.md
@@ -1,0 +1,109 @@
+# C · Interview recruitment
+
+**Ready-to-paste** posts and messages to recruit participants for the
+[interviews](/en/05-interview-guide) (qualitative research). Complements the
+[survey distribution kit](/en/c-distribution): the survey gives **breadth**
+(numbers), the interviews give **depth** (the why, the exact words).
+
+::: tip Principles (same rules as for the survey)
+- **Frame as "a beginner learning"**, never "test my app" — and propose **no
+  solution** during the interview (it biases the answers).
+- **Read each community's rules**; ask **moderators** when in doubt
+  (r/Homebrewing restricts recruitment).
+- **Contribute a little first** (useful replies), then post.
+- **Promise to share the summary** → big goodwill boost.
+- Don't spam several places the same day.
+:::
+
+## Target and volume
+
+**Regular / intermediate** brewers (see Q0 in the [guide](/en/05-interview-guide):
+not first-timers, not single-tool pros). **Soft filter** in the public post, **real
+screening in private** before the call. Aim for **10-15 interviews**, FR/EN mix,
+until **saturation** (when new interviews stop surprising you).
+
+## 1 · brassageamateur.com forum (FR)
+
+**Title:** Débutant : comment gérez-vous vos recettes ? J'aimerais en discuter 30 min
+
+```
+Bonjour à tous,
+
+Vous brassez depuis bien plus longtemps que moi, et j'aimerais apprendre
+de votre façon de gérer vos recettes au quotidien : où vous les notez, ce
+qui vous agace, et comment vous adaptez celles des autres à votre matériel.
+
+J'aimerais en discuter de vive voix avec quelques-uns d'entre vous — un
+échange détendu de 25-30 min, en visio, au tél, ou autour d'une bière si
+on est dans le coin. Juste pour vous écouter raconter votre façon de faire.
+Rien à installer, rien à vendre.
+
+Je partagerai bien sûr une synthèse de ce que j'apprends, ici même, pour
+que ça serve à tout le monde.
+
+Si vous brassez régulièrement et que ça vous tente, laissez un commentaire
+ou envoyez-moi un message — je m'adapte à vos dispos. Merci beaucoup pour
+votre temps !
+```
+
+## 2 · r/Homebrewing (EN)
+
+::: warning Rules
+Read the sub's rules **before** posting; many restrict recruitment. Offer mods a
+dedicated thread if needed. This is a **call**, not a survey link — so it isn't
+blocked by the missing EN survey form.
+:::
+
+**Title:** New to brewing — could I chat with a few of you about how you manage your recipes? (~30 min)
+
+```
+Hi all,
+
+You've been brewing far longer than me, and I'd love to learn from how you
+manage your recipes day to day: where you keep them, what's annoying about
+it, and how you adapt other people's recipes to your own setup.
+
+I'd love to talk it through with a few of you — a relaxed 25-30 min chat
+over video, a call, or a beer if you're nearby. Just to hear how you
+actually do it. Nothing to install, nothing to sell.
+
+I'll share a summary of what I learn back here, of course.
+
+If you brew regularly and you're up for it, drop a comment or DM me and
+I'll work around your schedule. Mods — happy to move this to a dedicated
+thread if you prefer. Thanks for your time!
+```
+
+## 3 · Bonus channel — survey opt-in contacts
+
+The [survey](/en/c-survey) offers an **optional contact** at the end ("only if
+you're open to a chat"). Those respondents are your **first candidate list** for
+interviews: re-contact them with the framing message below. This is the
+**survey → interviews funnel** (mixed methods).
+
+## 4 · Private framing message (before the call)
+
+Send once the person is in, to lock a slot **and collect recording consent**.
+
+```
+Hi [name], thanks so much for being up for this!
+
+Would [slot 1] or [slot 2] work? The chat runs 25-30 min — over video, a
+call, or in person if we're nearby, whatever suits you.
+
+So I don't miss anything you tell me, I'd like to record and transcribe our
+chat (with a small voice recorder): it's only for my notes, quotes will be
+anonymised, and the recording is never shared. Is that okay with you?
+
+Talk soon, and thanks again!
+```
+
+## 5 · Capture (PLAUD) & GDPR
+
+- Recording via **PLAUD** (a voice recorder that auto-transcribes) → **verbatim**
+  transcript, ideal for filling the [guide](/en/05-interview-guide)'s capture
+  sheet word-for-word.
+- **Consent is mandatory** before recording (see message above); state that the
+  audio is **transcribed** (cloud processing).
+- **Anonymise** quotes in the study; **never share** the raw audio; delete the
+  recording after transcription.

--- a/docs/marketing/needs-study/en/c-interview-recruitment.md
+++ b/docs/marketing/needs-study/en/c-interview-recruitment.md
@@ -92,8 +92,9 @@ Would [slot 1] or [slot 2] work? The chat runs 25-30 min — over video, a
 call, or in person if we're nearby, whatever suits you.
 
 So I don't miss anything you tell me, I'd like to record and transcribe our
-chat (with a small voice recorder): it's only for my notes, quotes will be
-anonymised, and the recording is never shared. Is that okay with you?
+chat (with a small voice recorder whose transcription runs through an online
+service): it's only for my notes, quotes will be anonymised, and the
+recording is never shared. Is that okay with you?
 
 Talk soon, and thanks again!
 ```


### PR DESCRIPTION
## Summary

Add a new **Interview recruitment** page (FR + EN mirror) under section C (primary research) of the marketing needs-study site, documenting how to recruit participants for the qualitative interviews.

## Context

Resuming the needs study (epic #1075) on the primary-research phase. The interview *guide* already exists; what was missing is the *recruitment* kit. This page provides it, complementing the existing survey distribution kit (mixed methods: survey = breadth, interviews = depth).

Page contents (5 sections):
- Community principles (read rules, contribute first, share the summary, no app pitch, propose no solution mid-interview)
- Ready-to-paste posts for brassageamateur.com (FR) and r/Homebrewing (EN)
- Survey opt-in contacts as the survey to interviews funnel
- Private framing message with recording consent (PLAUD) sent before the call
- PLAUD capture + GDPR hygiene (consent, anonymised quotes, never share raw audio)

Sidebar entries added in both locales.

## Checklist

- [x] FR page + EN mirror, sidebar updated in both locales
- [x] `npm run docs:build` passes locally
- [x] No content changes outside the needs-study site
- [ ] Reviewed