### PR TITLE
docs(conception): mobile scan sequence — encyclopedia-first cutover (#1186)

### DIFF
--- a/docs/architecture/diagrams/beer-encyclopedia/08-sequence-mobile-scan.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/08-sequence-mobile-scan.md
@@ -1,0 +1,124 @@
+# Diagramme de séquence — mobile — Résoudre un code-barres en fiche bière (UC4, mobile↔API)
+
+> **Réalise :** UC4 — Identifier une bière par code-barres, **côté mobile** (résolution + affichage)
+> **Code concerné :** `packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts`, `.../data/beers-import.api.ts`, `.../data/scan-lookup.api.ts`
+> **ADR liés :** ADR-0005 (split backend — l'encyclopedia possède la connaissance bière), ADR-0013 (la conception fait foi)
+> **Voir aussi :** `02-sequence-import-by-ean.md` (réalisation backend UC4) · `07-class-api-contract.md` (`BeerRead`) · `../../traceability-matrix.md` · issue #1186 (cutover)
+
+## Contexte
+
+Séquence **cible** de la résolution d'un scan code-barres côté mobile. Elle acte le
+**cutover décidé (#1186, finalisation d'ADR-0005)** : le mobile résout le code-barres
+contre **l'encyclopedia** (la source riche : nom, brasserie, style, ABV, ingrédients),
+**et non plus contre NestJS en premier**.
+
+**Pourquoi ce changement.** L'état **actuel** (à retirer) est NestJS-first : le mobile
+appelle `GET /scan/lookup/:ean`, NestJS re-interroge OpenFoodFacts lui-même et répond une
+fiche **pauvre** (juste le nom) ; l'encyclopedia riche n'était atteinte qu'en **secours**
+(404 NestJS). Pour toute bière que NestJS sait résoudre (la majorité des bières mainstream),
+l'enrichissement (#1182/#1185) était donc court-circuité. Le cutover inverse la priorité.
+
+**Migration en deux temps :**
+1. **Transitoire** (petit, OTA) — encyclopedia **d'abord**, NestJS en **secours** sur `503`
+   (réversible, NestJS reste un filet le temps de valider).
+2. **Cible** — encyclopedia **seule** ; NestJS sort du chemin scan (`GET /scan/lookup` +
+   `scan_catalog_items` + son client OFF retirés). NestJS garde son domaine : auth, recettes,
+   brassins, academy, feedback.
+
+**Note auth.** L'encyclopedia est **publique/sans auth** (cohérent avec sa vocation de
+référence publique, ADR-0005) → les **lectures** deviennent publiques ; l'**écriture** d'un
+scan reste encadrée par `is_verified=false` + la future file de validation UC9.
+
+## Diagramme (Mermaid — flux cible)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor U as Utilisateur
+  participant M as Mobile (scan use-case)
+  participant E as beer-encyclopedia (FastAPI)
+  participant OFF as OpenFoodFacts
+  participant N as NestJS (secours transitoire)
+
+  U->>M: Scanne un code-barres
+  M->>M: normalise + valide la longueur (EAN-8…14)
+  alt mode démo (dataSource.useDemoData)
+    M->>M: lit demoScanCatalog (hors-ligne)
+    M-->>U: fiche démo (ou "non reconnue")
+  else mode live — encyclopedia d'abord
+    M->>E: POST /beers/import-by-ean { ean }
+    Note over E: DB-first ; sur cache-miss, import OFF
+    alt connue (DB) ou trouvée via OFF
+      E->>OFF: lookup EAN (si cache-miss)
+      OFF-->>E: produit (ou rien)
+      E->>E: upsert Beer(is_verified=false) + EntitySource (provenance)
+      E-->>M: 200/201 BeerRead (nom, brewery_name, style_name, abv, description, …)
+      M->>M: mappe → ScanCatalogItem
+      M-->>U: fiche enrichie
+    else 404 (ni DB ni OFF ne connaissent)
+      E-->>M: 404
+      M-->>U: "bière non reconnue" (futur : capture étiquette UC5)
+    else 503 (encyclopedia indisponible)
+      E-->>M: 503
+      Note over M,N: TRANSITOIRE uniquement — retiré à la cible
+      M->>N: GET /scan/lookup/:ean (secours)
+      N-->>M: fiche (pauvre) ou 404/503
+      M-->>U: fiche de secours ou "indisponible"
+    end
+  end
+```
+
+_Même flux en **PlantUML** (à garder synchronisé avec le bloc Mermaid)._
+
+```plantuml
+@startuml
+title sd — mobile — résoudre un code-barres (UC4, flux cible : encyclopedia-first)
+actor Utilisateur as U
+participant "Mobile\n(scan use-case)" as M
+participant "beer-encyclopedia" as E
+participant "OpenFoodFacts" as OFF
+participant "NestJS\n(secours transitoire)" as N
+
+U -> M : Scanne un code-barres
+M -> M : normalise + valide (EAN-8..14)
+alt mode démo
+  M -> M : demoScanCatalog (hors-ligne)
+  M --> U : fiche démo / non reconnue
+else live — encyclopedia d'abord
+  M -> E : POST /beers/import-by-ean { ean }
+  alt connue (DB) ou via OFF
+    E -> OFF : lookup EAN (si cache-miss)
+    OFF --> E : produit / rien
+    E -> E : upsert Beer(is_verified=false) + EntitySource
+    E --> M : 200/201 BeerRead (riche)
+    M --> U : fiche enrichie
+  else 404
+    E --> M : 404
+    M --> U : non reconnue (futur UC5)
+  else 503
+    E --> M : 503
+    note over M, N : TRANSITOIRE — retiré à la cible
+    M -> N : GET /scan/lookup/:ean
+    N --> M : fiche pauvre / 404 / 503
+    M --> U : secours / indisponible
+  end
+end
+@enduml
+```
+
+## Notes
+
+- **Cible vs transitoire.** Le bloc `503 → NestJS` est **transitoire** : un filet le temps de
+  valider l'encyclopedia-first par OTA. À la cible, ce bloc disparaît (un `503` devient
+  directement « service indisponible ») et le chemin scan de NestJS est retiré (issue #1186).
+- **Écriture sur lecture.** `import-by-ean` **persiste** (upsert) à chaque résolution réussie :
+  le cutover fait donc que **chaque scan mainstream nourrit l'encyclopedia** (objectif
+  d'enrichissement de la base), au lieu de remplir `scan_catalog_items` côté NestJS.
+- **Mapping d'erreurs (inchangé pour l'UI).** `404` → `ScanLookupBeerNotFoundError` ;
+  `503` → `ScanLookupServiceUnavailableError`. Le `422 NOT_A_BEER` (garde NestJS) n'a pas
+  d'équivalent encyclopedia aujourd'hui — à traiter lors du retrait NestJS (#1186).
+- **Démo inchangé.** La branche `dataSource.useDemoData` lit `demoScanCatalog` et ne touche
+  aucun backend (le scan démo reste hors-ligne).
+- **Conformité.** Le code (`scan-lookup.use-cases.ts`) doit se conformer à cette séquence :
+  appeler l'encyclopedia d'abord. Étape 1 (transitoire) = inverser l'ordre actuel ; le retrait
+  de NestJS du chemin scan est l'étape 2 (#1186).

--- a/docs/architecture/diagrams/beer-encyclopedia/08-sequence-mobile-scan.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/08-sequence-mobile-scan.md
@@ -19,11 +19,14 @@ fiche **pauvre** (juste le nom) ; l'encyclopedia riche n'était atteinte qu'en *
 l'enrichissement (#1182/#1185) était donc court-circuité. Le cutover inverse la priorité.
 
 **Migration en deux temps :**
-1. **Transitoire** (petit, OTA) — encyclopedia **d'abord**, NestJS en **secours** sur `503`
-   (réversible, NestJS reste un filet le temps de valider).
-2. **Cible** — encyclopedia **seule** ; NestJS sort du chemin scan (`GET /scan/lookup` +
-   `scan_catalog_items` + son client OFF retirés). NestJS garde son domaine : auth, recettes,
-   brassins, academy, feedback.
+1. **Transitoire** (petit, OTA) — encyclopedia **d'abord**, NestJS en **secours** sur `404`
+   **ou** `503`. Le secours sur `404` est requis tant que la migration
+   `scan_catalog_items → beers` (#1150) n'est pas faite : une bière présente **uniquement**
+   dans une ligne seed/manual côté NestJS régresserait sinon en « non reconnue ». Réversible,
+   NestJS reste un filet le temps de valider.
+2. **Cible** — encyclopedia **seule** ; un `404` devient « non reconnue » directement et NestJS
+   sort du chemin scan (`GET /scan/lookup` + `scan_catalog_items` + son client OFF retirés).
+   NestJS garde son domaine : auth, recettes, brassins, academy, feedback.
 
 **Note auth.** L'encyclopedia est **publique/sans auth** (cohérent avec sa vocation de
 référence publique, ADR-0005) → les **lectures** deviennent publiques ; l'**écriture** d'un
@@ -55,16 +58,19 @@ sequenceDiagram
       E-->>M: 200/201 BeerRead (nom, brewery_name, style_name, abv, description, …)
       M->>M: mappe → ScanCatalogItem
       M-->>U: fiche enrichie
-    else 404 (ni DB ni OFF ne connaissent)
-      E-->>M: 404
-      M-->>U: "bière non reconnue" (futur : capture étiquette UC5)
-    else 503 (encyclopedia indisponible)
-      E-->>M: 503
-      Note over M,N: TRANSITOIRE uniquement — retiré à la cible
-      M->>N: GET /scan/lookup/:ean (secours)
-      N-->>M: fiche (pauvre) ou 404/503
-      M-->>U: fiche de secours ou "indisponible"
+    else 404 (inconnue) ou 503 (indisponible) — secours TRANSITOIRE
+      E-->>M: 404 ou 503
+      Note over M,N: TRANSITOIRE (jusqu'à la migration scan_catalog→beers #1150) — retiré à la cible
+      M->>N: GET /scan/lookup/:ean (peut détenir une ligne seed/manual)
+      alt NestJS sert
+        N-->>M: fiche (pauvre)
+        M-->>U: fiche de secours
+      else NestJS 404 / 503
+        N-->>M: 404 / 503
+        M-->>U: "non reconnue" (futur UC5) / "indisponible"
+      end
     end
+    Note over M: Cible (post-#1150) : un 404 encyclopedia → "non reconnue" directement, sans NestJS
   end
 ```
 
@@ -92,15 +98,17 @@ else live — encyclopedia d'abord
     E -> E : upsert Beer(is_verified=false) + EntitySource
     E --> M : 200/201 BeerRead (riche)
     M --> U : fiche enrichie
-  else 404
-    E --> M : 404
-    M --> U : non reconnue (futur UC5)
-  else 503
-    E --> M : 503
-    note over M, N : TRANSITOIRE — retiré à la cible
-    M -> N : GET /scan/lookup/:ean
-    N --> M : fiche pauvre / 404 / 503
-    M --> U : secours / indisponible
+  else 404 (inconnue) ou 503 (indisponible) — secours TRANSITOIRE
+    E --> M : 404 ou 503
+    note over M, N : TRANSITOIRE (jusqu'à migration #1150) — retiré à la cible
+    M -> N : GET /scan/lookup/:ean (peut détenir une ligne seed/manual)
+    alt NestJS sert
+      N --> M : fiche pauvre
+      M --> U : fiche de secours
+    else NestJS 404 / 503
+      N --> M : 404 / 503
+      M --> U : non reconnue (futur UC5) / indisponible
+    end
   end
 end
 @enduml
@@ -108,9 +116,12 @@ end
 
 ## Notes
 
-- **Cible vs transitoire.** Le bloc `503 → NestJS` est **transitoire** : un filet le temps de
-  valider l'encyclopedia-first par OTA. À la cible, ce bloc disparaît (un `503` devient
-  directement « service indisponible ») et le chemin scan de NestJS est retiré (issue #1186).
+- **Cible vs transitoire.** Le secours NestJS sur `404`/`503` est **transitoire** : un filet le
+  temps de valider l'encyclopedia-first par OTA, et **surtout** tant que `scan_catalog_items`
+  n'est pas migré vers `beers` (#1150) — sans le secours sur `404`, une bière présente seulement
+  en seed/manual côté NestJS régresserait en « non reconnue ». À la cible (post-#1150), ce bloc
+  disparaît : un `404` devient « non reconnue » et un `503` « service indisponible »
+  directement, et le chemin scan de NestJS est retiré (issue #1186).
 - **Écriture sur lecture.** `import-by-ean` **persiste** (upsert) à chaque résolution réussie :
   le cutover fait donc que **chaque scan mainstream nourrit l'encyclopedia** (objectif
   d'enrichissement de la base), au lieu de remplir `scan_catalog_items` côté NestJS.

--- a/docs/architecture/traceability-matrix.md
+++ b/docs/architecture/traceability-matrix.md
@@ -23,7 +23,7 @@ Couvre le domaine **beer-encyclopedia** (backend). S'étendra aux autres package
 | Classes — contrat API (DTO) | [`07-class-api-contract.md`](diagrams/beer-encyclopedia/07-class-api-contract.md) | 🎯 cible (`BeerRead` + `brewery_name`/`style_name` dénormalisés ; code à conformer) |
 | États | [`05-state.md`](diagrams/beer-encyclopedia/05-state.md) | ✅ (modération + provenance) |
 | Data-flow | [`06-data-flow.md`](diagrams/beer-encyclopedia/06-data-flow.md) | ✅ (import EAN + PII) |
-| Séquence mobile — UC4 (scan + affichage) | _(package mobile, futur chantier mobile↔API)_ | ⬜ à créer |
+| Séquence mobile — UC4 (scan + affichage) | [`08-sequence-mobile-scan.md`](diagrams/beer-encyclopedia/08-sequence-mobile-scan.md) | 🎯 cible (encyclopedia-first ; cutover #1186 ; code à conformer) |
 
 ## Matrice — cas d'usage → réalisations
 


### PR DESCRIPTION
## Why — conception-first for the scan cutover (#1186)
The traceability matrix marked "Séquence mobile — UC4 (scan + affichage)" as **à créer**. This fills that gap **and** conceives the cutover that fixes the live blocker (mainstream beers served thin because the mobile is NestJS-first).

## What
New sequence diagram **`08-sequence-mobile-scan`** (Mermaid + PlantUML): the mobile resolves a barcode against the **encyclopedia first** (the rich source — name, brewery, style, ABV, ingredients), not NestJS.

Two-step migration captured:
1. **Transitional** — encyclopedia-first, NestJS as a `503` fallback (small, OTA, reversible).
2. **Target** — encyclopedia-only; NestJS scan path (`/scan/lookup` + `scan_catalog_items` + its OFF client) retired. NestJS keeps auth/recettes/brassins/academy/feedback.

Notes: every resolved scan **persists** to the encyclopedia (the DB-enrichment goal); UI error mapping unchanged (404 → not-found, 503 → unavailable); demo mode untouched; auth posture (public reads, `is_verified` + UC9 gating writes).

Traceability matrix updated (🎯 cible). Code to be conformed in #1186. No code in this PR.