### PR TITLE
feat(website): move feedback widget to staging-only, off production

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -16,15 +16,17 @@ name: Website Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
     paths:
       - "packages/website/**"
       - ".github/workflows/website-deploy.yml"
   workflow_dispatch:
 
-# A single in-flight website deployment at a time.
+# One in-flight deployment per branch: `main` (production) and `staging`
+# (the long-lived staging environment, alias staging.brasse-bouillon-website.pages.dev)
+# deploy independently and must not block each other.
 concurrency:
-  group: website-deploy
+  group: website-deploy-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,12 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-06-01
 
+### PR #1158 — feat(website): feedback widget → staging-only + new staging environment
+
+- Branch `feat/website-widget-staging-only`. The feedback widget is reframed as a dev-only tool: its host gate is flipped from production (`brasse-bouillon.com`) to `staging.brasse-bouillon-website.pages.dev` + `localhost`/`127.0.0.1`, so it no longer loads on prod. Cache-bust `feedback-widget.js?v=20260601` on all 10 pages.
+- New **staging** environment: the deploy workflow now also triggers on a long-lived `staging` branch (Cloudflare Pages branch alias → stable URL `staging.brasse-bouillon-website.pages.dev`); `concurrency` scoped per branch so staging/prod deploys don't block each other.
+- Cross-repo follow-up: `feedback-pipeline-worker` CORS allow-list must add `https://staging.brasse-bouillon-website.pages.dev` for the submit flow to work on staging.
+
 ### Website production domain `brasse-bouillon.com` cut over to Cloudflare
 
 - DNS authority delegated Namecheap → Cloudflare (NS `craig.ns.cloudflare.com` + `noor.ns.cloudflare.com`); Namecheap now registrar-only, no DNSSEC. Zone reduced to `TXT google-site-verification` + proxied `CNAME @` / `www → brasse-bouillon-website.pages.dev` (CNAME flattening on the apex).

--- a/packages/website/cookies-en.html
+++ b/packages/website/cookies-en.html
@@ -87,6 +87,6 @@
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/cookies.html
+++ b/packages/website/cookies.html
@@ -89,6 +89,6 @@
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/feedback-widget.js
+++ b/packages/website/feedback-widget.js
@@ -4,18 +4,24 @@
  * Single source for the "Report" widget, referenced by every page so its
  * config lives in one place (no duplicated inline snippet to keep in sync).
  *
- * It loads the Cloudflare Worker widget bundle ONLY on the production domain:
- * the Worker's CORS allow-list is prod-only, so on localhost / previews the
- * submit flow would break and the third-party request would be pointless.
- * The dynamic import keeps the worker bundle off non-prod pages entirely.
+ * The feedback widget is a DEVELOPMENT tool, not a production feature: it loads
+ * the Cloudflare Worker widget bundle ONLY on the staging environment (and on
+ * localhost for local review), never on the public production site. This keeps
+ * the "Report" UI and the third-party Worker request off brasse-bouillon.com
+ * entirely. The Worker's CORS allow-list must include each host below for the
+ * submit flow to succeed.
  */
-const PROD_HOSTS = ['brasse-bouillon.com', 'www.brasse-bouillon.com'];
+const WIDGET_HOSTS = [
+  'staging.brasse-bouillon-website.pages.dev',
+  'localhost',
+  '127.0.0.1',
+];
 const WIDGET_SRC =
   'https://feedback-pipeline-worker.bbd-concept.workers.dev/widget.js';
 const ENDPOINT =
   'https://feedback-pipeline-worker.bbd-concept.workers.dev/ingest';
 
-if (PROD_HOSTS.includes(window.location.hostname)) {
+if (WIDGET_HOSTS.includes(window.location.hostname)) {
   import(WIDGET_SRC)
     .then(({ mountFeedbackWidget }) => {
       mountFeedbackWidget({ projectId: 'brasse-bouillon', endpoint: ENDPOINT });

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -78,6 +78,6 @@
 
   <script src="site.js?v=20260523-2"></script>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -578,6 +578,6 @@
     });
   </script>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/legal-en.html
+++ b/packages/website/legal-en.html
@@ -103,6 +103,6 @@
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/legal.html
+++ b/packages/website/legal.html
@@ -103,6 +103,6 @@
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -119,6 +119,6 @@
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -119,6 +119,6 @@
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/terms-en.html
+++ b/packages/website/terms-en.html
@@ -108,6 +108,6 @@
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/terms.html
+++ b/packages/website/terms.html
@@ -107,6 +107,6 @@
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
-  <script type="module" src="feedback-widget.js?v=20260523"></script>
+  <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Make the feedback widget a **staging-only development tool** and stand up a long-lived **staging environment** on Cloudflare Pages.

- `feedback-widget.js` — flip the host gate from the production domain to `staging.brasse-bouillon-website.pages.dev` + `localhost`/`127.0.0.1` (local review). The widget no longer loads on `brasse-bouillon.com`.
- `website-deploy.yml` — also trigger on the `staging` branch; scope the `concurrency` group per branch so staging and production deploys don't block each other.
- Bump the `feedback-widget.js` cache-bust to `?v=20260601` across all 10 pages.

## Context

The feedback widget is a development tool (collecting feedback while iterating), not a feature for end users. It was loading on production (`brasse-bouillon.com`). We remove it from production and host it on a dedicated, internet-reachable staging environment instead.

Cloudflare Pages gives each branch a stable alias `<branch>.<project>.pages.dev`, so a long-lived `staging` branch yields the stable URL **`staging.brasse-bouillon-website.pages.dev`**. The same hostname-gated `feedback-widget.js` ships everywhere but only mounts the widget on staging/localhost — production stays clean.

## Follow-up (separate repo, required for submit to work on staging)

The `feedback-pipeline-worker` CORS allow-list must add `https://staging.brasse-bouillon-website.pages.dev`. Until then the widget renders on staging but submissions are blocked by CORS.

## After merge

Create the `staging` branch from `main` and push it → deploys to `staging.brasse-bouillon-website.pages.dev`.

## Checklist

- [x] `feedback-widget.js` syntax-checked (`node --check`)
- [x] Workflow YAML valid
- [x] Cache-bust bumped on all pages
- [x] No production behavior beyond removing the widget
- [ ] PROJECT_LOG entry (added in this PR)