### PR TITLE
feat(recipes/api): allow reading ingredients of public recipes

### DIFF
--- a/packages/api/src/recipe/recipe-ingredients.service.spec.ts
+++ b/packages/api/src/recipe/recipe-ingredients.service.spec.ts
@@ -422,7 +422,7 @@ describe('RecipeIngredientsService', () => {
       await expect(service.getWater(OTHER, recipe.id)).resolves.toBeNull();
     });
 
-    it('still hides a PRIVATE recipe ingredients from a non-owner', async () => {
+    it("still hides a PRIVATE recipe's ingredients from a non-owner", async () => {
       const recipe = await createRecipe(); // private by default
       await service.addFermentable(OWNER, recipe.id, {
         name: 'Secret Malt',

--- a/packages/api/src/recipe/recipe-ingredients.service.spec.ts
+++ b/packages/api/src/recipe/recipe-ingredients.service.spec.ts
@@ -17,6 +17,7 @@ import { RecipeOrmEntity } from './entities/recipe.orm.entity';
 import { RecipeService } from './services/recipe.service';
 import { RecipeStepOrmEntity } from './entities/recipe-step.orm.entity';
 import { RecipeStepType } from './domain/enums/recipe-step-type.enum';
+import { RecipeVisibility } from './domain/enums/recipe-visibility.enum';
 import { RecipeWaterOrmEntity } from './entities/recipe-water.orm.entity';
 import { RecipeYeastOrmEntity } from './entities/recipe-yeast.orm.entity';
 import { RecipeYeastType } from './domain/enums/recipe-yeast-type.enum';
@@ -387,6 +388,64 @@ describe('RecipeIngredientsService', () => {
       await expect(service.getWater(OTHER, recipe.id)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  // ─── Public-readable reads (#1134) ──────────────────────────────────────────
+
+  describe('public-readable reads (#1134)', () => {
+    async function makePublic(recipeId: string) {
+      await recipeRepo.update(recipeId, {
+        visibility: RecipeVisibility.PUBLIC,
+      });
+    }
+
+    it('lets a non-owner read the ingredients of a PUBLIC recipe', async () => {
+      const recipe = await createRecipe();
+      await service.addFermentable(OWNER, recipe.id, {
+        name: 'Maris Otter',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 5000,
+      });
+      await makePublic(recipe.id);
+
+      // Owner-seeded fermentable is visible to the non-owner viewer, and the
+      // other (empty) ingredient reads no longer throw for a public recipe.
+      await expect(
+        service.listFermentables(OTHER, recipe.id),
+      ).resolves.toHaveLength(1);
+      await expect(service.listHops(OTHER, recipe.id)).resolves.toEqual([]);
+      await expect(service.listYeasts(OTHER, recipe.id)).resolves.toEqual([]);
+      await expect(service.listAdditives(OTHER, recipe.id)).resolves.toEqual(
+        [],
+      );
+      await expect(service.getWater(OTHER, recipe.id)).resolves.toBeNull();
+    });
+
+    it('still hides a PRIVATE recipe ingredients from a non-owner', async () => {
+      const recipe = await createRecipe(); // private by default
+      await service.addFermentable(OWNER, recipe.id, {
+        name: 'Secret Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 1000,
+      });
+
+      await expect(service.listFermentables(OTHER, recipe.id)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('keeps writes owner-only even on a PUBLIC recipe', async () => {
+      const recipe = await createRecipe();
+      await makePublic(recipe.id);
+
+      await expect(
+        service.addFermentable(OTHER, recipe.id, {
+          name: 'Sneaky Malt',
+          type: RecipeFermentableType.GRAIN,
+          weight_g: 1,
+        }),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/packages/api/src/recipe/services/recipe-ingredients.service.ts
+++ b/packages/api/src/recipe/services/recipe-ingredients.service.ts
@@ -25,7 +25,9 @@ import { UpsertRecipeWaterDto } from '../dtos/upsert-recipe-water.dto';
  * Application service for managing recipe ingredients:
  * fermentables, hops, yeasts, additives (1:N) and water profile (1:1).
  *
- * All operations enforce ownership via RecipeService.getMineById().
+ * Writes enforce ownership via RecipeService.getMineById(); reads use
+ * RecipeService.getReadableById() so a viewer can read a PUBLIC recipe's
+ * ingredients (owner or public — #1134), never a private/unlisted one.
  */
 @Injectable()
 export class RecipeIngredientsService {
@@ -49,7 +51,7 @@ export class RecipeIngredientsService {
     ownerId: string,
     recipeId: string,
   ): Promise<RecipeFermentableOrmEntity[]> {
-    await this.assertOwnership(ownerId, recipeId);
+    await this.assertReadable(ownerId, recipeId);
     return this.fermentableRepo.find({
       where: { recipe_id: recipeId },
       order: { created_at: 'ASC' },
@@ -115,7 +117,7 @@ export class RecipeIngredientsService {
     ownerId: string,
     recipeId: string,
   ): Promise<RecipeHopOrmEntity[]> {
-    await this.assertOwnership(ownerId, recipeId);
+    await this.assertReadable(ownerId, recipeId);
     return this.hopRepo.find({
       where: { recipe_id: recipeId },
       order: { created_at: 'ASC' },
@@ -185,7 +187,7 @@ export class RecipeIngredientsService {
     ownerId: string,
     recipeId: string,
   ): Promise<RecipeYeastOrmEntity[]> {
-    await this.assertOwnership(ownerId, recipeId);
+    await this.assertReadable(ownerId, recipeId);
     return this.yeastRepo.find({
       where: { recipe_id: recipeId },
       order: { created_at: 'ASC' },
@@ -255,7 +257,7 @@ export class RecipeIngredientsService {
     ownerId: string,
     recipeId: string,
   ): Promise<RecipeAdditiveOrmEntity[]> {
-    await this.assertOwnership(ownerId, recipeId);
+    await this.assertReadable(ownerId, recipeId);
     return this.additiveRepo.find({
       where: { recipe_id: recipeId },
       order: { created_at: 'ASC' },
@@ -322,7 +324,7 @@ export class RecipeIngredientsService {
     ownerId: string,
     recipeId: string,
   ): Promise<RecipeWaterOrmEntity | null> {
-    await this.assertOwnership(ownerId, recipeId);
+    await this.assertReadable(ownerId, recipeId);
     return this.waterRepo.findOne({ where: { recipe_id: recipeId } });
   }
 
@@ -388,6 +390,20 @@ export class RecipeIngredientsService {
     recipeId: string,
   ): Promise<void> {
     await this.recipeService.getMineById(ownerId, recipeId);
+  }
+
+  /**
+   * Asserts that the recipe is READABLE by the viewer — i.e. they own it
+   * or it is PUBLIC (#1134). Throws NotFoundException otherwise (no leak of
+   * private/unlisted recipes). Used by the read paths so the Catalog / scan
+   * detail can hydrate a public recipe's ingredients; writes keep using
+   * assertOwnership.
+   */
+  private async assertReadable(
+    viewerId: string,
+    recipeId: string,
+  ): Promise<void> {
+    await this.recipeService.getReadableById(viewerId, recipeId);
   }
 
   private async findFermentableOrThrow(

--- a/packages/api/src/recipe/services/recipe-ingredients.service.ts
+++ b/packages/api/src/recipe/services/recipe-ingredients.service.ts
@@ -48,10 +48,10 @@ export class RecipeIngredientsService {
   // ─── Fermentables ───────────────────────────────────────────────────────────
 
   async listFermentables(
-    ownerId: string,
+    viewerId: string,
     recipeId: string,
   ): Promise<RecipeFermentableOrmEntity[]> {
-    await this.assertReadable(ownerId, recipeId);
+    await this.assertReadable(viewerId, recipeId);
     return this.fermentableRepo.find({
       where: { recipe_id: recipeId },
       order: { created_at: 'ASC' },
@@ -114,10 +114,10 @@ export class RecipeIngredientsService {
   // ─── Hops ───────────────────────────────────────────────────────────────────
 
   async listHops(
-    ownerId: string,
+    viewerId: string,
     recipeId: string,
   ): Promise<RecipeHopOrmEntity[]> {
-    await this.assertReadable(ownerId, recipeId);
+    await this.assertReadable(viewerId, recipeId);
     return this.hopRepo.find({
       where: { recipe_id: recipeId },
       order: { created_at: 'ASC' },
@@ -184,10 +184,10 @@ export class RecipeIngredientsService {
   // ─── Yeasts ─────────────────────────────────────────────────────────────────
 
   async listYeasts(
-    ownerId: string,
+    viewerId: string,
     recipeId: string,
   ): Promise<RecipeYeastOrmEntity[]> {
-    await this.assertReadable(ownerId, recipeId);
+    await this.assertReadable(viewerId, recipeId);
     return this.yeastRepo.find({
       where: { recipe_id: recipeId },
       order: { created_at: 'ASC' },
@@ -254,10 +254,10 @@ export class RecipeIngredientsService {
   // ─── Additives ──────────────────────────────────────────────────────────────
 
   async listAdditives(
-    ownerId: string,
+    viewerId: string,
     recipeId: string,
   ): Promise<RecipeAdditiveOrmEntity[]> {
-    await this.assertReadable(ownerId, recipeId);
+    await this.assertReadable(viewerId, recipeId);
     return this.additiveRepo.find({
       where: { recipe_id: recipeId },
       order: { created_at: 'ASC' },
@@ -321,10 +321,10 @@ export class RecipeIngredientsService {
   // ─── Water Profile (1:1) ────────────────────────────────────────────────────
 
   async getWater(
-    ownerId: string,
+    viewerId: string,
     recipeId: string,
   ): Promise<RecipeWaterOrmEntity | null> {
-    await this.assertReadable(ownerId, recipeId);
+    await this.assertReadable(viewerId, recipeId);
     return this.waterRepo.findOne({ where: { recipe_id: recipeId } });
   }
 


### PR DESCRIPTION
## Summary

The recipe ingredient sub-resource GET endpoints (`/recipes/:id/{fermentables,hops,yeasts,additives,water}`) were **owner-only** (`assertOwnership` → `getMineById`), so a viewer browsing a PUBLIC recipe (the Catalog / scan-equivalent target, all owned by the system user) got a 404 and could never see its ingredients. This opens those reads to public recipes — the backend half of #1134.

## Context

- New private guard `assertReadable(viewerId, recipeId)` → `RecipeService.getReadableById` (owner **OR** `visibility === public`, else `NotFoundException` — no leak of private/unlisted recipes). Mirrors how `GET /recipes/:id` and `/recipes/public` already gate public reads.
- Applied to the 5 read methods only: `listFermentables`, `listHops`, `listYeasts`, `listAdditives`, `getWater`.
- **All 14 write methods keep `assertOwnership`** (owner-only) — no change.
- **Steps** were already public-readable (`listMineSteps` uses `getReadableById`); no change needed.
- No migration, no new routes.

## Checklist

- [x] `lint:check` clean, `build` (tsc) green
- [x] 146 recipe-module specs pass, incl. new H/S/E: non-owner reads a PUBLIC recipe's ingredients; a PRIVATE recipe stays hidden from non-owners; writes remain owner-only even on a public recipe
- [x] No private/unlisted leak (NotFound semantics preserved)
- [x] No `any`, named exports, no raw SQL

Part of #1134. Follow-up: seed recipe content (ingredients + steps) so public recipes actually display data.