### PR TITLE
refactor(scan): move BeerInfoCardScreen data-fetching to TanStack Query

### DIFF
--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -462,7 +462,17 @@ function MatchingRecipesSection({
         `La recette « ${recipe.name} » sera ajoutée à ton carnet.`,
         [
           { text: "Annuler", style: "cancel" },
-          { text: "Importer", onPress: () => importMutation.mutate(recipe) },
+          {
+            text: "Importer",
+            // Re-check before firing: a second confirmation (e.g. another
+            // row's Alert opened before this one was answered) must not
+            // launch a concurrent import. Restores the guard the previous
+            // performImport had at call time.
+            onPress: () => {
+              if (importMutation.isPending) return;
+              importMutation.mutate(recipe);
+            },
+          },
         ],
         { cancelable: true },
       );

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -205,6 +205,11 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
     // pointless. Recoverable variants expose a manual "Réessayer" button
     // (canRetry) wired to refetch(), matching the previous behaviour.
     retry: false,
+    // Always fetch on mount/scan instead of serving the provider's
+    // inherited 30s-stale cache: a freshly catalogued beer (or a fixed
+    // not-found) must surface immediately on re-scan, as it did before
+    // the migration (the useEffect re-ran on every mount).
+    staleTime: 0,
   });
 
   const status = useMemo<ScreenStatus>(() => {
@@ -216,14 +221,23 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
         canRetry: false,
       };
     }
-    if (lookupQuery.isError) {
-      return mapErrorToStatus(lookupQuery.error);
-    }
     if (lookupQuery.data) {
       return { kind: "ready", result: lookupQuery.data };
     }
+    // `isError` stays true while a manual refetch() is in flight, so only
+    // surface the error UI when no fetch is running — otherwise pressing
+    // "Réessayer" would keep the error visible instead of showing loading.
+    if (lookupQuery.isError && !lookupQuery.isFetching) {
+      return mapErrorToStatus(lookupQuery.error);
+    }
     return { kind: "loading" };
-  }, [barcode, lookupQuery.isError, lookupQuery.error, lookupQuery.data]);
+  }, [
+    barcode,
+    lookupQuery.data,
+    lookupQuery.isError,
+    lookupQuery.isFetching,
+    lookupQuery.error,
+  ]);
 
   const handleRetry = useCallback(() => {
     void lookupQuery.refetch();
@@ -394,6 +408,9 @@ function MatchingRecipesSection({
     queryFn: () => getMatchingRecipes(beer),
     // Single attempt then surface the load-error card, as before.
     retry: false,
+    // Re-fetch matches on each scan rather than serving the inherited
+    // 30s-stale cache (consistent with the lookup query above).
+    staleTime: 0,
   });
   const matching = matchingQuery.data ?? null;
 

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo } from "react";
 import {
   Alert,
   Linking,
@@ -35,13 +35,13 @@ import {
 import type {
   ScanCatalogItem,
   ScanLookupResult,
-  ScanMatchingResult,
   ScanRecipeMatch,
 } from "@/features/scan/domain/scan.types";
 import { BeerHero } from "@/features/scan/presentation/components/BeerHero";
 import { Collapsible } from "@/features/scan/presentation/components/Collapsible";
 import { getDemoBreweryStory } from "@/mocks/demo-data";
 
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 
 type BeerInfoCardScreenProps = {
@@ -196,30 +196,38 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
   const router = useRouter();
   const barcode = resolveBarcodeParam(barcodeParam);
 
-  const [status, setStatus] = useState<ScreenStatus>({ kind: "loading" });
+  const lookupQuery = useQuery({
+    queryKey: ["scan", "lookup", barcode],
+    queryFn: () => lookupBeerByBarcode(barcode as string),
+    enabled: Boolean(barcode),
+    // Lookup errors are typed business outcomes (not-found, not-a-beer,
+    // invalid) mapped to dedicated UI states — auto-retrying them is
+    // pointless. Recoverable variants expose a manual "Réessayer" button
+    // (canRetry) wired to refetch(), matching the previous behaviour.
+    retry: false,
+  });
 
-  const fetch = useCallback(async () => {
+  const status = useMemo<ScreenStatus>(() => {
     if (!barcode) {
-      setStatus({
+      return {
         kind: "error",
         variant: "invalid",
         message: ERROR_INVALID,
         canRetry: false,
-      });
-      return;
+      };
     }
-    setStatus({ kind: "loading" });
-    try {
-      const result = await lookupBeerByBarcode(barcode);
-      setStatus({ kind: "ready", result });
-    } catch (error) {
-      setStatus(mapErrorToStatus(error));
+    if (lookupQuery.isError) {
+      return mapErrorToStatus(lookupQuery.error);
     }
-  }, [barcode]);
+    if (lookupQuery.data) {
+      return { kind: "ready", result: lookupQuery.data };
+    }
+    return { kind: "loading" };
+  }, [barcode, lookupQuery.isError, lookupQuery.error, lookupQuery.data]);
 
-  useEffect(() => {
-    void fetch();
-  }, [fetch]);
+  const handleRetry = useCallback(() => {
+    void lookupQuery.refetch();
+  }, [lookupQuery]);
 
   const handleBack = useCallback(() => {
     router.replace("/(app)/dashboard/scan" as never);
@@ -233,7 +241,7 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
     return (
       <Screen
         error={status.message}
-        onRetry={status.canRetry ? fetch : undefined}
+        onRetry={status.canRetry ? handleRetry : undefined}
       >
         <ListHeader
           title="Résultat du scan"
@@ -381,24 +389,35 @@ function MatchingRecipesSection({
   beer: Pick<ScanCatalogItem, "id" | "barcode">;
   onImported: (recipeId: string) => void;
 }>) {
-  const [matching, setMatching] = useState<ScanMatchingResult | null>(null);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [importingId, setImportingId] = useState<string | null>(null);
+  const matchingQuery = useQuery({
+    queryKey: ["scan", "matching", beer.id ?? beer.barcode],
+    queryFn: () => getMatchingRecipes(beer),
+    // Single attempt then surface the load-error card, as before.
+    retry: false,
+  });
+  const matching = matchingQuery.data ?? null;
 
-  useEffect(() => {
-    let cancelled = false;
-    setLoadError(null);
-    void getMatchingRecipes(beer)
-      .then((result) => {
-        if (!cancelled) setMatching(result);
-      })
-      .catch(() => {
-        if (!cancelled) setLoadError(MATCHING_LOAD_ERROR);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [beer]);
+  const importMutation = useMutation({
+    mutationFn: (recipe: ScanRecipeMatch) =>
+      importRecipeFromCommunity(getImportSourceId(recipe)),
+    onSuccess: (result) => {
+      Alert.alert(
+        "Recette importée",
+        `« ${result.name} » a été ajoutée à Mes Recettes.`,
+        [
+          { text: "Plus tard", style: "cancel" },
+          {
+            text: "Voir la recette",
+            onPress: () => onImported(result.recipeId),
+          },
+        ],
+        { cancelable: true },
+      );
+    },
+    onError: () => {
+      Alert.alert("Import impossible", IMPORT_ERROR_MESSAGE);
+    },
+  });
 
   const officialRecipe = useMemo<ScanRecipeMatch | null>(() => {
     if (!matching) return null;
@@ -412,33 +431,6 @@ function MatchingRecipesSection({
       .slice(0, EQUIVALENTS_LIMIT);
   }, [matching]);
 
-  const performImport = useCallback(
-    async (sourceId: string) => {
-      if (importingId) return;
-      setImportingId(sourceId);
-      try {
-        const result = await importRecipeFromCommunity(sourceId);
-        Alert.alert(
-          "Recette importée",
-          `« ${result.name} » a été ajoutée à Mes Recettes.`,
-          [
-            { text: "Plus tard", style: "cancel" },
-            {
-              text: "Voir la recette",
-              onPress: () => onImported(result.recipeId),
-            },
-          ],
-          { cancelable: true },
-        );
-      } catch {
-        Alert.alert("Import impossible", IMPORT_ERROR_MESSAGE);
-      } finally {
-        setImportingId(null);
-      }
-    },
-    [importingId, onImported],
-  );
-
   /**
    * Issue #766 — pre-flight confirmation before the import call.
    * Without this, a stray tap on a community recipe row imports it
@@ -447,29 +439,24 @@ function MatchingRecipesSection({
    */
   const handleImport = useCallback(
     (recipe: ScanRecipeMatch) => {
-      if (importingId) return;
+      if (importMutation.isPending) return;
       Alert.alert(
         "Importer cette recette ?",
         `La recette « ${recipe.name} » sera ajoutée à ton carnet.`,
         [
           { text: "Annuler", style: "cancel" },
-          {
-            text: "Importer",
-            onPress: () => {
-              void performImport(getImportSourceId(recipe));
-            },
-          },
+          { text: "Importer", onPress: () => importMutation.mutate(recipe) },
         ],
         { cancelable: true },
       );
     },
-    [importingId, performImport],
+    [importMutation],
   );
 
-  if (loadError) {
+  if (matchingQuery.isError) {
     return (
       <Card style={styles.recipesCard}>
-        <Text style={styles.recipesEmpty}>{loadError}</Text>
+        <Text style={styles.recipesEmpty}>{MATCHING_LOAD_ERROR}</Text>
       </Card>
     );
   }
@@ -501,8 +488,11 @@ function MatchingRecipesSection({
           </Text>
           <RecipeRow
             recipe={officialRecipe}
-            isImporting={importingId === officialRecipe.recipeId}
-            isDisabled={importingId !== null}
+            isImporting={
+              importMutation.isPending &&
+              importMutation.variables?.recipeId === officialRecipe.recipeId
+            }
+            isDisabled={importMutation.isPending}
             onPress={() => handleImport(officialRecipe)}
             highlightOfficial
           />
@@ -525,8 +515,11 @@ function MatchingRecipesSection({
             <RecipeRow
               key={recipe.recipeId}
               recipe={recipe}
-              isImporting={importingId === recipe.recipeId}
-              isDisabled={importingId !== null}
+              isImporting={
+                importMutation.isPending &&
+                importMutation.variables?.recipeId === recipe.recipeId
+              }
+              isDisabled={importMutation.isPending}
               onPress={() => handleImport(recipe)}
             />
           ))}

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -326,6 +326,37 @@ describe("BeerInfoCardScreen", () => {
       ).toBeTruthy();
     });
 
+    it("shows the loading state (hides the error) while a retry is in flight", async () => {
+      mockedLookup.mockRejectedValueOnce(
+        new ScanLookupServiceUnavailableError("5060277380019"),
+      );
+      // Second lookup: a controllable pending promise so we can observe
+      // the in-flight state after pressing Réessayer.
+      let resolveRetry: (result: ScanLookupResult) => void = () => {};
+      mockedLookup.mockImplementationOnce(
+        () =>
+          new Promise<ScanLookupResult>((resolve) => {
+            resolveRetry = resolve;
+          }),
+      );
+
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      await screen.findByText(/temporairement indisponible/);
+      fireEvent.press(screen.getByText("Réessayer"));
+
+      // The refetch is in flight: isError stays true, but the screen must
+      // transition to loading, so the error message must disappear.
+      await waitFor(() =>
+        expect(screen.queryByText(/temporairement indisponible/)).toBeNull(),
+      );
+
+      await act(async () => {
+        resolveRetry(buildResult());
+      });
+      expect(await screen.findByText("Punk IPA")).toBeTruthy();
+    });
+
     describe("unknown beer graceful UX (Issue #796)", () => {
       let openUrlSpy: jest.SpyInstance;
 

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -7,6 +7,7 @@ import {
   waitFor,
 } from "@testing-library/react-native";
 import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { BeerInfoCardScreen } from "@/features/scan/presentation/BeerInfoCardScreen";
 import { getMatchingRecipes } from "@/features/scan/application/recipe-matching.use-cases";
@@ -64,6 +65,22 @@ const mockedImport = importRecipeFromCommunity as jest.MockedFunction<
 const mockedMatching = getMatchingRecipes as jest.MockedFunction<
   typeof getMatchingRecipes
 >;
+
+// The screen now fetches via TanStack Query, so it must render inside a
+// QueryClientProvider. A fresh client per render keeps the cache from
+// leaking between tests; retry is off so rejected mocks surface their
+// error state immediately (no retry/backoff delays).
+function renderScreen(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
 
 // Default matching response — Punk IPA scan returns a curated trio
 // of equivalent IPA-family recipes. Tests can override per case.
@@ -157,7 +174,7 @@ describe("BeerInfoCardScreen", () => {
     it("renders hero, at-a-glance words, and recipes for a known beer", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       expect(await screen.findByText("Punk IPA")).toBeTruthy();
       expect(screen.getByText("BrewDog")).toBeTruthy();
@@ -178,7 +195,7 @@ describe("BeerInfoCardScreen", () => {
     it("calls the use-case with the barcode from the route param", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Punk IPA");
       expect(mockedLookup).toHaveBeenCalledWith("5060277380019");
@@ -187,7 +204,7 @@ describe("BeerInfoCardScreen", () => {
     it("handles barcodeParam passed as an array (Expo Router edge case)", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(
+      renderScreen(
         <BeerInfoCardScreen
           barcodeParam={["5060277380019", "extra"] as string[]}
         />,
@@ -211,7 +228,7 @@ describe("BeerInfoCardScreen", () => {
         }),
       );
 
-      render(<BeerInfoCardScreen barcodeParam="0000000000000" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="0000000000000" />);
 
       expect(await screen.findByText("Mystery Beer")).toBeTruthy();
       const inconnuLabels = screen.getAllByText("Inconnu");
@@ -223,7 +240,7 @@ describe("BeerInfoCardScreen", () => {
         buildResult({ abv: null, ibu: null, colorEbc: null }),
       );
 
-      render(<BeerInfoCardScreen barcodeParam="0000000000000" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="0000000000000" />);
 
       await screen.findByText("Punk IPA");
       expect(screen.getByText("—")).toBeTruthy();
@@ -234,7 +251,7 @@ describe("BeerInfoCardScreen", () => {
     it("does not render technical details before the fold is opened", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Punk IPA");
       // "Notes aromatiques" is inside Technical Details fold
@@ -244,7 +261,7 @@ describe("BeerInfoCardScreen", () => {
     it("renders technical details after the fold is opened", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Punk IPA");
       fireEvent.press(
@@ -258,7 +275,7 @@ describe("BeerInfoCardScreen", () => {
     it("renders the curated brewery story when the fold is opened (BrewDog)", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Punk IPA");
       fireEvent.press(
@@ -273,7 +290,7 @@ describe("BeerInfoCardScreen", () => {
         buildResult({ brewery: "Unknown Brewery" }),
       );
 
-      render(<BeerInfoCardScreen barcodeParam="0000000000000" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="0000000000000" />);
 
       await screen.findByText("Punk IPA");
       fireEvent.press(
@@ -290,7 +307,7 @@ describe("BeerInfoCardScreen", () => {
         new ScanLookupBeerNotFoundError("0000000000000"),
       );
 
-      render(<BeerInfoCardScreen barcodeParam="0000000000000" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="0000000000000" />);
 
       expect(
         await screen.findByText(/n'est pas dans notre catalogue/),
@@ -302,7 +319,7 @@ describe("BeerInfoCardScreen", () => {
         new ScanLookupServiceUnavailableError("5060277380019"),
       );
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       expect(
         await screen.findByText(/temporairement indisponible/),
@@ -327,7 +344,7 @@ describe("BeerInfoCardScreen", () => {
           new ScanLookupBeerNotFoundError("3760215750042"),
         );
 
-        render(<BeerInfoCardScreen barcodeParam="3760215750042" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="3760215750042" />);
 
         await screen.findByText(/n'est pas dans notre catalogue/);
         expect(screen.getByText("3760215750042")).toBeTruthy();
@@ -339,7 +356,7 @@ describe("BeerInfoCardScreen", () => {
           new ScanLookupBeerNotFoundError("3760215750042"),
         );
 
-        render(<BeerInfoCardScreen barcodeParam="3760215750042" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="3760215750042" />);
 
         const cta = await screen.findByLabelText(
           /Suggérer une correction par email/i,
@@ -358,7 +375,7 @@ describe("BeerInfoCardScreen", () => {
           new ScanLookupBeerNotFoundError("3760215750042"),
         );
 
-        render(<BeerInfoCardScreen barcodeParam="3760215750042" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="3760215750042" />);
 
         const cta = await screen.findByLabelText(
           /Ajouter cette bière au catalogue par email/i,
@@ -377,7 +394,7 @@ describe("BeerInfoCardScreen", () => {
           new ScanLookupServiceUnavailableError("5060277380019"),
         );
 
-        render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
         await screen.findByText(/temporairement indisponible/);
         expect(screen.queryByText(/Code-barres scanné/i)).toBeNull();
@@ -393,7 +410,7 @@ describe("BeerInfoCardScreen", () => {
           new ScanLookupNotABeerError("5449000000996", "Coca-Cola Original"),
         );
 
-        render(<BeerInfoCardScreen barcodeParam="5449000000996" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="5449000000996" />);
 
         expect(await screen.findByText(/Coca-Cola Original/i)).toBeTruthy();
         expect(screen.getByText(/ce n'est pas une bière/i)).toBeTruthy();
@@ -409,7 +426,7 @@ describe("BeerInfoCardScreen", () => {
           new ScanLookupNotABeerError("5449000000996", null),
         );
 
-        render(<BeerInfoCardScreen barcodeParam="5449000000996" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="5449000000996" />);
 
         expect(
           await screen.findByText(/Ce produit n'est pas une bière/i),
@@ -421,7 +438,7 @@ describe("BeerInfoCardScreen", () => {
           new ScanLookupNotABeerError("5449000000996", "Coca-Cola Original"),
         );
 
-        render(<BeerInfoCardScreen barcodeParam="5449000000996" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="5449000000996" />);
 
         const cta = await screen.findByLabelText(
           /Retourner au scan pour tenter une autre bouteille/i,
@@ -435,7 +452,7 @@ describe("BeerInfoCardScreen", () => {
     describe("photo fallback CTA on invalid barcode (Issue #797)", () => {
       it("renders 'Photographier l'étiquette' CTA when the screen lands without a barcode param", async () => {
         // No barcodeParam → sets ERROR_INVALID directly without hitting the lookup.
-        render(<BeerInfoCardScreen barcodeParam={undefined} />);
+        renderScreen(<BeerInfoCardScreen barcodeParam={undefined} />);
 
         expect(
           await screen.findByLabelText(/Photographier l'étiquette/i),
@@ -444,7 +461,7 @@ describe("BeerInfoCardScreen", () => {
       });
 
       it("opens an informational alert referencing v0.2 / epic #751 when the CTA is pressed", async () => {
-        render(<BeerInfoCardScreen barcodeParam={undefined} />);
+        renderScreen(<BeerInfoCardScreen barcodeParam={undefined} />);
 
         const cta = await screen.findByLabelText(/Photographier l'étiquette/i);
         fireEvent.press(cta);
@@ -461,7 +478,7 @@ describe("BeerInfoCardScreen", () => {
           new ScanLookupBeerNotFoundError("3760215750042"),
         );
 
-        render(<BeerInfoCardScreen barcodeParam="3760215750042" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="3760215750042" />);
 
         await screen.findByText(/n'est pas dans notre catalogue/);
         expect(
@@ -505,7 +522,7 @@ describe("BeerInfoCardScreen", () => {
         name: "Session IPA Citra",
       });
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       const row = await screen.findByLabelText(/Importer Session IPA Citra/);
       await act(async () => {
@@ -545,7 +562,7 @@ describe("BeerInfoCardScreen", () => {
         name: "Session IPA Citra",
       });
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       const row = await screen.findByLabelText(/Importer Session IPA Citra/);
       await act(async () => {
@@ -579,7 +596,7 @@ describe("BeerInfoCardScreen", () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
       mockedImport.mockRejectedValueOnce(new Error("boom"));
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       const row = await screen.findByLabelText(/Importer Session IPA Citra/);
       await act(async () => {
@@ -599,7 +616,7 @@ describe("BeerInfoCardScreen", () => {
     describe("pre-flight confirmation modal (Issue #766)", () => {
       it("opens a confirmation Alert with the recipe name on tap", async () => {
         mockedLookup.mockResolvedValueOnce(buildResult());
-        render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
         const row = await screen.findByLabelText(/Importer Session IPA Citra/);
         await act(async () => {
@@ -618,7 +635,7 @@ describe("BeerInfoCardScreen", () => {
 
       it("does not call the import API when the user taps Annuler", async () => {
         mockedLookup.mockResolvedValueOnce(buildResult());
-        render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+        renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
         const row = await screen.findByLabelText(/Importer Session IPA Citra/);
         await act(async () => {
@@ -649,7 +666,7 @@ describe("BeerInfoCardScreen", () => {
         lowConfidence: true,
       });
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       const warning = await screen.findByText(
         /Aucune recette très similaire dans la base/,
@@ -661,7 +678,7 @@ describe("BeerInfoCardScreen", () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
       // default beforeEach already sets lowConfidence: false
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       // Wait for the rankings to be rendered (find the first equivalent).
       await screen.findByText("Session IPA Citra");
@@ -688,7 +705,7 @@ describe("BeerInfoCardScreen", () => {
         lowConfidence: false,
       });
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       // Official section title appears.
       const officialTitle = await screen.findByText(/🏆 Recette officielle/);
@@ -703,7 +720,7 @@ describe("BeerInfoCardScreen", () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
       // default mock: PUNK_IPA_MATCHES — no isOfficial=true
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Session IPA Citra");
       expect(screen.queryByText(/🏆 Recette officielle/)).toBeNull();
@@ -728,7 +745,7 @@ describe("BeerInfoCardScreen", () => {
         lowConfidence: false,
       });
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       await screen.findByText("Session IPA Citra");
       expect(screen.getByText("NEIPA Tropical")).toBeTruthy();
@@ -744,7 +761,7 @@ describe("BeerInfoCardScreen", () => {
         lowConfidence: false,
       });
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       const empty = await screen.findByText(
         /Aucune recette équivalente n'a encore été partagée/,
@@ -771,7 +788,7 @@ describe("BeerInfoCardScreen", () => {
         lowConfidence: true,
       });
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       // Official section appears.
       expect(await screen.findByText(/🏆 Recette officielle/)).toBeTruthy();
@@ -785,7 +802,7 @@ describe("BeerInfoCardScreen", () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
       mockedMatching.mockRejectedValueOnce(new Error("network"));
 
-      render(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
       const errorMsg = await screen.findByText(
         /Impossible de charger les recettes équivalentes/,


### PR DESCRIPTION
## Summary

Migrates `BeerInfoCardScreen` from hand-rolled `useState`+`useEffect` data-fetching to TanStack Query, aligning it with every other data screen in the app (mobile CLAUDE.md: no `useState`+`useEffect` for remote data). Last useState/useEffect remote-fetch removed from the screen.

## Context

- **Beer lookup** → `useQuery` (`retry: false`). Typed business errors (not-found, not-a-beer, invalid, unavailable) map to the same `ScreenStatus` variants via the **unchanged `mapErrorToStatus`**; recoverable variants keep their manual "Réessayer" wired to `refetch()`.
- **Equivalent recipes** → `useQuery` (`retry: false`; error surfaces the existing load-error card).
- **Community import** → `useMutation` (`isPending` replaces the manual `importingId` state).
- Drive-by fix: the per-row import spinner is now keyed by `recipeId`, fixing a latent live-mode mismatch where `getImportSourceId` can return `publicRecipeId` (≠ `recipeId`), so the spinner never highlighted the right row in live mode.

No UI or error-handling behaviour changes — only the fetch plumbing, which now gains caching + request dedup.

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format)
- [x] `BeerInfoCardScreen` tests green — 34/34 (happy / not-found / unavailable+retry / not-a-beer / import success+error+confirm / matching official+equivalents+empty+error+low-confidence)
- [x] Tests wrap the screen in a per-test `QueryClientProvider` (retry off)
- [x] No `any`, named exports only, no direct `fetch`

Part of #1128. Closes #1133.