### PR TITLE
fix(recipes): translate the Brewing tab to French (#1172)

### DIFF
--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -371,6 +371,47 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     ).toBe(true);
   });
 
+  it("shows the empty-state hint on the Brewing recipe view when the recipe has no steps", async () => {
+    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue({
+      ...baseViewModel,
+      steps: [],
+    });
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("brewing");
+    fireEvent.press(screen.getByTestId("recipe-process-filter-recipe"));
+
+    expect(
+      screen.getByText("Pas d'étapes renseignées pour cette recette."),
+    ).toBeTruthy();
+  });
+
+  it("renders a step without a description on the Brewing recipe view", async () => {
+    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue({
+      ...baseViewModel,
+      steps: [
+        {
+          recipeId: "r1",
+          stepOrder: 0,
+          label: "Empâtage maison",
+          type: "mash",
+          description: null,
+        },
+      ],
+    });
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    switchToTab("brewing");
+    fireEvent.press(screen.getByTestId("recipe-process-filter-recipe"));
+
+    expect(screen.getByText("1. Empâtage maison")).toBeTruthy();
+    expect(screen.getByText("Empâtage")).toBeTruthy();
+    // No description row for a step that has none.
+    expect(screen.queryByText("Hold at 67°C")).toBeNull();
+  });
+
   it("hides the sticky CTA on the Notes & Reviews tab", async () => {
     renderRecipeDetails();
 

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -336,9 +336,18 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     expect(screen.getByTestId("recipe-brewing-tab")).toBeTruthy();
     expect(screen.getByText("Aperçu du process")).toBeTruthy();
 
+    // Process modes are labelled in French (#1172).
+    expect(screen.getByText("Phases de brassage")).toBeTruthy();
+    expect(screen.getByText("Étapes de la recette")).toBeTruthy();
+    expect(screen.getByText("Condensé")).toBeTruthy();
+    // The default "phases" view shows French brewing-phase titles.
+    expect(screen.getByText("🪣 EMPÂTAGE")).toBeTruthy();
+
     fireEvent.press(screen.getByTestId("recipe-process-filter-recipe"));
     expect(screen.getByText("1. Mash")).toBeTruthy();
     expect(screen.getByText("Hold at 67°C")).toBeTruthy();
+    // The step-type chip renders the French label, not the raw enum.
+    expect(screen.getByText("Empâtage")).toBeTruthy();
 
     fireEvent.press(screen.getByTestId("recipe-process-filter-compact"));
     expect(screen.getByText("Étapes recette : 1")).toBeTruthy();

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -343,6 +343,17 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     // The default "phases" view shows French brewing-phase titles.
     expect(screen.getByText("🪣 EMPÂTAGE")).toBeTruthy();
 
+    // The active mode chip exposes its selected state to screen readers
+    // (#1172, Copilot review).
+    expect(
+      screen.getByTestId("recipe-process-filter-phases").props
+        .accessibilityState.selected,
+    ).toBe(true);
+    expect(
+      screen.getByTestId("recipe-process-filter-recipe").props
+        .accessibilityState.selected,
+    ).toBe(false);
+
     fireEvent.press(screen.getByTestId("recipe-process-filter-recipe"));
     expect(screen.getByText("1. Mash")).toBeTruthy();
     expect(screen.getByText("Hold at 67°C")).toBeTruthy();
@@ -353,6 +364,11 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     expect(screen.getByText("Étapes recette : 1")).toBeTruthy();
     expect(screen.getByText("Ingrédients : 1")).toBeTruthy();
     expect(screen.getByText("Matériel : 1")).toBeTruthy();
+    // Selection state follows the active mode.
+    expect(
+      screen.getByTestId("recipe-process-filter-compact").props
+        .accessibilityState.selected,
+    ).toBe(true);
   });
 
   it("hides the sticky CTA on the Notes & Reviews tab", async () => {

--- a/packages/mobile-app/src/features/recipes/presentation/recipe-details.constants.ts
+++ b/packages/mobile-app/src/features/recipes/presentation/recipe-details.constants.ts
@@ -1,4 +1,5 @@
 import type { WaterStylePresetId } from "@/features/tools/domain/water-profiles";
+import type { RecipeStepType } from "@/features/recipes/domain/recipe.types";
 
 export type RecipeVolumeInputMode = "manual" | "equipment";
 
@@ -25,10 +26,24 @@ export const RECIPE_PROCESS_DISPLAY_OPTIONS: {
   id: RecipeProcessDisplayMode;
   label: string;
 }[] = [
-  { id: "phases", label: "Brew phases" },
-  { id: "recipe", label: "Recipe steps" },
-  { id: "compact", label: "Compact" },
+  { id: "phases", label: "Phases de brassage" },
+  { id: "recipe", label: "Étapes de la recette" },
+  { id: "compact", label: "Condensé" },
 ];
+
+/**
+ * French display labels for the recipe step type enum. The API serves
+ * the raw enum value (`mash`, `boil`, …); the Brewing tab renders this
+ * map so the step-type chip reads in French (#1172). The per-step
+ * `label`/`description` text still comes from the recipe data itself.
+ */
+export const RECIPE_STEP_TYPE_LABELS: Record<RecipeStepType, string> = {
+  mash: "Empâtage",
+  boil: "Ébullition",
+  whirlpool: "Whirlpool",
+  fermentation: "Fermentation",
+  packaging: "Conditionnement",
+};
 
 export type BrewingPhase = {
   id: string;
@@ -39,68 +54,71 @@ export type BrewingPhase = {
 export const BREWING_PHASES: BrewingPhase[] = [
   {
     id: "malting",
-    title: "🌾 MALTING",
-    details: "Preparation and activation of grain enzymes.",
+    title: "🌾 MALTAGE",
+    details: "Préparation et activation des enzymes du grain.",
   },
   {
     id: "milling",
-    title: "🔨 MILLING",
-    details: "Crush grains to expose starch while preserving husks.",
+    title: "🔨 CONCASSAGE",
+    details:
+      "Concasser le grain pour exposer l'amidon en préservant les enveloppes.",
   },
   {
     id: "mashing",
-    title: "🪣 MASHING",
-    details: "Maische with temperature rests for sugar conversion.",
+    title: "🪣 EMPÂTAGE",
+    details:
+      "Maische avec paliers de température pour la conversion des sucres.",
   },
   {
     id: "lautering",
-    title: "🔽 LAUTERING",
-    details: "Separate sweet wort from spent grains.",
+    title: "🔽 FILTRATION",
+    details: "Séparer le moût sucré des drêches.",
   },
   {
     id: "sparging",
-    title: "💧 SPARGING",
-    details: "Rinse grains to recover remaining sugars.",
+    title: "💧 RINÇAGE",
+    details: "Rincer les drêches pour récupérer les sucres restants.",
   },
   {
     id: "boiling",
-    title: "🔥 BOIL",
-    details: "60 to 90 minutes for sterilization and concentration.",
+    title: "🔥 ÉBULLITION",
+    details: "60 à 90 minutes pour la stérilisation et la concentration.",
   },
   {
     id: "hopping",
-    title: "🌿 HOPPING",
-    details: "Build bitterness, flavor, and aroma profile.",
+    title: "🌿 HOUBLONNAGE",
+    details: "Construire l'amertume, la saveur et le profil aromatique.",
   },
   {
     id: "cooling",
-    title: "❄️ COOLING",
-    details: "Rapidly cool wort from boiling to yeast pitch range.",
+    title: "❄️ REFROIDISSEMENT",
+    details:
+      "Refroidir rapidement le moût jusqu'à la température d'ensemencement.",
   },
   {
     id: "pitching",
-    title: "🧫 YEAST PITCHING",
-    details: "Inoculate wort with selected yeast strain.",
+    title: "🧫 ENSEMENCEMENT",
+    details: "Inoculer le moût avec la souche de levure choisie.",
   },
   {
     id: "primary-fermentation",
-    title: "🍺 PRIMARY FERMENTATION",
-    details: "Main fermentation phase for 1 to 2 weeks.",
+    title: "🍺 FERMENTATION PRIMAIRE",
+    details: "Phase de fermentation principale, 1 à 2 semaines.",
   },
   {
     id: "secondary-fermentation",
-    title: "🔄 SECONDARY FERMENTATION",
-    details: "Conditioning and flavor refinement.",
+    title: "🔄 FERMENTATION SECONDAIRE",
+    details: "Garde et affinage des arômes.",
   },
   {
     id: "packaging",
-    title: "🍶 PACKAGING",
-    details: "Bottle or keg preparation.",
+    title: "🍶 CONDITIONNEMENT",
+    details: "Mise en bouteille ou en fût.",
   },
   {
     id: "maturation",
     title: "✅ MATURATION",
-    details: "Carbonation and final flavor integration.",
+    details: "Carbonatation et intégration finale des saveurs.",
   },
 ];
 

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/BrewingTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/BrewingTab.tsx
@@ -6,6 +6,7 @@ import { colors, radius, spacing, typography } from "@/core/theme";
 import {
   BREWING_PHASES,
   RECIPE_PROCESS_DISPLAY_OPTIONS,
+  RECIPE_STEP_TYPE_LABELS,
   RecipeProcessDisplayMode,
 } from "@/features/recipes/presentation/recipe-details.constants";
 import type { RecipeStep } from "@/features/recipes/domain/recipe.types";
@@ -53,7 +54,7 @@ export function BrewingTab({
             key={option.id}
             testID={`recipe-process-filter-${option.id}`}
             accessibilityRole="button"
-            accessibilityLabel={`Use ${option.label.toLowerCase()} process display mode`}
+            accessibilityLabel={`Afficher le process en mode ${option.label.toLowerCase()}`}
             style={[
               styles.toggleChip,
               processDisplayMode === option.id && styles.toggleChipActive,
@@ -93,7 +94,9 @@ export function BrewingTab({
                   <Text style={styles.stepTitle}>
                     {item.stepOrder + 1}. {item.label}
                   </Text>
-                  <Text style={styles.stepType}>{item.type}</Text>
+                  <Text style={styles.stepType}>
+                    {RECIPE_STEP_TYPE_LABELS[item.type]}
+                  </Text>
                 </View>
                 {item.description ? (
                   <Text style={styles.stepDescription}>{item.description}</Text>

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/BrewingTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/BrewingTab.tsx
@@ -20,6 +20,37 @@ type BrewingTabProps = Readonly<{
 }>;
 
 /**
+ * Renders the recipe-authored steps for the "recipe" process mode, or
+ * an empty-state hint when the recipe carries none. Extracted to keep
+ * the tab's JSX free of nested ternaries (Sonar S3358).
+ */
+function renderRecipeSteps(steps: RecipeStep[]) {
+  if (steps.length === 0) {
+    return (
+      <Text style={styles.emptyText}>
+        Pas d'étapes renseignées pour cette recette.
+      </Text>
+    );
+  }
+
+  return steps.map((item) => (
+    <View key={`${item.recipeId}-${item.stepOrder}`} style={styles.stepRow}>
+      <View style={styles.stepHeader}>
+        <Text style={styles.stepTitle}>
+          {item.stepOrder + 1}. {item.label}
+        </Text>
+        <Text style={styles.stepType}>
+          {RECIPE_STEP_TYPE_LABELS[item.type]}
+        </Text>
+      </View>
+      {item.description ? (
+        <Text style={styles.stepDescription}>{item.description}</Text>
+      ) : null}
+    </View>
+  ));
+}
+
+/**
  * Brewing tab of the redesigned recipe detail screen
  * (Issue #740, Round 4 v2 — 5-tab layout).
  *
@@ -55,6 +86,7 @@ export function BrewingTab({
             testID={`recipe-process-filter-${option.id}`}
             accessibilityRole="button"
             accessibilityLabel={`Afficher le process en mode ${option.label.toLowerCase()}`}
+            accessibilityState={{ selected: processDisplayMode === option.id }}
             style={[
               styles.toggleChip,
               processDisplayMode === option.id && styles.toggleChipActive,
@@ -83,32 +115,7 @@ export function BrewingTab({
             ))
           : null}
 
-        {processDisplayMode === "recipe" ? (
-          steps.length > 0 ? (
-            steps.map((item) => (
-              <View
-                key={`${item.recipeId}-${item.stepOrder}`}
-                style={styles.stepRow}
-              >
-                <View style={styles.stepHeader}>
-                  <Text style={styles.stepTitle}>
-                    {item.stepOrder + 1}. {item.label}
-                  </Text>
-                  <Text style={styles.stepType}>
-                    {RECIPE_STEP_TYPE_LABELS[item.type]}
-                  </Text>
-                </View>
-                {item.description ? (
-                  <Text style={styles.stepDescription}>{item.description}</Text>
-                ) : null}
-              </View>
-            ))
-          ) : (
-            <Text style={styles.emptyText}>
-              Pas d'étapes renseignées pour cette recette.
-            </Text>
-          )
-        ) : null}
+        {processDisplayMode === "recipe" ? renderRecipeSteps(steps) : null}
 
         {processDisplayMode === "compact" ? (
           <>


### PR DESCRIPTION
## Why
Found during live device testing of an imported recipe (epic #1128 / #1134): the recipe-detail **Brewing** tab shipped English UI strings, breaking the French-only UI rule. The raw section labels (`brew phases`, `recipe steps`, `compact`) read like debug toggles.

## What
i18n pass on the Brewing tab only:
- **Display modes**: `Brew phases` → **Phases de brassage**, `Recipe steps` → **Étapes de la recette**, `Compact` → **Condensé**.
- **13 reference brewing phases** (titles + details) translated with standard French brewing vocabulary — Maltage, Concassage, **Empâtage**, Filtration, **Rinçage**, Ébullition, **Houblonnage**, Refroidissement, **Ensemencement**, Fermentation primaire/secondaire, Conditionnement, Maturation.
- New `RECIPE_STEP_TYPE_LABELS` map → the step-type chip renders in French (`mash` → Empâtage, …) instead of the raw enum.
- Accessibility label translated.

## Scope
**i18n only.** The ergonomic redesign of the three display modes (which is itself confusing UX) stays tracked on #1172 as a separate, designed effort.

### Known boundary (out of scope)
Each step's `label`/`description` comes from the **recipe data** — for default-workflow recipes that text is English (`RecipeWorkflowService.getDefaultWorkflow()` + the seed). Translating the backend default workflow is a separate backend follow-up, not a frontend constant.

## Tests
`RecipeDetailsScreen.test.tsx` — the Brewing-tab case now asserts the French mode labels, a French phase title (`🪣 EMPÂTAGE`), and the French step-type chip (`Empâtage`). Focused suite green; typecheck + lint clean.

Part of #1172.