### PR TITLE
feat(scan): surface brewery + style names on the scanned beer fiche

### DIFF
--- a/packages/beer-encyclopedia/api/routers/beers.py
+++ b/packages/beer-encyclopedia/api/routers/beers.py
@@ -81,6 +81,32 @@ async def _validate_fks(
         raise HTTPException(status_code=422, detail="style_id does not exist.")
 
 
+async def _beer_read_with_names(session: AsyncSession, beer: Beer) -> BeerRead:
+    """Serialise a ``Beer`` to ``BeerRead`` with the denormalised
+    ``brewery_name`` / ``style_name`` resolved from the FKs
+    (see ``07-class-api-contract``).
+
+    Resolves via ``session.get`` (identity-map first, no extra query when the
+    row is already loaded) rather than touching ``beer.brewery`` /
+    ``beer.style`` relationship attributes — the engine is async, where a
+    lazy-load on an unloaded relationship raises. Names are ``None`` when the
+    FK is null or points to a missing row.
+    """
+
+    dto = BeerRead.model_validate(beer)
+    brewery_name: str | None = None
+    style_name: str | None = None
+    if beer.brewery_id is not None:
+        brewery = await session.get(Brewery, beer.brewery_id)
+        brewery_name = brewery.name if brewery is not None else None
+    if beer.style_id is not None:
+        style = await session.get(Style, beer.style_id)
+        style_name = style.name if style is not None else None
+    return dto.model_copy(
+        update={"brewery_name": brewery_name, "style_name": style_name}
+    )
+
+
 @router.post(
     "/import-by-ean",
     response_model=BeerRead,
@@ -151,7 +177,7 @@ async def import_beer_by_ean(
     ).scalar_one_or_none()
     if existing is not None:
         response.status_code = status.HTTP_200_OK
-        return BeerRead.model_validate(existing)
+        return await _beer_read_with_names(session, existing)
 
     try:
         snapshot = await off_client.fetch_by_ean(payload.ean)
@@ -182,7 +208,7 @@ async def import_beer_by_ean(
     response.status_code = (
         status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
     )
-    return BeerRead.model_validate(result.beer)
+    return await _beer_read_with_names(session, result.beer)
 
 
 @router.get("", response_model=BeerList)

--- a/packages/beer-encyclopedia/api/schemas/beer.py
+++ b/packages/beer-encyclopedia/api/schemas/beer.py
@@ -51,6 +51,13 @@ class BeerRead(BeerBase):
 
     id: uuid.UUID
     slug: str
+    # Denormalised names resolved from the brewery_id / style_id FKs so
+    # clients (the mobile scan fiche) can display "BrewDog" / "IPA" without a
+    # second round-trip. Read-only projections of the Beer→Brewery / Beer→Style
+    # relations (07-class-api-contract); null when the FK or the relation is
+    # unresolved. Only endpoints that resolve them populate these.
+    brewery_name: str | None = None
+    style_name: str | None = None
     is_verified: bool
     source: str
     ean_code: str | None = None

--- a/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
@@ -183,6 +183,12 @@ async def test_import_links_resolved_style_and_description(
     response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
     assert response.status_code == 201
 
+    # The response carries the denormalised names (07-class-api-contract) so
+    # the mobile fiche shows them without a second round-trip.
+    body = response.json()
+    assert body["style_name"] == "India Pale Ale"
+    assert body["brewery_name"] == "Some Brewery"
+
     beer = (
         await db_session.execute(
             select(Beer).where(Beer.ean_code == EAN_PELFORTH)
@@ -211,6 +217,11 @@ async def test_import_leaves_style_none_when_slug_not_seeded(
 
     response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
     assert response.status_code == 201
+
+    # No brewery (brand None) and no resolvable style → both names null.
+    body = response.json()
+    assert body["style_name"] is None
+    assert body["brewery_name"] is None
 
     beer = (
         await db_session.execute(

--- a/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
+++ b/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
@@ -30,6 +30,8 @@ type PythonBeerReadDto = {
   slug: string;
   brewery_id: string | null;
   style_id: string | null;
+  brewery_name: string | null;
+  style_name: string | null;
   abv: string | null;
   ibu: number | null;
   srm: number | null;
@@ -55,6 +57,8 @@ function buildDto(
     slug: "pelforth-brune",
     brewery_id: "b1d2c3e4-1111-2222-3333-444455556666",
     style_id: "5d6e7f80-aaaa-bbbb-cccc-ddddeeee0001",
+    brewery_name: "Pelforth",
+    style_name: "Brune",
     abv: "6.5",
     ibu: 22,
     srm: 30,
@@ -205,8 +209,21 @@ describe("beers-import.api / importBeerByEan", () => {
       expect(item.fetchedAt).toBeNull();
     });
 
-    it("substitutes 'Brasserie inconnue' / 'Style inconnu' placeholders (FK UUIDs not yet enriched)", async () => {
-      mockRequest.mockResolvedValueOnce(buildDto());
+    it("uses the server-resolved brewery_name / style_name when present", async () => {
+      mockRequest.mockResolvedValueOnce(
+        buildDto({ brewery_name: "BrewDog", style_name: "India Pale Ale" }),
+      );
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.brewery).toBe("BrewDog");
+      expect(item.style).toBe("India Pale Ale");
+    });
+
+    it("falls back to placeholders when brewery_name / style_name are null", async () => {
+      mockRequest.mockResolvedValueOnce(
+        buildDto({ brewery_name: null, style_name: null }),
+      );
 
       const { item } = await importBeerByEan("3760231860119");
 

--- a/packages/mobile-app/src/features/scan/data/beers-import.api.ts
+++ b/packages/mobile-app/src/features/scan/data/beers-import.api.ts
@@ -38,6 +38,10 @@ interface PythonBeerReadDto {
   slug: string;
   brewery_id: string | null;
   style_id: string | null;
+  // Denormalised names resolved server-side from the FKs
+  // (07-class-api-contract); null when the FK/relation is unresolved.
+  brewery_name: string | null;
+  style_name: string | null;
   abv: string | null; // Pydantic Decimal serialises as string
   ibu: number | null;
   srm: number | null;
@@ -118,10 +122,11 @@ function mapPythonBeerToCatalogItem(
     id: dto.id,
     barcode: ean,
     name: dto.name,
-    // Brewery / style names live in separate Python tables. Until
-    // BeerRead is enriched server-side we surface a placeholder.
-    brewery: "Brasserie inconnue",
-    style: "Style inconnu",
+    // Brewery / style names are resolved server-side from the FKs
+    // (07-class-api-contract). Fall back to a placeholder only when the
+    // server could not resolve one (FK null or relation missing).
+    brewery: dto.brewery_name ?? "Brasserie inconnue",
+    style: dto.style_name ?? "Style inconnu",
     abv: dto.abv === null ? null : Number(dto.abv),
     ibu: dto.ibu,
     colorEbc: srmToEbc(dto.srm),
@@ -146,11 +151,11 @@ function mapPythonBeerToCatalogItem(
 /**
  * Call the Python beer-encyclopedia to resolve a barcode, importing
  * from Open Food Facts on first occurrence. Returns a
- * `ScanLookupResult` whose `item` carries placeholders for the fields
- * Python does not yet expose (brewery name, style name,
- * fermentation type, aromatic tags). The presentation layer should
- * render the fiche in a degraded-but-functional state until the
- * server-side enrichment ships.
+ * `ScanLookupResult`. Brewery and style names are resolved server-side
+ * (07-class-api-contract); the `item` still carries placeholders for the
+ * fields Python does not yet expose (fermentation type, aromatic tags).
+ * The presentation layer should render the fiche in a
+ * degraded-but-functional state until the remaining enrichment ships.
  *
  * Throws (for the use-case to translate):
  * - HttpError 503 — `EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL` is not


### PR DESCRIPTION
## Why
The scan fiche showed **"Brasserie inconnue" / "Style inconnu"** even when the beer was recognised: `BeerRead` returned only the `brewery_id`/`style_id` **UUIDs**, so the mobile had no name to render. This conforms the code to the DTO contract modelled in **#1184** (`07-class-api-contract`).

## What
- **encyclopedia** — `BeerRead` gains read-only `brewery_name` / `style_name`. `POST /beers/import-by-ean` resolves them via `_beer_read_with_names`, using `session.get` (identity-map first, **no async lazy-load** on the relationship attributes). Null when the FK is null/unresolved. **Domain-preserving** (no new entity/column/relation).
- **mobile** — `beers-import.api` maps the new fields, falling back to the placeholders only when the server returns null.

ABV/IBU still come straight from the source (null when OFF omits them) — per-beer web/AI enrichment stays the later #1175 slice.

## Tests
- encyclopedia: `import-by-ean` asserts the names in the response (resolved **and** null cases). **152 tests** green, ruff clean.
- mobile: mapper covers names-present + null-fallback. **44 scan tests** green, tsc + eslint clean.

## After merge
Redeploy the encyclopedia (so the API returns the names) + rebuild the APK (so the fiche shows "BrewDog / IPA").

Conforms to #1184. Part of #1175.