### PR TITLE
docs(conception): model the beer API DTO contract (BeerRead denormalized names)

### DIFF
--- a/docs/architecture/diagrams/beer-encyclopedia/07-class-api-contract.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/07-class-api-contract.md
@@ -1,0 +1,177 @@
+# Diagramme de classes — beer-encyclopedia — contrat API (DTO Pydantic)
+
+> **Périmètre :** schémas Pydantic exposés par le routeur `beers` (forme des requêtes/réponses HTTP)
+> **Code concerné :** `api/schemas/beer.py`, `api/schemas/common.py`
+> **ADR liés :** ADR-0005 (split encyclopédie/produit — l'API encyclopédie est consommée par le mobile), repo ADR-0013 (`Beer` normalisé canonique), ADR-0015 (ingestion/enrichissement)
+> **Voir aussi :** `04-class.md` (modèle de domaine), `02-sequence-import-by-ean.md` (renvoie `BeerRead`), `03-component.md` (composant `schemas`), `../../traceability-matrix.md`
+
+## Contexte
+
+`04-class.md` modélise le **domaine** (entités ORM). Ce diagramme modélise la **couche
+contrat** : les DTO Pydantic que l'API sérialise en entrée/sortie HTTP — distincts des
+entités. Il existe parce que des **clients externes** en dépendent : le mobile lit
+`BeerRead` via le fallback scan (`mapPythonBeerToCatalogItem` dans
+`features/scan/data/beers-import.api.ts`), et la séquence `import-by-ean` (UC4) répond
+`200/201 (BeerRead)`.
+
+**Décision modélisée ici (target) :** `BeerRead` expose **`brewery_name` et `style_name`
+dénormalisés** — des projections **en lecture seule** des relations `Beer → Brewery` et
+`Beer → Style` déjà présentes au modèle de domaine (04-class). Objectif : le client affiche
+« BrewDog » / « IPA » **sans second aller-retour** (résoudre l'UUID en nom). Le domaine est
+**inchangé** (aucune nouvelle entité/colonne/relation) ; c'est une mise en forme du DTO.
+
+**Lisibilité :** `?` marque un champ optionnel (`| None`). Les contraintes de validation
+(`min_length`, `ge/le`, `pattern`) sont notées en commentaire, pas exhaustives — la source
+reste `api/schemas/beer.py`.
+
+## Diagramme (Mermaid — aperçu rapide)
+
+```mermaid
+classDiagram
+  class BeerBase {
+    +str name
+    +UUID brewery_id?
+    +UUID style_id?
+    +Decimal abv?
+    +int ibu?
+    +int srm?
+    +str description?
+    +bool is_active
+  }
+  class BeerCreate {
+    <<POST /beers body>>
+  }
+  class BeerUpdate {
+    <<PATCH /beers/{id} body — tous optionnels>>
+    +str name?
+    +UUID brewery_id?
+    +UUID style_id?
+    +Decimal abv?
+    +int ibu?
+    +int srm?
+    +str description?
+    +bool is_active?
+    +bool is_verified?
+  }
+  class BeerRead {
+    <<from_attributes=true>>
+    +UUID id
+    +str slug
+    +str brewery_name?
+    +str style_name?
+    +bool is_verified
+    +str source
+    +str ean_code?
+    +str legal_denomination?
+    +str country_of_origin?
+    +list~str~ allergens?
+    +int alcohol_group?
+    +datetime created_at
+    +datetime updated_at
+  }
+  class BeerList {
+    +list~BeerRead~ items
+    +PaginationMeta meta
+  }
+  class BeerImportByEanRequest {
+    <<POST /beers/import-by-ean body>>
+    +str ean
+  }
+
+  BeerBase <|-- BeerCreate
+  BeerBase <|-- BeerRead
+  BeerList "1" o-- "0..*" BeerRead : items
+  BeerRead ..> Beer : projette (from_attributes)
+  BeerRead ..> Brewery : brewery_name (dénormalisé, lecture)
+  BeerRead ..> Style : style_name (dénormalisé, lecture)
+```
+
+_Même contrat en **PlantUML** (notation magistrale). À garder **synchronisé** avec le bloc Mermaid._
+
+```plantuml
+@startuml
+title cd — beer-encyclopedia (contrat API / DTO Pydantic, target)
+skinparam classAttributeIconSize 0
+skinparam shadowing false
+hide methods
+
+class BeerBase {
+  +name : str
+  +brewery_id : UUID?
+  +style_id : UUID?
+  +abv : Decimal?
+  +ibu : int?
+  +srm : int?
+  +description : str?
+  +is_active : bool
+}
+class BeerCreate <<POST /beers>>
+class BeerUpdate <<PATCH body, all optional>> {
+  +name : str?
+  +brewery_id : UUID?
+  +style_id : UUID?
+  +abv : Decimal?
+  +ibu : int?
+  +srm : int?
+  +description : str?
+  +is_active : bool?
+  +is_verified : bool?
+}
+class BeerRead <<from_attributes>> {
+  +id : UUID
+  +slug : str
+  +brewery_name : str?
+  +style_name : str?
+  +is_verified : bool
+  +source : str
+  +ean_code : str?
+  +legal_denomination : str?
+  +country_of_origin : str?
+  +allergens : list<str>?
+  +alcohol_group : int?
+  +created_at : datetime
+  +updated_at : datetime
+}
+class BeerList {
+  +items : list<BeerRead>
+  +meta : PaginationMeta
+}
+class BeerImportByEanRequest <<POST /beers/import-by-ean>> {
+  +ean : str
+}
+
+BeerBase <|-- BeerCreate
+BeerBase <|-- BeerRead
+BeerList "1" o-- "0..*" BeerRead : items
+BeerRead ..> Beer : projette (from_attributes)
+BeerRead ..> Brewery : brewery_name (dénormalisé)
+BeerRead ..> Style : style_name (dénormalisé)
+@enduml
+```
+
+## Notes
+
+- **`brewery_name` / `style_name` (nouveau, target).** Projections **en lecture seule** des
+  relations `Beer → Brewery.name` / `Beer → Style.name` (04-class). **Null** quand la FK est
+  nulle ou que le nom n'est pas résolu. Le serveur les résout explicitement (requête sur la
+  relation) **sans lazy-load** — l'API est en SQLAlchemy async, où un accès paresseux à une
+  relation non chargée lève une erreur. Endpoints qui les peuplent : au minimum
+  `POST /beers/import-by-ean` (consommé par le mobile) ; les autres réponses laissent ces
+  champs à `null` (rétro-compatible) tant qu'ils ne sont pas enrichis.
+- **Domain-preserving.** Aucune nouvelle entité, colonne ou relation : `brewery_id`/`style_id`
+  + les relations existent déjà au modèle de domaine. Ce diagramme n'ajoute que la **forme du
+  DTO de lecture**.
+- **Pourquoi modéliser le DTO.** Un client externe (le mobile, ADR-0005) dépend de ce contrat ;
+  `BeerRead` ne renvoyait que les UUID `brewery_id`/`style_id`, obligeant le client à afficher
+  « Style inconnu / Brasserie inconnue ». Le TODO côté mobile
+  (`beers-import.api.ts`) référence cet enrichissement « avant l'étape de dépréciation NestJS
+  de la roadmap ADR-0005 ».
+- **Héritage.** `BeerCreate` et `BeerRead` héritent de `BeerBase` ; `BeerUpdate` est autonome
+  (tous champs optionnels, sémantique PATCH). `BeerImportByEanRequest` est autonome (l'import
+  ne prend que l'EAN ; le reste dérive de la source externe — voir `02-sequence-import-by-ean`).
+- **Validation (edge).** `ean` : `min 8 / max 14`, `pattern` EAN-8/UPC-A/EAN-13/EAN-14 ;
+  `abv ∈ [0,100]`, `ibu ∈ [0,1000]`, `srm ∈ [0,100]`, `name` non vide. Mêmes règles que le
+  validateur ORM, pour un 422 cohérent au bord de l'API.
+- **Conformité.** Ce contrat est la cible que le code (`api/schemas/beer.py` + la résolution
+  des noms dans `api/routers/beers.py`) doit satisfaire. Implémentation après validation de ce
+  diagramme.

--- a/docs/architecture/diagrams/beer-encyclopedia/07-class-api-contract.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/07-class-api-contract.md
@@ -11,7 +11,8 @@
 contrat** : les DTO Pydantic que l'API sérialise en entrée/sortie HTTP — distincts des
 entités. Il existe parce que des **clients externes** en dépendent : le mobile lit
 `BeerRead` via le fallback scan (`mapPythonBeerToCatalogItem` dans
-`features/scan/data/beers-import.api.ts`), et la séquence `import-by-ean` (UC4) répond
+`packages/mobile-app/src/features/scan/data/beers-import.api.ts`), et la séquence
+`import-by-ean` (UC4) répond
 `200/201 (BeerRead)`.
 
 **Décision modélisée ici (target) :** `BeerRead` expose **`brewery_name` et `style_name`
@@ -54,7 +55,7 @@ classDiagram
     +bool is_verified?
   }
   class BeerRead {
-    <<from_attributes=true>>
+    <<from_attributes>>
     +UUID id
     +str slug
     +str brewery_name?

--- a/docs/architecture/traceability-matrix.md
+++ b/docs/architecture/traceability-matrix.md
@@ -20,6 +20,7 @@ Couvre le domaine **beer-encyclopedia** (backend). S'étendra aux autres package
 | Séquence — UC5 (scan/identification) | [`02-sequence-scan.md`](diagrams/beer-encyclopedia/02-sequence-scan.md) | ✅ (délègue à `scan/02b`) |
 | Composant | [`03-component.md`](diagrams/beer-encyclopedia/03-component.md) | ✅ (simple ; sources cibles → `scan/`) |
 | Classes | [`04-class.md`](diagrams/beer-encyclopedia/04-class.md) | ✅ (conforme code ; `source=scan` cible) |
+| Classes — contrat API (DTO) | [`07-class-api-contract.md`](diagrams/beer-encyclopedia/07-class-api-contract.md) | 🎯 cible (`BeerRead` + `brewery_name`/`style_name` dénormalisés ; code à conformer) |
 | États | [`05-state.md`](diagrams/beer-encyclopedia/05-state.md) | ✅ (modération + provenance) |
 | Data-flow | [`06-data-flow.md`](diagrams/beer-encyclopedia/06-data-flow.md) | ✅ (import EAN + PII) |
 | Séquence mobile — UC4 (scan + affichage) | _(package mobile, futur chantier mobile↔API)_ | ⬜ à créer |


### PR DESCRIPTION
## Why — conception-first
Before exposing `style_name`/`brewery_name` on `BeerRead` (so the mobile scan fiche shows "IPA"/"BrewDog" instead of "Style inconnu"), we model the API DTO **contract** first. The beer-encyclopedia study modelled the **domain** (`04-class`) and the API **component** structure (`03-component`) but never the **field-level shape** of the Pydantic DTOs — this fills that gap.

## What
New class diagram **`07-class-api-contract.md`** (Mermaid + PlantUML) for the `beers` router schemas: `BeerBase`, `BeerCreate`, `BeerUpdate`, `BeerRead`, `BeerList`, `BeerImportByEanRequest` — fields, inheritance, validation notes.

**Target decision captured:** `BeerRead` exposes read-only **`brewery_name`** + **`style_name`**, denormalized projections of the already-modelled `Beer → Brewery` / `Beer → Style` relations. **Domain-preserving** (no new entity/column/relation); resolved server-side **without async lazy-load**; null when the FK/relation is unresolved.

Traceability matrix updated (🎯 cible — code to be conformed).

## Next (separate PR, after this is accepted)
Conform the code: add the two fields to `api/schemas/beer.py` + resolve the names in `api/routers/beers.py` (import-by-ean), then use them in the mobile `beers-import.api.ts`.

Part of #1175. No code in this PR.