### PR TITLE
docs(website): finalize Cloudflare Pages migration — ADR-0014 + drop vestigial CNAME

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -58,10 +58,7 @@ jobs:
           done
 
           # Required scalar files — fail loudly if any go missing.
-          # CNAME is GitHub-Pages-specific and unused by Cloudflare Pages,
-          # but kept in staging until the custom domain is cut over so a
-          # rollback to Pages stays possible.
-          for required in favicon.ico CNAME sitemap.xml robots.txt; do
+          for required in favicon.ico sitemap.xml robots.txt; do
             cp "$src/$required" _site/
           done
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ Currently accepted ADRs (see each file for the `Status` line and full rationale)
 - [ADR-0003 — Consent as a single source of truth](docs/architecture/decisions/0003-consent-single-source-of-truth.md)
 - [ADR-0004 — Data locality hybrid principle](docs/architecture/decisions/0004-data-locality-hybrid-principle.md)
 - [ADR-0005 — Backend split (encyclopedia vs product)](docs/architecture/decisions/0005-backend-split-encyclopedia-vs-product.md)
+- [ADR-0014 — Website hosting on Cloudflare Pages, DNS authority on Cloudflare](docs/architecture/decisions/0014-website-hosting-cloudflare-pages-dns.md)
 
 When a new ADR is accepted, add its file link here (no dates, no per-ADR summaries — open the file for the live status and content). When reviewing a PR, flag any diff that violates these ADRs and cite the ADR number and clause in the review comment.
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -5,6 +5,21 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ---
 
+## 2026-06-01
+
+### Website production domain `brasse-bouillon.com` cut over to Cloudflare
+
+- DNS authority delegated Namecheap → Cloudflare (NS `craig.ns.cloudflare.com` + `noor.ns.cloudflare.com`); Namecheap now registrar-only, no DNSSEC. Zone reduced to `TXT google-site-verification` + proxied `CNAME @` / `www → brasse-bouillon-website.pages.dev` (CNAME flattening on the apex).
+- Removed the 4 GitHub Pages apex `A` records (`185.199.108-111.153`), the old `www → benoit-bremaud.github.io` CNAME, and the legacy `A backend → 109.18.26.95` (Ydays/Klouders vestige, unused — real API is `brasse-bouillon-api.fly.dev`).
+- Verified live: apex 200, www 200, `http`→`https` 301, Google Trust Services cert (Universal SSL). Decision recorded in ADR-0014, vestigial repo `CNAME` removed → PR #1157.
+
+## 2026-05-29
+
+### PR #1144 merged (`f56ef9f`) — ci(website): deploy to Cloudflare Pages instead of GitHub Pages
+
+- Branch `chore/website-cloudflare-pages`, 2 commits (`524ffc6`, `9496f32`). Replaced the GitHub Pages publish chain (`configure-pages` / `upload-pages-artifact` / `deploy-pages`) with a Cloudflare Pages Direct Upload (`npx wrangler@3 pages deploy`) to the new `brasse-bouillon-website` project; reuses repo secrets `CLOUDFLARE_API_TOKEN` (Pages:Edit) + `CLOUDFLARE_ACCOUNT_ID`. Live at `brasse-bouillon-website.pages.dev`. Reason: repo went private on a GitHub Free plan → Pages stopped serving (apex 404).
+- Copilot (2): derive the deploy branch from `github.ref_name` (production on `main`, preview elsewhere); replaced the blanket `continue-on-error` project-create with a targeted bootstrap tolerating only the "already exists" case.
+
 ## 2026-05-28
 
 ### PR #1124 merged (`80b0588`) — feat(scan): recognize six physical demo bottles in the offline catalogue

--- a/docs/architecture/decisions/0014-website-hosting-cloudflare-pages-dns.md
+++ b/docs/architecture/decisions/0014-website-hosting-cloudflare-pages-dns.md
@@ -1,0 +1,100 @@
+# ADR-0014 — Website hosting on Cloudflare Pages, DNS authority on Cloudflare
+
+**Status**  Accepted
+**Date**    2026-05-29
+**Owners**  @benoit-bremaud
+
+> Supersedes the implicit "GitHub Pages on the custom domain" hosting
+> assumption for `packages/website` (and the hosting half of the
+> machine-local `website-pages-deploy` runbook). The site content and the
+> public-asset staging logic are unchanged — only the host and the DNS
+> authority move.
+
+---
+
+## Context
+
+- `packages/website` is the marketing site: plain static HTML/CSS/JS, no
+  build step, served at the **root** of `brasse-bouillon.com`. Asset
+  references are relative; the canonical URL is the **naked apex**
+  (`https://brasse-bouillon.com/`, asserted by every `<link rel="canonical">`).
+- It was published via **GitHub Pages** on the custom domain. When the repo
+  `benoit-bremaud/brasse-bouillon` turned **private** on a GitHub **Free**
+  plan, Pages stopped serving (Free serves Pages from public repos only) and
+  the apex began returning **404**.
+- DNS for `brasse-bouillon.com` was hosted at **Namecheap (BasicDNS)**:
+  apex `A` records → GitHub Pages IPs `185.199.108-111.153`, `CNAME www →
+  benoit-bremaud.github.io`, one `TXT google-site-verification` (Search
+  Console), and a stale `A backend → 109.18.26.95` (a residential SFR IP — a
+  self-hosted NestJS API from the Ydays/Klouders era, no longer used; the
+  real API is `brasse-bouillon-api.fly.dev`). No MX, no DNSSEC.
+- A **Cloudflare account already exists** and hosts other web properties
+  (the needs-study site `brasse-bouillon-marketing.pages.dev`, the feedback
+  Worker). Repo Actions secrets `CLOUDFLARE_API_TOKEN` (scoped Pages:Edit)
+  and `CLOUDFLARE_ACCOUNT_ID` are already provisioned.
+
+## Decision
+
+**Host `packages/website` on Cloudflare Pages and move DNS authority for
+`brasse-bouillon.com` to Cloudflare.** Namecheap remains the **registrar
+only**.
+
+1. **Hosting** — a dedicated Cloudflare Pages project
+   **`brasse-bouillon-website`** (distinct from `brasse-bouillon-marketing`).
+2. **Deploy** — GitHub Actions **Direct Upload** via `wrangler pages deploy`
+   on push to `main` (and `workflow_dispatch`). The target branch is derived
+   from `github.ref_name`: `main` is the production branch, any other branch
+   produces a Cloudflare **preview** deployment. Project bootstrap tolerates
+   only the "already exists" case. (PR #1144.)
+3. **DNS authority** — delegate `brasse-bouillon.com` nameservers from
+   Namecheap BasicDNS to **Cloudflare**. Choosing Cloudflare DNS is what makes
+   the **apex** resolve to Pages cleanly (CNAME flattening), which Namecheap
+   BasicDNS cannot do for a naked apex.
+4. **Clean-slate target zone** — the Cloudflare zone holds **only**:
+
+   | Type  | Name        | Content                             | Proxy     | Origin |
+   |-------|-------------|-------------------------------------|-----------|--------|
+   | TXT   | `@`         | `google-site-verification=J2oPuRCC1KJ5z-…` | DNS only | kept (Search Console) |
+   | CNAME | `@` (apex)  | `brasse-bouillon-website.pages.dev` | Proxied   | auto-created by the Pages custom domain |
+   | CNAME | `www`       | `brasse-bouillon-website.pages.dev` | Proxied   | auto-created by the Pages custom domain |
+
+   Explicitly **removed**: the 4 GitHub Pages apex `A` records, the old
+   `CNAME www`, and the legacy `A backend`.
+5. **Registrar hygiene (Namecheap)** — Auto-Renew ON, Registrar Lock ON,
+   Domain Privacy ON. Switching to Custom DNS auto-deactivates the old
+   BasicDNS host records (no manual deletion needed there).
+
+**Ruled out**
+- *Keep GitHub Pages* — incompatible with a private repo on the Free plan.
+- *Keep DNS at Namecheap with a `www` CNAME only* — Namecheap BasicDNS has no
+  proper apex CNAME/ALIAS, and the apex is the canonical URL.
+
+## Consequences
+
+**Positive**
+- The site is served again on the canonical apex, with automatic TLS + CDN.
+- One Cloudflare account fronts every web property; consistent tooling.
+- Per-branch preview deployments come for free with the ref-derived branch.
+- The DNS zone is minimal and documented (this ADR is the source of truth).
+
+**Negative / accepted**
+- DNS resolution now depends on Cloudflare; the nameserver migration carries
+  a propagation delay (minutes–hours).
+- The in-repo `packages/website/CNAME` file is now **vestigial**
+  (GitHub-Pages-specific) and must be removed in a follow-up, along with its
+  entry in the workflow staging step.
+
+## Roadmap
+
+- [x] PR #1144 — deploy workflow → Cloudflare Pages; live on
+  `brasse-bouillon-website.pages.dev`.
+- [ ] Delegate NS Namecheap → Cloudflare; apply the clean-slate zone; add the
+  Pages custom domains (`brasse-bouillon.com`, `www`).
+- [ ] Remove the vestigial `packages/website/CNAME` from the repo + staging.
+- [ ] (Optional) Enable DNSSEC via Cloudflare (DS record added at Namecheap).
+
+## References
+
+- PR #1144 — `ci(website): deploy to Cloudflare Pages instead of GitHub Pages`.
+- [ADR-0001](0001-build-for-today-design-for-tomorrow.md) — build for today.
+- Machine-local runbook `website-pages-deploy` (hosting half now superseded).

--- a/docs/architecture/decisions/0014-website-hosting-cloudflare-pages-dns.md
+++ b/docs/architecture/decisions/0014-website-hosting-cloudflare-pages-dns.md
@@ -88,9 +88,10 @@ only**.
 
 - [x] PR #1144 — deploy workflow → Cloudflare Pages; live on
   `brasse-bouillon-website.pages.dev`.
-- [ ] Delegate NS Namecheap → Cloudflare; apply the clean-slate zone; add the
-  Pages custom domains (`brasse-bouillon.com`, `www`).
-- [ ] Remove the vestigial `packages/website/CNAME` from the repo + staging.
+- [x] Delegate NS Namecheap → Cloudflare; apply the clean-slate zone; add the
+  Pages custom domains (`brasse-bouillon.com`, `www`). Done 2026-06-01.
+- [x] Remove the vestigial `packages/website/CNAME` from the repo + staging
+  (this PR).
 - [ ] (Optional) Enable DNSSEC via Cloudflare (DS record added at Namecheap).
 
 ## References

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -50,6 +50,7 @@ Every ADR follows the same skeleton (inspired by Michael Nygard's template):
 | [0010](0010-recipe-step-type-nine-phase.md) | Extend `RecipeStepType` to the 9-phase brewing set | Proposed | 2026-05-25 |
 | [0011](0011-creator-role-above-admin.md) | Single-holder `CREATOR` role above `ADMIN` | Proposed | 2026-05-25 |
 | [0012](0012-rgpd-anonymize-authored-public-content.md) | RGPD: anonymize authored public content on deletion | Proposed | 2026-05-25 |
+| [0014](0014-website-hosting-cloudflare-pages-dns.md) | Website hosting on Cloudflare Pages, DNS authority on Cloudflare | Accepted | 2026-05-29 |
 
 > **Numbers 0006–0008 are reserved** (not yet drafted) for decisions already
 > referenced by open epics: 0006 — private journal vs. social product (#833),

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -56,6 +56,10 @@ Every ADR follows the same skeleton (inspired by Michael Nygard's template):
 > referenced by open epics: 0006 — private journal vs. social product (#833),
 > 0007 — monetization model (#834, #879, #883), 0008 — AI-generated content
 > policy (#834). They will be added here when drafted.
+>
+> **0013** (beer canonical model & conception order) is being drafted on a
+> separate branch and is not yet merged to `main`; it will be added to this
+> index when it lands. That is why the index jumps from 0012 to 0014.
 
 ---
 

--- a/packages/website/CNAME
+++ b/packages/website/CNAME
@@ -1,1 +1,0 @@
-brasse-bouillon.com


### PR DESCRIPTION
## Summary

Finalize and **document** the website migration from GitHub Pages to Cloudflare Pages:

- **ADR-0014** — `Website hosting on Cloudflare Pages, DNS authority on Cloudflare`. Captures the decision, the clean-slate target DNS zone, the records removed, and the registrar-hygiene checklist. Indexed in the decisions `README.md` and the root `CLAUDE.md` accepted-ADR list.
- **Remove the vestigial `packages/website/CNAME`** (a GitHub Pages artifact) and its entry in the deploy workflow's required-files staging list. The custom domain is now configured on the Cloudflare Pages project, so the file is unused.

## Context

The marketing site moved off GitHub Pages (which stopped serving once the repo went private on a Free plan) to Cloudflare Pages in PR #1144. The custom domain `brasse-bouillon.com` was then cut over to Cloudflare on 2026-06-01: DNS authority delegated Namecheap → Cloudflare, zone cleaned to a minimal set (TXT verification + apex/www CNAMEs to Pages), legacy `backend` and GitHub Pages apex records removed. Apex + www now serve HTTPS 200 with a Cloudflare-managed certificate. This PR records that decision and removes the last GitHub-Pages-specific leftover.

## Checklist

- [x] ADR follows the repo MADR skeleton; indexed in README + CLAUDE.md
- [x] Workflow YAML still valid after removing the CNAME staging line
- [x] No site source files changed beyond the CNAME removal
- [x] Cutover verified live (apex 200, www 200, http→https 301, cert valid, TXT preserved)
- [ ] PROJECT_LOG entry (added in this PR)