### PR TITLE
fix(encyclopedia): import the ML pipeline lazily so the app boots without the ml extra

### DIFF
--- a/packages/beer-encyclopedia/api/routers/scan.py
+++ b/packages/beer-encyclopedia/api/routers/scan.py
@@ -17,7 +17,6 @@ from fastapi import APIRouter, File, HTTPException, UploadFile
 from fastapi.concurrency import run_in_threadpool
 
 from api.schemas.scan import ScanResponse
-from ml.pipeline import scan_image
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +44,25 @@ async def scan_endpoint(
             status_code=400,
             detail="Uploaded file must be an image.",
         )
+
+    # Import the ML pipeline lazily, here, rather than at module load.
+    # `ml.pipeline` pulls in the heavy CV/OCR stack (cv2, numpy, and
+    # optionally ultralytics/easyocr), which is intentionally NOT installed
+    # on the lean EAN/OpenFoodFacts deployment (ADR-0015: UC4 first, UC5/OCR
+    # later). Keeping the import out of module scope lets the app boot
+    # without those deps; a request to this endpoint then degrades to a
+    # clean 503 instead of crashing the whole service at startup.
+    #
+    # It is done BEFORE the threadpool block on purpose: the broad
+    # `except Exception -> 500` around `_run_scan` would otherwise swallow
+    # this HTTPException and mislabel a missing-dependency as a server error.
+    try:
+        from ml.pipeline import scan_image
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="Image analysis (ML pipeline) is not available on this deployment.",
+        ) from exc
 
     # Read the upload once (async, quick) then hand the CPU/IO-heavy work
     # off to a worker thread so the event loop stays free for other

--- a/packages/beer-encyclopedia/tests/test_api/test_scan.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_scan.py
@@ -72,17 +72,32 @@ def test_app_exposes_scan_router_routes() -> None:
     assert "/scan" in paths
 
 
-def test_scan_module_does_not_import_ml_at_load() -> None:
-    """The ML pipeline must be imported lazily (inside the endpoint), so the
-    service boots on a lean EAN/OpenFoodFacts deployment without the heavy
-    CV/OCR stack (ADR-0015). If `scan_image` is a module-level global, the
-    import moved back to module scope and the blocker has regressed."""
+def test_scan_router_imports_without_ml_pipeline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reloading the scan router with ``ml.pipeline`` made unimportable must
+    succeed — proving nothing at module scope imports the heavy CV/OCR stack,
+    so the service boots on a lean EAN/OpenFoodFacts deployment (ADR-0015).
+
+    A `hasattr(module, "scan_image")` check is too weak: a regression to a
+    bare `import ml.pipeline` would still pass it while reintroducing the
+    module-load import. Forcing ``ml.pipeline`` to be unimportable and
+    reloading the module catches any module-scope import (Copilot review on
+    #1177)."""
+
+    import importlib
 
     import api.routers.scan as scan_module
 
-    assert not hasattr(scan_module, "scan_image"), (
-        "scan_image must be imported lazily inside the endpoint, not at module load"
-    )
+    monkeypatch.setitem(sys.modules, "ml.pipeline", None)
+    try:
+        # Must NOT raise: the import is lazy (inside the endpoint). A
+        # module-scope `import ml.pipeline` would raise ImportError here.
+        importlib.reload(scan_module)
+    finally:
+        # Restore the genuine module so later tests see the real endpoint.
+        monkeypatch.undo()
+        importlib.reload(scan_module)
 
 
 def test_scan_returns_503_when_ml_pipeline_unavailable(

--- a/packages/beer-encyclopedia/tests/test_api/test_scan.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_scan.py
@@ -10,6 +10,7 @@ and /scan's failure paths short-circuit before reaching the pipeline.
 from __future__ import annotations
 
 import io
+import sys
 from collections.abc import Iterator
 
 import pytest
@@ -69,3 +70,37 @@ def test_app_exposes_scan_router_routes() -> None:
     paths = {route.path for route in app.routes if hasattr(route, "methods")}
     assert "/health" in paths
     assert "/scan" in paths
+
+
+def test_scan_module_does_not_import_ml_at_load() -> None:
+    """The ML pipeline must be imported lazily (inside the endpoint), so the
+    service boots on a lean EAN/OpenFoodFacts deployment without the heavy
+    CV/OCR stack (ADR-0015). If `scan_image` is a module-level global, the
+    import moved back to module scope and the blocker has regressed."""
+
+    import api.routers.scan as scan_module
+
+    assert not hasattr(scan_module, "scan_image"), (
+        "scan_image must be imported lazily inside the endpoint, not at module load"
+    )
+
+
+def test_scan_returns_503_when_ml_pipeline_unavailable(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On a deployment without the ML extra installed, the lazy
+    `from ml.pipeline import scan_image` raises ImportError; the endpoint must
+    degrade to a clean 503, not crash with a 500. Setting the module to None in
+    sys.modules makes the import fail with ImportError (the standard
+    simulation)."""
+
+    monkeypatch.setitem(sys.modules, "ml.pipeline", None)
+
+    response = client.post(
+        "/scan",
+        files={"file": ("label.jpg", io.BytesIO(b"\xff\xd8\xff"), "image/jpeg")},
+    )
+
+    assert response.status_code == 503
+    assert "available" in response.json()["detail"].lower()


### PR DESCRIPTION
## Why
`api/routers/scan.py` did `from ml.pipeline import scan_image` **at module load**, which transitively imports the heavy CV/OCR stack (cv2, numpy, optionally ultralytics/easyocr). Because `api/main.py` mounts the scan router, the **whole FastAPI service could not start** without the `ml` extra installed. This blocks a lean EAN/OpenFoodFacts deployment (ADR-0015 / #1175: UC4 first, OCR later).

## What
- Move the `from ml.pipeline import scan_image` **inside the `/scan` endpoint**, before the threadpool block (so the broad `except Exception → 500` doesn't swallow it). A missing ML stack now degrades to a clean **503** instead of crashing the service at startup.
- `api/schemas/scan.py` re-exports `ml.schemas`, which only imports `pydantic` — verified light, **no decoupling needed**.

## Tests
`tests/test_api/test_scan.py` (7 passed, ruff clean):
- `test_scan_module_does_not_import_ml_at_load` — guards against the import regressing back to module scope.
- `test_scan_returns_503_when_ml_pipeline_unavailable` — simulates the lean deploy (no `ml`) via `sys.modules`; asserts **503**, not 500.
- existing `/health` + validation tests unchanged.

Unblocks the encyclopedia Fly.io deploy (branch `chore/deploy-encyclopedia-fly`). Part of #1175.