### PR TITLE
feat(api/seeds): seed ingredients + steps for scan-reachable public recipes

### DIFF
--- a/packages/api/scripts/run-demo-batch-seed.ts
+++ b/packages/api/scripts/run-demo-batch-seed.ts
@@ -23,7 +23,10 @@ import { BatchStepOrmEntity } from '../src/batch/entities/batch-step.orm.entity'
 import { RecipeOrmEntity } from '../src/recipe/entities/recipe.orm.entity';
 import { User } from '../src/user/entities/user.entity';
 import { seedDemoBatch } from '../src/database/seeds/demo-batch.seed';
-import { seedPublicRecipes } from '../src/database/seeds/public-recipes.seed';
+import {
+  buildPublicRecipeSubResourceRepos,
+  seedPublicRecipes,
+} from '../src/database/seeds/public-recipes.seed';
 import { seedSystemUser } from '../src/database/seeds/system-user.seed';
 
 async function main(): Promise<void> {
@@ -41,7 +44,11 @@ async function main(): Promise<void> {
   // recipe_id). Required even on re-runs because it brings the
   // schema row up to the latest curated values.
   const recipeRepo = dataSource.getRepository(RecipeOrmEntity);
-  const recipeResult = await seedPublicRecipes(recipeRepo);
+  const recipeResult = await seedPublicRecipes(
+    recipeRepo,
+    undefined,
+    buildPublicRecipeSubResourceRepos(dataSource),
+  );
   console.log('Public recipes seed:', recipeResult);
 
   // Step 3 — demo batch + 7 brewing-day steps.

--- a/packages/api/scripts/run-public-recipes-seed.ts
+++ b/packages/api/scripts/run-public-recipes-seed.ts
@@ -18,7 +18,10 @@ import 'reflect-metadata';
 import dataSource from '../src/database/data-source';
 import { RecipeOrmEntity } from '../src/recipe/entities/recipe.orm.entity';
 import { User } from '../src/user/entities/user.entity';
-import { seedPublicRecipes } from '../src/database/seeds/public-recipes.seed';
+import {
+  buildPublicRecipeSubResourceRepos,
+  seedPublicRecipes,
+} from '../src/database/seeds/public-recipes.seed';
 import { seedSystemUser } from '../src/database/seeds/system-user.seed';
 
 async function main(): Promise<void> {
@@ -32,9 +35,16 @@ async function main(): Promise<void> {
   const userResult = await seedSystemUser(userRepo);
   console.log('System user seed:', userResult);
 
-  // Step 2 — public recipes owned by the system user.
+  // Step 2 — public recipes owned by the system user, with their
+  // full content (ingredients + steps) for the scan-reachable rows.
+  // The sub-resource repos must be passed or the content sub-tables
+  // stay empty (Codex review on PR #1170).
   const recipeRepo = dataSource.getRepository(RecipeOrmEntity);
-  const recipeResult = await seedPublicRecipes(recipeRepo);
+  const recipeResult = await seedPublicRecipes(
+    recipeRepo,
+    undefined,
+    buildPublicRecipeSubResourceRepos(dataSource),
+  );
   console.log('Public recipes seed:', recipeResult);
 
   await dataSource.destroy();

--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -1,13 +1,42 @@
 import { Repository } from 'typeorm';
 
+import { RecipeFermentableType } from '../../recipe/domain/enums/recipe-fermentable-type.enum';
+import { RecipeHopAdditionStage } from '../../recipe/domain/enums/recipe-hop-addition-stage.enum';
+import { RecipeHopType } from '../../recipe/domain/enums/recipe-hop-type.enum';
 import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
 import { RecipeVisibility } from '../../recipe/domain/enums/recipe-visibility.enum';
+import { RecipeWorkflowService } from '../../recipe/domain/services/recipe-workflow.service';
+import { RecipeYeastType } from '../../recipe/domain/enums/recipe-yeast-type.enum';
 import {
+  DEFAULT_WORKFLOW_STEPS,
   PUBLIC_RECIPES_SEED,
   PUBLIC_RECIPES_SYSTEM_OWNER_ID,
+  PublicRecipeSubResourceRepos,
   seedPublicRecipes,
 } from './public-recipes.seed';
-import { buildRepoMock } from './seed-test-utils';
+import { buildRepoMock, RepoMock } from './seed-test-utils';
+
+/** UUIDs of the three scan-reachable recipes garnished with full
+ * content (Punk IPA official + its two IPA-family equivalents). */
+const SESSION_IPA_ID = '00000000-0000-4000-8000-000000000001';
+const NEIPA_ID = '00000000-0000-4000-8000-000000000002';
+const WHITE_IPA_ID = '00000000-0000-4000-8000-000000000003';
+const PUNK_IPA_ID = '00000000-0000-4000-8000-00000000000b';
+const GARNISHED_IDS = [SESSION_IPA_ID, WHITE_IPA_ID, PUNK_IPA_ID];
+
+function buildSubRepos(): {
+  fermentableRepo: RepoMock;
+  hopRepo: RepoMock;
+  yeastRepo: RepoMock;
+  stepRepo: RepoMock;
+} {
+  return {
+    fermentableRepo: buildRepoMock(),
+    hopRepo: buildRepoMock(),
+    yeastRepo: buildRepoMock(),
+    stepRepo: buildRepoMock(),
+  };
+}
 
 describe('seedPublicRecipes (Issue #701)', () => {
   describe('happy path', () => {
@@ -175,6 +204,153 @@ describe('seedPublicRecipes (Issue #701)', () => {
       }
       // No duplicates.
       expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+});
+
+describe('public recipe content (ingredients + steps, #1134)', () => {
+  describe('seed data integrity', () => {
+    it('garnishes exactly the three scan-reachable recipes with full content', () => {
+      const withContent = PUBLIC_RECIPES_SEED.filter((r) => r.fermentables);
+      expect(withContent.map((r) => r.id).sort()).toEqual(
+        [...GARNISHED_IDS].sort(),
+      );
+    });
+
+    it('gives every garnished recipe fermentables, hops, yeasts and the 5-step workflow', () => {
+      for (const id of GARNISHED_IDS) {
+        const recipe = PUBLIC_RECIPES_SEED.find((r) => r.id === id);
+        expect(recipe).toBeDefined();
+        expect(recipe?.fermentables?.length).toBeGreaterThan(0);
+        expect(recipe?.hops?.length).toBeGreaterThan(0);
+        expect(recipe?.yeasts?.length).toBeGreaterThan(0);
+        // Every garnished recipe references the shared default workflow.
+        expect(recipe?.steps).toBe(DEFAULT_WORKFLOW_STEPS);
+        expect(recipe?.steps).toHaveLength(5);
+      }
+    });
+
+    it('leaves the metadata-only recipes (e.g. NEIPA Tropical) without content arrays', () => {
+      const neipa = PUBLIC_RECIPES_SEED.find((r) => r.id === NEIPA_ID);
+      expect(neipa?.fermentables).toBeUndefined();
+      expect(neipa?.hops).toBeUndefined();
+      expect(neipa?.yeasts).toBeUndefined();
+      expect(neipa?.steps).toBeUndefined();
+    });
+
+    it('uses valid enum values and positive quantities across all content', () => {
+      for (const recipe of PUBLIC_RECIPES_SEED) {
+        for (const fermentable of recipe.fermentables ?? []) {
+          expect(Object.values(RecipeFermentableType)).toContain(
+            fermentable.type,
+          );
+          expect(fermentable.weight_g).toBeGreaterThan(0);
+        }
+        for (const hop of recipe.hops ?? []) {
+          expect(Object.values(RecipeHopType)).toContain(hop.type);
+          expect(Object.values(RecipeHopAdditionStage)).toContain(
+            hop.addition_stage,
+          );
+          expect(hop.weight_g).toBeGreaterThan(0);
+        }
+        for (const yeast of recipe.yeasts ?? []) {
+          expect(Object.values(RecipeYeastType)).toContain(yeast.type);
+          expect(yeast.amount_g).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    it('keeps DEFAULT_WORKFLOW_STEPS structurally identical to RecipeWorkflowService.getDefaultWorkflow()', () => {
+      // Non-owner viewers of a public recipe never trigger the lazy
+      // `ensureDefaultSteps` write (Issue #779) — so the seeded steps
+      // must match the workflow an owner would get materialised, or
+      // the two code paths would drift.
+      const workflow = new RecipeWorkflowService().getDefaultWorkflow();
+      expect(DEFAULT_WORKFLOW_STEPS).toHaveLength(workflow.length);
+      workflow.forEach((step, index) => {
+        expect(DEFAULT_WORKFLOW_STEPS[index].step_order).toBe(step.order);
+        expect(DEFAULT_WORKFLOW_STEPS[index].type).toBe(step.type);
+        expect(DEFAULT_WORKFLOW_STEPS[index].label).toBe(step.label);
+        expect(DEFAULT_WORKFLOW_STEPS[index].description).toBe(
+          step.description,
+        );
+      });
+    });
+  });
+
+  describe('sub-resource seeding (happy path)', () => {
+    it('wipes and refills every sub-table for a garnished recipe with recipe_id stamped', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+      const sub = buildSubRepos();
+      const punk = PUBLIC_RECIPES_SEED.find((r) => r.id === PUNK_IPA_ID);
+      expect(punk).toBeDefined();
+
+      await seedPublicRecipes(
+        repo as unknown as Repository<RecipeOrmEntity>,
+        [punk!],
+        sub as unknown as PublicRecipeSubResourceRepos,
+      );
+
+      expect(sub.fermentableRepo.delete).toHaveBeenCalledWith({
+        recipe_id: PUNK_IPA_ID,
+      });
+      expect(sub.hopRepo.delete).toHaveBeenCalledWith({
+        recipe_id: PUNK_IPA_ID,
+      });
+      expect(sub.yeastRepo.delete).toHaveBeenCalledWith({
+        recipe_id: PUNK_IPA_ID,
+      });
+      expect(sub.stepRepo.delete).toHaveBeenCalledWith({
+        recipe_id: PUNK_IPA_ID,
+      });
+
+      expect(sub.fermentableRepo.create).toHaveBeenCalledTimes(
+        punk!.fermentables!.length,
+      );
+      expect(sub.hopRepo.create).toHaveBeenCalledTimes(punk!.hops!.length);
+      expect(sub.yeastRepo.create).toHaveBeenCalledTimes(punk!.yeasts!.length);
+      expect(sub.stepRepo.create).toHaveBeenCalledTimes(5);
+
+      const firstHop = (sub.hopRepo.create.mock.calls[0] as unknown[])[0] as {
+        recipe_id: string;
+      };
+      expect(firstHop.recipe_id).toBe(PUNK_IPA_ID);
+    });
+  });
+
+  describe('sub-resource seeding (sad / edge)', () => {
+    it('leaves sub-tables untouched for a metadata-only recipe even when subRepos is supplied', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+      const sub = buildSubRepos();
+      const neipa = PUBLIC_RECIPES_SEED.find((r) => r.id === NEIPA_ID);
+
+      await seedPublicRecipes(
+        repo as unknown as Repository<RecipeOrmEntity>,
+        [neipa!],
+        sub as unknown as PublicRecipeSubResourceRepos,
+      );
+
+      expect(sub.fermentableRepo.delete).not.toHaveBeenCalled();
+      expect(sub.fermentableRepo.create).not.toHaveBeenCalled();
+      expect(sub.hopRepo.create).not.toHaveBeenCalled();
+      expect(sub.yeastRepo.create).not.toHaveBeenCalled();
+      expect(sub.stepRepo.create).not.toHaveBeenCalled();
+    });
+
+    it('returns the same {inserted,updated,total} shape whether or not subRepos is passed', async () => {
+      const repo = buildRepoMock();
+      repo.findOne.mockResolvedValue(null);
+      const sub = buildSubRepos();
+
+      const result = await seedPublicRecipes(
+        repo as unknown as Repository<RecipeOrmEntity>,
+        PUBLIC_RECIPES_SEED,
+        sub as unknown as PublicRecipeSubResourceRepos,
+      );
+
+      expect(result).toEqual({ inserted: 11, updated: 0, total: 11 });
     });
   });
 });

--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -16,13 +16,17 @@ import {
 } from './public-recipes.seed';
 import { buildRepoMock, RepoMock } from './seed-test-utils';
 
-/** UUIDs of the three scan-reachable recipes garnished with full
- * content (Punk IPA official + its two IPA-family equivalents). */
+/** UUIDs of the four scan-reachable recipes garnished with full
+ * content: the Punk IPA "official" row plus its three IPA-family
+ * equivalents (Session IPA, NEIPA, White IPA), which the mobile
+ * `PUNK_IPA_RECIPE_MATCHES` list all expose for a Punk IPA scan. */
 const SESSION_IPA_ID = '00000000-0000-4000-8000-000000000001';
 const NEIPA_ID = '00000000-0000-4000-8000-000000000002';
 const WHITE_IPA_ID = '00000000-0000-4000-8000-000000000003';
 const PUNK_IPA_ID = '00000000-0000-4000-8000-00000000000b';
-const GARNISHED_IDS = [SESSION_IPA_ID, WHITE_IPA_ID, PUNK_IPA_ID];
+const GARNISHED_IDS = [SESSION_IPA_ID, NEIPA_ID, WHITE_IPA_ID, PUNK_IPA_ID];
+/** A recipe that intentionally stays metadata-only (Belgian Tripel). */
+const METADATA_ONLY_ID = '00000000-0000-4000-8000-000000000004';
 
 function buildSubRepos(): {
   fermentableRepo: RepoMock;
@@ -210,7 +214,7 @@ describe('seedPublicRecipes (Issue #701)', () => {
 
 describe('public recipe content (ingredients + steps, #1134)', () => {
   describe('seed data integrity', () => {
-    it('garnishes exactly the three scan-reachable recipes with full content', () => {
+    it('garnishes exactly the four scan-reachable recipes with full content', () => {
       const withContent = PUBLIC_RECIPES_SEED.filter((r) => r.fermentables);
       expect(withContent.map((r) => r.id).sort()).toEqual(
         [...GARNISHED_IDS].sort(),
@@ -230,12 +234,12 @@ describe('public recipe content (ingredients + steps, #1134)', () => {
       }
     });
 
-    it('leaves the metadata-only recipes (e.g. NEIPA Tropical) without content arrays', () => {
-      const neipa = PUBLIC_RECIPES_SEED.find((r) => r.id === NEIPA_ID);
-      expect(neipa?.fermentables).toBeUndefined();
-      expect(neipa?.hops).toBeUndefined();
-      expect(neipa?.yeasts).toBeUndefined();
-      expect(neipa?.steps).toBeUndefined();
+    it('leaves the metadata-only recipes (e.g. Belgian Tripel) without content arrays', () => {
+      const tripel = PUBLIC_RECIPES_SEED.find((r) => r.id === METADATA_ONLY_ID);
+      expect(tripel?.fermentables).toBeUndefined();
+      expect(tripel?.hops).toBeUndefined();
+      expect(tripel?.yeasts).toBeUndefined();
+      expect(tripel?.steps).toBeUndefined();
     });
 
     it('uses valid enum values and positive quantities across all content', () => {
@@ -320,29 +324,38 @@ describe('public recipe content (ingredients + steps, #1134)', () => {
   });
 
   describe('sub-resource seeding (sad / edge)', () => {
-    it('leaves sub-tables untouched for a metadata-only recipe even when subRepos is supplied', async () => {
+    it('leaves every sub-table untouched (no delete, no create) for a metadata-only recipe even when subRepos is supplied', async () => {
       const repo = buildRepoMock();
       repo.findOne.mockResolvedValue(null);
       const sub = buildSubRepos();
-      const neipa = PUBLIC_RECIPES_SEED.find((r) => r.id === NEIPA_ID);
+      const tripel = PUBLIC_RECIPES_SEED.find((r) => r.id === METADATA_ONLY_ID);
 
       await seedPublicRecipes(
         repo as unknown as Repository<RecipeOrmEntity>,
-        [neipa!],
+        [tripel!],
         sub as unknown as PublicRecipeSubResourceRepos,
       );
 
-      expect(sub.fermentableRepo.delete).not.toHaveBeenCalled();
-      expect(sub.fermentableRepo.create).not.toHaveBeenCalled();
-      expect(sub.hopRepo.create).not.toHaveBeenCalled();
-      expect(sub.yeastRepo.create).not.toHaveBeenCalled();
-      expect(sub.stepRepo.create).not.toHaveBeenCalled();
+      // Assert neither delete nor create fires on ANY of the four
+      // repos — a metadata-only recipe must not touch its content
+      // sub-tables, so a regression that started wiping hops/yeasts/
+      // steps for such rows would be caught here.
+      for (const childRepo of [
+        sub.fermentableRepo,
+        sub.hopRepo,
+        sub.yeastRepo,
+        sub.stepRepo,
+      ]) {
+        expect(childRepo.delete).not.toHaveBeenCalled();
+        expect(childRepo.create).not.toHaveBeenCalled();
+      }
     });
 
     it('returns the same {inserted,updated,total} shape whether or not subRepos is passed', async () => {
       const repo = buildRepoMock();
       repo.findOne.mockResolvedValue(null);
       const sub = buildSubRepos();
+      const total = PUBLIC_RECIPES_SEED.length;
 
       const result = await seedPublicRecipes(
         repo as unknown as Repository<RecipeOrmEntity>,
@@ -350,7 +363,7 @@ describe('public recipe content (ingredients + steps, #1134)', () => {
         sub as unknown as PublicRecipeSubResourceRepos,
       );
 
-      expect(result).toEqual({ inserted: 11, updated: 0, total: 11 });
+      expect(result).toEqual({ inserted: total, updated: 0, total });
     });
   });
 });

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -1,7 +1,16 @@
 import { Repository } from 'typeorm';
 
+import { RecipeFermentableOrmEntity } from '../../recipe/entities/recipe-fermentable.orm.entity';
+import { RecipeFermentableType } from '../../recipe/domain/enums/recipe-fermentable-type.enum';
+import { RecipeHopAdditionStage } from '../../recipe/domain/enums/recipe-hop-addition-stage.enum';
+import { RecipeHopOrmEntity } from '../../recipe/entities/recipe-hop.orm.entity';
+import { RecipeHopType } from '../../recipe/domain/enums/recipe-hop-type.enum';
 import { RecipeOrmEntity } from '../../recipe/entities/recipe.orm.entity';
+import { RecipeStepOrmEntity } from '../../recipe/entities/recipe-step.orm.entity';
+import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
 import { RecipeVisibility } from '../../recipe/domain/enums/recipe-visibility.enum';
+import { RecipeYeastOrmEntity } from '../../recipe/entities/recipe-yeast.orm.entity';
+import { RecipeYeastType } from '../../recipe/domain/enums/recipe-yeast-type.enum';
 import { SYSTEM_USER_ID } from './system-user.seed';
 
 /**
@@ -36,9 +45,111 @@ import { SYSTEM_USER_ID } from './system-user.seed';
 export const PUBLIC_RECIPES_SYSTEM_OWNER_ID = SYSTEM_USER_ID;
 
 /**
+ * Fermentable entry in the seed data. Mirrors the mutable columns of
+ * `RecipeFermentableOrmEntity` (minus the autogen id / recipe_id /
+ * timestamps). Same shape contract as the BrewDog DIY Dog seed.
+ */
+export interface PublicRecipeFermentableSeed {
+  name: string;
+  type: RecipeFermentableType;
+  weight_g: number;
+  potential_gravity?: number;
+  color_ebc?: number;
+}
+
+/**
+ * Hop addition in the seed data. `addition_time_min` is
+ * minutes-from-knockout for BOIL additions, days-of-contact for
+ * DRY_HOP additions, and may be omitted for WHIRLPOOL additions whose
+ * timing the source recipe leaves unspecified.
+ */
+export interface PublicRecipeHopSeed {
+  variety: string;
+  type: RecipeHopType;
+  weight_g: number;
+  alpha_acid_percent?: number;
+  addition_stage: RecipeHopAdditionStage;
+  addition_time_min?: number;
+}
+
+/**
+ * Yeast addition in the seed data. `amount_g` defaults to one
+ * dry-yeast sachet (~11.5 g) when the source recipe documents no
+ * pitch rate.
+ */
+export interface PublicRecipeYeastSeed {
+  name: string;
+  type: RecipeYeastType;
+  amount_g: number;
+  attenuation_percent?: number;
+  temperature_min_c?: number;
+  temperature_max_c?: number;
+}
+
+/**
+ * Brewing step in the seed data. Mirrors `RecipeStepOrmEntity`'s
+ * mutable columns (`step_order` is part of the composite PK).
+ */
+export interface PublicRecipeStepSeed {
+  step_order: number;
+  type: RecipeStepType;
+  label: string;
+  description?: string | null;
+}
+
+/**
+ * Canonical five-stage brewing workflow shared by every seeded
+ * recipe that carries steps. Kept structurally identical to
+ * `RecipeWorkflowService.getDefaultWorkflow()` (asserted by a parity
+ * test) so a non-owner reading a public recipe's `/steps` sees the
+ * same default workflow an owner gets lazily materialised — the
+ * `ensureDefaultSteps` write only fires for owners (Issue #779), so
+ * public recipes must ship their steps explicitly.
+ */
+export const DEFAULT_WORKFLOW_STEPS: readonly PublicRecipeStepSeed[] = [
+  {
+    step_order: 0,
+    type: RecipeStepType.MASH,
+    label: 'Mash',
+    description: 'Mash grains to extract fermentable sugars.',
+  },
+  {
+    step_order: 1,
+    type: RecipeStepType.BOIL,
+    label: 'Boil',
+    description: 'Boil wort and add hops according to schedule.',
+  },
+  {
+    step_order: 2,
+    type: RecipeStepType.WHIRLPOOL,
+    label: 'Whirlpool',
+    description: 'Whirlpool and cool the wort before fermentation.',
+  },
+  {
+    step_order: 3,
+    type: RecipeStepType.FERMENTATION,
+    label: 'Fermentation',
+    description: 'Ferment wort with yeast until final gravity is reached.',
+  },
+  {
+    step_order: 4,
+    type: RecipeStepType.PACKAGING,
+    label: 'Packaging',
+    description: 'Package beer (bottling/kegging) and carbonate.',
+  },
+];
+
+/**
  * Shape of one seeded public recipe. Brewing metrics are
  * approximations from public datasheets and BJCP style guidelines,
  * adapted for a 20L homebrew batch.
+ *
+ * The optional `fermentables` / `hops` / `yeasts` / `steps` arrays
+ * carry the full recipe content. They are populated only for the
+ * scan-reachable recipes (the Punk IPA "official" row and its
+ * equivalents) so the live mobile recipe-detail screen shows real
+ * ingredients and a brewing workflow rather than an empty shell.
+ * Metadata-only recipes leave them undefined.
  */
 export interface PublicRecipeSeed {
   id: string;
@@ -66,6 +177,18 @@ export interface PublicRecipeSeed {
    * Codex caught on PR #773.
    */
   is_official?: boolean;
+  /**
+   * Full grain bill for the recipe (recipe_fermentables rows). Only
+   * set on scan-reachable recipes; metadata-only rows leave it
+   * undefined and seed no fermentables.
+   */
+  fermentables?: readonly PublicRecipeFermentableSeed[];
+  /** Full hop schedule (recipe_hops rows). Same optionality contract. */
+  hops?: readonly PublicRecipeHopSeed[];
+  /** Yeast strains (recipe_yeasts rows). Same optionality contract. */
+  yeasts?: readonly PublicRecipeYeastSeed[];
+  /** Brewing workflow (recipe_steps rows). Same optionality contract. */
+  steps?: readonly PublicRecipeStepSeed[];
 }
 
 /**
@@ -92,6 +215,73 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     efficiency_target: 72,
     avg_rating: 4.7,
     brew_count: 23,
+    // Light, mono-Citra session IPA. Modest bittering charge, big
+    // late + dry-hop load for the "nez explosif d'agrumes" without
+    // pushing IBU past the session range.
+    fermentables: [
+      {
+        name: 'Pale Ale Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 3700,
+        color_ebc: 7,
+      },
+      {
+        name: 'CaraPils',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 250,
+        color_ebc: 4,
+      },
+      {
+        name: 'Wheat Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 200,
+        color_ebc: 4,
+      },
+    ],
+    hops: [
+      {
+        variety: 'Citra',
+        type: RecipeHopType.PELLET,
+        weight_g: 10,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 60,
+      },
+      {
+        variety: 'Citra',
+        type: RecipeHopType.PELLET,
+        weight_g: 20,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 10,
+      },
+      {
+        variety: 'Citra',
+        type: RecipeHopType.PELLET,
+        weight_g: 25,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.WHIRLPOOL,
+      },
+      {
+        variety: 'Citra',
+        type: RecipeHopType.PELLET,
+        weight_g: 40,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.DRY_HOP,
+        addition_time_min: 4,
+      },
+    ],
+    yeasts: [
+      {
+        name: 'Fermentis SafAle US-05',
+        type: RecipeYeastType.ALE,
+        amount_g: 11.5,
+        attenuation_percent: 81,
+        temperature_min_c: 15,
+        temperature_max_c: 22,
+      },
+    ],
+    steps: DEFAULT_WORKFLOW_STEPS,
   },
   {
     id: '00000000-0000-4000-8000-000000000002',
@@ -126,6 +316,74 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     efficiency_target: 72,
     avg_rating: 4.3,
     brew_count: 12,
+    // Witbier + IPA hybrid: ~45% wheat base, Belgian witbier yeast for
+    // the phenolic/spicy bridge, American hops for the IPA backbone.
+    // Coriander + orange peel (in the description) are spice additives,
+    // out of scope for the ingredient sub-tables modelled here.
+    fermentables: [
+      {
+        name: 'Pilsner Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 2200,
+        color_ebc: 3,
+      },
+      {
+        name: 'Wheat Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 2000,
+        color_ebc: 4,
+      },
+      {
+        name: 'CaraPils',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 200,
+        color_ebc: 4,
+      },
+    ],
+    hops: [
+      {
+        variety: 'Cascade',
+        type: RecipeHopType.PELLET,
+        weight_g: 18,
+        alpha_acid_percent: 6,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 60,
+      },
+      {
+        variety: 'Amarillo',
+        type: RecipeHopType.PELLET,
+        weight_g: 20,
+        alpha_acid_percent: 9,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 10,
+      },
+      {
+        variety: 'Citra',
+        type: RecipeHopType.PELLET,
+        weight_g: 20,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.WHIRLPOOL,
+      },
+      {
+        variety: 'Cascade',
+        type: RecipeHopType.PELLET,
+        weight_g: 25,
+        alpha_acid_percent: 6,
+        addition_stage: RecipeHopAdditionStage.DRY_HOP,
+        addition_time_min: 4,
+      },
+    ],
+    yeasts: [
+      {
+        name: 'Wyeast 3944 Belgian Witbier',
+        type: RecipeYeastType.ALE,
+        amount_g: 11.5,
+        attenuation_percent: 74,
+        temperature_min_c: 18,
+        temperature_max_c: 24,
+      },
+    ],
+    steps: DEFAULT_WORKFLOW_STEPS,
   },
   // --- Belgian / Saison family (matches La Chouffe + La Goudale) ---
   {
@@ -282,6 +540,132 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     efficiency_target: 75,
     avg_rating: 4.9,
     brew_count: 312,
+    // Post-2010 canonical Punk IPA, 23L batch. Matches the row's own
+    // description: Maris Otter + Caramalt base, five American hops
+    // (Ahtanum, Chinook, Nelson Sauvin, Cascade, Simcoe) split across
+    // boil / whirlpool / dry-hop, US-05 yeast. This is the scan-flow's
+    // "official" recipe — it MUST carry content so the live detail
+    // screen is not an empty shell when tapped.
+    fermentables: [
+      {
+        name: 'Maris Otter Extra Pale',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 5300,
+        color_ebc: 6,
+      },
+      {
+        name: 'Caramalt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 250,
+        color_ebc: 50,
+      },
+    ],
+    hops: [
+      {
+        variety: 'Ahtanum',
+        type: RecipeHopType.PELLET,
+        weight_g: 17.5,
+        alpha_acid_percent: 5,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 60,
+      },
+      {
+        variety: 'Chinook',
+        type: RecipeHopType.PELLET,
+        weight_g: 15,
+        alpha_acid_percent: 13,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 60,
+      },
+      {
+        variety: 'Ahtanum',
+        type: RecipeHopType.PELLET,
+        weight_g: 12.5,
+        alpha_acid_percent: 5,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 15,
+      },
+      {
+        variety: 'Chinook',
+        type: RecipeHopType.PELLET,
+        weight_g: 12.5,
+        alpha_acid_percent: 13,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 15,
+      },
+      {
+        variety: 'Nelson Sauvin',
+        type: RecipeHopType.PELLET,
+        weight_g: 12.5,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.WHIRLPOOL,
+      },
+      {
+        variety: 'Cascade',
+        type: RecipeHopType.PELLET,
+        weight_g: 12.5,
+        alpha_acid_percent: 6,
+        addition_stage: RecipeHopAdditionStage.WHIRLPOOL,
+      },
+      {
+        variety: 'Simcoe',
+        type: RecipeHopType.PELLET,
+        weight_g: 12.5,
+        alpha_acid_percent: 13,
+        addition_stage: RecipeHopAdditionStage.WHIRLPOOL,
+      },
+      {
+        variety: 'Ahtanum',
+        type: RecipeHopType.PELLET,
+        weight_g: 18.8,
+        alpha_acid_percent: 5,
+        addition_stage: RecipeHopAdditionStage.DRY_HOP,
+        addition_time_min: 4,
+      },
+      {
+        variety: 'Chinook',
+        type: RecipeHopType.PELLET,
+        weight_g: 18.8,
+        alpha_acid_percent: 13,
+        addition_stage: RecipeHopAdditionStage.DRY_HOP,
+        addition_time_min: 4,
+      },
+      {
+        variety: 'Nelson Sauvin',
+        type: RecipeHopType.PELLET,
+        weight_g: 18.8,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.DRY_HOP,
+        addition_time_min: 4,
+      },
+      {
+        variety: 'Cascade',
+        type: RecipeHopType.PELLET,
+        weight_g: 18.8,
+        alpha_acid_percent: 6,
+        addition_stage: RecipeHopAdditionStage.DRY_HOP,
+        addition_time_min: 4,
+      },
+      {
+        variety: 'Simcoe',
+        type: RecipeHopType.PELLET,
+        weight_g: 18.8,
+        alpha_acid_percent: 13,
+        addition_stage: RecipeHopAdditionStage.DRY_HOP,
+        addition_time_min: 4,
+      },
+    ],
+    yeasts: [
+      {
+        name: 'Fermentis SafAle US-05',
+        type: RecipeYeastType.ALE,
+        amount_g: 11.5,
+        attenuation_percent: 81,
+        temperature_min_c: 15,
+        temperature_max_c: 22,
+      },
+    ],
+    steps: DEFAULT_WORKFLOW_STEPS,
   },
 ];
 
@@ -294,6 +678,68 @@ export interface SeedPublicRecipesResult {
   inserted: number;
   updated: number;
   total: number;
+}
+
+/**
+ * The four sub-resource repositories needed to persist a recipe's
+ * full content (grain bill / hop schedule / yeast / steps). Optional
+ * on `seedPublicRecipes` — when omitted the loader seeds recipe
+ * metadata only (its historical behaviour). When provided, every seed
+ * recipe that declares the matching array gets its sub-tables
+ * wiped-and-refilled idempotently.
+ */
+export interface PublicRecipeSubResourceRepos {
+  fermentableRepo: Repository<RecipeFermentableOrmEntity>;
+  hopRepo: Repository<RecipeHopOrmEntity>;
+  yeastRepo: Repository<RecipeYeastOrmEntity>;
+  stepRepo: Repository<RecipeStepOrmEntity>;
+}
+
+/**
+ * Wipe-and-refill the sub-tables for one recipe. Mirrors the BrewDog
+ * DIY Dog seed: for each declared ingredient/step array, delete the
+ * recipe's existing rows then bulk-insert the seed's — so re-running
+ * converges on exactly what the seed declares, regardless of drift.
+ * An undeclared array is left untouched (no delete), so metadata-only
+ * recipes never lose data they never owned.
+ */
+async function seedRecipeSubResources(
+  repos: PublicRecipeSubResourceRepos,
+  recipe: PublicRecipeSeed,
+): Promise<void> {
+  const { fermentableRepo, hopRepo, yeastRepo, stepRepo } = repos;
+
+  if (recipe.fermentables) {
+    await fermentableRepo.delete({ recipe_id: recipe.id });
+    for (const fermentable of recipe.fermentables) {
+      await fermentableRepo.save(
+        fermentableRepo.create({ recipe_id: recipe.id, ...fermentable }),
+      );
+    }
+  }
+
+  if (recipe.hops) {
+    await hopRepo.delete({ recipe_id: recipe.id });
+    for (const hop of recipe.hops) {
+      await hopRepo.save(hopRepo.create({ recipe_id: recipe.id, ...hop }));
+    }
+  }
+
+  if (recipe.yeasts) {
+    await yeastRepo.delete({ recipe_id: recipe.id });
+    for (const yeast of recipe.yeasts) {
+      await yeastRepo.save(
+        yeastRepo.create({ recipe_id: recipe.id, ...yeast }),
+      );
+    }
+  }
+
+  if (recipe.steps) {
+    await stepRepo.delete({ recipe_id: recipe.id });
+    for (const step of recipe.steps) {
+      await stepRepo.save(stepRepo.create({ recipe_id: recipe.id, ...step }));
+    }
+  }
 }
 
 /**
@@ -311,10 +757,18 @@ export interface SeedPublicRecipesResult {
  * reserved for brewer-endorsed clones tied to a specific demo bottle
  * (currently only the BrewDog DIY Dog clone for Punk IPA — Issue
  * #911 unblocks the demo Beat 4 "🏆 Recette officielle" section).
+ *
+ * When `subRepos` is supplied, each recipe that declares
+ * `fermentables` / `hops` / `yeasts` / `steps` also gets those
+ * sub-tables wiped-and-refilled (see `seedRecipeSubResources`). This
+ * is what makes the scan-reachable recipes show real content on the
+ * live mobile detail screen. Omitting `subRepos` preserves the
+ * original metadata-only behaviour for callers that don't need it.
  */
 export async function seedPublicRecipes(
   repository: Repository<RecipeOrmEntity>,
   recipes: readonly PublicRecipeSeed[] = PUBLIC_RECIPES_SEED,
+  subRepos?: PublicRecipeSubResourceRepos,
 ): Promise<SeedPublicRecipesResult> {
   let inserted = 0;
   let updated = 0;
@@ -358,6 +812,10 @@ export async function seedPublicRecipes(
       const created = repository.create({ id: recipe.id, ...payload });
       await repository.save(created);
       inserted += 1;
+    }
+
+    if (subRepos) {
+      await seedRecipeSubResources(subRepos, recipe);
     }
   }
 

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -1,4 +1,4 @@
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 
 import { RecipeFermentableOrmEntity } from '../../recipe/entities/recipe-fermentable.orm.entity';
 import { RecipeFermentableType } from '../../recipe/domain/enums/recipe-fermentable-type.enum';
@@ -299,6 +299,89 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     efficiency_target: 70,
     avg_rating: 4.5,
     brew_count: 18,
+    // Hazy NEIPA: oat/wheat base for body + haze, minimal bittering,
+    // the bitterness budget spent late — big whirlpool + dry-hop of
+    // Citra + Mosaic for the "dry-hop massif" tropical nose. London
+    // Ale III yeast for the fruity esters and soft mouthfeel.
+    fermentables: [
+      {
+        name: 'Pale Ale Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 3400,
+        color_ebc: 7,
+      },
+      {
+        name: 'Wheat Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 1000,
+        color_ebc: 4,
+      },
+      {
+        name: 'Flaked Oats',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 500,
+        color_ebc: 2,
+      },
+    ],
+    hops: [
+      {
+        variety: 'Magnum',
+        type: RecipeHopType.PELLET,
+        weight_g: 8,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 60,
+      },
+      {
+        variety: 'Citra',
+        type: RecipeHopType.PELLET,
+        weight_g: 15,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 5,
+      },
+      {
+        variety: 'Citra',
+        type: RecipeHopType.PELLET,
+        weight_g: 25,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.WHIRLPOOL,
+      },
+      {
+        variety: 'Mosaic',
+        type: RecipeHopType.PELLET,
+        weight_g: 25,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.WHIRLPOOL,
+      },
+      {
+        variety: 'Citra',
+        type: RecipeHopType.PELLET,
+        weight_g: 30,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.DRY_HOP,
+        addition_time_min: 4,
+      },
+      {
+        variety: 'Mosaic',
+        type: RecipeHopType.PELLET,
+        weight_g: 30,
+        alpha_acid_percent: 12,
+        addition_stage: RecipeHopAdditionStage.DRY_HOP,
+        addition_time_min: 4,
+      },
+    ],
+    yeasts: [
+      {
+        name: 'Wyeast 1318 London Ale III',
+        type: RecipeYeastType.ALE,
+        amount_g: 11.5,
+        attenuation_percent: 75,
+        temperature_min_c: 18,
+        temperature_max_c: 22,
+      },
+    ],
+    steps: DEFAULT_WORKFLOW_STEPS,
   },
   {
     id: '00000000-0000-4000-8000-000000000003',
@@ -696,9 +779,27 @@ export interface PublicRecipeSubResourceRepos {
 }
 
 /**
+ * Resolves the four sub-resource repositories from a DataSource —
+ * the single place every entrypoint (the `run-public-recipes-seed` /
+ * `run-demo-batch-seed` scripts, prod `fly ssh` invocations) builds
+ * them, so none can silently fall back to metadata-only seeding by
+ * forgetting a repo (Codex review on PR #1170).
+ */
+export function buildPublicRecipeSubResourceRepos(
+  dataSource: DataSource,
+): PublicRecipeSubResourceRepos {
+  return {
+    fermentableRepo: dataSource.getRepository(RecipeFermentableOrmEntity),
+    hopRepo: dataSource.getRepository(RecipeHopOrmEntity),
+    yeastRepo: dataSource.getRepository(RecipeYeastOrmEntity),
+    stepRepo: dataSource.getRepository(RecipeStepOrmEntity),
+  };
+}
+
+/**
  * Wipe-and-refill the sub-tables for one recipe. Mirrors the BrewDog
  * DIY Dog seed: for each declared ingredient/step array, delete the
- * recipe's existing rows then bulk-insert the seed's — so re-running
+ * recipe's existing rows then insert the seed's one by one — so re-running
  * converges on exactly what the seed declares, regardless of drift.
  * An undeclared array is left untouched (no delete), so metadata-only
  * recipes never lose data they never owned.


### PR DESCRIPTION
## Why

Scanning a beer in the **live** build (`preview`, `USE_DEMO_DATA=false`) and tapping an equivalent recipe opened an almost-empty detail screen: the public seed recipes carried brewing-metric **metadata only**, and a non-owner viewer never triggers the lazy `ensureDefaultSteps` write (Issue #779). So over the API both the ingredient sub-tables (`/recipes/:id/{fermentables,hops,yeasts,additives}`) and the steps (`/recipes/:id/steps`) returned empty for a scanner who is not the recipe's owner.

`GET /recipes/:id`, `/steps` and the ingredient routes are all public-readable (`getReadableById` / `assertReadable`, #1167), so the only missing piece is **data**: the rows simply had no content.

## What

Garnish the three scan-reachable IPA-family public recipes with full content so the live detail screen shows real ingredients + a brewing workflow:

| Recipe | id suffix | Content |
|--------|-----------|---------|
| BrewDog DIY Dog Punk IPA (official) | `…00b` | Maris Otter + Caramalt, 5 US hops (Ahtanum, Chinook, Nelson Sauvin, Cascade, Simcoe) across boil/whirlpool/dry-hop, US-05 |
| Session IPA Citra | `…001` | Pale + CaraPils + wheat, mono-Citra boil/whirlpool/dry-hop, US-05 |
| White IPA | `…003` | Pilsner + wheat base, US hops, Belgian Witbier yeast |

All three get the canonical **5-step workflow** (Mash → Boil → Whirlpool → Fermentation → Packaging).

### Mechanics
- `PublicRecipeSeed` gains optional `fermentables` / `hops` / `yeasts` / `steps`. Metadata-only rows leave them undefined and seed nothing new.
- `DEFAULT_WORKFLOW_STEPS` is kept structurally identical to `RecipeWorkflowService.getDefaultWorkflow()` — enforced by a parity test so the seeded steps never drift from what an owner gets lazily.
- `seedPublicRecipes` accepts optional sub-resource repos and **wipe-and-refills** each declared sub-table idempotently (mirrors the BrewDog DIY Dog seed). Omitting them preserves the historical metadata-only behaviour, so the `{inserted,updated,total}` result contract and every existing caller stay unchanged.

## Tests
`public-recipes.seed.spec.ts` — 18 passing:
- data integrity: exactly the 3 scan-reachable recipes garnished; each has fermentables/hops/yeasts + the 5-step workflow; valid enum values + positive quantities across all content;
- workflow parity with `RecipeWorkflowService`;
- seeding side-effects: wipe-and-refill happy path (recipe_id stamped, per-table counts), metadata-only no-op even when repos are supplied, stable result shape.

Full `seeds` + `recipe` suites green (302 tests).

## Deploy note
Content lands in prod by redeploying the API (compiled seed) and running `seedPublicRecipes` with the four sub-resource repos via `fly ssh console`. Idempotent — safe to re-run.

Part of #1134.