### PR TITLE
feat(recipes): match recipes by characteristics, not a scan-catalog id

### DIFF
--- a/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
+++ b/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
@@ -1,0 +1,90 @@
+# Sequence diagram — recipes — Match community recipes to a beer (by characteristics)
+
+> **Feature**: epic #740; matching algorithm #699; scan cutover #1186 (this decoupling).
+> **Code**: `src/recipe/services/recipe-matching.service.ts`, `src/recipe/controllers/recipe.controller.ts`; mobile `features/scan/data/recipe-matching.api.ts`.
+> **ADRs**: ADR-0005 (recipes are product data → NestJS), ADR-0013 (conception is the contract).
+> **See also**: `../beer-encyclopedia/08-sequence-mobile-scan.md` (the scan fiche that triggers this), `../../traceability-matrix.md`.
+
+## Context
+
+The scan fiche ("recettes équivalentes") ranks community recipes against the **scanned beer**.
+The ranking algorithm (#699) scores each recipe purely on the beer's **characteristics** —
+`style × 50 + ABV × 25 + IBU × 15 + colour × 10` (weights renormalised when a criterion is
+missing). It never needs the beer's identity, only those four values.
+
+**Target decision (this diagram).** The match endpoint takes the **characteristics directly**,
+not a `scan_catalog_items` id. Reason: the scan cutover (#1186) makes the mobile resolve a
+barcode against the **beer-encyclopedia**, whose `BeerRead` carries a Python `beers` UUID that
+is **absent** from NestJS `scan_catalog_items` — so the legacy `GET /recipes/match/:beerId`
+(which `findOne`s a scan-catalog row by id) 404s for every encyclopedia-sourced beer. Passing
+the characteristics removes that coupling and keeps matching working for **any** source
+(encyclopedia, NestJS, or a future one).
+
+The legacy id-based route stays as a thin wrapper (load the scan-catalog row → delegate to the
+same scorer) until the NestJS scan path is retired (#1186 step 2).
+
+## Diagram (Mermaid)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant M as Mobile (scan fiche)
+  participant API as NestJS /recipes
+  participant DB as Recipes DB
+
+  Note over M: beer recognised — has style / abv / ibu / colorEbc<br/>(from the encyclopedia or NestJS)
+  M->>API: POST /recipes/match { style?, abv?, ibu?, colorEbc? }
+  API->>API: rankByCharacteristics(carac)
+  API->>DB: load PUBLIC candidate recipes
+  DB-->>API: recipes[]
+  loop each candidate
+    API->>API: score = style×50 + abv×25 + ibu×15 + colour×10 (renorm if a criterion is null)
+  end
+  API->>API: sort desc (score, then rating, then id) ; take top-N (≤10)
+  API->>API: low_confidence = best score < 40
+  API-->>M: 200 { rankings[], low_confidence }
+  M-->>M: render "recettes équivalentes" (or the low-confidence note)
+```
+
+_Same flow in **PlantUML** (keep synchronised with the Mermaid block)._
+
+```plantuml
+@startuml
+title sd — recipes — match by characteristics (target)
+participant "Mobile\n(scan fiche)" as M
+participant "NestJS /recipes" as API
+participant "Recipes DB" as DB
+
+note over M : beer recognised — style / abv / ibu / colorEbc\n(encyclopedia or NestJS)
+M -> API : POST /recipes/match { style?, abv?, ibu?, colorEbc? }
+API -> API : rankByCharacteristics(carac)
+API -> DB : load PUBLIC candidates
+DB --> API : recipes[]
+loop each candidate
+  API -> API : score = style*50 + abv*25 + ibu*15 + colour*10 (renorm if null)
+end
+API -> API : sort (score, rating, id) ; top-N (<=10)
+API -> API : low_confidence = best < 40
+API --> M : 200 { rankings[], low_confidence }
+M --> M : render "recettes équivalentes" / low-confidence note
+@enduml
+```
+
+## Notes
+
+- **Inputs (all optional, all nullable).** `style: string`, `abv: number`, `ibu: number`,
+  `colorEbc: number`. The mobile maps EBC ↔ the API's colour unit consistently with the scan
+  fiche (`ScanCatalogItem.colorEbc`). A missing criterion is dropped and the remaining weights
+  are renormalised — so a beer with only style + abv still ranks.
+- **Scoring unchanged.** `rankByCharacteristics` is the exact existing scorer extracted out of
+  `rankForBeer`; sub-scores, weights, ordering, and the `low_confidence` (< 40) rule are
+  identical. Only the **source** of the characteristics changes.
+- **Backward compatibility.** `GET /recipes/match/:beerId` stays: it loads the
+  `scan_catalog_items` row, then calls `rankByCharacteristics(row)`. Removed when the NestJS
+  scan path is retired (#1186 step 2). No behaviour change for existing callers.
+- **Why not key off the beer id.** Identity is not a matching input; coupling to
+  `scan_catalog_items` is exactly what blocks the encyclopedia cutover. Characteristics are
+  source-agnostic.
+- **Conformance.** The code (`recipe-matching.service.ts` + the controller + the mobile data
+  layer) must satisfy this contract: a characteristics endpoint, the scorer shared with the
+  legacy route. Implementation follows validation of this diagram.

--- a/packages/api/src/recipe/controllers/recipe.controller.spec.ts
+++ b/packages/api/src/recipe/controllers/recipe.controller.spec.ts
@@ -114,6 +114,7 @@ describe('RecipeController', () => {
           provide: RecipeMatchingService,
           useValue: {
             rankForBeer: jest.fn(),
+            rankByCharacteristics: jest.fn(),
           },
         },
       ],
@@ -475,6 +476,47 @@ describe('RecipeController', () => {
       await expect(controller.matchForBeer(beerId)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('matchByCharacteristics() - POST /recipes/match', () => {
+    it('happy: maps the body characteristics to the matcher and returns the envelope', async () => {
+      const envelope = {
+        rankings: [{ recipe: mockRecipeOrm, score: 80 }],
+        low_confidence: false,
+      };
+      const spy = jest
+        .spyOn(matching, 'rankByCharacteristics')
+        .mockResolvedValue(envelope);
+
+      const result = await controller.matchByCharacteristics({
+        style: 'Blonde Ale',
+        abv: 6.6,
+        colorEbc: 12,
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        style: 'Blonde Ale',
+        abv: 6.6,
+        ibu: null,
+        color_ebc: 12,
+      });
+      expect(result).toBe(envelope);
+    });
+
+    it('edge: omitted characteristics map to null (renormalised matching)', async () => {
+      const spy = jest
+        .spyOn(matching, 'rankByCharacteristics')
+        .mockResolvedValue({ rankings: [], low_confidence: true });
+
+      await controller.matchByCharacteristics({ style: 'Stout' });
+
+      expect(spy).toHaveBeenCalledWith({
+        style: 'Stout',
+        abv: null,
+        ibu: null,
+        color_ebc: null,
+      });
     });
   });
 });

--- a/packages/api/src/recipe/controllers/recipe.controller.ts
+++ b/packages/api/src/recipe/controllers/recipe.controller.ts
@@ -28,6 +28,7 @@ import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { User } from '../../user/entities/user.entity';
 
 import { CreateRecipeDto } from '../dtos/create-recipe.dto';
+import { MatchByCharacteristicsDto } from '../dtos/match-by-characteristics.dto';
 import { RankedRecipeResponseDto } from '../dtos/ranked-recipe.dto';
 import { RecipeIbuEstimateDto } from '../dtos/recipe-ibu-estimate.dto';
 import { PublicRecipeDto } from '../dtos/public-recipe.dto';
@@ -112,6 +113,29 @@ export class RecipeController {
     @Param('beerId', new ParseUUIDPipe()) beerId: string,
   ): Promise<RankedRecipeResponseDto> {
     return this.matching.rankForBeer(beerId);
+  }
+
+  @Post('match')
+  @ApiOperation({
+    summary:
+      "Rank PUBLIC recipes by a beer's characteristics (style/ABV/IBU/colour) — source-agnostic (scan cutover #1186)",
+    description:
+      'Same ranking as `GET /recipes/match/:beerId` but driven by the beer characteristics in the body instead of a `scan_catalog_items` id, so the mobile scan fiche can match a beer resolved from the beer-encyclopedia (whose UUID is not a scan-catalog row). Every field is optional; missing criteria are dropped and the remaining weights renormalised. Returns the same `{ rankings, low_confidence }` envelope.',
+  })
+  @ApiOkResponse({
+    description:
+      'Response envelope `{ rankings: [{recipe, score}], low_confidence: boolean }`',
+  })
+  async matchByCharacteristics(
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    dto: MatchByCharacteristicsDto,
+  ): Promise<RankedRecipeResponseDto> {
+    return this.matching.rankByCharacteristics({
+      style: dto.style ?? null,
+      abv: dto.abv ?? null,
+      ibu: dto.ibu ?? null,
+      color_ebc: dto.colorEbc ?? null,
+    });
   }
 
   @Get('public')

--- a/packages/api/src/recipe/dtos/match-by-characteristics.dto.ts
+++ b/packages/api/src/recipe/dtos/match-by-characteristics.dto.ts
@@ -1,0 +1,34 @@
+import { IsNumber, IsOptional, IsString, Max, Min } from 'class-validator';
+
+/**
+ * Body for `POST /recipes/match` — the recognised beer's characteristics
+ * the matcher scores against (style × 50 + ABV × 25 + IBU × 15 +
+ * colour × 10). Every field is optional: a missing criterion is dropped
+ * and the remaining weights are renormalised, so a beer with only a
+ * style + ABV still ranks.
+ *
+ * Decouples matching from the `scan_catalog_items` id (scan cutover
+ * #1186) — see docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md.
+ */
+export class MatchByCharacteristicsDto {
+  @IsOptional()
+  @IsString()
+  style?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  abv?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1000)
+  ibu?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  colorEbc?: number;
+}

--- a/packages/api/src/recipe/services/recipe-matching.service.spec.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.spec.ts
@@ -589,6 +589,98 @@ describe('RecipeMatchingService (Issue #699)', () => {
       expect(service.computeQuality(recipe)).toBe(0);
     });
   });
+
+  // ---------------------------------------------------------------
+  // rankByCharacteristics — the source-agnostic core (scan cutover #1186)
+  // ---------------------------------------------------------------
+  describe('rankByCharacteristics (integration — no scan_catalog row)', () => {
+    it('happy: ranks the closest recipe from characteristics alone (no beer id)', async () => {
+      await Promise.all([
+        seedRecipe(recipeRepo, {
+          name: 'Session IPA Citra',
+          style: 'Session IPA',
+          abv_estimated: 4.6,
+          avg_rating: 4.7,
+        }),
+        seedRecipe(recipeRepo, {
+          name: 'Belgian Tripel',
+          style: 'Belgian Tripel',
+          abv_estimated: 8.5,
+          avg_rating: 4.8,
+        }),
+      ]);
+
+      const { rankings, low_confidence } = await service.rankByCharacteristics(
+        { style: 'Session IPA', abv: 4.5 },
+        3,
+      );
+
+      expect(rankings[0].recipe.name).toBe('Session IPA Citra');
+      expect(low_confidence).toBe(false);
+    });
+
+    it('edge: still ranks (renormalised) when only a style is provided', async () => {
+      await seedRecipe(recipeRepo, {
+        name: 'IPA',
+        style: 'IPA',
+        abv_estimated: 6,
+        avg_rating: 4.5,
+      });
+
+      const { rankings } = await service.rankByCharacteristics(
+        { style: 'IPA' },
+        3,
+      );
+
+      expect(rankings).toHaveLength(1);
+      expect(rankings[0].recipe.name).toBe('IPA');
+    });
+
+    it('edge: empty characteristics still returns the candidates, flagged low confidence', async () => {
+      await seedRecipe(recipeRepo, {
+        name: 'Whatever',
+        style: 'IPA',
+        abv_estimated: 6,
+        avg_rating: 4,
+      });
+
+      const { rankings, low_confidence } = await service.rankByCharacteristics(
+        { style: null },
+        3,
+      );
+
+      expect(rankings).toHaveLength(1);
+      expect(low_confidence).toBe(true);
+    });
+
+    it('parity: rankForBeer delegates here — same ranking for the same characteristics', async () => {
+      const beerId = await seedBeer(catalogRepo, { style: 'Stout', abv: 5 });
+      await Promise.all([
+        seedRecipe(recipeRepo, {
+          name: 'Dry Stout',
+          style: 'Stout',
+          abv_estimated: 4.8,
+          avg_rating: 4.6,
+        }),
+        seedRecipe(recipeRepo, {
+          name: 'Hazy IPA',
+          style: 'NEIPA',
+          abv_estimated: 6.5,
+          avg_rating: 4.5,
+        }),
+      ]);
+
+      const viaBeer = await service.rankForBeer(beerId, 3);
+      const viaCharacteristics = await service.rankByCharacteristics(
+        { style: 'Stout', abv: 5 },
+        3,
+      );
+
+      expect(viaCharacteristics.rankings.map((r) => r.recipe.name)).toEqual(
+        viaBeer.rankings.map((r) => r.recipe.name),
+      );
+    });
+  });
 });
 
 // -----------------------------------------------------------------

--- a/packages/api/src/recipe/services/recipe-matching.service.spec.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.spec.ts
@@ -680,6 +680,25 @@ describe('RecipeMatchingService (Issue #699)', () => {
         viaBeer.rankings.map((r) => r.recipe.name),
       );
     });
+
+    it('treats a whitespace-only style as absent (renormalised, not a 0 penalty)', () => {
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: 4,
+      });
+
+      const whitespace = service.computeSimilarity(
+        { style: '  ', abv: 5.5 },
+        recipe,
+      );
+      const absent = service.computeSimilarity(
+        { style: null, abv: 5.5 },
+        recipe,
+      );
+
+      expect(whitespace).toBe(absent);
+    });
   });
 });
 

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -435,7 +435,10 @@ export class RecipeMatchingService {
     beerStyle: string | null | undefined,
     recipeStyle: string | null | undefined,
   ): number | null {
-    if (!beerStyle || !recipeStyle) return null;
+    // Treat a blank/whitespace style as *absent* (→ null → dropped by
+    // renormalisation) rather than a present criterion scoring 0, which
+    // would unfairly penalise similarity (Copilot review on #1190).
+    if (!beerStyle?.trim() || !recipeStyle?.trim()) return null;
     return this.scoreStyle(beerStyle, recipeStyle);
   }
 

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -11,6 +11,21 @@ import {
 } from '../dtos/ranked-recipe.dto';
 
 /**
+ * The beer characteristics the matcher scores against — style, ABV,
+ * bitterness (IBU) and colour (EBC). This is the *only* input the
+ * ranking needs; it is deliberately decoupled from how the beer was
+ * identified (a `scan_catalog_items` row, a beer-encyclopedia
+ * `BeerRead`, …) so matching works for any source (scan cutover #1186).
+ * See docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md.
+ */
+export interface BeerCharacteristics {
+  style: string | null;
+  abv?: number | null;
+  ibu?: number | null;
+  color_ebc?: number | null;
+}
+
+/**
  * Score-based recipe matching — full brainstorm scan-2026-04-24 §3
  * formula. Extends the minimal-viable scope shipped in PR #773 with
  * the four remaining components, weight renormalization when a
@@ -70,7 +85,22 @@ export class RecipeMatchingService {
         `Beer catalog item ${beerCatalogItemId} not found`,
       );
     }
+    return this.rankByCharacteristics(beer, limit);
+  }
 
+  /**
+   * Rank PUBLIC recipes against a beer's characteristics (style, ABV,
+   * IBU, colour) — the source-agnostic core of the matcher. `rankForBeer`
+   * is a thin wrapper that loads a `scan_catalog_items` row and delegates
+   * here; the mobile scan fiche calls this directly with the recognised
+   * beer's characteristics (from the encyclopedia or NestJS), so matching
+   * no longer depends on a scan-catalog id (#1186). Scoring, ordering and
+   * the `low_confidence` rule are unchanged.
+   */
+  async rankByCharacteristics(
+    beer: BeerCharacteristics,
+    limit = 3,
+  ): Promise<RankedRecipeResponseDto> {
     const candidates = await this.recipeRepo.find({
       where: { visibility: RecipeVisibility.PUBLIC },
     });
@@ -137,7 +167,7 @@ export class RecipeMatchingService {
    * ranked relative to each other by their rating/brew_count/recency.
    */
   computeFinalScore(
-    beer: ScanCatalogItemOrmEntity,
+    beer: BeerCharacteristics,
     recipe: RecipeOrmEntity,
   ): number {
     const similarity = recipe.is_official
@@ -157,7 +187,7 @@ export class RecipeMatchingService {
    * Returns 0 if all four criteria are missing.
    */
   computeSimilarity(
-    beer: ScanCatalogItemOrmEntity,
+    beer: BeerCharacteristics,
     recipe: RecipeOrmEntity,
   ): number {
     const components: { weight: number; score: number | null }[] = [

--- a/packages/mobile-app/src/features/scan/application/__tests__/recipe-matching.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/recipe-matching.use-cases.test.ts
@@ -120,23 +120,31 @@ describe("getMatchingRecipes (Issue #700)", () => {
       expect(result).toBe(apiResponse);
     });
 
-    it("edge: forwards null characteristics unchanged (the API renormalises)", async () => {
+    it("edge: forwards null numeric characteristics unchanged (the API renormalises)", async () => {
       mockApiFetch.mockResolvedValue({ rankings: [], lowConfidence: true });
 
       await getMatchingRecipes(
-        makeBeer({
-          style: "Style inconnu",
-          abv: null,
-          ibu: null,
-          colorEbc: null,
-        }),
+        makeBeer({ style: "Stout", abv: null, ibu: null, colorEbc: null }),
       );
 
       expect(mockApiFetch).toHaveBeenCalledWith({
-        style: "Style inconnu",
+        style: "Stout",
         abv: null,
         ibu: null,
         colorEbc: null,
+      });
+    });
+
+    it("edge: a placeholder style ('Style inconnu') is sent as null so the matcher renormalises", async () => {
+      mockApiFetch.mockResolvedValue({ rankings: [], lowConfidence: true });
+
+      await getMatchingRecipes(makeBeer({ style: "Style inconnu" }));
+
+      expect(mockApiFetch).toHaveBeenCalledWith({
+        style: null,
+        abv: 5.4,
+        ibu: 45,
+        colorEbc: 14,
       });
     });
 

--- a/packages/mobile-app/src/features/scan/application/__tests__/recipe-matching.use-cases.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/recipe-matching.use-cases.test.ts
@@ -24,6 +24,25 @@ const mockDemoEquivalents = getDemoEquivalentRecipes as jest.MockedFunction<
   typeof getDemoEquivalentRecipes
 >;
 
+function makeBeer(
+  overrides: Partial<{
+    barcode: string;
+    style: string;
+    abv: number | null;
+    ibu: number | null;
+    colorEbc: number | null;
+  }> = {},
+) {
+  return {
+    barcode: "5060277380019",
+    style: "American IPA",
+    abv: 5.4,
+    ibu: 45,
+    colorEbc: 14,
+    ...overrides,
+  };
+}
+
 describe("getMatchingRecipes (Issue #700)", () => {
   beforeEach(() => {
     mockApiFetch.mockReset();
@@ -46,10 +65,7 @@ describe("getMatchingRecipes (Issue #700)", () => {
       ];
       mockDemoEquivalents.mockReturnValue(demoRecipes);
 
-      const result = await getMatchingRecipes({
-        id: "uuid-beer",
-        barcode: "5060277380019",
-      });
+      const result = await getMatchingRecipes(makeBeer());
 
       expect(mockDemoEquivalents).toHaveBeenCalledWith("5060277380019");
       expect(mockApiFetch).not.toHaveBeenCalled();
@@ -62,10 +78,9 @@ describe("getMatchingRecipes (Issue #700)", () => {
     it("sad: when the demo set has no match for the barcode, returns empty rankings + low_confidence=true", async () => {
       mockDemoEquivalents.mockReturnValue([]);
 
-      const result = await getMatchingRecipes({
-        id: "uuid-beer",
-        barcode: "9999999999999",
-      });
+      const result = await getMatchingRecipes(
+        makeBeer({ barcode: "9999999999999" }),
+      );
 
       expect(result).toEqual({ rankings: [], lowConfidence: true });
     });
@@ -76,7 +91,7 @@ describe("getMatchingRecipes (Issue #700)", () => {
       dataSourceMock.useDemoData = false;
     });
 
-    it("happy: forwards the call to the API with the catalog item id and passes through the envelope", async () => {
+    it("happy: forwards the beer characteristics to the API and passes through the envelope", async () => {
       const apiResponse = {
         rankings: [
           {
@@ -93,14 +108,36 @@ describe("getMatchingRecipes (Issue #700)", () => {
       };
       mockApiFetch.mockResolvedValue(apiResponse);
 
-      const result = await getMatchingRecipes({
-        id: "uuid-beer",
-        barcode: "5060277380019",
-      });
+      const result = await getMatchingRecipes(makeBeer());
 
-      expect(mockApiFetch).toHaveBeenCalledWith("uuid-beer");
+      expect(mockApiFetch).toHaveBeenCalledWith({
+        style: "American IPA",
+        abv: 5.4,
+        ibu: 45,
+        colorEbc: 14,
+      });
       expect(mockDemoEquivalents).not.toHaveBeenCalled();
       expect(result).toBe(apiResponse);
+    });
+
+    it("edge: forwards null characteristics unchanged (the API renormalises)", async () => {
+      mockApiFetch.mockResolvedValue({ rankings: [], lowConfidence: true });
+
+      await getMatchingRecipes(
+        makeBeer({
+          style: "Style inconnu",
+          abv: null,
+          ibu: null,
+          colorEbc: null,
+        }),
+      );
+
+      expect(mockApiFetch).toHaveBeenCalledWith({
+        style: "Style inconnu",
+        abv: null,
+        ibu: null,
+        colorEbc: null,
+      });
     });
 
     it("sad: low_confidence=true from the API surfaces unchanged in the envelope", async () => {
@@ -109,10 +146,7 @@ describe("getMatchingRecipes (Issue #700)", () => {
         lowConfidence: true,
       });
 
-      const result = await getMatchingRecipes({
-        id: "uuid-beer",
-        barcode: "5060277380019",
-      });
+      const result = await getMatchingRecipes(makeBeer());
 
       expect(result.lowConfidence).toBe(true);
     });

--- a/packages/mobile-app/src/features/scan/application/recipe-matching.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/recipe-matching.use-cases.ts
@@ -18,6 +18,7 @@
  */
 import { dataSource } from "@/core/data/data-source";
 
+import { SCAN_STYLE_PLACEHOLDER } from "@/features/scan/data/beers-import.api";
 import { fetchMatchingRecipes } from "@/features/scan/data/recipe-matching.api";
 import type {
   ScanCatalogItem,
@@ -49,7 +50,10 @@ export async function getMatchingRecipes(
   }
 
   return fetchMatchingRecipes({
-    style: beer.style,
+    // "Style inconnu" is a display placeholder, not a real style — send
+    // null so the matcher renormalises rather than scoring it as a
+    // present-but-mismatched style (Codex P2 on #1190).
+    style: beer.style === SCAN_STYLE_PLACEHOLDER ? null : beer.style,
     abv: beer.abv,
     ibu: beer.ibu,
     colorEbc: beer.colorEbc,

--- a/packages/mobile-app/src/features/scan/application/recipe-matching.use-cases.ts
+++ b/packages/mobile-app/src/features/scan/application/recipe-matching.use-cases.ts
@@ -28,12 +28,14 @@ import { getDemoEquivalentRecipes } from "@/mocks/demo-data";
 /**
  * Resolve the top-N matching recipes for a given recognised beer.
  *
- * Accepts the full `ScanCatalogItem` so the use-case has both the
- * `barcode` (demo lookup key) and the `id` (backend lookup key)
- * without forcing the caller to pick the right one upstream.
+ * Accepts the `barcode` (demo lookup key) plus the matching
+ * characteristics (`style`/`abv`/`ibu`/`colorEbc`) the backend scores
+ * against. The match no longer keys off the `scan_catalog_items` id, so
+ * it works for beers resolved from the encyclopedia (scan cutover
+ * #1186).
  */
 export async function getMatchingRecipes(
-  beer: Pick<ScanCatalogItem, "id" | "barcode">,
+  beer: Pick<ScanCatalogItem, "barcode" | "style" | "abv" | "ibu" | "colorEbc">,
 ): Promise<ScanMatchingResult> {
   if (dataSource.useDemoData) {
     const rankings = getDemoEquivalentRecipes(beer.barcode);
@@ -46,5 +48,10 @@ export async function getMatchingRecipes(
     };
   }
 
-  return fetchMatchingRecipes(beer.id);
+  return fetchMatchingRecipes({
+    style: beer.style,
+    abv: beer.abv,
+    ibu: beer.ibu,
+    colorEbc: beer.colorEbc,
+  });
 }

--- a/packages/mobile-app/src/features/scan/data/beers-import.api.ts
+++ b/packages/mobile-app/src/features/scan/data/beers-import.api.ts
@@ -114,6 +114,15 @@ function inferLookupSource(dto: PythonBeerReadDto): ScanLookupSource {
   return "cache_hit_fresh";
 }
 
+/**
+ * Display placeholders used when the server could not resolve a brewery
+ * or style name. Exported so consumers (e.g. recipe matching) can treat
+ * them as "absent" instead of feeding the literal placeholder text into
+ * an algorithm that would mistake it for a real value.
+ */
+export const SCAN_BREWERY_PLACEHOLDER = "Brasserie inconnue";
+export const SCAN_STYLE_PLACEHOLDER = "Style inconnu";
+
 function mapPythonBeerToCatalogItem(
   dto: PythonBeerReadDto,
   ean: string,
@@ -125,8 +134,8 @@ function mapPythonBeerToCatalogItem(
     // Brewery / style names are resolved server-side from the FKs
     // (07-class-api-contract). Fall back to a placeholder only when the
     // server could not resolve one (FK null or relation missing).
-    brewery: dto.brewery_name ?? "Brasserie inconnue",
-    style: dto.style_name ?? "Style inconnu",
+    brewery: dto.brewery_name ?? SCAN_BREWERY_PLACEHOLDER,
+    style: dto.style_name ?? SCAN_STYLE_PLACEHOLDER,
     abv: dto.abv === null ? null : Number(dto.abv),
     ibu: dto.ibu,
     colorEbc: srmToEbc(dto.srm),

--- a/packages/mobile-app/src/features/scan/data/recipe-matching.api.ts
+++ b/packages/mobile-app/src/features/scan/data/recipe-matching.api.ts
@@ -62,20 +62,45 @@ function mapRankedRecipe(dto: RankedRecipeWireDto): ScanRecipeMatch {
 }
 
 /**
- * Fetch the top-N recipes that best match the given beer catalog
- * item id, plus the `low_confidence` flag the API computes when the
- * best match is genuinely below the threshold (per brainstorm
+ * The recognised beer's characteristics the matcher scores against.
+ * Source-agnostic: the values come from the scanned beer (encyclopedia
+ * or NestJS), not a `scan_catalog_items` id — so matching keeps working
+ * after the scan cutover (#1186). See
+ * docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md.
+ */
+export interface BeerMatchCharacteristics {
+  style: string | null;
+  abv: number | null;
+  ibu: number | null;
+  colorEbc: number | null;
+}
+
+/**
+ * Fetch the top-N recipes that best match the given beer
+ * characteristics, plus the `low_confidence` flag the API computes when
+ * the best match is genuinely below the threshold (per brainstorm
  * scan-2026-04-24 §3.4 + Codex P1 fix on PR #792).
+ *
+ * POSTs the characteristics to `/recipes/match` instead of keying off a
+ * `scan_catalog_items` id — required once the scan resolves beers from
+ * the encyclopedia (#1186). Missing values are omitted; the API
+ * renormalises the weights.
  *
  * Throws on transport or HTTP errors — the use-case layer is
  * responsible for translating those into UI-facing error messages.
  */
 export async function fetchMatchingRecipes(
-  beerCatalogItemId: string,
+  characteristics: BeerMatchCharacteristics,
 ): Promise<ScanMatchingResult> {
-  const data = await request<MatchingResponseWireDto>(
-    `/recipes/match/${beerCatalogItemId}`,
-  );
+  const data = await request<MatchingResponseWireDto>("/recipes/match", {
+    method: "POST",
+    body: {
+      style: characteristics.style ?? undefined,
+      abv: characteristics.abv ?? undefined,
+      ibu: characteristics.ibu ?? undefined,
+      colorEbc: characteristics.colorEbc ?? undefined,
+    },
+  });
   return {
     rankings: data.rankings.map(mapRankedRecipe),
     lowConfidence: data.low_confidence,

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -400,7 +400,10 @@ function MatchingRecipesSection({
   beer,
   onImported,
 }: Readonly<{
-  beer: Pick<ScanCatalogItem, "id" | "barcode">;
+  beer: Pick<
+    ScanCatalogItem,
+    "id" | "barcode" | "style" | "abv" | "ibu" | "colorEbc"
+  >;
   onImported: (recipeId: string) => void;
 }>) {
   const matchingQuery = useQuery({


### PR DESCRIPTION
## Why
Unblocks the scan cutover (#1186). Once the mobile resolves a barcode against the beer-encyclopedia, the beer carries a Python `beers` UUID that is **absent** from NestJS `scan_catalog_items`, so the legacy `GET /recipes/match/:beerId` (which `findOne`s a scan-catalog row) **404s for every encyclopedia beer** — the Codex **P1** on #1189. Identity is not a matching input: the algorithm only needs **style / ABV / IBU / colour**. Conforms to the conception `06-sequence-recipe-matching`.

## What
- **NestJS** — extract the scorer into `rankByCharacteristics({style, abv, ibu, color_ebc})`; `rankForBeer` now loads the scan-catalog row then delegates (unchanged). New **`POST /recipes/match`** (`MatchByCharacteristicsDto`, all fields optional/renormalised). Scoring, ordering and `low_confidence` are **identical**. The legacy `:beerId` route stays until the NestJS scan path is retired (#1186 step 2).
- **Mobile** — `fetchMatchingRecipes` POSTs the scanned beer's characteristics; `getMatchingRecipes` + `MatchingRecipesSection` pass them through (no more id-keying).

## Tests
- API: service (`rankByCharacteristics` happy/edge/parity with `rankForBeer`), controller (POST body → characteristics mapping). **72 recipe tests** green; build + eslint + prettier clean.
- Mobile: use-case forwards characteristics (+ null edge). **207 scan tests** green; tsc + eslint + prettier clean.

## Sequencing
Lands **before** the cutover #1188 (conception) + #1189 (code), which it unblocks.

Part of #1186 / #699.