### PR TITLE
fix(recipes): style-gate the official-recipe shortcut (Leffe Blonde → Punk IPA)

### DIFF
--- a/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
+++ b/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
@@ -84,9 +84,10 @@ M --> M : render "recettes équivalentes" / low-confidence note
   off-style official (e.g. an IPA for a Leffe Blonde) is ranked on its honest similarity
   instead, so it no longer floats above a genuine same-style match. Style-compatible officials
   stay promoted.
-- **Backward compatibility.** `GET /recipes/match/:beerId` stays: it loads the
-  `scan_catalog_items` row, then calls `rankByCharacteristics(row)`. Removed when the NestJS
-  scan path is retired (#1186 step 2). No behaviour change for existing callers.
+- **Backward compatibility.** `GET /recipes/match/:beerId` stays (same request/response
+  contract): it loads the `scan_catalog_items` row, then calls `rankByCharacteristics(row)`.
+  Removed when the NestJS scan path is retired (#1186 step 2). The **interface** is unchanged;
+  the **ranking** reflects the style-gated official promotion (#1193) for both routes.
 - **Why not key off the beer id.** Identity is not a matching input; coupling to
   `scan_catalog_items` is exactly what blocks the encyclopedia cutover. Characteristics are
   source-agnostic.

--- a/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
+++ b/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
@@ -76,9 +76,14 @@ M --> M : render "recettes équivalentes" / low-confidence note
   `colorEbc: number`. The mobile maps EBC ↔ the API's colour unit consistently with the scan
   fiche (`ScanCatalogItem.colorEbc`). A missing criterion is dropped and the remaining weights
   are renormalised — so a beer with only style + abv still ranks.
-- **Scoring unchanged.** `rankByCharacteristics` is the exact existing scorer extracted out of
-  `rankForBeer`; sub-scores, weights, ordering, and the `low_confidence` (< 40) rule are
-  identical. Only the **source** of the characteristics changes.
+- **Scoring (mostly) unchanged.** `rankByCharacteristics` is the existing scorer extracted out
+  of `rankForBeer`; sub-scores, weights, and the `low_confidence` (< 40) rule are identical.
+  Only the **source** of the characteristics changes.
+- **Style-gated official promotion (#1193).** The official-recipe shortcut (similarity = 100)
+  applies **only when the official is style-compatible** (the style sub-score is positive). An
+  off-style official (e.g. an IPA for a Leffe Blonde) is ranked on its honest similarity
+  instead, so it no longer floats above a genuine same-style match. Style-compatible officials
+  stay promoted.
 - **Backward compatibility.** `GET /recipes/match/:beerId` stays: it loads the
   `scan_catalog_items` row, then calls `rankByCharacteristics(row)`. Removed when the NestJS
   scan path is retired (#1186 step 2). No behaviour change for existing callers.

--- a/packages/api/src/recipe/services/recipe-matching.service.spec.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.spec.ts
@@ -162,17 +162,36 @@ describe('RecipeMatchingService (Issue #699)', () => {
       expect(service.computeFinalScore(beer, recipe)).toBe(100);
     });
 
-    it('happy: official-recipe shortcut sets similarity=100; quality still varies', () => {
-      // Style mismatch + null rating: similarity=100 (shortcut),
-      // quality=0 (no rating, no brew_count, no recency).
-      // Final = 100*0.7 + 0*0.3 = 70.
+    it('happy: a style-compatible official gets the shortcut (similarity=100)', () => {
+      // Same style → style-compatible → shortcut. Null quality → 70.
       const official = makeRecipe({
-        style: 'Pilsner',
+        style: 'IPA',
         abv_estimated: null,
         avg_rating: null,
         is_official: true,
       });
       expect(service.computeFinalScore(beer, official)).toBeCloseTo(70, 5);
+    });
+
+    it('#1193: an off-style official does NOT get the shortcut and cannot outrank a genuine style match', () => {
+      // Pilsner official for an IPA beer → style score 0 → not
+      // style-compatible → no shortcut → ranked on its honest (low)
+      // similarity, so a same-style non-official scores higher.
+      const offStyleOfficial = makeRecipe({
+        style: 'Pilsner',
+        abv_estimated: null,
+        avg_rating: null,
+        is_official: true,
+      });
+      const sameStyleNonOfficial = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: 4,
+      });
+
+      expect(service.computeFinalScore(beer, offStyleOfficial)).toBeLessThan(
+        service.computeFinalScore(beer, sameStyleNonOfficial),
+      );
     });
 
     it('edge: a recipe with no style nor ABV nor rating still scores deterministically (0)', () => {
@@ -231,28 +250,28 @@ describe('RecipeMatchingService (Issue #699)', () => {
       expect(low_confidence).toBe(false);
     });
 
-    it('happy: an official-flagged recipe beats every non-official peer', async () => {
+    it('happy: a style-compatible official beats non-official peers (#1193)', async () => {
       const beerId = await seedBeer(catalogRepo, {
         style: 'Pilsner',
         abv: 5,
       });
       await seedRecipe(recipeRepo, {
         name: 'Random NEIPA',
-        style: 'NEIPA',
+        style: 'NEIPA', // off the beer style
         abv_estimated: 6.5,
         avg_rating: 5,
       });
       await seedRecipe(recipeRepo, {
-        name: 'Brewer-Endorsed Clone',
-        style: 'Belgian Tripel', // wildly off the beer style
-        abv_estimated: 9, // wildly off the beer ABV
+        name: 'Brewer-Endorsed Pilsner',
+        style: 'Pilsner', // same style → shortcut applies
+        abv_estimated: 9, // ABV off, but the style gate is satisfied
         avg_rating: null, // no rating
         is_official: true,
       });
 
       const { rankings } = await service.rankForBeer(beerId, 3);
-      expect(rankings[0].recipe.name).toBe('Brewer-Endorsed Clone');
-      // Similarity = 100 (official shortcut), quality = 0 (no
+      expect(rankings[0].recipe.name).toBe('Brewer-Endorsed Pilsner');
+      // Style-compatible → similarity = 100 (shortcut), quality = 0 (no
       // avg_rating, no brew_count, no recency). Final = 100*0.7 = 70.
       expect(rankings[0].score).toBeCloseTo(70, 5);
     });
@@ -379,12 +398,11 @@ describe('RecipeMatchingService (Issue #699)', () => {
       expect(low_confidence).toBe(true);
     });
 
-    it('low_confidence: still true when an irrelevant official-tagged recipe tops the ranking (Codex P1 #792)', async () => {
-      // `is_official` is global, not per-beer. A single official
-      // recipe with a style/ABV/everything mismatch should NOT
-      // suppress the low_confidence warning just because the
-      // shortcut sets its similarity to 100. The honest score
-      // (computed similarity + quality) decides.
+    it('low_confidence: an off-style official is not inflated by the shortcut and the warning fires (#1193 supersedes #792)', async () => {
+      // Since #1193 the official shortcut applies only to a
+      // style-compatible official. An off-style official no longer
+      // inflates its headline to 70 — it is ranked on its honest (low)
+      // similarity — and the low_confidence warning still fires.
       const beerId = await seedBeer(catalogRepo, {
         style: 'Pilsner',
         abv: 4.5,
@@ -398,11 +416,8 @@ describe('RecipeMatchingService (Issue #699)', () => {
       });
 
       const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
-      // The headline score still reflects the shortcut (≥ 70 because
-      // similarity=100 × 0.7 + quality=0 × 0.3), so the recipe stays
-      // visually prominent.
-      expect(rankings[0].score).toBeGreaterThanOrEqual(70);
-      // But the warning still fires — the actual similarity is 0.
+      // No shortcut for an off-style official → honest (low) headline.
+      expect(rankings[0].score).toBeLessThan(40);
       expect(low_confidence).toBe(true);
     });
 
@@ -698,6 +713,31 @@ describe('RecipeMatchingService (Issue #699)', () => {
       );
 
       expect(whitespace).toBe(absent);
+    });
+
+    it('#1193: a blonde beer ranks a same-style recipe above an off-style official (the Leffe case)', async () => {
+      await Promise.all([
+        seedRecipe(recipeRepo, {
+          name: 'Punk IPA (official)',
+          style: 'American IPA',
+          abv_estimated: 5.4,
+          avg_rating: 4.9,
+          is_official: true,
+        }),
+        seedRecipe(recipeRepo, {
+          name: 'Belgian Blonde',
+          style: 'Blonde Ale',
+          abv_estimated: 6.5,
+          avg_rating: 4.2,
+        }),
+      ]);
+
+      const { rankings } = await service.rankByCharacteristics(
+        { style: 'Blonde Ale', abv: 6.6 },
+        3,
+      );
+
+      expect(rankings[0].recipe.name).toBe('Belgian Blonde');
     });
   });
 });

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -162,17 +162,25 @@ export class RecipeMatchingService {
    * Combines similarity (70%) and quality (30%), each computed with
    * weight renormalization if a sub-criterion is missing.
    *
-   * The official-recipe shortcut wins outright on the similarity
-   * axis only — quality still varies, so two officials can be
-   * ranked relative to each other by their rating/brew_count/recency.
+   * The official-recipe shortcut (similarity = 100) applies **only when
+   * the official is style-compatible** with the scanned beer — i.e. the
+   * style sub-score is positive (exact or same-family). An off-style
+   * official (e.g. an IPA for a Leffe Blonde) no longer floats above a
+   * genuine style match; it is ranked on its honest similarity instead,
+   * so a same-style non-official can outrank it (#1193). Quality still
+   * varies, so two style-compatible officials are ordered by their
+   * rating/brew_count/recency.
    */
   computeFinalScore(
     beer: BeerCharacteristics,
     recipe: RecipeOrmEntity,
   ): number {
-    const similarity = recipe.is_official
-      ? 100
-      : this.computeSimilarity(beer, recipe);
+    const styleScore = this.maybeStyleScore(beer.style, recipe.style);
+    const styleCompatible = styleScore !== null && styleScore > 0;
+    const similarity =
+      recipe.is_official && styleCompatible
+        ? 100
+        : this.computeSimilarity(beer, recipe);
     const quality = this.computeQuality(recipe);
     return similarity * 0.7 + quality * 0.3;
   }

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -45,8 +45,10 @@ export interface BeerCharacteristics {
  *                      (response envelope flag, lets the UI display
  *                      a discreet "no very similar recipe" warning).
  *
- * The official-recipe shortcut still applies — `is_official=true`
- * sets similarity to 100 by definition; quality still varies.
+ * The official-recipe shortcut applies **only to a style-compatible
+ * official** (`is_official=true` AND a positive style sub-score) →
+ * similarity 100; an off-style official is ranked on its honest
+ * similarity instead (#1193). Quality still varies.
  *
  * Sub-score scales (0..100):
  * - style — exact match 100, family containment 70, else 0
@@ -130,18 +132,14 @@ export class RecipeMatchingService {
 
     // `low_confidence` reflects whether the best match is genuinely
     // similar to the scanned beer — NOT the headline score after the
-    // official-shortcut. `is_official` is a GLOBAL flag (per recipe,
-    // not per beer): without a per-beer relationship, a single
-    // officially-tagged recipe irrelevant to the scanned beer would
-    // always inflate the headline score to 70 and silently suppress
-    // the warning. Codex P1 on PR #792 caught exactly this.
-    //
-    // Fix: compute the "honest" score (similarity WITHOUT the
-    // shortcut + quality) on the top recipe, and use THAT for the
-    // threshold check. The ranking itself still uses the shortcut
-    // so officials remain prominent on screen — but if they happen
-    // to be irrelevant to the beer (style/ABV mismatch), the UI
-    // honestly tells the user via the low_confidence flag.
+    // official shortcut. Since #1193 the shortcut is style-gated, so an
+    // off-style official is no longer inflated to the top; but a
+    // style-compatible official still scores 100 on similarity, which on
+    // its own (style match, ABV/quality unknown) can sit above the 40
+    // threshold while not being a strong overall match. So we still
+    // compute the "honest" score (similarity WITHOUT the shortcut +
+    // quality) on the top recipe and use THAT for the threshold check
+    // (the original Codex P1 on PR #792), keeping the warning truthful.
     let honestTopScore = 0;
     if (top.length > 0) {
       const best = top[0].recipe;

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -396,9 +396,11 @@ export class RecipeMatchingService {
       { count: 100, score: 95 },
       { count: 500, score: 100 },
     ];
-    if (brewCount <= anchors[0].count) return anchors[0].score * brewCount;
-    if (brewCount >= anchors[anchors.length - 1].count) {
-      return anchors[anchors.length - 1].score;
+    const first = anchors[0];
+    const last = anchors.at(-1) ?? first; // `anchors` is a non-empty literal
+    if (brewCount <= first.count) return first.score * brewCount;
+    if (brewCount >= last.count) {
+      return last.score;
     }
     for (let i = 0; i < anchors.length - 1; i += 1) {
       const lo = anchors[i];


### PR DESCRIPTION
## Why
Scanning a **Leffe Blonde** proposed an official **BrewDog Punk IPA** as the top "recette équivalente" — an IPA for a blonde (#1193). The matcher gave **every** `is_official` recipe a similarity shortcut of **100 regardless of style**, so an off-style official floated above genuine same-style matches; the `low_confidence` flag only warned, it didn't change the ranking.

## What
`computeFinalScore`: the official shortcut now applies **only when the official is style-compatible** (the style sub-score is positive). An off-style official is ranked on its **honest** similarity, so a same-style non-official can outrank it. Style-compatible officials stay promoted. Supersedes the #792 "inflated headline + warning" behaviour for off-style officials.

## Tests
- unit: off-style official `<` same-style non-official; a style-compatible official keeps the shortcut.
- integration: a Blonde-Ale beer ranks a **blonde** recipe above an official **IPA** (the Leffe case).
- the two prior official-shortcut tests updated to the gated behaviour.

**75 recipe tests** green; build + eslint + prettier clean. Conception note added to `06-sequence-recipe-matching`.

## Note
Visible once the scan runs the cutover code (encyclopedia-first → real style reaches the matcher). Backend-only — needs an API redeploy. Part of the cutover delivery.

Closes #1193. Part of #699 / #1186.