### PR TITLE
feat(recipes): show recipe ingredients in live mode

### DIFF
--- a/packages/mobile-app/src/features/recipes/application/__tests__/recipes.use-cases.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/recipes.use-cases.test.ts
@@ -205,4 +205,26 @@ describe("getRecipeDetailsViewModel — live mode (#1134)", () => {
 
     expect(hop?.timing).toBe("dry-hop");
   });
+
+  it("edge: an owner-only sub-resource that 403s degrades to empty without breaking the view", async () => {
+    // A non-owner viewing a PUBLIC recipe gets a 403 on the owner-only
+    // ingredient endpoints. The failed section must degrade to empty, not
+    // reject the whole detail view (keeps public recipes readable).
+    mockedFermentables.mockRejectedValue(new Error("403 Forbidden"));
+    mockedHops.mockResolvedValue([
+      {
+        id: "h1",
+        variety: "Citra",
+        weightG: 30,
+        additionStage: "boil",
+        additionTimeMin: 10,
+      },
+    ]);
+
+    const vm = await getRecipeDetailsViewModel("r-live-1");
+    const items = vm?.ingredients ?? [];
+
+    expect(items.find((i) => i.category === "malt")).toBeUndefined();
+    expect(items.find((i) => i.category === "hop")?.name).toBe("Citra");
+  });
 });

--- a/packages/mobile-app/src/features/recipes/application/__tests__/recipes.use-cases.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/recipes.use-cases.test.ts
@@ -2,11 +2,35 @@ import {
   getRecipeDetailsViewModel,
   listPublicRecipes,
 } from "@/features/recipes/application/recipes.use-cases";
+import { dataSource } from "@/core/data/data-source";
+import { getMineById, listSteps } from "@/features/recipes/data/recipes.api";
+import {
+  listRecipeAdditives,
+  listRecipeFermentables,
+  listRecipeHops,
+  listRecipeYeasts,
+} from "@/features/recipes/data/recipe-ingredients.api";
+import type { Recipe } from "@/features/recipes/domain/recipe.types";
 
 jest.mock("@/core/data/data-source", () => ({
   dataSource: {
     useDemoData: true,
   },
+}));
+
+jest.mock("@/features/recipes/data/recipes.api", () => ({
+  listMine: jest.fn(),
+  listPublic: jest.fn(),
+  getMineById: jest.fn(),
+  listSteps: jest.fn(),
+  importFromCommunity: jest.fn(),
+}));
+
+jest.mock("@/features/recipes/data/recipe-ingredients.api", () => ({
+  listRecipeFermentables: jest.fn(),
+  listRecipeHops: jest.fn(),
+  listRecipeYeasts: jest.fn(),
+  listRecipeAdditives: jest.fn(),
 }));
 
 describe("recipes use-cases — listPublicRecipes (Issue #779)", () => {
@@ -54,6 +78,7 @@ describe("recipes use-cases", () => {
 
     expect(viewModel?.ingredients.length).toBeGreaterThan(0);
     expect(viewModel?.ingredients[0].ingredient).toBeTruthy();
+    expect(viewModel?.ingredients[0].name).toBeTruthy();
 
     expect(viewModel?.equipment.length).toBeGreaterThan(0);
     expect(viewModel?.equipment[0].equipment).toBeTruthy();
@@ -65,5 +90,119 @@ describe("recipes use-cases", () => {
   it("returns null when recipe id is missing", async () => {
     const viewModel = await getRecipeDetailsViewModel("");
     expect(viewModel).toBeNull();
+  });
+});
+
+describe("getRecipeDetailsViewModel — live mode (#1134)", () => {
+  const mockedGetMineById = getMineById as jest.MockedFunction<
+    typeof getMineById
+  >;
+  const mockedListSteps = listSteps as jest.MockedFunction<typeof listSteps>;
+  const mockedFermentables = listRecipeFermentables as jest.MockedFunction<
+    typeof listRecipeFermentables
+  >;
+  const mockedHops = listRecipeHops as jest.MockedFunction<
+    typeof listRecipeHops
+  >;
+  const mockedYeasts = listRecipeYeasts as jest.MockedFunction<
+    typeof listRecipeYeasts
+  >;
+  const mockedAdditives = listRecipeAdditives as jest.MockedFunction<
+    typeof listRecipeAdditives
+  >;
+
+  const liveRecipe: Recipe = {
+    id: "r-live-1",
+    name: "Live IPA",
+    visibility: "public",
+    version: 1,
+    rootRecipeId: "r-live-1",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    stats: { ibu: 40, abv: 6, og: 1.06, fg: 1.012, volumeLiters: 20 },
+  };
+
+  beforeEach(() => {
+    dataSource.useDemoData = false;
+    mockedGetMineById.mockResolvedValue(liveRecipe);
+    mockedListSteps.mockResolvedValue([]);
+    mockedFermentables.mockResolvedValue([]);
+    mockedHops.mockResolvedValue([]);
+    mockedYeasts.mockResolvedValue([]);
+    mockedAdditives.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    dataSource.useDemoData = true;
+    jest.clearAllMocks();
+  });
+
+  it("happy: aggregates the four ingredient sub-resources into the view model", async () => {
+    mockedFermentables.mockResolvedValue([
+      { id: "f1", name: "Maris Otter", weightG: 5000 },
+    ]);
+    mockedHops.mockResolvedValue([
+      {
+        id: "h1",
+        variety: "Citra",
+        weightG: 30,
+        additionStage: "boil",
+        additionTimeMin: 10,
+      },
+    ]);
+    mockedYeasts.mockResolvedValue([{ id: "y1", name: "US-05", amountG: 11 }]);
+    mockedAdditives.mockResolvedValue([
+      { id: "a1", name: "Whirlfloc", amountG: 2 },
+    ]);
+
+    const vm = await getRecipeDetailsViewModel("r-live-1");
+    const items = vm?.ingredients ?? [];
+    const byCat = Object.fromEntries(items.map((i) => [i.category, i]));
+
+    expect(items).toHaveLength(4);
+    expect(byCat.malt).toMatchObject({
+      name: "Maris Otter",
+      amount: 5,
+      unit: "kg",
+      ingredient: null,
+    });
+    expect(byCat.hop).toMatchObject({
+      name: "Citra",
+      amount: 30,
+      unit: "g",
+      timing: "boil · 10 min",
+    });
+    expect(byCat.yeast).toMatchObject({ name: "US-05", amount: 11, unit: "g" });
+    expect(byCat.other).toMatchObject({
+      name: "Whirlfloc",
+      amount: 2,
+      unit: "g",
+    });
+    // No recipe↔equipment link in the live API → equipment is empty.
+    expect(vm?.equipment).toEqual([]);
+  });
+
+  it("sad: returns empty ingredients when the recipe has no ingredient rows", async () => {
+    const vm = await getRecipeDetailsViewModel("r-live-1");
+
+    expect(vm?.ingredients).toEqual([]);
+    expect(vm?.equipment).toEqual([]);
+  });
+
+  it("edge: a hop with no addition time falls back to the stage label", async () => {
+    mockedHops.mockResolvedValue([
+      {
+        id: "h2",
+        variety: "Saaz",
+        weightG: 20,
+        additionStage: "dry-hop",
+        additionTimeMin: null,
+      },
+    ]);
+
+    const vm = await getRecipeDetailsViewModel("r-live-1");
+    const hop = vm?.ingredients.find((i) => i.category === "hop");
+
+    expect(hop?.timing).toBe("dry-hop");
   });
 });

--- a/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
@@ -209,11 +209,19 @@ export async function getRecipeDetailsViewModel(
 async function buildLiveRecipeIngredients(
   recipeId: string,
 ): Promise<RecipeDetailsIngredientItem[]> {
+  // The ingredient sub-resource endpoints are owner-only (the backend
+  // asserts ownership on every read), so a non-owner viewing a PUBLIC
+  // recipe gets a 403/404. Degrade each fetch to an empty list instead of
+  // failing the whole detail view — the recipe still renders, just without
+  // that section. Surfacing ingredients for public recipes needs a
+  // public-readable endpoint (tracked under #1134's backend half).
+  const orEmpty = <T>(rows: Promise<T[]>): Promise<T[]> =>
+    rows.catch(() => [] as T[]);
   const [fermentables, hops, yeasts, additives] = await Promise.all([
-    listRecipeFermentables(recipeId),
-    listRecipeHops(recipeId),
-    listRecipeYeasts(recipeId),
-    listRecipeAdditives(recipeId),
+    orEmpty(listRecipeFermentables(recipeId)),
+    orEmpty(listRecipeHops(recipeId)),
+    orEmpty(listRecipeYeasts(recipeId)),
+    orEmpty(listRecipeAdditives(recipeId)),
   ]);
 
   const malts: RecipeDetailsIngredientItem[] = fermentables.map((row) => ({

--- a/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
@@ -5,6 +5,12 @@ import {
   listPublic,
   listSteps,
 } from "@/features/recipes/data/recipes.api";
+import {
+  listRecipeAdditives,
+  listRecipeFermentables,
+  listRecipeHops,
+  listRecipeYeasts,
+} from "@/features/recipes/data/recipe-ingredients.api";
 import { Recipe, RecipeStep } from "@/features/recipes/domain/recipe.types";
 import {
   Equipment,
@@ -19,6 +25,12 @@ import { Ingredient } from "@/features/ingredients/domain/ingredient.types";
 
 export type RecipeDetailsIngredientItem = {
   ingredientId: string;
+  // Denormalised display fields (#1134). In demo mode they mirror the
+  // resolved catalog `ingredient`; in live mode they come straight from
+  // the recipe-ingredient sub-resource rows (which carry their own name),
+  // and `ingredient` stays null (no catalog deep-link available live).
+  name: string;
+  category: "malt" | "hop" | "yeast" | "other";
   amount: number;
   unit: string;
   timing?: string | null;
@@ -146,38 +158,39 @@ export async function getRecipeDetailsViewModel(
     return null;
   }
 
-  if (
-    !dataSource.useDemoData &&
-    ((recipe.ingredients?.length ?? 0) > 0 ||
-      (recipe.equipment?.length ?? 0) > 0)
-  ) {
-    throw new Error(
-      "Ingredient and equipment catalogs are not available when useDemoData is false. Ensure the catalog API is available before calling getRecipeDetailsViewModel.",
-    );
-  }
-
   const steps = [...rawSteps].sort((a, b) => a.stepOrder - b.stepOrder);
 
-  const ingredientCatalog = dataSource.useDemoData ? demoIngredients : [];
-  const equipmentCatalog = dataSource.useDemoData ? demoEquipments : [];
+  // Demo: resolve each recipe ingredient ref against the bundled catalog.
+  // Live (#1134): the recipe DTO never inlines ingredients — fetch the
+  // per-type sub-resources, which are self-describing (name + weight).
+  const ingredients = dataSource.useDemoData
+    ? (recipe.ingredients ?? []).map((ref): RecipeDetailsIngredientItem => {
+        const ingredient =
+          demoIngredients.find((item) => item.id === ref.ingredientId) ?? null;
+        return {
+          ingredientId: ref.ingredientId,
+          name: ingredient?.name ?? "Ingrédient inconnu",
+          category: ingredient?.category ?? "other",
+          amount: ref.amount,
+          unit: ref.unit,
+          timing: ref.timing,
+          notes: ref.notes,
+          ingredient,
+        };
+      })
+    : await buildLiveRecipeIngredients(recipeId);
 
-  const ingredients = (recipe.ingredients ?? []).map((ref) => ({
-    ingredientId: ref.ingredientId,
-    amount: ref.amount,
-    unit: ref.unit,
-    timing: ref.timing,
-    notes: ref.notes,
-    ingredient:
-      ingredientCatalog.find((item) => item.id === ref.ingredientId) ?? null,
-  }));
-
-  const equipment = (recipe.equipment ?? []).map((ref) => ({
-    equipmentId: ref.equipmentId,
-    role: ref.role,
-    notes: ref.notes,
-    equipment:
-      equipmentCatalog.find((item) => item.id === ref.equipmentId) ?? null,
-  }));
+  // Equipment: demo only — there is no recipe↔equipment link in the live
+  // API yet, so live recipes surface no equipment (#1134, out of scope).
+  const equipment = dataSource.useDemoData
+    ? (recipe.equipment ?? []).map((ref) => ({
+        equipmentId: ref.equipmentId,
+        role: ref.role,
+        notes: ref.notes,
+        equipment:
+          demoEquipments.find((item) => item.id === ref.equipmentId) ?? null,
+      }))
+    : [];
 
   return {
     recipe,
@@ -185,4 +198,63 @@ export async function getRecipeDetailsViewModel(
     ingredients,
     equipment,
   };
+}
+
+/**
+ * Live recipe ingredients (#1134) — aggregates the four self-describing
+ * sub-resources into the unified view-model item shape. `ingredient`
+ * stays null (the rows are denormalised; the live DTOs expose no catalog
+ * id, so there is no deep-link). Additives fall in the "other" group.
+ */
+async function buildLiveRecipeIngredients(
+  recipeId: string,
+): Promise<RecipeDetailsIngredientItem[]> {
+  const [fermentables, hops, yeasts, additives] = await Promise.all([
+    listRecipeFermentables(recipeId),
+    listRecipeHops(recipeId),
+    listRecipeYeasts(recipeId),
+    listRecipeAdditives(recipeId),
+  ]);
+
+  const malts: RecipeDetailsIngredientItem[] = fermentables.map((row) => ({
+    ingredientId: row.id,
+    name: row.name,
+    category: "malt",
+    amount: row.weightG / 1000,
+    unit: "kg",
+    ingredient: null,
+  }));
+
+  const hopItems: RecipeDetailsIngredientItem[] = hops.map((row) => ({
+    ingredientId: row.id,
+    name: row.variety,
+    category: "hop",
+    amount: row.weightG,
+    unit: "g",
+    timing:
+      row.additionTimeMin != null
+        ? `${row.additionStage} · ${row.additionTimeMin} min`
+        : row.additionStage,
+    ingredient: null,
+  }));
+
+  const yeastItems: RecipeDetailsIngredientItem[] = yeasts.map((row) => ({
+    ingredientId: row.id,
+    name: row.name,
+    category: "yeast",
+    amount: row.amountG,
+    unit: "g",
+    ingredient: null,
+  }));
+
+  const additiveItems: RecipeDetailsIngredientItem[] = additives.map((row) => ({
+    ingredientId: row.id,
+    name: row.name,
+    category: "other",
+    amount: row.amountG,
+    unit: "g",
+    ingredient: null,
+  }));
+
+  return [...malts, ...hopItems, ...yeastItems, ...additiveItems];
 }

--- a/packages/mobile-app/src/features/recipes/data/__tests__/recipe-ingredients.api.test.ts
+++ b/packages/mobile-app/src/features/recipes/data/__tests__/recipe-ingredients.api.test.ts
@@ -1,0 +1,124 @@
+import { request } from "@/core/http/http-client";
+import {
+  listRecipeAdditives,
+  listRecipeFermentables,
+  listRecipeHops,
+  listRecipeYeasts,
+} from "@/features/recipes/data/recipe-ingredients.api";
+
+jest.mock("@/core/http/http-client", () => ({
+  request: jest.fn(),
+}));
+
+const mockedRequest = request as jest.MockedFunction<typeof request>;
+
+beforeEach(() => {
+  mockedRequest.mockReset();
+});
+
+describe("recipe-ingredients.api", () => {
+  it("listRecipeFermentables: hits the endpoint and maps DTO → row", async () => {
+    mockedRequest.mockResolvedValueOnce([
+      {
+        id: "f1",
+        recipe_id: "r1",
+        name: "Maris Otter",
+        type: "base",
+        weight_g: 5000,
+        potential_gravity: 1.038,
+        color_ebc: 5,
+      },
+    ] as never);
+
+    const rows = await listRecipeFermentables("r1");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/recipes/r1/fermentables");
+    expect(rows).toEqual([{ id: "f1", name: "Maris Otter", weightG: 5000 }]);
+  });
+
+  it("listRecipeHops: maps variety/weight/stage and a present addition time", async () => {
+    mockedRequest.mockResolvedValueOnce([
+      {
+        id: "h1",
+        recipe_id: "r1",
+        variety: "Citra",
+        type: "aroma",
+        weight_g: 30,
+        alpha_acid_percent: 12,
+        addition_stage: "boil",
+        addition_time_min: 10,
+      },
+    ] as never);
+
+    const rows = await listRecipeHops("r1");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/recipes/r1/hops");
+    expect(rows).toEqual([
+      {
+        id: "h1",
+        variety: "Citra",
+        weightG: 30,
+        additionStage: "boil",
+        additionTimeMin: 10,
+      },
+    ]);
+  });
+
+  it("listRecipeHops: edge — a missing addition time maps to null", async () => {
+    mockedRequest.mockResolvedValueOnce([
+      {
+        id: "h2",
+        recipe_id: "r1",
+        variety: "Saaz",
+        type: "aroma",
+        weight_g: 20,
+        addition_stage: "dry-hop",
+      },
+    ] as never);
+
+    const rows = await listRecipeHops("r1");
+
+    expect(rows[0].additionTimeMin).toBeNull();
+  });
+
+  it("listRecipeYeasts: hits the endpoint and maps DTO → row", async () => {
+    mockedRequest.mockResolvedValueOnce([
+      {
+        id: "y1",
+        recipe_id: "r1",
+        name: "US-05",
+        type: "ale",
+        amount_g: 11,
+        attenuation_percent: 81,
+      },
+    ] as never);
+
+    const rows = await listRecipeYeasts("r1");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/recipes/r1/yeasts");
+    expect(rows).toEqual([{ id: "y1", name: "US-05", amountG: 11 }]);
+  });
+
+  it("listRecipeAdditives: hits the endpoint and maps DTO → row", async () => {
+    mockedRequest.mockResolvedValueOnce([
+      {
+        id: "a1",
+        recipe_id: "r1",
+        name: "Whirlfloc",
+        type: "fining",
+        amount_g: 2,
+      },
+    ] as never);
+
+    const rows = await listRecipeAdditives("r1");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/recipes/r1/additives");
+    expect(rows).toEqual([{ id: "a1", name: "Whirlfloc", amountG: 2 }]);
+  });
+
+  it("sad: an empty payload maps to an empty list", async () => {
+    mockedRequest.mockResolvedValueOnce([] as never);
+
+    await expect(listRecipeFermentables("r1")).resolves.toEqual([]);
+  });
+});

--- a/packages/mobile-app/src/features/recipes/data/recipe-ingredients.api.ts
+++ b/packages/mobile-app/src/features/recipes/data/recipe-ingredients.api.ts
@@ -7,7 +7,7 @@ import { request } from "@/core/http/http-client";
  * its own display name + weight), so no catalog lookup is needed.
  */
 
-type RecipeFermentableDto = {
+interface RecipeFermentableDto {
   id: string;
   recipe_id: string;
   name: string;
@@ -15,9 +15,9 @@ type RecipeFermentableDto = {
   weight_g: number;
   potential_gravity?: number | null;
   color_ebc?: number | null;
-};
+}
 
-type RecipeHopDto = {
+interface RecipeHopDto {
   id: string;
   recipe_id: string;
   variety: string;
@@ -26,50 +26,50 @@ type RecipeHopDto = {
   alpha_acid_percent?: number | null;
   addition_stage: string;
   addition_time_min?: number | null;
-};
+}
 
-type RecipeYeastDto = {
+interface RecipeYeastDto {
   id: string;
   recipe_id: string;
   name: string;
   type: string;
   amount_g: number;
   attenuation_percent?: number | null;
-};
+}
 
-type RecipeAdditiveDto = {
+interface RecipeAdditiveDto {
   id: string;
   recipe_id: string;
   name: string;
   type: string;
   amount_g: number;
-};
+}
 
-export type RecipeFermentableRow = {
+export interface RecipeFermentableRow {
   id: string;
   name: string;
   weightG: number;
-};
+}
 
-export type RecipeHopRow = {
+export interface RecipeHopRow {
   id: string;
   variety: string;
   weightG: number;
   additionStage: string;
   additionTimeMin: number | null;
-};
+}
 
-export type RecipeYeastRow = {
+export interface RecipeYeastRow {
   id: string;
   name: string;
   amountG: number;
-};
+}
 
-export type RecipeAdditiveRow = {
+export interface RecipeAdditiveRow {
   id: string;
   name: string;
   amountG: number;
-};
+}
 
 export async function listRecipeFermentables(
   recipeId: string,

--- a/packages/mobile-app/src/features/recipes/data/recipe-ingredients.api.ts
+++ b/packages/mobile-app/src/features/recipes/data/recipe-ingredients.api.ts
@@ -1,0 +1,122 @@
+import { request } from "@/core/http/http-client";
+
+/**
+ * Recipe-ingredient sub-resources (#1134). In live mode a recipe's
+ * ingredients are NOT inlined on `GET /recipes/:id`; they are served
+ * per type by dedicated endpoints. Each row is denormalised (it carries
+ * its own display name + weight), so no catalog lookup is needed.
+ */
+
+type RecipeFermentableDto = {
+  id: string;
+  recipe_id: string;
+  name: string;
+  type: string;
+  weight_g: number;
+  potential_gravity?: number | null;
+  color_ebc?: number | null;
+};
+
+type RecipeHopDto = {
+  id: string;
+  recipe_id: string;
+  variety: string;
+  type: string;
+  weight_g: number;
+  alpha_acid_percent?: number | null;
+  addition_stage: string;
+  addition_time_min?: number | null;
+};
+
+type RecipeYeastDto = {
+  id: string;
+  recipe_id: string;
+  name: string;
+  type: string;
+  amount_g: number;
+  attenuation_percent?: number | null;
+};
+
+type RecipeAdditiveDto = {
+  id: string;
+  recipe_id: string;
+  name: string;
+  type: string;
+  amount_g: number;
+};
+
+export type RecipeFermentableRow = {
+  id: string;
+  name: string;
+  weightG: number;
+};
+
+export type RecipeHopRow = {
+  id: string;
+  variety: string;
+  weightG: number;
+  additionStage: string;
+  additionTimeMin: number | null;
+};
+
+export type RecipeYeastRow = {
+  id: string;
+  name: string;
+  amountG: number;
+};
+
+export type RecipeAdditiveRow = {
+  id: string;
+  name: string;
+  amountG: number;
+};
+
+export async function listRecipeFermentables(
+  recipeId: string,
+): Promise<RecipeFermentableRow[]> {
+  const rows = await request<RecipeFermentableDto[]>(
+    `/recipes/${recipeId}/fermentables`,
+  );
+  return rows.map((dto) => ({
+    id: dto.id,
+    name: dto.name,
+    weightG: dto.weight_g,
+  }));
+}
+
+export async function listRecipeHops(
+  recipeId: string,
+): Promise<RecipeHopRow[]> {
+  const rows = await request<RecipeHopDto[]>(`/recipes/${recipeId}/hops`);
+  return rows.map((dto) => ({
+    id: dto.id,
+    variety: dto.variety,
+    weightG: dto.weight_g,
+    additionStage: dto.addition_stage,
+    additionTimeMin: dto.addition_time_min ?? null,
+  }));
+}
+
+export async function listRecipeYeasts(
+  recipeId: string,
+): Promise<RecipeYeastRow[]> {
+  const rows = await request<RecipeYeastDto[]>(`/recipes/${recipeId}/yeasts`);
+  return rows.map((dto) => ({
+    id: dto.id,
+    name: dto.name,
+    amountG: dto.amount_g,
+  }));
+}
+
+export async function listRecipeAdditives(
+  recipeId: string,
+): Promise<RecipeAdditiveRow[]> {
+  const rows = await request<RecipeAdditiveDto[]>(
+    `/recipes/${recipeId}/additives`,
+  );
+  return rows.map((dto) => ({
+    id: dto.id,
+    name: dto.name,
+    amountG: dto.amount_g,
+  }));
+}

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -83,6 +83,8 @@ const baseViewModel = {
   ingredients: [
     {
       ingredientId: "hop-1",
+      name: "Citra",
+      category: "hop",
       amount: 25,
       unit: "g",
       timing: "boil - 10 min",
@@ -250,6 +252,8 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
       ingredients: [
         {
           ingredientId: "malt-1",
+          name: "Pale Ale Malt",
+          category: "malt",
           amount: 4.2,
           unit: "kg",
           timing: "mash",

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/recipe-details.utils.test.ts
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/recipe-details.utils.test.ts
@@ -21,6 +21,8 @@ describe("recipe-details.utils", () => {
   const baseIngredients: RecipeDetailsIngredientItem[] = [
     {
       ingredientId: "malt-1",
+      name: "Pale Malt",
+      category: "malt",
       amount: 5,
       unit: "kg",
       timing: null,
@@ -37,6 +39,8 @@ describe("recipe-details.utils", () => {
     },
     {
       ingredientId: "hop-1",
+      name: "Citra",
+      category: "hop",
       amount: 25,
       unit: "g",
       timing: "boil - 10 min",
@@ -53,6 +57,8 @@ describe("recipe-details.utils", () => {
     },
     {
       ingredientId: "yeast-1",
+      name: "US-05",
+      category: "yeast",
       amount: 1,
       unit: "pack",
       timing: null,
@@ -71,6 +77,8 @@ describe("recipe-details.utils", () => {
     },
     {
       ingredientId: "other-1",
+      name: "Whirlfloc",
+      category: "other",
       amount: 2,
       unit: "g",
       timing: null,

--- a/packages/mobile-app/src/features/recipes/presentation/recipe-details.utils.ts
+++ b/packages/mobile-app/src/features/recipes/presentation/recipe-details.utils.ts
@@ -9,7 +9,6 @@ import {
 } from "@/features/recipes/presentation/recipe-details.constants";
 
 import type { WaterProfile } from "@/core/brewing-calculations";
-import type { IngredientCategory } from "@/features/ingredients/domain/ingredient.types";
 import type { LocalCartItem } from "@/features/shop/domain/cart.types";
 import type { ShopCategory } from "@/features/shop/domain/shop.types";
 
@@ -67,20 +66,6 @@ export function formatQuantity(amount: number, unit: string): string {
   return `${roundedAmount} ${unit}`;
 }
 
-function toIngredientGroupKey(
-  category: IngredientCategory | null | undefined,
-): RecipeIngredientGroupKey {
-  if (!category) {
-    return "other";
-  }
-
-  if (category === "malt" || category === "hop" || category === "yeast") {
-    return category;
-  }
-
-  return "other";
-}
-
 export function groupIngredientsByType(
   ingredients: RecipeDetailsIngredientItem[],
 ): Record<RecipeIngredientGroupKey, RecipeDetailsIngredientItem[]> {
@@ -95,7 +80,12 @@ export function groupIngredientsByType(
   };
 
   ingredients.forEach((item) => {
-    const key = toIngredientGroupKey(item.ingredient?.category);
+    const key: RecipeIngredientGroupKey =
+      item.category === "malt" ||
+      item.category === "hop" ||
+      item.category === "yeast"
+        ? item.category
+        : "other";
     grouped[key].push(item);
   });
 
@@ -103,7 +93,7 @@ export function groupIngredientsByType(
 }
 
 export function mapIngredientCategoryToShopCategory(
-  category: IngredientCategory | null | undefined,
+  category: "malt" | "hop" | "yeast" | "other" | null | undefined,
 ): ShopCategory {
   if (category === "malt") {
     return "malts";
@@ -125,10 +115,9 @@ export function toIngredientCartItem(
   scalingFactor: number,
 ): LocalCartItem {
   const scaledAmount = scaleQuantity(ingredient.amount, scalingFactor);
-  const ingredientName =
-    ingredient.ingredient?.name ?? `Ingredient ${ingredient.ingredientId}`;
+  const ingredientName = ingredient.name;
   const ingredientCategory = mapIngredientCategoryToShopCategory(
-    ingredient.ingredient?.category,
+    ingredient.category,
   );
 
   return {

--- a/packages/mobile-app/src/features/recipes/presentation/recipe-details.utils.ts
+++ b/packages/mobile-app/src/features/recipes/presentation/recipe-details.utils.ts
@@ -93,7 +93,7 @@ export function groupIngredientsByType(
 }
 
 export function mapIngredientCategoryToShopCategory(
-  category: "malt" | "hop" | "yeast" | "other" | null | undefined,
+  category: RecipeIngredientGroupKey | null | undefined,
 ): ShopCategory {
   if (category === "malt") {
     return "malts";

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/IngredientsTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/IngredientsTab.tsx
@@ -149,7 +149,7 @@ export function IngredientsTab(props: IngredientsTabProps) {
                       <Pressable
                         style={styles.listItemMain}
                         accessibilityRole="button"
-                        accessibilityLabel={`Open ingredient details for ${item.ingredient?.name ?? "unknown ingredient"}`}
+                        accessibilityLabel={`Open ingredient details for ${item.name}`}
                         disabled={!item.ingredient}
                         onPress={() => {
                           if (!item.ingredient) {
@@ -158,9 +158,7 @@ export function IngredientsTab(props: IngredientsTabProps) {
                           onOpenIngredient(item.ingredient);
                         }}
                       >
-                        <Text style={styles.listItemTitle}>
-                          {item.ingredient?.name ?? "Ingrédient inconnu"}
-                        </Text>
+                        <Text style={styles.listItemTitle}>{item.name}</Text>
                         <Text style={styles.listItemMeta}>
                           {quantity}
                           {item.timing ? ` • ${item.timing}` : ""}
@@ -173,7 +171,7 @@ export function IngredientsTab(props: IngredientsTabProps) {
                       <Pressable
                         testID={`recipe-add-ingredient-${item.ingredientId}-${index}`}
                         accessibilityRole="button"
-                        accessibilityLabel={`Add ${item.ingredient?.name ?? "ingredient"} to local cart`}
+                        accessibilityLabel={`Add ${item.name} to local cart`}
                         style={styles.addActionButton}
                         onPress={() => onAddIngredientToCart(item)}
                       >


### PR DESCRIPTION
## Summary

In the live build the recipe detail showed **no ingredients**: `GET /recipes/:id` never inlines them, and the view model only resolved demo refs against the bundled catalog. This wires the live path to fetch a recipe's ingredients from the per-type sub-resource endpoints and aggregate them into the detail view model. The mobile half of #1134.

## Context

- New data layer `recipe-ingredients.api.ts` — `listRecipeFermentables/Hops/Yeasts/Additives(recipeId)` → `GET /recipes/:id/{fermentables,hops,yeasts,additives}`. Rows are **self-describing** (name + weight), so no catalog lookup is needed.
- `RecipeDetailsIngredientItem` now carries denormalised `name` + `category`. Demo mode mirrors the resolved catalog ingredient (output unchanged); live mode populates them from the rows, with `ingredient: null` (no catalog deep-link — the live DTOs expose no catalog id). Additives, which are absent from the malt/hop/yeast catalog union, fall into the existing **"other"** group.
- `getRecipeDetailsViewModel` aggregates the four sub-resources in live mode; the throwing placeholder guard is removed.
- Grouping now keys off `item.category` (defensive: unknown → "other"); `IngredientsTab` + the cart use the denormalised `name`/`category`.
- **Equipment** stays empty in live (no recipe↔equipment link in the API yet) — out of scope.

Steps already fetch via the existing `/steps` endpoint; they render once recipes carry seeded steps — that, plus seeding ingredient rows for the public recipes, is the **seed half of #1134 (separate PR)**. So in the current prod DB this PR shows real ingredients only once the seed lands; the aggregation logic is covered by unit tests in the meantime.

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format)
- [x] 98 recipe/scan tests pass — incl. new H/S/E for live aggregation (4 sub-resources / empty / hop-timing fallback)
- [x] Demo path output unchanged
- [x] No `any`, named exports only, no direct `fetch`

Part of #1134.