### PR TITLE
feat(auth): purge session on mid-session 401 (token expiry)

### DIFF
--- a/packages/mobile-app/src/core/auth/__tests__/auth-context.test.tsx
+++ b/packages/mobile-app/src/core/auth/__tests__/auth-context.test.tsx
@@ -18,11 +18,18 @@ const mockSessionLoad = jest.fn();
 const mockSessionSetAccessToken = jest.fn();
 const mockSessionClear = jest.fn();
 
+// Capture the handler the provider registers via setUnauthorizedHandler,
+// so tests can simulate a mid-session 401 by invoking it directly.
+let capturedUnauthorizedHandler: (() => void) | null = null;
+
 jest.mock("@/core/auth/session", () => ({
   authSession: {
     load: () => mockSessionLoad(),
     setAccessToken: (token: string) => mockSessionSetAccessToken(token),
     clear: () => mockSessionClear(),
+    setUnauthorizedHandler: (handler: (() => void) | null) => {
+      capturedUnauthorizedHandler = handler;
+    },
   },
 }));
 
@@ -65,6 +72,7 @@ describe("AuthProvider — demo-trigger credentials (Issue #822)", () => {
     mockSessionClear.mockReset().mockResolvedValue(undefined);
     dataSourceMock.useDemoData = false;
     envMock.useDemoData = false;
+    capturedUnauthorizedHandler = null;
   });
 
   it("happy path: demo trigger credentials flip dataSource into demo mode and create a synthetic session without hitting the API", async () => {
@@ -200,6 +208,77 @@ describe("AuthProvider — demo-trigger credentials (Issue #822)", () => {
 
     expect(mockApiGetCurrentUser).not.toHaveBeenCalled();
     expect(dataSourceMock.useDemoData).toBe(true);
+    expect(result.current.session?.user.email).toBe(
+      "marie.brasseur@example.com",
+    );
+  });
+});
+
+describe("AuthProvider — mid-session 401 / token expiry (#1130)", () => {
+  beforeEach(() => {
+    mockApiLogin.mockReset();
+    mockSessionLoad.mockReset().mockResolvedValue(null);
+    mockSessionSetAccessToken.mockReset().mockResolvedValue(undefined);
+    mockSessionClear.mockReset().mockResolvedValue(undefined);
+    dataSourceMock.useDemoData = false;
+    envMock.useDemoData = false;
+    capturedUnauthorizedHandler = null;
+  });
+
+  it("happy: a registered live session is purged when the unauthorized handler fires", async () => {
+    mockApiLogin.mockResolvedValue({
+      accessToken: "real-token-abc",
+      user: {
+        id: "u-real-1",
+        email: "lea@brasse-bouillon.test",
+        username: "lea",
+        role: "user",
+        isActive: true,
+        createdAt: "2026-04-30T00:00:00.000Z",
+        updatedAt: "2026-04-30T00:00:00.000Z",
+      },
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.login("lea@brasse-bouillon.test", "StrongPass123!");
+    });
+    expect(result.current.session?.user.id).toBe("u-real-1");
+
+    expect(capturedUnauthorizedHandler).not.toBeNull();
+    await act(async () => {
+      capturedUnauthorizedHandler?.();
+    });
+
+    expect(mockSessionClear).toHaveBeenCalled();
+    expect(result.current.session).toBeNull();
+    expect(result.current.error).toBe("Session expirée, reconnecte-toi.");
+  });
+
+  it("edge: the unauthorized handler is a no-op in demo mode (demo session preserved)", async () => {
+    dataSourceMock.useDemoData = true;
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.login(DEMO_TRIGGER_EMAIL, DEMO_TRIGGER_PASSWORD);
+    });
+    expect(result.current.session?.user.email).toBe(
+      "marie.brasseur@example.com",
+    );
+
+    await act(async () => {
+      capturedUnauthorizedHandler?.();
+    });
+
+    expect(mockSessionClear).not.toHaveBeenCalled();
     expect(result.current.session?.user.email).toBe(
       "marie.brasseur@example.com",
     );

--- a/packages/mobile-app/src/core/auth/__tests__/session.test.ts
+++ b/packages/mobile-app/src/core/auth/__tests__/session.test.ts
@@ -1,0 +1,37 @@
+jest.mock("expo-secure-store", () => ({
+  isAvailableAsync: jest.fn().mockResolvedValue(false),
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
+}));
+
+import { authSession } from "@/core/auth/session";
+
+describe("authSession — unauthorized handler registry (#1130)", () => {
+  afterEach(() => {
+    authSession.setUnauthorizedHandler(null);
+  });
+
+  it("happy: notifyUnauthorized invokes the registered handler", () => {
+    const handler = jest.fn();
+    authSession.setUnauthorizedHandler(handler);
+
+    authSession.notifyUnauthorized();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("sad: notifyUnauthorized is a no-op when no handler is registered", () => {
+    expect(() => authSession.notifyUnauthorized()).not.toThrow();
+  });
+
+  it("edge: a null handler clears a previously registered one", () => {
+    const handler = jest.fn();
+    authSession.setUnauthorizedHandler(handler);
+    authSession.setUnauthorizedHandler(null);
+
+    authSession.notifyUnauthorized();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile-app/src/core/auth/auth-context.tsx
+++ b/packages/mobile-app/src/core/auth/auth-context.tsx
@@ -108,6 +108,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     loadSession();
   }, []);
 
+  // Register a global handler invoked when any *authenticated* request
+  // returns 401 (token expired/invalidated mid-session). Purge the session
+  // so the router falls back to the sign-in screen. The demo session never
+  // reaches the live backend, so it is left untouched as a safety net.
+  useEffect(() => {
+    authSession.setUnauthorizedHandler(() => {
+      if (dataSource.useDemoData) {
+        return;
+      }
+      void authSession.clear();
+      setSession(null);
+      setError("Session expirée, reconnecte-toi.");
+    });
+
+    return () => {
+      authSession.setUnauthorizedHandler(null);
+    };
+  }, []);
+
   const handleLogin = async (email: string, password: string) => {
     setIsLoading(true);
     setError(null);

--- a/packages/mobile-app/src/core/auth/session.ts
+++ b/packages/mobile-app/src/core/auth/session.ts
@@ -5,6 +5,12 @@ const ACCESS_TOKEN_KEY = "brassebouillon.access_token";
 let accessToken: string | null = null;
 let secureStoreAvailable: boolean | null = null;
 
+// Invoked by the HTTP client when an *authenticated* request comes back
+// 401 (token expired/invalidated mid-session). The auth context registers
+// a handler here to purge the session and bounce the user to sign-in.
+// Kept on this low-level module so the HTTP client never imports React.
+let unauthorizedHandler: (() => void) | null = null;
+
 async function canUseSecureStore(): Promise<boolean> {
   if (secureStoreAvailable !== null) {
     return secureStoreAvailable;
@@ -115,5 +121,11 @@ export const authSession = {
   async clear() {
     accessToken = null;
     await deletePersistedToken();
+  },
+  setUnauthorizedHandler(handler: (() => void) | null) {
+    unauthorizedHandler = handler;
+  },
+  notifyUnauthorized() {
+    unauthorizedHandler?.();
   },
 };

--- a/packages/mobile-app/src/core/http/__tests__/http-client.test.ts
+++ b/packages/mobile-app/src/core/http/__tests__/http-client.test.ts
@@ -5,6 +5,7 @@ import { HttpError } from "@/core/http/http-error";
 jest.mock("@/core/auth/session", () => ({
   authSession: {
     getAccessToken: jest.fn(),
+    notifyUnauthorized: jest.fn(),
   },
 }));
 
@@ -20,6 +21,11 @@ jest.mock("@/core/config/env", () => ({
 const mockGetAccessToken = authSession.getAccessToken as jest.MockedFunction<
   typeof authSession.getAccessToken
 >;
+
+const mockNotifyUnauthorized =
+  authSession.notifyUnauthorized as jest.MockedFunction<
+    typeof authSession.notifyUnauthorized
+  >;
 
 const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
 
@@ -45,6 +51,7 @@ describe("http-client / request", () => {
   beforeEach(() => {
     fetchMock.mockReset();
     mockGetAccessToken.mockReset();
+    mockNotifyUnauthorized.mockReset();
   });
 
   describe("URL construction", () => {
@@ -216,6 +223,42 @@ describe("http-client / request", () => {
 
       expect(rejected).toBeInstanceOf(HttpError);
       expect((rejected as HttpError).status).toBe(500);
+    });
+  });
+
+  describe("401 / session expiry (#1130)", () => {
+    it("happy: notifies unauthorized on a 401 from an authenticated request", async () => {
+      fetchMock.mockResolvedValueOnce(
+        buildResponse({ message: "Unauthorized" }, { status: 401 }),
+      );
+
+      await request("/auth/me").catch(() => undefined);
+
+      expect(mockNotifyUnauthorized).toHaveBeenCalledTimes(1);
+    });
+
+    it("sad: does NOT notify on a 401 from an unauthenticated request (login with bad credentials)", async () => {
+      fetchMock.mockResolvedValueOnce(
+        buildResponse({ message: "Invalid credentials" }, { status: 401 }),
+      );
+
+      await request("/auth/login", {
+        method: "POST",
+        body: { email: "a@b.c", password: "wrong" },
+        auth: false,
+      }).catch(() => undefined);
+
+      expect(mockNotifyUnauthorized).not.toHaveBeenCalled();
+    });
+
+    it("edge: does NOT notify on a non-401 error from an authenticated request", async () => {
+      fetchMock.mockResolvedValueOnce(
+        buildResponse({ message: "Forbidden" }, { status: 403 }),
+      );
+
+      await request("/recipes").catch(() => undefined);
+
+      expect(mockNotifyUnauthorized).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/mobile-app/src/core/http/__tests__/http-client.test.ts
+++ b/packages/mobile-app/src/core/http/__tests__/http-client.test.ts
@@ -227,7 +227,10 @@ describe("http-client / request", () => {
   });
 
   describe("401 / session expiry (#1130)", () => {
-    it("happy: notifies unauthorized on a 401 from an authenticated request", async () => {
+    it("happy: notifies unauthorized on a 401 when the request token is still current", async () => {
+      // getAccessToken is read twice: to attach the header and to compare
+      // against the still-current token on the 401 path — keep it constant.
+      mockGetAccessToken.mockReturnValue("the-jwt");
       fetchMock.mockResolvedValueOnce(
         buildResponse({ message: "Unauthorized" }, { status: 401 }),
       );
@@ -235,6 +238,22 @@ describe("http-client / request", () => {
       await request("/auth/me").catch(() => undefined);
 
       expect(mockNotifyUnauthorized).toHaveBeenCalledTimes(1);
+    });
+
+    it("edge: does NOT notify on a stale 401 whose token was replaced mid-flight (logout/re-login race)", async () => {
+      // Token attached to the request ("old"), then the user logged out and
+      // back in so the current token is now "new". The stale 401 must not
+      // purge the freshly authenticated session.
+      mockGetAccessToken
+        .mockReturnValueOnce("old-token") // attach
+        .mockReturnValueOnce("new-token"); // compare on 401
+      fetchMock.mockResolvedValueOnce(
+        buildResponse({ message: "Unauthorized" }, { status: 401 }),
+      );
+
+      await request("/auth/me").catch(() => undefined);
+
+      expect(mockNotifyUnauthorized).not.toHaveBeenCalled();
     });
 
     it("sad: does NOT notify on a 401 from an unauthenticated request (login with bad credentials)", async () => {

--- a/packages/mobile-app/src/core/http/http-client.ts
+++ b/packages/mobile-app/src/core/http/http-client.ts
@@ -67,6 +67,15 @@ export async function request<T>(
   const payload = await parseBody(response);
 
   if (!response.ok) {
+    // A 401 on an *authenticated* request means the token expired or was
+    // invalidated mid-session — notify so the session can be purged. Gated
+    // on `auth` so a 401 from an unauthenticated call (e.g. login with bad
+    // credentials, which passes `auth: false`) is treated as a normal
+    // failure and never triggers a logout/redirect.
+    if (response.status === 401 && auth) {
+      authSession.notifyUnauthorized();
+    }
+
     const message =
       typeof payload === "object" && payload && "message" in payload
         ? String(payload.message)

--- a/packages/mobile-app/src/core/http/http-client.ts
+++ b/packages/mobile-app/src/core/http/http-client.ts
@@ -51,10 +51,13 @@ export async function request<T>(
     ...headers,
   };
 
+  // Captured outside the block so the 401 path below can tell whether the
+  // token that produced the 401 is still the current one.
+  let attachedToken: string | null = null;
   if (auth) {
-    const token = authSession.getAccessToken();
-    if (token) {
-      mergedHeaders.Authorization = `Bearer ${token}`;
+    attachedToken = authSession.getAccessToken();
+    if (attachedToken) {
+      mergedHeaders.Authorization = `Bearer ${attachedToken}`;
     }
   }
 
@@ -71,8 +74,15 @@ export async function request<T>(
     // invalidated mid-session — notify so the session can be purged. Gated
     // on `auth` so a 401 from an unauthenticated call (e.g. login with bad
     // credentials, which passes `auth: false`) is treated as a normal
-    // failure and never triggers a logout/redirect.
-    if (response.status === 401 && auth) {
+    // failure and never triggers a logout/redirect. Also require the token
+    // that produced this 401 to still be the current one: a stale in-flight
+    // request from before a logout/re-login must not purge the fresh session.
+    if (
+      response.status === 401 &&
+      auth &&
+      attachedToken &&
+      attachedToken === authSession.getAccessToken()
+    ) {
       authSession.notifyUnauthorized();
     }
 


### PR DESCRIPTION
## Summary

Wires global handling of a mid-session **401** (expired/invalidated JWT) so the app
no longer leaves the user "logged in" with a dead token. Any authenticated request that
returns 401 now clears the persisted session and bounces the user back to sign-in.

This is the last missing piece of #1130: the auth chain (`login` / `register` /
`getCurrentUser` / token storage / `Authorization: Bearer`) was already implemented and
verified live against Fly.io — only token-expiry handling was absent.

## Context

- `session.ts` — registerable unauthorized-handler (`setUnauthorizedHandler` /
  `notifyUnauthorized`), kept on the low-level module so the HTTP client never imports React.
- `http-client.ts` — invoke `notifyUnauthorized()` on a 401 **only for authenticated
  requests** (`auth === true`). A 401 from login with bad credentials (`auth: false`)
  stays a normal failure — no logout/redirect.
- `auth-context.tsx` — register the handler to clear the session and surface a FR message;
  no-op in demo mode; cleaned up on unmount.

Verified end-to-end against `https://brasse-bouillon-api.fly.dev` (register → login →
`/auth/me` with Bearer → `DELETE /auth/me`): full cycle returns 201/200/200/200 and the
throwaway test account was deleted (re-login → 401, prod left clean).

Part of #1128.

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format)
- [x] Auth test surface green — 58/58 across 5 suites (H/S/E)
- [x] New behaviour covered: authenticated 401 purges session; `auth:false` 401 does not; demo mode no-op
- [x] Live contract verified against Fly.io
- [x] No `any`, named exports only, no direct `fetch` outside the http client

Closes #1130.