### PR TITLE
chore(encyclopedia): Fly.io deployment (Dockerfile + fly.toml, SQLite-on-volume)

### DIFF
--- a/packages/beer-encyclopedia/.dockerignore
+++ b/packages/beer-encyclopedia/.dockerignore
@@ -1,0 +1,25 @@
+# Keep the build context lean WITHOUT dropping anything imported at runtime.
+#
+# IMPORTANT: do NOT exclude `ml/`, `db/`, `api/`, `importers/`, `migrations/`,
+# `scripts/`, `data/`, `configs/`, `pyproject.toml` or `alembic.ini`:
+# - `pip install .` reads the source to install the `api`/`ml`/`db`/`importers`
+#   packages (pyproject `include`);
+# - `api/schemas/scan.py` imports `ml.schemas` at module load, so the `ml/`
+#   source must be present even though the heavy `ml` *extra* is not installed;
+# - `alembic upgrade head` needs `alembic.ini` + `migrations/` at runtime;
+# - the seed scripts under `scripts/` are run on the deployed machine.
+.venv
+**/__pycache__
+**/*.pyc
+*.egg-info
+.pytest_cache
+.ruff_cache
+.git
+.gitignore
+tests
+scan-photos
+docs
+*.db
+*.sqlite
+.env
+.env.*

--- a/packages/beer-encyclopedia/Dockerfile
+++ b/packages/beer-encyclopedia/Dockerfile
@@ -1,0 +1,35 @@
+# Beer-encyclopedia (FastAPI) — production image for Fly.io.
+#
+# Runs on SQLite stored on a Fly volume (mounted at /app/data), mirroring
+# the NestJS API's deployment pattern (ADR-0001 "build for today"). The
+# Alembic migrations are verified SQLite-compatible (batch_alter_table,
+# JSON-variant columns, no CREATE EXTENSION); `is_postgres()` runtime guards
+# degrade pg_trgm search to a substring match on SQLite — acceptable for the
+# current catalogue size, upgradeable to Postgres later (see ADR-0015 / #1175).
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PIP_NO_CACHE_DIR=1
+
+# gcc is a safety net for any source-only dependency wheel (e.g. asyncpg on
+# uncommon platforms). Removed from the final layer to keep the image lean.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . .
+
+# Install the app + the SQLite async driver explicitly (aiosqlite ships in the
+# `dev` extra; we want it in prod without pulling pytest/ruff). The heavy `ml`
+# extra (YOLO/EasyOCR) is intentionally NOT installed — label OCR (UC5) is a
+# later slice; this image serves the EAN / OpenFoodFacts path (UC4).
+RUN pip install . "aiosqlite>=0.20"
+
+EXPOSE 8080
+
+# Apply migrations (idempotent) then serve. Shell form so `&&` is honoured;
+# a failed migration exits the container and Fly restarts it.
+CMD alembic upgrade head && uvicorn api.main:app --host 0.0.0.0 --port 8080

--- a/packages/beer-encyclopedia/Dockerfile
+++ b/packages/beer-encyclopedia/Dockerfile
@@ -14,12 +14,10 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1
 
-# gcc is a safety net for any source-only dependency wheel (e.g. asyncpg on
-# uncommon platforms). Removed from the final layer to keep the image lean.
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc \
-    && rm -rf /var/lib/apt/lists/*
-
+# No build toolchain: every runtime dependency (fastapi, uvicorn, sqlalchemy,
+# alembic, asyncpg, aiosqlite, pydantic) ships a manylinux wheel for
+# cp312-slim, so the image needs no compiler — keeping it lean and reducing
+# the attack surface.
 COPY . .
 
 # Install the app + the SQLite async driver explicitly (aiosqlite ships in the
@@ -30,6 +28,14 @@ RUN pip install . "aiosqlite>=0.20"
 
 EXPOSE 8080
 
-# Apply migrations (idempotent) then serve. Shell form so `&&` is honoured;
-# a failed migration exits the container and Fly restarts it.
-CMD alembic upgrade head && uvicorn api.main:app --host 0.0.0.0 --port 8080
+# Boot sequence (all idempotent): apply migrations, ensure the
+# `openfoodfacts` Source row exists (a FK requirement for
+# /beers/import-by-ean — without it the endpoint 503s on a fresh volume),
+# then `exec` uvicorn so it replaces the shell and runs as PID 1 — giving
+# Fly's SIGTERM proper graceful-shutdown handling. A failed migration or seed
+# exits the container and Fly restarts it. (Reference data — styles, legal
+# denominations — stays a manual one-off seed; only the source is required to
+# serve imports.)
+CMD alembic upgrade head \
+    && python scripts/seed_sources.py \
+    && exec uvicorn api.main:app --host 0.0.0.0 --port 8080

--- a/packages/beer-encyclopedia/fly.toml
+++ b/packages/beer-encyclopedia/fly.toml
@@ -1,0 +1,41 @@
+# Fly.io deployment for the beer-encyclopedia (FastAPI).
+#
+# Lean EAN / OpenFoodFacts image (UC4) on SQLite-on-volume — the heavy `ml`
+# extra (label OCR, UC5) is intentionally not installed, and the scan router
+# imports it lazily (PR #1177) so the service boots without it. See
+# ADR-0015 / epic #1175.
+app = "brasse-bouillon-encyclopedia"
+primary_region = "cdg"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PYTHONUNBUFFERED = "1"
+  # SQLite on the mounted volume (4 slashes = absolute path). Change to a
+  # Postgres DATABASE_URL secret if/when full-text search is needed.
+  DATABASE_URL = "sqlite+aiosqlite:////app/data/encyclopedia.db"
+
+[[mounts]]
+  source = "enc_data"
+  destination = "/app/data"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = true
+  min_machines_running = 1
+  processes = ["app"]
+
+  [[http_service.checks]]
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "20s"
+    method = "GET"
+    path = "/health"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "512mb"
+  cpus = 1


### PR DESCRIPTION
## What
Deploys the **beer-encyclopedia** (FastAPI) to Fly.io as a lean EAN / OpenFoodFacts image (UC4) — **already deployed and verified live** from this branch.

- **Dockerfile** — `python:3.12-slim`, `pip install . "aiosqlite>=0.20"` (the heavy `ml` extra is NOT installed; the scan router imports `ml.pipeline` lazily — #1177 — so the app boots without it and the OCR endpoint degrades to 503). `CMD alembic upgrade head && uvicorn api.main:app`.
- **fly.toml** — app `brasse-bouillon-encyclopedia`, region `cdg`, SQLite on the `enc_data` volume (`DATABASE_URL=sqlite+aiosqlite:////app/data/encyclopedia.db`), `/health` check. Mirrors the NestJS API's SQLite-on-volume pattern.
- **.dockerignore** — keeps everything imported/run at runtime (`ml/`, `db/`, `importers/`, `migrations/`, `scripts/`, `data/`, `configs/`); only drops `.venv`, caches, `tests`, `scan-photos`, `docs`, `*.db`. Build context is the package dir.

## Verified live
- `GET https://brasse-bouillon-encyclopedia.fly.dev/health` → **200** `{"status":"ok"}` (app boots without the `ml` extra ✓).
- Seeded prod: 1 source (openfoodfacts), 15 styles, 10 FR legal denominations.
- `POST /beers/import-by-ean {"ean":"5056025440494"}` → **201**, persisted `BREWDOG IPA` (`source=openfoodfacts`, `is_verified=false`, brewery + EntitySource provenance) — UC4 end-to-end ✓.

DB choice (SQLite-on-volume) per ADR-0015; `alembic upgrade head` verified SQLite-compatible. Part of #1175.