### PR TITLE
docs(architecture): ADR-0016 — recipe-matching v2 (weighted criteria + completeness + BJCP families)

### DIFF
--- a/docs/architecture/decisions/0016-recipe-equivalence-matching-v2.md
+++ b/docs/architecture/decisions/0016-recipe-equivalence-matching-v2.md
@@ -5,7 +5,7 @@
 **Owners**  @benoit-bremaud
 **Relates** #699 (matcher), #1190 (match by characteristics), #1193 (official style-gate), #1198 (style family), epic #1175. Conception: [`../diagrams/recipes/06-sequence-recipe-matching.md`](../diagrams/recipes/06-sequence-recipe-matching.md).
 
-> Supersedes the **scoring** behaviour of the matcher described implicitly in #699/#1190/#1193 (the API contract — `POST /recipes/match` by characteristics — is unchanged). This ADR fixes *how* the similarity is computed.
+> Supersedes the **scoring** behaviour of the matcher described implicitly in #699/#1190/#1193. This ADR fixes *how* the similarity is computed. The `POST /recipes/match` **request** contract is unchanged; the **response** gains an additive, backward-compatible per-ranking `completeness` field (D4) — a contract *extension*, not a break.
 
 ## Context
 
@@ -39,11 +39,11 @@ Weights are the **full-data** weights. They are **not** re-tuned per beer — D3
 `styleSimilarity(beerStyle, recipeStyle) ∈ {1.0, 0.7, 0.4, 0}`:
 
 - **1.0** — same canonical style.
-- **0.7** — same **BJCP family** (Appendix A). e.g. *Blonde Ale ≈ Kölsch* (both **Pale Ale** family); *Munich Helles ≈ International Pale Lager* (both **Pale Lager**).
+- **0.7** — same **BJCP family** (mapped in the [Appendix](#appendix--bjcp-family--tier-map-for-the-seeded-styles) below; families per BJCP 2021 Appendix A). e.g. *Blonde Ale ≈ Kölsch* (both **Pale Ale** family); *Munich Helles ≈ International Pale Lager* (both **Pale Lager**).
 - **0.4** — different family but same **colour tier + strength tier** (e.g. a pale-standard ale vs a pale-standard lager).
 - **0** — otherwise.
 
-Both the beer's style and the (free-text) recipe style are normalised to a BJCP family + colour/strength tier (see Appendix). This replaces `scoreStyle`'s exact/substring logic; the old behaviour is the degenerate 1.0/0 case.
+Both the beer's style and the (free-text) recipe style are normalised to a BJCP family + colour/strength tier (see Appendix). This replaces `scoreStyle`'s **name-based heuristic** (exact match → 100, else substring containment → 70, else 0); that heuristic becomes the degenerate end of the graded scale (exact → 1.0, no relation → 0), with the family/tier tiers (0.7/0.4) added in between.
 
 ### D3 — Match strength = renormalised (Gower-style) weighted similarity
 

--- a/docs/architecture/decisions/0016-recipe-equivalence-matching-v2.md
+++ b/docs/architecture/decisions/0016-recipe-equivalence-matching-v2.md
@@ -1,0 +1,123 @@
+# ADR-0016 — Recipe-equivalence matching v2: weighted criteria, completeness ratio, and BJCP style families
+
+**Status**  Proposed
+**Date**    2026-06-05
+**Owners**  @benoit-bremaud
+**Relates** #699 (matcher), #1190 (match by characteristics), #1193 (official style-gate), #1198 (style family), epic #1175. Conception: [`../diagrams/recipes/06-sequence-recipe-matching.md`](../diagrams/recipes/06-sequence-recipe-matching.md).
+
+> Supersedes the **scoring** behaviour of the matcher described implicitly in #699/#1190/#1193 (the API contract — `POST /recipes/match` by characteristics — is unchanged). This ADR fixes *how* the similarity is computed.
+
+## Context
+
+The scan fiche ranks community recipes against the scanned beer ("recettes équivalentes"). After the cutover (#1189) + matching-by-characteristics (#1190) + the official style-gate (#1193), a real-device test of **Leffe Blonde** still returned **Saison** and **NEIPA** as the top "equivalents", with the blonde/light recipes (`Bière Blonde à l'Ancienne`, `International Pale Lager`, `Kölsch`) ranked below.
+
+Root causes:
+
+1. **Style is matched by name, not by family.** `scoreStyle` does exact (100) or substring-containment (70), else 0. `"Blonde Ale"` does not substring-match `"Kölsch"` / `"International Pale Lager"`, so **every** recipe scored style = 0; with no style signal the ranking collapsed onto ABV proximity + community rating → a Saison won.
+2. **No explicit confidence.** When the scanned beer is sparse (OpenFoodFacts rarely carries IBU/SRM), the match rested on 1–2 criteria but the UI presented it as if it were a full comparison.
+
+We grounded the redesign in brewing science rather than opinion (research workflow, 2026-06-05; sources at the end): BJCP 2021, sensory/perceptual studies, beer recommender systems, and missing-data best practice (Gower distance / case-based reasoning).
+
+## Decision
+
+A weighted, **completeness-aware** similarity, with **two strictly-separate signals**.
+
+### D1 — Criteria and weights (full-data weights)
+
+| Criterion | Weight | Grounding |
+|---|---:|---|
+| **Style (by BJCP family)** | **40** | Dominant identity signal. BJCP: the written sensory profile *"defines the style"*; the numbers *"determine judging order, not whether an example should be disqualified."* Unanimous across all research angles. |
+| **Colour (SRM/EBC)** | **22** | Strongest cheap numeric discriminator; the first pre-taste cue (crossmodal studies). BJCP promotes colour to a first-class style tag (pale/amber/dark). |
+| **Bitterness (IBU)** | **18** | Strong post-taste driver (liking r≈−0.91) but BJCP frames it as a *balance* attribute, and ranges overlap inside a family → mid weight. |
+| **ABV** | **14** | Real but secondary; BJCP elevates *strength* to a tag, but its apparent weight is partly confounded with body/colour. |
+| **Ingredients (when known)** | **6** | Confirmatory only, never a gate. BJCP: identity is the *sensory result* of ingredients+process, not the ingredient list; data is mostly absent on commercial beers and hop/yeast names are fungible. |
+
+Weights are the **full-data** weights. They are **not** re-tuned per beer — D3's renormalisation adapts them to whatever is actually known.
+
+### D2 — Style similarity is **graded by BJCP family**, not name-equality
+
+`styleSimilarity(beerStyle, recipeStyle) ∈ {1.0, 0.7, 0.4, 0}`:
+
+- **1.0** — same canonical style.
+- **0.7** — same **BJCP family** (Appendix A). e.g. *Blonde Ale ≈ Kölsch* (both **Pale Ale** family); *Munich Helles ≈ International Pale Lager* (both **Pale Lager**).
+- **0.4** — different family but same **colour tier + strength tier** (e.g. a pale-standard ale vs a pale-standard lager).
+- **0** — otherwise.
+
+Both the beer's style and the (free-text) recipe style are normalised to a BJCP family + colour/strength tier (see Appendix). This replaces `scoreStyle`'s exact/substring logic; the old behaviour is the degenerate 1.0/0 case.
+
+### D3 — Match strength = renormalised (Gower-style) weighted similarity
+
+```
+matchStrength = Σ over present-and-comparable criteria [ weight × localSimilarity ]
+                ────────────────────────────────────────────────────────────────
+                Σ over present-and-comparable criteria [ weight ]
+```
+
+A criterion absent on **either** side **drops out of both numerator and denominator** — it is neither scored 0 (a false penalty) nor imputed. This is the textbook Gower-distance / case-based-reasoning "disregard-and-renormalise" rule.
+
+### D4 — Completeness ratio = the confidence signal (the user's "Punk IPA ≈ 100%")
+
+```
+completeness = Σ over comparable criteria [ weight ] / Σ over all criteria [ weight ]   ∈ [0..1]
+```
+
+This is the **denominator of D3 over the full weight (100)**. It measures how much of the full picture the comparison actually used. A match resting on `style + ABV` (≈ 0.54) is honestly weaker-evidence than one resting on all five (1.0). It is surfaced to the UI as the match's reliability — **distinct from D3's match strength**. (Completeness ≠ importance: a fully-documented official recipe is highly *complete* yet ingredients still weigh little for *similarity*.)
+
+### D5 — Acceptance threshold → "no reliable equivalent"
+
+A candidate is shown only when **both** `matchStrength ≥ S_min` **and** `completeness ≥ C_min` (initial defaults `S_min`, `C_min` as env-tunable constants; calibrate on real OpenFoodFacts coverage). Below the threshold the section shows an honest empty state — *"Pas encore de recette équivalente fiable pour cette bière"* + an invite to contribute — instead of a misleading closest match. This replaces "always show the closest with a low-confidence banner".
+
+### D6 — Official-recipe promotion stays style-gated (from #1193)
+
+Unchanged: the official shortcut applies only to a **style-compatible** official (style similarity > 0). It does not bypass D5.
+
+## Out of scope (deferred, captured)
+
+- **Imputation** of a colour/IBU band from the style family — **no** for the MVP (keeps completeness honest; consistent with "we won't mass-spec every beer"). Possible later as a *confidence-gated* enhancement (imputed values count at a reduced rate).
+- **Ingredients by role** (yeast > hop/malt, compared by character not literal string) — MVP uses simple overlap; refine later.
+- **A flavour/aroma (textual descriptors) axis** — two research angles call it the true second discriminant; **#1198 / backlog** (Beer2Vec-style). Out of the five-criterion MVP.
+- **Colour 22 vs IBU 18** is the point where sources diverge most (BJCP elevates colour; consumer studies rate IBU higher). Kept colour ≥ IBU; revisit with real data.
+
+## Consequences
+
+- The 15 seeded encyclopedia `Style` rows (and free-text recipe styles) need a **BJCP family + colour-tier + strength-tier** mapping (Appendix). The encyclopedia `Style` model has `category` (fermentation) + `srm_min/max` + `abv_min/max`; add a `family` mapping (column or lookup) — to be modelled in the encyclopedia class diagram before coding.
+- `RecipeMatchingService` (NestJS, where matching lives today, ADR-0005) changes its `computeSimilarity` to the D2/D3 form and returns `completeness` alongside `low_confidence`; `06-sequence-recipe-matching` is updated.
+- The matcher becomes **data-coverage-aware**: when OFF gives only style + ABV, the ranking honestly uses those two and flags the completeness, instead of inventing precision.
+
+## Appendix — BJCP family / tier map for the seeded styles
+
+Source: BJCP 2021 Appendix A (Styles Sorted Using Style Family) + per-style colour/strength tags.
+
+| Seeded style | BJCP family | Colour tier | Strength tier |
+|---|---|---|---|
+| Blonde Ale (`blonde_ale`) | Pale Ale | pale | standard |
+| Saison (`saison`) | Pale Ale | pale | standard |
+| India Pale Ale (`ipa`) | IPA | pale | standard |
+| Pilsner (`pilsner`) | Pale Lager | pale | standard |
+| Lager (`lager`) | Pale Lager | pale | standard |
+| Hefeweizen (`hefeweizen`) | Wheat Beer | pale | standard |
+| Wheat Beer (`wheat`) | Wheat Beer | pale | standard |
+| Amber Ale (`amber_ale`) | Amber Ale | amber | standard |
+| Belgian Dubbel (`dubbel`) | Belgian Ale (amber) | amber | standard |
+| Belgian Tripel (`tripel`) | Strong Belgian Ale | pale | strong |
+| Belgian Quadrupel (`quadrupel`) | Strong Belgian Ale | dark | strong |
+| Barleywine (`barleywine`) | Strong Ale | amber/dark | strong |
+| Porter (`porter`) | Porter | dark | standard |
+| Stout (`stout`) | Stout | dark | standard |
+| Sour Ale (`sour`) | Sour Ale | (varies) | standard |
+
+Free-text recipe styles (e.g. `International Pale Lager`, `Kölsch`, `NEIPA`, `Bière Blonde à l'Ancienne`) are normalised into the same families via an alias table (BJCP names + common FR/EN synonyms + accent folding).
+
+## Sources
+
+- **BJCP 2021 — Introduction**: the sensory profile defines the style; vital stats are guidelines not absolutes — bjcp.org/beer-styles/introduction-to-the-2021-guidelines
+- **BJCP FAQ — "Where did those numbers come from"**: OG/FG/IBU/SRM/ABV are guideline ranges, breakpoints sometimes artificial — bjcp.org/faq
+- **BJCP 2021 Appendix A — Styles Sorted Using Style Family**: the canonical relatedness map (Pale Lager vs Pale Ale families) — styles.bjcp.org/bjcp-2021-beer/a/3-styles-sorted-using-style-family
+- **BJCP per-style tags** (colour + strength as first-class tags, e.g. Blonde Ale 18A) — bjcp.org/style/2021/18/18A/blonde-ale
+- **Crossmodal colour study** (colour as dominant pre-taste cue) — pmc.ncbi.nlm.nih.gov/articles/PMC5742240
+- **Consumer study on commercial beers** (IBU r≈−0.91, colour r≈−0.95 with liking; alcohol non-significant) — pmc.ncbi.nlm.nih.gov/articles/PMC11167190
+- **StatMatch `gower.dist`** — the missing-feature renormalisation formula (the completeness-ratio denominator) — rdrr.io/cran/StatMatch/man/gower.dist.html
+- **Case-based reasoning local-global principle** — disregard-and-renormalise unknown descriptors — ar5iv.labs.arxiv.org/html/1905.08581
+- **MNAR in recommendation catalogues** — low coverage is informative, not neutral — arxiv.org/pdf/2009.02623
+- **BU:GU balance guidance** — never judge bitterness by IBU alone — beerconnoisseur.com/articles/beers-vital-stats-abv-ibu-srm-og
+- **Beer2Vec / flavour-text similarity** — textual descriptors beat raw stats, cross style lines — arxiv.org/abs/2208.04223

--- a/docs/architecture/diagrams/beer-encyclopedia/04-class.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/04-class.md
@@ -54,6 +54,7 @@ classDiagram
     +str name
     +str slug
     +str category?
+    +str family?
     +Decimal abv_min?
     +Decimal abv_max?
     +int ibu_min?
@@ -176,6 +177,7 @@ class Style {
   +str name
   +str slug
   +str category?
+  +str family?
   +Decimal abv_min?
   +Decimal abv_max?
   +int ibu_min?
@@ -183,6 +185,10 @@ class Style {
   +int srm_min?
   +int srm_max?
 }
+note bottom of Style
+  family : BJCP style family (* cible ADR-0016)
+  not yet in code — graded match D2
+end note
 class Ingredient {
   +str name
   +str category
@@ -267,6 +273,11 @@ Source "1" o-- "0..*" EntitySource : cascade
 - **Provenance `Beer.source`** : dans le **code** = `{openfoodfacts, internal, community}` ;
   la **vue cible** ajoute `scan` (identification par étiquette, UC5) — **pas encore dans le
   code** : divergence tracée #1156.
+- **`Style.family` (cible ADR-0016)** : famille BJCP du style (ex. _Blonde Ale_, _Kölsch_ →
+  `Pale Ale`), support de la similarité de style **graduée par famille** du matcher v2
+  (ADR-0016 D2). **Pas encore dans le code** ; les paliers couleur/force se dérivent des bandes
+  `srm_*`/`abv_*` existantes. À implémenter (colonne ou table d'alias) avant le codage du
+  matcher v2 — voir `../recipes/06-sequence-recipe-matching.md`.
 
 ### Contraintes de colonnes (hors diagramme, depuis `db/models/*`)
 

--- a/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
+++ b/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
@@ -49,13 +49,13 @@ sequenceDiagram
   API->>DB: load PUBLIC candidate recipes
   DB-->>API: recipes[]
   loop each candidate
-    API->>API: localSim per criterion<br/>style → BJCP family {1.0/0.7/0.4/0} ; abv·ibu·colour → numeric proximity
+    API->>API: localSim per criterion<br/>style → BJCP family {1.0/0.7/0.4/0} ; abv·ibu·colour → numeric proximity ; ingredients → overlap
     API->>API: matchStrength = Σ[w×localSim] / Σ[w] over present-and-comparable criteria<br/>(weights: style 40, colour 22, ibu 18, abv 14, ingredients 6 — Gower renorm)
     API->>API: completeness = Σ[comparable w] / 100
     API->>API: official + style-compatible ⇒ matchStrength = 1.0 (#1193 gate)
   end
+  API->>API: keep ALL candidates with matchStrength ≥ S_min AND completeness ≥ C_min<br/>(filter the full set BEFORE truncating)
   API->>API: sort desc (matchStrength, then rating, then id) ; take top-N (≤10)
-  API->>API: keep only candidates with matchStrength ≥ S_min AND completeness ≥ C_min
   API-->>M: 200 { rankings[ { …, completeness } ], low_confidence }
   M-->>M: render "recettes équivalentes" + completeness<br/>OR honest empty state if none pass the threshold
 ```
@@ -75,13 +75,13 @@ API -> API : rankByCharacteristics(carac)
 API -> DB : load PUBLIC candidates
 DB --> API : recipes[]
 loop each candidate
-  API -> API : localSim (style→BJCP family {1.0/0.7/0.4/0} ; abv·ibu·colour→proximity)
+  API -> API : localSim (style→BJCP family {1.0/0.7/0.4/0} ; abv·ibu·colour→proximity ; ingredients→overlap)
   API -> API : matchStrength = sum(w*localSim)/sum(w) over present-and-comparable\n(weights: style 40, colour 22, ibu 18, abv 14, ingredients 6 — Gower renorm)
   API -> API : completeness = sum(comparable w)/100
   API -> API : official + style-compatible => matchStrength = 1.0 (#1193 gate)
 end
+API -> API : keep ALL matchStrength >= S_min AND completeness >= C_min (filter before truncating)
 API -> API : sort (matchStrength, rating, id) ; top-N (<=10)
-API -> API : keep only matchStrength >= S_min AND completeness >= C_min
 API --> M : 200 { rankings[ {..., completeness} ], low_confidence }
 M --> M : render "recettes équivalentes" + completeness / honest empty state
 @enduml
@@ -107,7 +107,9 @@ M --> M : render "recettes équivalentes" + completeness / honest empty state
     signal returned alongside each ranking, distinct from match strength.
 - **Acceptance threshold (ADR-0016 D5).** A candidate is shown only when
   `matchStrength ≥ S_min` **AND** `completeness ≥ C_min` (env-tunable; calibrate on real
-  OpenFoodFacts coverage). Below it, the section renders an honest empty state
+  OpenFoodFacts coverage). **The threshold filters the full scored set *before* the top-N
+  truncation** — so a reliable match ranked just below a high-strength-but-low-completeness
+  candidate is never hidden by the cut. Below the threshold, the section renders an honest empty state
   (*"Pas encore de recette équivalente fiable pour cette bière"* + invite to contribute),
   not a misleading closest match. `low_confidence` is retained in the envelope for
   backward-compatibility but the empty-state replaces the old "show closest + banner".

--- a/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
+++ b/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
@@ -1,27 +1,38 @@
 # Sequence diagram — recipes — Match community recipes to a beer (by characteristics)
 
-> **Feature**: epic #740; matching algorithm #699; scan cutover #1186 (this decoupling).
+> **Feature**: epic #740; matching algorithm #699; scan cutover #1186 (this decoupling); matcher v2 **ADR-0016** (#1198).
 > **Code**: `src/recipe/services/recipe-matching.service.ts`, `src/recipe/controllers/recipe.controller.ts`; mobile `features/scan/data/recipe-matching.api.ts`.
-> **ADRs**: ADR-0005 (recipes are product data → NestJS), ADR-0013 (conception is the contract).
+> **ADRs**: ADR-0005 (recipes are product data → NestJS), ADR-0013 (conception is the contract), **ADR-0016** (weighted criteria + completeness ratio + BJCP style families — the scoring this diagram now reflects).
 > **See also**: `../beer-encyclopedia/08-sequence-mobile-scan.md` (the scan fiche that triggers this), `../../traceability-matrix.md`.
 
 ## Context
 
 The scan fiche ("recettes équivalentes") ranks community recipes against the **scanned beer**.
-The ranking algorithm (#699) scores each recipe purely on the beer's **characteristics** —
-`style × 50 + ABV × 25 + IBU × 15 + colour × 10` (weights renormalised when a criterion is
-missing). It never needs the beer's identity, only those four values.
-
-**Target decision (this diagram).** The match endpoint takes the **characteristics directly**,
-not a `scan_catalog_items` id. Reason: the scan cutover (#1186) makes the mobile resolve a
-barcode against the **beer-encyclopedia**, whose `BeerRead` carries a Python `beers` UUID that
-is **absent** from NestJS `scan_catalog_items` — so the legacy `GET /recipes/match/:beerId`
-(which `findOne`s a scan-catalog row by id) 404s for every encyclopedia-sourced beer. Passing
-the characteristics removes that coupling and keeps matching working for **any** source
-(encyclopedia, NestJS, or a future one).
+The match endpoint takes the beer's **characteristics directly** (`style`, `abv`, `ibu`,
+`colorEbc`), not a `scan_catalog_items` id. Reason: the scan cutover (#1186) makes the mobile
+resolve a barcode against the **beer-encyclopedia**, whose `BeerRead` carries a Python `beers`
+UUID that is **absent** from NestJS `scan_catalog_items` — so the legacy
+`GET /recipes/match/:beerId` (which `findOne`s a scan-catalog row by id) 404s for every
+encyclopedia-sourced beer. Passing the characteristics removes that coupling and keeps matching
+working for **any** source (encyclopedia, NestJS, or a future one).
 
 The legacy id-based route stays as a thin wrapper (load the scan-catalog row → delegate to the
 same scorer) until the NestJS scan path is retired (#1186 step 2).
+
+**Scoring — matcher v2 (ADR-0016).** This diagram reflects the v2 scoring, *not* the original
+`style×50 + abv×25 + ibu×15 + colour×10` exact-name scheme. The v2 changes (all from ADR-0016):
+
+1. **Style is graded by BJCP family**, not name-equality: `styleSimilarity ∈ {1.0 same style,
+   0.7 same family, 0.4 same colour+strength tier, 0 else}` — so *Blonde Ale ≈ Kölsch* no longer
+   scores 0.
+2. **Full-data weights** are Style **40**, Colour **22**, IBU **18**, ABV **14**, Ingredients **6**.
+3. **Match strength** is the Gower-renormalised weighted similarity: a criterion absent on either
+   side drops out of **both** numerator and denominator (never scored 0, never imputed).
+4. **Completeness ratio** = comparable weight / 100 is a **separate** confidence signal (how much
+   of the full picture the comparison used).
+5. **Acceptance threshold**: a candidate is shown only when `matchStrength ≥ S_min` **and**
+   `completeness ≥ C_min`; otherwise the section shows an honest empty state instead of a
+   misleading closest match.
 
 ## Diagram (Mermaid)
 
@@ -38,12 +49,15 @@ sequenceDiagram
   API->>DB: load PUBLIC candidate recipes
   DB-->>API: recipes[]
   loop each candidate
-    API->>API: score = style×50 + abv×25 + ibu×15 + colour×10 (renorm if a criterion is null)
+    API->>API: localSim per criterion<br/>style → BJCP family {1.0/0.7/0.4/0} ; abv·ibu·colour → numeric proximity
+    API->>API: matchStrength = Σ[w×localSim] / Σ[w] over present-and-comparable criteria<br/>(weights: style 40, colour 22, ibu 18, abv 14, ingredients 6 — Gower renorm)
+    API->>API: completeness = Σ[comparable w] / 100
+    API->>API: official + style-compatible ⇒ matchStrength = 1.0 (#1193 gate)
   end
-  API->>API: sort desc (score, then rating, then id) ; take top-N (≤10)
-  API->>API: low_confidence = best score < 40
-  API-->>M: 200 { rankings[], low_confidence }
-  M-->>M: render "recettes équivalentes" (or the low-confidence note)
+  API->>API: sort desc (matchStrength, then rating, then id) ; take top-N (≤10)
+  API->>API: keep only candidates with matchStrength ≥ S_min AND completeness ≥ C_min
+  API-->>M: 200 { rankings[ { …, completeness } ], low_confidence }
+  M-->>M: render "recettes équivalentes" + completeness<br/>OR honest empty state if none pass the threshold
 ```
 
 _Same flow in **PlantUML** (keep synchronised with the Mermaid block)._
@@ -61,12 +75,15 @@ API -> API : rankByCharacteristics(carac)
 API -> DB : load PUBLIC candidates
 DB --> API : recipes[]
 loop each candidate
-  API -> API : score = style*50 + abv*25 + ibu*15 + colour*10 (renorm if null)
+  API -> API : localSim (style→BJCP family {1.0/0.7/0.4/0} ; abv·ibu·colour→proximity)
+  API -> API : matchStrength = sum(w*localSim)/sum(w) over present-and-comparable\n(weights: style 40, colour 22, ibu 18, abv 14, ingredients 6 — Gower renorm)
+  API -> API : completeness = sum(comparable w)/100
+  API -> API : official + style-compatible => matchStrength = 1.0 (#1193 gate)
 end
-API -> API : sort (score, rating, id) ; top-N (<=10)
-API -> API : low_confidence = best < 40
-API --> M : 200 { rankings[], low_confidence }
-M --> M : render "recettes équivalentes" / low-confidence note
+API -> API : sort (matchStrength, rating, id) ; top-N (<=10)
+API -> API : keep only matchStrength >= S_min AND completeness >= C_min
+API --> M : 200 { rankings[ {..., completeness} ], low_confidence }
+M --> M : render "recettes équivalentes" + completeness / honest empty state
 @enduml
 ```
 
@@ -74,15 +91,30 @@ M --> M : render "recettes équivalentes" / low-confidence note
 
 - **Inputs (all optional, all nullable).** `style: string`, `abv: number`, `ibu: number`,
   `colorEbc: number`. The mobile maps EBC ↔ the API's colour unit consistently with the scan
-  fiche (`ScanCatalogItem.colorEbc`). A missing criterion is dropped and the remaining weights
-  are renormalised — so a beer with only style + abv still ranks.
-- **Scoring (mostly) unchanged.** `rankByCharacteristics` is the existing scorer extracted out
-  of `rankForBeer`; sub-scores, weights, and the `low_confidence` (< 40) rule are identical.
-  Only the **source** of the characteristics changes.
-- **Style-gated official promotion (#1193).** The official-recipe shortcut (similarity = 100)
-  applies **only when the official is style-compatible** (the style sub-score is positive). An
-  off-style official (e.g. an IPA for a Leffe Blonde) is ranked on its honest similarity
-  instead, so it no longer floats above a genuine same-style match. Style-compatible officials
+  fiche (`ScanCatalogItem.colorEbc`). A missing criterion **drops out of both numerator and
+  denominator** of the match-strength ratio (Gower renormalisation) — so a beer with only
+  style + abv still ranks, on those two criteria, with its completeness flagged.
+- **Scoring — matcher v2 (ADR-0016).** Per-criterion local similarity × full-data weight,
+  renormalised over present-and-comparable criteria:
+  - **Style → BJCP family** (ADR-0016 D2): `1.0` same style, `0.7` same family, `0.4` same
+    colour+strength tier, `0` else. Replaces the old exact/substring `scoreStyle` so
+    *Blonde Ale ≈ Kölsch* (both Pale Ale family) no longer scores 0.
+  - **Weights** (ADR-0016 D1): style **40**, colour **22**, ibu **18**, abv **14**,
+    ingredients **6**.
+  - **`matchStrength`** (ADR-0016 D3) = `Σ[w×localSim] / Σ[w]` over present-and-comparable
+    criteria, `∈ [0..1]`.
+  - **`completeness`** (ADR-0016 D4) = `Σ[comparable w] / 100` — a **separate** confidence
+    signal returned alongside each ranking, distinct from match strength.
+- **Acceptance threshold (ADR-0016 D5).** A candidate is shown only when
+  `matchStrength ≥ S_min` **AND** `completeness ≥ C_min` (env-tunable; calibrate on real
+  OpenFoodFacts coverage). Below it, the section renders an honest empty state
+  (*"Pas encore de recette équivalente fiable pour cette bière"* + invite to contribute),
+  not a misleading closest match. `low_confidence` is retained in the envelope for
+  backward-compatibility but the empty-state replaces the old "show closest + banner".
+- **Style-gated official promotion (#1193, ADR-0016 D6).** The official-recipe shortcut
+  (matchStrength = 1.0) applies **only when the official is style-compatible** (style local
+  similarity > 0). An off-style official (e.g. an IPA for a Leffe Blonde) is ranked on its
+  honest similarity instead, and does not bypass the D5 threshold. Style-compatible officials
   stay promoted.
 - **Backward compatibility.** `GET /recipes/match/:beerId` stays (same request/response
   contract): it loads the `scan_catalog_items` row, then calls `rankByCharacteristics(row)`.
@@ -91,6 +123,12 @@ M --> M : render "recettes équivalentes" / low-confidence note
 - **Why not key off the beer id.** Identity is not a matching input; coupling to
   `scan_catalog_items` is exactly what blocks the encyclopedia cutover. Characteristics are
   source-agnostic.
+- **Style → BJCP family mapping (prerequisite).** D2 needs every seeded style and every
+  free-text recipe style normalised to a BJCP family + colour/strength tier (ADR-0016 Appendix).
+  The encyclopedia `Style` model carries `category`/`srm`/`abv` but **no `family`** — that field
+  (or an alias lookup) must be modelled in the encyclopedia class diagram before coding.
 - **Conformance.** The code (`recipe-matching.service.ts` + the controller + the mobile data
-  layer) must satisfy this contract: a characteristics endpoint, the scorer shared with the
-  legacy route. Implementation follows validation of this diagram.
+  layer) must satisfy this contract and the ADR-0016 scoring: a characteristics endpoint, the
+  BJCP-family-graded weighted-renormalised scorer shared with the legacy route, `completeness`
+  returned per ranking, and the D5 threshold/empty-state. Implementation follows validation of
+  this diagram and ADR-0016.

--- a/docs/architecture/specs/scan-algorithms.md
+++ b/docs/architecture/specs/scan-algorithms.md
@@ -448,8 +448,8 @@ These are deliberately deferred to the implementation issues. They do not block 
 
 OpenFoodFacts `category` / `style` data is crowd-sourced and frequently generic or wrong. Concrete case: the barcode lookup for **Leffe Blonde (EAN `5410228142218`)** returns OFF categories that list both "Lagers" and "Ales" — but Leffe Blonde is a top-fermented Belgian abbey **ale**, not a lager. Treat any OFF-derived `style` / `fermentation_type` as a starting hypothesis, never as ground truth:
 
-- When the completeness ratio is below threshold, Phase 8 web verification must reconcile the style against an authoritative source rather than copy the OFF category.
-- When a value is shown without verification, flag it (`isStyleEstimated: true`) so the UI never presents a crowd-sourced category as a confirmed fact.
+- An OFF-derived `style` / `fermentation_type` is **always estimated until verified**, independent of the completeness ratio. Completeness measures how *many* criteria are present, not whether the OFF style is *correct* — a fully-populated beer can still carry a wrong crowd-sourced category. Always flag it (`isStyleEstimated: true`) so the UI never presents an OFF category as a confirmed fact.
+- Phase 8 web verification reconciles the style against an authoritative source and is the only mechanism that clears the estimated flag (it does not copy the OFF category).
 - For mainstream beers, seed canonical values directly in the curated `scan_catalog_items` so the OFF category never reaches the user (e.g. a Leffe Blonde seed entry with `fermentation_type = ALE`).
 - The long-term mechanism is [ADR-0015](../decisions/0015-beer-ingestion-enrichment-strategy.md)'s per-source veracity coefficient: OFF categories rank below brewery datasheets and curated directories.
 

--- a/docs/architecture/specs/scan-algorithms.md
+++ b/docs/architecture/specs/scan-algorithms.md
@@ -442,6 +442,16 @@ These are deliberately deferred to the implementation issues. They do not block 
 | Cloud Vision OCR + Claude vision per scan costs ≥ €0.05 | Med | Low | Cap enrichment frequency per user (#942), cache results, surface per-day cost in #942. |
 | User stops mid-rotation and the partial panorama is unusable | Low | Med | Detect short captures (< 12 frames) and either retry or fall back to "show what we have, no enrichment". |
 | Loop-closure false-positives on label patterns that legitimately repeat (e.g. La Trappe with 4 identical motifs) | Low | Med | Combine perceptual hash with feature matching, not just one signal; minimum frame threshold reduces risk. |
+| OpenFoodFacts category/style is crowd-sourced and often wrong, e.g. a beer mis-tagged as a lager | Med | High | Never trust the OFF category as ground truth — see §8.5. |
+
+### 8.5 OpenFoodFacts categories are a hypothesis, not ground truth
+
+OpenFoodFacts `category` / `style` data is crowd-sourced and frequently generic or wrong. Concrete case: the barcode lookup for **Leffe Blonde (EAN `5410228142218`)** returns OFF categories that list both "Lagers" and "Ales" — but Leffe Blonde is a top-fermented Belgian abbey **ale**, not a lager. Treat any OFF-derived `style` / `fermentation_type` as a starting hypothesis, never as ground truth:
+
+- When the completeness ratio is below threshold, Phase 8 web verification must reconcile the style against an authoritative source rather than copy the OFF category.
+- When a value is shown without verification, flag it (`isStyleEstimated: true`) so the UI never presents a crowd-sourced category as a confirmed fact.
+- For mainstream beers, seed canonical values directly in the curated `scan_catalog_items` so the OFF category never reaches the user (e.g. a Leffe Blonde seed entry with `fermentation_type = ALE`).
+- The long-term mechanism is [ADR-0015](../decisions/0015-beer-ingestion-enrichment-strategy.md)'s per-source veracity coefficient: OFF categories rank below brewery datasheets and curated directories.
 
 ---
 


### PR DESCRIPTION
## What

Formalises the **scan recipe-equivalence matcher v2** — the conception (contract) that must be validated *before* coding, per ADR-0013.

This is a **docs-only / conception** PR. No production code changes. The `POST /recipes/match` API contract is **unchanged**; only the *scoring* (how similarity is computed) is redefined.

## Why

A real-device test of **Leffe Blonde** still ranked **Saison** and **NEIPA** above the genuine blonde/light recipes, even after the cutover (#1189), match-by-characteristics (#1190), and the official style-gate (#1193). Two root causes:

1. **Style was matched by name, not family** — `scoreStyle` did exact (100) / substring (70) / else 0. `"Blonde Ale"` does not substring-match `"Kölsch"` or `"International Pale Lager"`, so every recipe scored style = 0 and the ranking collapsed onto ABV proximity + rating → a Saison won.
2. **No explicit confidence** — sparse OpenFoodFacts data (rarely IBU/SRM) left matches resting on 1–2 criteria, presented as if full comparisons.

The redesign is grounded in brewing science (research workflow, 2026-06-05), not opinion: BJCP 2021, sensory/perceptual studies, beer recommenders, and missing-data best practice (Gower distance / case-based reasoning). Sources are listed in the ADR.

## Decisions (ADR-0016)

- **D1 — Criteria & full-data weights**: Style (by BJCP family) **40**, Colour SRM/EBC **22**, Bitterness IBU **18**, ABV **14**, Ingredients **6**. Each weight is source-grounded.
- **D2 — Style similarity graded by BJCP family**: `1.0` same style / `0.7` same family (e.g. *Blonde Ale ≈ Kölsch*, both Pale Ale) / `0.4` same colour+strength tier / `0` else. Replaces exact/substring matching.
- **D3 — Match strength = Gower-renormalised weighted similarity**: `Σ[w×localSim] / Σ[w]` over present-and-comparable criteria. A criterion absent on either side drops out of **both** numerator and denominator (never scored 0, never imputed).
- **D4 — Completeness ratio** = `Σ[comparable w] / 100` — a **separate** confidence signal (how much of the full picture the comparison used). The user's "Punk IPA ≈ 100 %" example.
- **D5 — Acceptance threshold**: show a candidate only when `matchStrength ≥ S_min` **and** `completeness ≥ C_min`; otherwise an honest empty state instead of a misleading closest match.
- **D6 — Official shortcut stays style-gated** (#1193), and does not bypass D5.

Out-of-scope (deferred, captured): imputation, ingredients-by-role, the flavour/aroma axis (#1198 / backlog), and the colour-22-vs-IBU-18 tension (revisit with real data).

## Files

- `docs/architecture/decisions/0016-recipe-equivalence-matching-v2.md` — the ADR (Proposed), with the BJCP family/tier appendix for the 15 seeded styles and the sources.
- `docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md` — Mermaid + PlantUML + notes updated to the v2 scoring.
- `docs/architecture/diagrams/beer-encyclopedia/04-class.md` — `Style.family` added, **marked ADR-0016 target** (not yet coded), prerequisite for D2. Follows the existing `Beer.source = scan` divergence-tracking convention.

## Conformance / next steps

- Status is **Proposed** — this PR is the validation gate. On acceptance, ADR-0016 is added to the root `CLAUDE.md` accepted-ADR list.
- Implementation (a follow-up PR) changes `RecipeMatchingService.computeSimilarity` to the D2/D3 form, returns `completeness` per ranking, applies D5, and requires the `Style.family` mapping in the encyclopedia first.

Relates #1198, #1190, #1193, epic #1175.
