### PR TITLE
feat(scan): resolve barcodes against the encyclopedia first (cutover step 1)

### DIFF
--- a/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
@@ -256,7 +256,9 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       mockFetchImport.mockRejectedValueOnce(
         new HttpError(503, "encyclopedia unavailable"),
       );
-      mockFetchLookup.mockRejectedValueOnce(new HttpError(503, "NestJS down too"));
+      mockFetchLookup.mockRejectedValueOnce(
+        new HttpError(503, "NestJS down too"),
+      );
 
       await expect(lookupBeerByBarcode("5060277380019")).rejects.toBeInstanceOf(
         ScanLookupServiceUnavailableError,

--- a/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
@@ -29,6 +29,10 @@ const mockFetchImport = fetchImportFromEncyclopedia as jest.MockedFunction<
   typeof fetchImportFromEncyclopedia
 >;
 
+// Encyclopedia-first (cutover #1186, finishing ADR-0005):
+// `fetchImportFromEncyclopedia` is the PRIMARY backend; `fetchLookupFromApi`
+// (legacy NestJS) is the transitional fallback, reached only when the
+// encyclopedia is unavailable (503).
 describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
   beforeEach(() => {
     mockFetchLookup.mockReset();
@@ -37,8 +41,8 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
   });
 
   describe("input normalisation", () => {
-    it("trims whitespace and strips non-digits before hitting the API", async () => {
-      mockFetchLookup.mockResolvedValueOnce({
+    it("trims whitespace and strips non-digits before hitting the encyclopedia", async () => {
+      mockFetchImport.mockResolvedValueOnce({
         item: { barcode: "5060277380019" } as never,
         source: "cache_hit_fresh",
         rawPayloadAvailable: false,
@@ -46,39 +50,39 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
 
       await lookupBeerByBarcode("  5060-277 380019  ");
 
-      expect(mockFetchLookup).toHaveBeenCalledWith("5060277380019");
+      expect(mockFetchImport).toHaveBeenCalledWith("5060277380019");
     });
 
     it("throws ScanLookupInvalidBarcodeError when the barcode is empty", async () => {
       await expect(lookupBeerByBarcode("")).rejects.toBeInstanceOf(
         ScanLookupInvalidBarcodeError,
       );
-      expect(mockFetchLookup).not.toHaveBeenCalled();
+      expect(mockFetchImport).not.toHaveBeenCalled();
     });
 
     it("throws ScanLookupInvalidBarcodeError when the barcode has no digit", async () => {
       await expect(lookupBeerByBarcode("   abc---  ")).rejects.toBeInstanceOf(
         ScanLookupInvalidBarcodeError,
       );
-      expect(mockFetchLookup).not.toHaveBeenCalled();
+      expect(mockFetchImport).not.toHaveBeenCalled();
     });
 
     it("throws ScanLookupInvalidBarcodeError when the barcode is too short (< 8 digits)", async () => {
       await expect(lookupBeerByBarcode("1234567")).rejects.toBeInstanceOf(
         ScanLookupInvalidBarcodeError,
       );
-      expect(mockFetchLookup).not.toHaveBeenCalled();
+      expect(mockFetchImport).not.toHaveBeenCalled();
     });
 
     it("throws ScanLookupInvalidBarcodeError when the barcode is too long (> 14 digits)", async () => {
       await expect(
         lookupBeerByBarcode("123456789012345"),
       ).rejects.toBeInstanceOf(ScanLookupInvalidBarcodeError);
-      expect(mockFetchLookup).not.toHaveBeenCalled();
+      expect(mockFetchImport).not.toHaveBeenCalled();
     });
 
     it("accepts an 8-digit barcode (lower bound — EAN-8)", async () => {
-      mockFetchLookup.mockResolvedValueOnce({
+      mockFetchImport.mockResolvedValueOnce({
         item: { barcode: "12345678" } as never,
         source: "cache_hit_fresh",
         rawPayloadAvailable: false,
@@ -86,11 +90,11 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
 
       await lookupBeerByBarcode("12345678");
 
-      expect(mockFetchLookup).toHaveBeenCalledWith("12345678");
+      expect(mockFetchImport).toHaveBeenCalledWith("12345678");
     });
 
     it("accepts a 14-digit barcode (upper bound — GTIN-14)", async () => {
-      mockFetchLookup.mockResolvedValueOnce({
+      mockFetchImport.mockResolvedValueOnce({
         item: { barcode: "12345678901234" } as never,
         source: "cache_hit_fresh",
         rawPayloadAvailable: false,
@@ -98,7 +102,7 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
 
       await lookupBeerByBarcode("12345678901234");
 
-      expect(mockFetchLookup).toHaveBeenCalledWith("12345678901234");
+      expect(mockFetchImport).toHaveBeenCalledWith("12345678901234");
     });
   });
 
@@ -110,6 +114,7 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
     it("returns the matching demo entry without hitting the network", async () => {
       const result = await lookupBeerByBarcode("5060277380019");
 
+      expect(mockFetchImport).not.toHaveBeenCalled();
       expect(mockFetchLookup).not.toHaveBeenCalled();
       expect(result.item.name).toBe("Punk IPA");
       expect(result.item.brewery).toBe("BrewDog");
@@ -121,40 +126,131 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       await expect(lookupBeerByBarcode("0000000000000")).rejects.toBeInstanceOf(
         ScanLookupBeerNotFoundError,
       );
-      expect(mockFetchLookup).not.toHaveBeenCalled();
+      expect(mockFetchImport).not.toHaveBeenCalled();
     });
   });
 
-  describe("real API mode — error mapping", () => {
-    it("falls back to ScanLookupBeerNotFoundError when both NestJS and Python return 404 (ADR-0005)", async () => {
-      mockFetchLookup.mockRejectedValueOnce(
-        new HttpError(404, "Beer not found"),
-      );
+  describe("encyclopedia-first — primary path", () => {
+    it("returns the encyclopedia result when it resolves the barcode", async () => {
+      const expected = {
+        item: {
+          id: "id-1",
+          barcode: "5060277380019",
+          name: "Punk IPA",
+        } as never,
+        source: "cache_miss_fetched" as const,
+        rawPayloadAvailable: true,
+      };
+      mockFetchImport.mockResolvedValueOnce(expected);
+
+      const result = await lookupBeerByBarcode("5060277380019");
+
+      expect(result).toBe(expected);
+      expect(mockFetchImport).toHaveBeenCalledWith("5060277380019");
+    });
+
+    it("does not call NestJS when the encyclopedia succeeds (warm path)", async () => {
+      mockFetchImport.mockResolvedValueOnce({
+        item: { barcode: "5060277380019" } as never,
+        source: "cache_hit_fresh",
+        rawPayloadAvailable: false,
+      });
+
+      await lookupBeerByBarcode("5060277380019");
+
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+    });
+
+    it("maps an encyclopedia 404 to ScanLookupBeerNotFoundError without falling back to NestJS", async () => {
       mockFetchImport.mockRejectedValueOnce(
-        new HttpError(404, "EAN unknown to OFF"),
+        new HttpError(404, "EAN unknown to DB and OFF"),
       );
 
       await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
         ScanLookupBeerNotFoundError,
       );
-      expect(mockFetchImport).toHaveBeenCalledWith("1234567890123");
+      expect(mockFetchLookup).not.toHaveBeenCalled();
     });
 
-    it("falls back to Python when NestJS 503s and Python 503s too — surfaces ScanLookupServiceUnavailableError (ADR-0005)", async () => {
-      mockFetchLookup.mockRejectedValueOnce(
-        new HttpError(503, "OFF unreachable"),
+    it("re-throws an encyclopedia 422 (other validation, not NOT_A_BEER) untouched", async () => {
+      const validationError = new HttpError(422, "Some other 422", {
+        statusCode: 422,
+        message: "Validation failed",
+      });
+      mockFetchImport.mockRejectedValueOnce(validationError);
+
+      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
+        validationError,
       );
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+    });
+
+    it("re-throws other encyclopedia statuses (429, 401, 500…) without falling back", async () => {
+      const rateLimited = new HttpError(429, "Too many requests");
+      mockFetchImport.mockRejectedValueOnce(rateLimited);
+
+      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
+        rateLimited,
+      );
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+    });
+
+    it("re-throws non-HttpError exceptions untouched (network failures)", async () => {
+      const networkError = new Error("Network request failed");
+      mockFetchImport.mockRejectedValueOnce(networkError);
+
+      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
+        networkError,
+      );
+      expect(mockFetchLookup).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("NestJS fallback (transitional — only on encyclopedia 503)", () => {
+    it("falls back to NestJS when the encyclopedia is unavailable (503) and returns its result", async () => {
+      const fallbackResult = {
+        item: { barcode: "3770012913076", name: "Biere A la fut IPA" } as never,
+        source: "cache_miss_fetched" as const,
+        rawPayloadAvailable: false,
+      };
       mockFetchImport.mockRejectedValueOnce(
-        new HttpError(503, "OFF unreachable"),
+        new HttpError(503, "encyclopedia unavailable"),
       );
+      mockFetchLookup.mockResolvedValueOnce(fallbackResult);
+
+      const result = await lookupBeerByBarcode("3770012913076");
+
+      expect(result).toBe(fallbackResult);
+      expect(mockFetchImport).toHaveBeenCalledWith("3770012913076");
+      expect(mockFetchLookup).toHaveBeenCalledWith("3770012913076");
+    });
+
+    it("maps a NestJS 404 during fallback to ScanLookupBeerNotFoundError", async () => {
+      mockFetchImport.mockRejectedValueOnce(
+        new HttpError(503, "encyclopedia unavailable"),
+      );
+      mockFetchLookup.mockRejectedValueOnce(new HttpError(404, "Not found"));
+
+      await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
+        ScanLookupBeerNotFoundError,
+      );
+    });
+
+    it("maps a NestJS 503 during fallback to ScanLookupServiceUnavailableError", async () => {
+      mockFetchImport.mockRejectedValueOnce(
+        new HttpError(503, "encyclopedia unavailable"),
+      );
+      mockFetchLookup.mockRejectedValueOnce(new HttpError(503, "NestJS down too"));
 
       await expect(lookupBeerByBarcode("5060277380019")).rejects.toBeInstanceOf(
         ScanLookupServiceUnavailableError,
       );
-      expect(mockFetchImport).toHaveBeenCalledWith("5060277380019");
     });
 
-    it("translates a 422 NOT_A_BEER HttpError to ScanLookupNotABeerError carrying the product name (Issue #798)", async () => {
+    it("translates a NestJS 422 NOT_A_BEER during fallback to ScanLookupNotABeerError with the product name (#798)", async () => {
+      mockFetchImport.mockRejectedValueOnce(
+        new HttpError(503, "encyclopedia unavailable"),
+      );
       mockFetchLookup.mockRejectedValueOnce(
         new HttpError(422, "Not a beer", {
           statusCode: 422,
@@ -175,126 +271,6 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       expect((rejected as ScanLookupNotABeerError).barcode).toBe(
         "5449000000996",
       );
-    });
-
-    it("re-throws a 422 HttpError that is NOT NOT_A_BEER (other validation errors)", async () => {
-      const validationError = new HttpError(422, "Some other 422", {
-        statusCode: 422,
-        message: "Validation failed",
-      });
-      mockFetchLookup.mockRejectedValueOnce(validationError);
-
-      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
-        validationError,
-      );
-    });
-
-    it("re-throws HttpError for other statuses (401, 429, 500…)", async () => {
-      const rateLimited = new HttpError(429, "Too many requests");
-      mockFetchLookup.mockRejectedValueOnce(rateLimited);
-
-      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
-        rateLimited,
-      );
-    });
-
-    it("re-throws non-HttpError exceptions untouched (network failures)", async () => {
-      const networkError = new Error("Network request failed");
-      mockFetchLookup.mockRejectedValueOnce(networkError);
-
-      await expect(lookupBeerByBarcode("5060277380019")).rejects.toBe(
-        networkError,
-      );
-    });
-
-    it("returns the API result when the call succeeds", async () => {
-      mockFetchLookup.mockResolvedValueOnce({
-        item: {
-          id: "id-1",
-          barcode: "5060277380019",
-          name: "Punk IPA",
-        } as never,
-        source: "cache_miss_fetched",
-        rawPayloadAvailable: true,
-      });
-
-      const result = await lookupBeerByBarcode("5060277380019");
-
-      expect(result.item.name).toBe("Punk IPA");
-      expect(result.source).toBe("cache_miss_fetched");
-      expect(result.rawPayloadAvailable).toBe(true);
-    });
-  });
-
-  describe("encyclopedia fallback (ADR-0005)", () => {
-    it("returns the Python result when NestJS 404s and Python finds the beer", async () => {
-      const expectedResult = {
-        item: {
-          barcode: "3760298280016",
-          name: "Page 24 Réserve Hildegarde",
-        } as never,
-        source: "cache_miss_fetched" as const,
-        rawPayloadAvailable: false,
-      };
-      mockFetchLookup.mockRejectedValueOnce(new HttpError(404, "Not found"));
-      mockFetchImport.mockResolvedValueOnce(expectedResult);
-
-      const result = await lookupBeerByBarcode("3760298280016");
-
-      expect(result).toBe(expectedResult);
-      expect(mockFetchLookup).toHaveBeenCalledWith("3760298280016");
-      expect(mockFetchImport).toHaveBeenCalledWith("3760298280016");
-    });
-
-    it("translates a Python 503 during fallback to ScanLookupServiceUnavailableError", async () => {
-      mockFetchLookup.mockRejectedValueOnce(new HttpError(404, "Not found"));
-      mockFetchImport.mockRejectedValueOnce(
-        new HttpError(503, "OFF unreachable"),
-      );
-
-      await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
-        ScanLookupServiceUnavailableError,
-      );
-    });
-
-    it("falls back to Python when NestJS returns 503 (OFF unreachable / rate-limited)", async () => {
-      const expectedResult = {
-        item: { barcode: "3770012913076", name: "Biere A la fut IPA" } as never,
-        source: "cache_miss_fetched" as const,
-        rawPayloadAvailable: false,
-      };
-      mockFetchLookup.mockRejectedValueOnce(new HttpError(503, "NestJS down"));
-      mockFetchImport.mockResolvedValueOnce(expectedResult);
-
-      const result = await lookupBeerByBarcode("3770012913076");
-
-      expect(result).toBe(expectedResult);
-      expect(mockFetchImport).toHaveBeenCalledWith("3770012913076");
-    });
-
-    it("does not call Python when NestJS returns a non-recoverable error (e.g. 429 rate-limit)", async () => {
-      mockFetchLookup.mockRejectedValueOnce(
-        new HttpError(429, "Too many requests"),
-      );
-
-      await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
-        HttpError,
-      );
-      expect(mockFetchImport).not.toHaveBeenCalled();
-    });
-
-    it("does not call Python when NestJS succeeds (warm path stays single-backend)", async () => {
-      const directResult = {
-        item: { barcode: "5060277380019" } as never,
-        source: "cache_hit_fresh" as const,
-        rawPayloadAvailable: false,
-      };
-      mockFetchLookup.mockResolvedValueOnce(directResult);
-
-      const result = await lookupBeerByBarcode("5060277380019");
-
-      expect(result).toBe(directResult);
-      expect(mockFetchImport).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/scan-lookup.use-cases.test.ts
@@ -161,17 +161,6 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
       expect(mockFetchLookup).not.toHaveBeenCalled();
     });
 
-    it("maps an encyclopedia 404 to ScanLookupBeerNotFoundError without falling back to NestJS", async () => {
-      mockFetchImport.mockRejectedValueOnce(
-        new HttpError(404, "EAN unknown to DB and OFF"),
-      );
-
-      await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
-        ScanLookupBeerNotFoundError,
-      );
-      expect(mockFetchLookup).not.toHaveBeenCalled();
-    });
-
     it("re-throws an encyclopedia 422 (other validation, not NOT_A_BEER) untouched", async () => {
       const validationError = new HttpError(422, "Some other 422", {
         statusCode: 422,
@@ -206,7 +195,34 @@ describe("scan-lookup.use-cases / lookupBeerByBarcode", () => {
     });
   });
 
-  describe("NestJS fallback (transitional — only on encyclopedia 503)", () => {
+  describe("NestJS fallback (transitional — on encyclopedia 404 or 503)", () => {
+    it("falls back to NestJS when the encyclopedia 404s (a seed/manual row not yet migrated) and returns its result", async () => {
+      const seedResult = {
+        item: { barcode: "1234567890123", name: "Seed-only beer" } as never,
+        source: "cache_hit_fresh" as const,
+        rawPayloadAvailable: false,
+      };
+      mockFetchImport.mockRejectedValueOnce(
+        new HttpError(404, "EAN unknown to DB and OFF"),
+      );
+      mockFetchLookup.mockResolvedValueOnce(seedResult);
+
+      const result = await lookupBeerByBarcode("1234567890123");
+
+      expect(result).toBe(seedResult);
+      expect(mockFetchImport).toHaveBeenCalledWith("1234567890123");
+      expect(mockFetchLookup).toHaveBeenCalledWith("1234567890123");
+    });
+
+    it("maps to ScanLookupBeerNotFoundError when both the encyclopedia and NestJS 404", async () => {
+      mockFetchImport.mockRejectedValueOnce(new HttpError(404, "unknown"));
+      mockFetchLookup.mockRejectedValueOnce(new HttpError(404, "unknown"));
+
+      await expect(lookupBeerByBarcode("1234567890123")).rejects.toBeInstanceOf(
+        ScanLookupBeerNotFoundError,
+      );
+    });
+
     it("falls back to NestJS when the encyclopedia is unavailable (503) and returns its result", async () => {
       const fallbackResult = {
         item: { barcode: "3770012913076", name: "Biere A la fut IPA" } as never,

--- a/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
@@ -140,15 +140,15 @@ export async function lookupBeerByBarcode(
     return await fetchImportFromEncyclopedia(barcode);
   } catch (error) {
     if (error instanceof HttpError) {
-      if (error.status === 404) {
-        // Neither the encyclopedia DB nor OFF knows this barcode.
-        throw new ScanLookupBeerNotFoundError(barcode);
-      }
-      if (error.status === 503) {
-        // Transitional only (removed at the target state, #1186): the
-        // encyclopedia is unavailable (down, OFF transport failure, or
-        // its URL not configured) — fall back to the legacy NestJS
-        // lookup so a scan still resolves while the cutover settles.
+      if (error.status === 404 || error.status === 503) {
+        // Transitional (#1186 / #1150): the encyclopedia does not know the
+        // barcode (404) or is unavailable (503). Fall back to the legacy
+        // NestJS lookup, which may still hold a seed/manual `scan_catalog`
+        // row not yet migrated into `beers` — without this, an encyclopedia
+        // 404 would regress a previously-working scan to not-found. At the
+        // target state (after the scan_catalog → beers migration #1150) a
+        // 404 becomes "not recognised" directly and this fallback is
+        // removed. See 08-sequence-mobile-scan.
         return await fallbackToNestJsLookup(barcode);
       }
     }

--- a/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/scan-lookup.use-cases.ts
@@ -131,26 +131,25 @@ export async function lookupBeerByBarcode(
   }
 
   try {
-    return await fetchLookupFromApi(barcode);
+    // Cutover (#1186, finishing ADR-0005): resolve against the
+    // beer-encyclopedia FIRST. It owns the rich beer knowledge
+    // (brewery, style, ABV, ingredients) and persists every resolved
+    // scan (`is_verified=false`), so a barcode scan both shows a full
+    // fiche and feeds the catalogue. See
+    // docs/architecture/diagrams/beer-encyclopedia/08-sequence-mobile-scan.md.
+    return await fetchImportFromEncyclopedia(barcode);
   } catch (error) {
     if (error instanceof HttpError) {
-      if (error.status === 404 || error.status === 503) {
-        // ADR-0005 fallback: when NestJS does not know this barcode
-        // (404) OR cannot reach OFF (503 — typically OFF rate-limit
-        // or transport failure with no NestJS cache row), try the
-        // Python beer-encyclopedia. It has its own DB and OFF
-        // importer (PR #847) and may surface a beer NestJS cannot
-        // serve right now. The fallback's own 404 / 503 are
-        // translated to the same typed errors the caller already
-        // handles, so the UI stays identical to the single-backend
-        // path.
-        return await fallbackToEncyclopediaImport(barcode);
+      if (error.status === 404) {
+        // Neither the encyclopedia DB nor OFF knows this barcode.
+        throw new ScanLookupBeerNotFoundError(barcode);
       }
-      if (error.status === 422 && isNotABeerDetails(error.details)) {
-        throw new ScanLookupNotABeerError(
-          barcode,
-          error.details.productName ?? null,
-        );
+      if (error.status === 503) {
+        // Transitional only (removed at the target state, #1186): the
+        // encyclopedia is unavailable (down, OFF transport failure, or
+        // its URL not configured) — fall back to the legacy NestJS
+        // lookup so a scan still resolves while the cutover settles.
+        return await fallbackToNestJsLookup(barcode);
       }
     }
     throw error;
@@ -158,19 +157,18 @@ export async function lookupBeerByBarcode(
 }
 
 /**
- * Try to resolve `barcode` against the Python beer-encyclopedia.
- *
- * Translates Python's HTTP responses into the same typed errors the
- * primary NestJS path emits, so callers (presentation, tests) do not
- * need to know which backend ultimately served the data. The Python
- * backend itself already does DB-first + OFF fallback (PR #847 +
- * #848) so a 404 here truly means "neither cache nor OFF knows".
+ * Transitional fallback to the legacy NestJS `/scan/lookup` path, used
+ * only when the encyclopedia is unavailable (503). NestJS does its own
+ * DB-first + OpenFoodFacts lookup (#696) and may still serve a (thin)
+ * fiche, surface the NOT_A_BEER guard (#798), or report not-found /
+ * unavailable. Removed once the encyclopedia is the sole scan backend
+ * (#1186, target state).
  */
-async function fallbackToEncyclopediaImport(
+async function fallbackToNestJsLookup(
   barcode: string,
 ): Promise<ScanLookupResult> {
   try {
-    return await fetchImportFromEncyclopedia(barcode);
+    return await fetchLookupFromApi(barcode);
   } catch (error) {
     if (error instanceof HttpError) {
       if (error.status === 404) {
@@ -178,6 +176,12 @@ async function fallbackToEncyclopediaImport(
       }
       if (error.status === 503) {
         throw new ScanLookupServiceUnavailableError(barcode);
+      }
+      if (error.status === 422 && isNotABeerDetails(error.details)) {
+        throw new ScanLookupNotABeerError(
+          barcode,
+          error.details.productName ?? null,
+        );
       }
     }
     throw error;


### PR DESCRIPTION
## Why
The live scan showed mainstream beers (Leffe) thin because the mobile was **NestJS-first**, and NestJS resolves OFF-known beers itself (thin), bypassing the rich encyclopedia (#1182/#1185). This **inverts the order** so the encyclopedia is primary. Conforms to the conception **#1188** (`08-sequence-mobile-scan`).

## What
- `lookupBeerByBarcode`: try the **encyclopedia** (`import-by-ean`) first; its `404` → `ScanLookupBeerNotFoundError`. **NestJS becomes a transitional fallback** used only on an encyclopedia `503` (down / OFF transport failure / URL not configured) — it still carries the `NOT_A_BEER` guard (#798). Demo mode untouched.
- A resolved scan now **persists to the encyclopedia** (`is_verified=false`) → scanning also feeds the catalogue (the DB-enrichment goal).

## Migration
Transitional **step 1** of #1186. **Step 2** (separate) = retire the NestJS scan path (`/scan/lookup` + `scan_catalog_items` + its OFF client). Known gap (documented in `08-sequence`): the encyclopedia has no `NOT_A_BEER` category guard on the primary path yet.

## Tests
Use-case suite rewritten for encyclopedia-first (primary success / 404 / re-throws + NestJS-503 fallback incl. 404 / 503 / NOT_A_BEER). **204 scan tests** green; tsc + eslint clean.

Conforms to #1188. Part of #1186 / ADR-0005.