### PR TITLE
feat(encyclopedia): extract style + description from the OpenFoodFacts response

### DIFF
--- a/packages/beer-encyclopedia/Dockerfile
+++ b/packages/beer-encyclopedia/Dockerfile
@@ -28,14 +28,16 @@ RUN pip install . "aiosqlite>=0.20"
 
 EXPOSE 8080
 
-# Boot sequence (all idempotent): apply migrations, ensure the
-# `openfoodfacts` Source row exists (a FK requirement for
-# /beers/import-by-ean — without it the endpoint 503s on a fresh volume),
-# then `exec` uvicorn so it replaces the shell and runs as PID 1 — giving
-# Fly's SIGTERM proper graceful-shutdown handling. A failed migration or seed
-# exits the container and Fly restarts it. (Reference data — styles, legal
-# denominations — stays a manual one-off seed; only the source is required to
-# serve imports.)
+# Boot sequence (all idempotent): apply migrations, then seed the catalogue
+# the import path depends on — the `openfoodfacts` Source (a FK requirement
+# for /beers/import-by-ean; without it the endpoint 503s on a fresh volume)
+# and the Style rows (so OFF category → Style resolution actually links a
+# `style_id` instead of silently staying null on a fresh volume). Finally
+# `exec` uvicorn so it replaces the shell and runs as PID 1 — giving Fly's
+# SIGTERM proper graceful-shutdown handling. A failed migration or seed exits
+# the container and Fly restarts it. (Legal denominations stay a manual
+# one-off seed; they are not on the scan/import hot path.)
 CMD alembic upgrade head \
     && python scripts/seed_sources.py \
+    && python scripts/seed_styles.py \
     && exec uvicorn api.main:app --host 0.0.0.0 --port 8080

--- a/packages/beer-encyclopedia/importers/base.py
+++ b/packages/beer-encyclopedia/importers/base.py
@@ -46,6 +46,15 @@ class ExternalBeerSnapshot:
     image_url: str | None = None
     """URL of the front-label image, when the source publishes one."""
 
+    style_slug: str | None = None
+    """Resolved canonical style slug (e.g. ``"ipa"``) when the source's
+    category taxonomy maps to one of the seeded ``Style`` rows; ``None``
+    when no confident match. Persistence looks it up against ``Style.slug``."""
+
+    description: str | None = None
+    """Free-text description (e.g. the source's ingredients list) when
+    available. ``None`` when the source omits it."""
+
     raw_payload: dict[str, object] = field(default_factory=dict)
     """Original payload kept for the ``EntitySource.raw_data`` audit trail.
 

--- a/packages/beer-encyclopedia/importers/openfoodfacts.py
+++ b/packages/beer-encyclopedia/importers/openfoodfacts.py
@@ -29,6 +29,7 @@ contact channel.
 from __future__ import annotations
 
 import os
+import re
 from decimal import Decimal, InvalidOperation
 
 import httpx
@@ -243,14 +244,34 @@ def _pick_style_slug(product: dict[str, object]) -> str | None:
     and returns the first confident match. Returns ``None`` when no rule
     matches, so beers without a recognisable style stay unclassified
     rather than mislabelled.
+
+    Matching is **segment-based**, not a raw substring search: each tag
+    has its ``xx:`` language prefix stripped and is split on ``-``/``_``
+    into segments, and a single-word keyword matches only a whole segment
+    (tolerating a simple ``s``/``es`` plural). This avoids false positives
+    like ``en:camembert`` → ``amber`` that a substring search would
+    produce. Hyphenated keywords (e.g. ``barley-wine``) fall back to a
+    per-tag substring match since they span segments.
     """
 
     tags = product.get("categories_tags")
     if not isinstance(tags, list):
         return None
-    haystack = " ".join(t.lower() for t in tags if isinstance(t, str))
+
+    segments: set[str] = set()
+    leaf_tags: list[str] = []
+    for tag in tags:
+        if not isinstance(tag, str):
+            continue
+        leaf = tag.lower().rpartition(":")[2] or tag.lower()
+        leaf_tags.append(leaf)
+        segments.update(seg for seg in re.split(r"[-_]", leaf) if seg)
+
     for keyword, slug in _OFF_CATEGORY_STYLE_RULES:
-        if keyword in haystack:
+        if "-" in keyword:
+            if any(keyword in leaf for leaf in leaf_tags):
+                return slug
+        elif segments & {keyword, f"{keyword}s", f"{keyword}es"}:
             return slug
     return None
 

--- a/packages/beer-encyclopedia/importers/openfoodfacts.py
+++ b/packages/beer-encyclopedia/importers/openfoodfacts.py
@@ -195,8 +195,79 @@ def _map_product_to_snapshot(
         country_of_origin=_pick_country_iso2(product),
         allergens=_pick_allergens(product),
         image_url=_pick_image_url(product),
+        style_slug=_pick_style_slug(product),
+        description=_pick_description(product),
         raw_payload=product,
     )
+
+
+# Maps an OFF category-tag keyword to one of the seeded `Style.slug`
+# values (see scripts/seed_styles.py). Ordered most-specific first so a
+# Punk IPA (`en:punk-ipa`, `en:pale-ales`) resolves to `ipa`, not a
+# broader style. Only confident, unambiguous keywords are listed —
+# anything unmatched stays `None` (no style guessed) rather than risking
+# a wrong classification the moderation queue would have to undo.
+_OFF_CATEGORY_STYLE_RULES: tuple[tuple[str, str], ...] = (
+    ("ipa", "ipa"),
+    ("stout", "stout"),
+    ("porter", "porter"),
+    ("pilsner", "pilsner"),
+    ("pils", "pilsner"),
+    ("hefeweizen", "hefeweizen"),
+    ("weizen", "hefeweizen"),
+    ("weiss", "hefeweizen"),
+    ("witbier", "wheat"),
+    ("wheat", "wheat"),
+    ("blanche", "wheat"),
+    ("quadrupel", "quadrupel"),
+    ("dubbel", "dubbel"),
+    ("tripel", "tripel"),
+    ("barley-wine", "barleywine"),
+    ("barleywine", "barleywine"),
+    ("saison", "saison"),
+    ("lambic", "sour"),
+    ("gose", "sour"),
+    ("sour", "sour"),
+    ("amber", "amber_ale"),
+    ("blonde", "blonde_ale"),
+    ("blond", "blonde_ale"),
+    ("lager", "lager"),
+)
+
+
+def _pick_style_slug(product: dict[str, object]) -> str | None:
+    """Resolve a canonical style slug from OFF's category taxonomy.
+
+    Scans ``categories_tags`` (e.g. ``["en:beers", "en:ales",
+    "en:pale-ales", "en:punk-ipa"]``) against `_OFF_CATEGORY_STYLE_RULES`
+    and returns the first confident match. Returns ``None`` when no rule
+    matches, so beers without a recognisable style stay unclassified
+    rather than mislabelled.
+    """
+
+    tags = product.get("categories_tags")
+    if not isinstance(tags, list):
+        return None
+    haystack = " ".join(t.lower() for t in tags if isinstance(t, str))
+    for keyword, slug in _OFF_CATEGORY_STYLE_RULES:
+        if keyword in haystack:
+            return slug
+    return None
+
+
+def _pick_description(product: dict[str, object]) -> str | None:
+    """Return a short free-text description from OFF.
+
+    Uses the localised then canonical ``ingredients_text`` (OFF rarely
+    carries a real beer description, but the ingredients list is useful
+    content for the fiche). ``None`` when absent/empty.
+    """
+
+    for key in ("ingredients_text_fr", "ingredients_text", "ingredients_text_en"):
+        value = product.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
 
 
 def _pick_name(product: dict[str, object]) -> str:

--- a/packages/beer-encyclopedia/importers/persistence.py
+++ b/packages/beer-encyclopedia/importers/persistence.py
@@ -213,9 +213,14 @@ def _refresh_beer_fields(
 
     - **Fill ``style_id`` / ``description`` only when empty.** These can
       now be derived from the source (style from OFF categories,
-      description from the ingredients list), so a re-import backfills
-      them when the row has none yet — but a non-null value (a
-      moderator's correction or an earlier source) is kept untouched.
+      description from the ingredients list), so this path fills them
+      when the row has none yet, while a non-null value (a moderator's
+      correction or an earlier source) is kept untouched. Note this only
+      runs when a fetch actually reaches the upsert: the current
+      ``POST /beers/import-by-ean`` route is DB-first and returns a known
+      EAN from the cache **without** re-fetching, so existing rows are
+      not backfilled by a plain duplicate import — that needs a real
+      re-fetch (a future refresh flag, or delete + re-import).
 
     - **Never clear on refresh.** A re-import only writes a value when
       the snapshot carries one (``brewery is not None``,

--- a/packages/beer-encyclopedia/importers/persistence.py
+++ b/packages/beer-encyclopedia/importers/persistence.py
@@ -16,7 +16,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.slug import build_unique_slug
-from db.models import Beer, Brewery, EntitySource, Source
+from db.models import Beer, Brewery, EntitySource, Source, Style
 from importers.base import ExternalBeerSnapshot
 
 
@@ -61,6 +61,7 @@ async def upsert_beer_from_snapshot(
 
     source = await _fetch_source_or_raise(session, source_name=source_name)
     brewery = await _upsert_brewery(session, name=snapshot.brand)
+    style = await _resolve_style(session, slug=snapshot.style_slug)
 
     existing_beer = (
         await session.execute(
@@ -73,11 +74,14 @@ async def upsert_beer_from_snapshot(
             session,
             snapshot=snapshot,
             brewery=brewery,
+            style=style,
             source_name=source_name,
         )
         created = True
     else:
-        _refresh_beer_fields(existing_beer, snapshot=snapshot, brewery=brewery)
+        _refresh_beer_fields(
+            existing_beer, snapshot=snapshot, brewery=brewery, style=style
+        )
         beer = existing_beer
         created = False
 
@@ -140,11 +144,28 @@ async def _upsert_brewery(
     return brewery
 
 
+async def _resolve_style(
+    session: AsyncSession, *, slug: str | None
+) -> Style | None:
+    """Look up a seeded ``Style`` by slug. Returns ``None`` when the
+    snapshot carries no style hint or the slug is not in the catalogue —
+    the importer only links to styles that already exist (it never
+    creates them), so an unrecognised slug leaves the beer unclassified.
+    """
+
+    if slug is None:
+        return None
+    return (
+        await session.execute(select(Style).where(Style.slug == slug))
+    ).scalar_one_or_none()
+
+
 async def _create_beer(
     session: AsyncSession,
     *,
     snapshot: ExternalBeerSnapshot,
     brewery: Brewery | None,
+    style: Style | None,
     source_name: str,
 ) -> Beer:
     """Insert a new beer row carrying the snapshot's payload.
@@ -161,7 +182,9 @@ async def _create_beer(
         name=snapshot.name,
         slug=slug,
         brewery_id=brewery.id if brewery is not None else None,
+        style_id=style.id if style is not None else None,
         abv=snapshot.abv,
+        description=snapshot.description,
         country_of_origin=snapshot.country_of_origin,
         allergens=list(snapshot.allergens) or None,
         ean_code=snapshot.external_id,
@@ -178,17 +201,21 @@ def _refresh_beer_fields(
     *,
     snapshot: ExternalBeerSnapshot,
     brewery: Brewery | None,
+    style: Style | None,
 ) -> None:
     """Update mutable fields on an existing beer row.
 
-    Two layered policies:
+    Three layered policies:
 
-    - **Never overwrite hand-edited fields.** ``name``, ``slug``,
-      ``description``, ``style_id`` and ``legal_denomination`` are
-      preserved unconditionally — they may have been corrected by a
-      moderator or refined by another source, and we do not have
-      enough context to know whether the snapshot value is more
-      accurate.
+    - **Never overwrite hand-edited fields.** ``name``, ``slug`` and
+      ``legal_denomination`` are preserved unconditionally — they may
+      have been corrected by a moderator or refined by another source.
+
+    - **Fill ``style_id`` / ``description`` only when empty.** These can
+      now be derived from the source (style from OFF categories,
+      description from the ingredients list), so a re-import backfills
+      them when the row has none yet — but a non-null value (a
+      moderator's correction or an earlier source) is kept untouched.
 
     - **Never clear on refresh.** A re-import only writes a value when
       the snapshot carries one (``brewery is not None``,
@@ -203,6 +230,10 @@ def _refresh_beer_fields(
 
     if brewery is not None:
         beer.brewery_id = brewery.id
+    if style is not None and beer.style_id is None:
+        beer.style_id = style.id
+    if snapshot.description and not beer.description:
+        beer.description = snapshot.description
     if snapshot.abv is not None:
         beer.abv = snapshot.abv
     if snapshot.country_of_origin is not None:

--- a/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
@@ -25,7 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.main import app
 from api.routers.beers import get_openfoodfacts_client
-from db.models import Beer, Brewery, EntitySource, Source
+from db.models import Beer, Brewery, EntitySource, Source, Style
 from importers.base import ExternalBeerSnapshot
 from importers.openfoodfacts import OpenFoodFactsError
 from scripts.seed_sources import seed_sources
@@ -156,6 +156,68 @@ async def test_first_import_creates_beer_and_returns_201(
     assert audit.entity_id == beer.id
     assert audit.raw_data == snapshot.raw_payload
     assert audit.last_synced_at is not None
+
+
+async def test_import_links_resolved_style_and_description(
+    client: TestClient,
+    db_session: AsyncSession,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    """A snapshot whose OFF categories resolved to a seeded style + an
+    ingredients description persists `Beer.style_id` and `Beer.description`."""
+    ipa = Style(name="India Pale Ale", slug="ipa", category="Ale")
+    db_session.add(ipa)
+    await db_session.flush()
+
+    snapshot = ExternalBeerSnapshot(
+        external_id=EAN_PELFORTH,
+        name="Hazy IPA",
+        brand="Some Brewery",
+        style_slug="ipa",
+        description="Eau, malt d'orge, houblon, levure.",
+        raw_payload={"code": EAN_PELFORTH},
+    )
+    stub_off_factory(lambda _: snapshot)
+
+    response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
+    assert response.status_code == 201
+
+    beer = (
+        await db_session.execute(
+            select(Beer).where(Beer.ean_code == EAN_PELFORTH)
+        )
+    ).scalar_one()
+    assert beer.style_id == ipa.id
+    assert beer.description == "Eau, malt d'orge, houblon, levure."
+
+
+async def test_import_leaves_style_none_when_slug_not_seeded(
+    client: TestClient,
+    db_session: AsyncSession,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    """An unrecognised style slug (no matching seeded Style) leaves the beer
+    unclassified — the importer links to existing styles, never creates them."""
+    snapshot = ExternalBeerSnapshot(
+        external_id=EAN_PELFORTH,
+        name="Mystery Brew",
+        brand=None,
+        style_slug="not-a-seeded-style",
+        raw_payload={"code": EAN_PELFORTH},
+    )
+    stub_off_factory(lambda _: snapshot)
+
+    response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
+    assert response.status_code == 201
+
+    beer = (
+        await db_session.execute(
+            select(Beer).where(Beer.ean_code == EAN_PELFORTH)
+        )
+    ).scalar_one()
+    assert beer.style_id is None
 
 
 async def test_import_creates_brewery_with_unique_slug(

--- a/packages/beer-encyclopedia/tests/test_importers/test_openfoodfacts_client.py
+++ b/packages/beer-encyclopedia/tests/test_importers/test_openfoodfacts_client.py
@@ -339,6 +339,25 @@ def test_pick_style_slug_returns_none_without_a_category_list() -> None:
     assert _pick_style_slug({"categories_tags": "en:beers"}) is None
 
 
+def test_pick_style_slug_ignores_substring_false_positives() -> None:
+    # `en:camembert` contains the substring "amber" but is not a beer
+    # style — segment matching must not map it to `amber_ale` (a raw
+    # substring search would). Likewise "sourdough" must not match "sour".
+    assert (
+        _pick_style_slug({"categories_tags": ["en:cheeses", "en:camembert"]})
+        is None
+    )
+    assert (
+        _pick_style_slug({"categories_tags": ["en:breads", "en:sourdough-bread"]})
+        is None
+    )
+
+
+def test_pick_style_slug_tolerates_plural_segment() -> None:
+    # OFF pluralises leaf categories (`en:stouts`, `en:porters`).
+    assert _pick_style_slug({"categories_tags": ["en:porters"]}) == "porter"
+
+
 # --- Description mapping (OFF ingredients text) --------------------------
 
 

--- a/packages/beer-encyclopedia/tests/test_importers/test_openfoodfacts_client.py
+++ b/packages/beer-encyclopedia/tests/test_importers/test_openfoodfacts_client.py
@@ -23,6 +23,8 @@ from importers.openfoodfacts import (
     DEFAULT_BASE_URL,
     OpenFoodFactsClient,
     OpenFoodFactsError,
+    _pick_description,
+    _pick_style_slug,
 )
 
 # Type alias for the mock-transport handler signature so every test
@@ -54,6 +56,8 @@ async def test_fetch_by_ean_returns_full_snapshot_for_known_product() -> None:
             "allergens_tags": ["en:gluten"],
             "image_front_url": "https://example.org/pelforth.jpg",
             "nutriments": {"alcohol_value": 6.5, "alcohol_unit": "% vol"},
+            "categories_tags": ["en:beers", "en:ales", "en:brown-ales"],
+            "ingredients_text": "Eau, malt d'orge, houblon, levure.",
         },
     }
 
@@ -72,6 +76,10 @@ async def test_fetch_by_ean_returns_full_snapshot_for_known_product() -> None:
     assert snapshot.country_of_origin == "FR"
     assert snapshot.allergens == ["gluten"]
     assert snapshot.image_url == "https://example.org/pelforth.jpg"
+    assert snapshot.description == "Eau, malt d'orge, houblon, levure."
+    # `en:brown-ales` maps to no seeded style → stays None (no
+    # over-classification), unlike the IPA case covered below.
+    assert snapshot.style_slug is None
     # Audit trail keeps the full source payload.
     assert snapshot.raw_payload == payload["product"]
 
@@ -301,3 +309,54 @@ async def test_image_url_falls_back_to_image_url_when_front_missing() -> None:
 
     assert snapshot is not None
     assert snapshot.image_url == "https://example.org/fallback.jpg"
+
+
+# --- Style mapping (OFF categories → seeded Style slug) ------------------
+
+
+def test_pick_style_slug_resolves_ipa_from_punk_ipa_categories() -> None:
+    product: dict[str, object] = {
+        "categories_tags": ["en:beers", "en:ales", "en:pale-ales", "en:punk-ipa"]
+    }
+    assert _pick_style_slug(product) == "ipa"
+
+
+def test_pick_style_slug_resolves_stout() -> None:
+    assert _pick_style_slug({"categories_tags": ["en:beers", "en:stouts"]}) == "stout"
+
+
+def test_pick_style_slug_returns_none_when_no_rule_matches() -> None:
+    # A bare beers/ales pair maps to no specific seeded style — better
+    # unclassified than mislabelled.
+    product: dict[str, object] = {
+        "categories_tags": ["en:beverages", "en:beers", "en:ales"]
+    }
+    assert _pick_style_slug(product) is None
+
+
+def test_pick_style_slug_returns_none_without_a_category_list() -> None:
+    assert _pick_style_slug({}) is None
+    assert _pick_style_slug({"categories_tags": "en:beers"}) is None
+
+
+# --- Description mapping (OFF ingredients text) --------------------------
+
+
+def test_pick_description_uses_ingredients_text() -> None:
+    assert (
+        _pick_description({"ingredients_text": "Eau, malt, houblon."})
+        == "Eau, malt, houblon."
+    )
+
+
+def test_pick_description_prefers_french_then_english_fallback() -> None:
+    assert (
+        _pick_description({"ingredients_text_fr": "FR", "ingredients_text": "EN"})
+        == "FR"
+    )
+    assert _pick_description({"ingredients_text_en": "EN only"}) == "EN only"
+
+
+def test_pick_description_returns_none_when_absent_or_blank() -> None:
+    assert _pick_description({}) is None
+    assert _pick_description({"ingredients_text": "   "}) is None


### PR DESCRIPTION
## Why
Device-testing the live scan showed a near-empty beer fiche (style/abv null). But part of the data **is in the OFF payload** — we just weren't mapping it (confirmed on the BrewDog IPA response: `categories_tags` has `en:pale-ales`/`en:punk-ipa`, `ingredients_text` is present, but `style_id`/`description` came back null). This widens the importer to use what OFF already gives.

## What
- **`_pick_style_slug`** — maps `categories_tags` to a seeded `Style.slug` via an ordered, most-specific-first rule table (`en:punk-ipa`/`en:pale-ales` → `ipa`; stout, porter, pilsner, wheat, tripel, dubbel, saison, sour, …). Unmatched → `None` (never guesses a wrong style).
- **`_pick_description`** — uses `ingredients_text` (fr → en fallback).
- **`ExternalBeerSnapshot`** gains `style_slug` + `description`.
- **Persistence** — `_resolve_style` looks the slug up against the **seeded** styles (never creates one) → sets `Beer.style_id`; sets `Beer.description`. On re-import, fills `style_id`/`description` **only when empty** → backfills beers imported before this change without clobbering a moderator's correction.

ABV/IBU/SRM stay null when OFF omits them (it's a food DB, not a beer DB) — that's the **web/AI enrichment** slice of #1175, not this one.

## Tests
Mapper unit tests (IPA/stout resolution, no-false-positive on bare beers/ales, blank handling) + import-by-ean integration (style+description persisted; unknown slug → `style_id` null). **150 package tests green**, ruff clean.

Part of #1175.