### PR TITLE
chore(mobile): point the scan fallback at the deployed beer-encyclopedia

### DIFF
--- a/packages/mobile-app/eas.json
+++ b/packages/mobile-app/eas.json
@@ -17,6 +17,7 @@
       },
       "env": {
         "EXPO_PUBLIC_API_URL": "https://brasse-bouillon-api.fly.dev",
+        "EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL": "https://brasse-bouillon-encyclopedia.fly.dev",
         "EXPO_PUBLIC_USE_DEMO_DATA": "false"
       }
     },
@@ -28,6 +29,7 @@
       },
       "env": {
         "EXPO_PUBLIC_API_URL": "https://brasse-bouillon-api.fly.dev",
+        "EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL": "https://brasse-bouillon-encyclopedia.fly.dev",
         "EXPO_PUBLIC_USE_DEMO_DATA": "true"
       }
     },


### PR DESCRIPTION
## What
Sets `EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL` = `https://brasse-bouillon-encyclopedia.fly.dev` in both the **`preview`** and **`preview-demo`** EAS profiles.

## Why
The mobile scan fallback (NestJS `/scan/lookup` 404/503 → encyclopedia `POST /beers/import-by-ean`, PR #847) was **already coded** but had no deployed target, so on a physical device the `encyclopediaUrlIsConfigured` guard fired a "not configured" 503. The encyclopedia is now live (#1178), so a scanned barcode unknown to the NestJS catalog resolves + persists via OpenFoodFacts (UC4, ADR-0015).

**No code change — env only.** The fallback logic in `scan-lookup.use-cases.ts` + `beers-import.api.ts` is unchanged.

## Verified
The deployed encyclopedia already serves UC4: `POST /beers/import-by-ean {"ean":"5056025440494"}` → 201, persisted `BREWDOG IPA` (`source=openfoodfacts`, `is_verified=false`).

Part of #1175. Device test (scan → fiche) to follow on the new build.