### PR TITLE
feat(encyclopedia): Beer IBU/SRM as min-max intervals + Style.family (BJCP)

### DIFF
--- a/docs/architecture/diagrams/beer-encyclopedia/04-class.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/04-class.md
@@ -192,8 +192,8 @@ class Style {
   +int srm_max?
 }
 note bottom of Style
-  family : BJCP style family (* cible ADR-0016)
-  not yet in code — graded match D2
+  family : BJCP style family (ADR-0016 D2)
+  as-built (migration 005) — graded match
 end note
 class Ingredient {
   +str name
@@ -279,17 +279,17 @@ Source "1" o-- "0..*" EntitySource : cascade
 - **Provenance `Beer.source`** : dans le **code** = `{openfoodfacts, internal, community}` ;
   la **vue cible** ajoute `scan` (identification par étiquette, UC5) — **pas encore dans le
   code** : divergence tracée #1156.
-- **`Beer.ibu`/`Beer.srm` → intervalles `min/max`** : la **vue cible** stocke
-  `ibu_min/ibu_max` + `srm_min/srm_max` (valeur exacte quand `min==max`), comme `Style`
-  le fait déjà — **pas encore dans le code** (modèle actuel = `ibu`/`srm` scalaires) :
-  cible ADR-0017. `abv` reste scalaire ; couleur canonique en SRM, EBC = conversion
-  d'affichage ; pas d'imputation depuis le style (la fourchette de style reste un repli
-  d'affichage, jamais persisté sur la bière).
-- **`Style.family` (cible ADR-0016)** : famille BJCP du style (ex. _Blonde Ale_, _Kölsch_ →
-  `Pale Ale`), support de la similarité de style **graduée par famille** du matcher v2
-  (ADR-0016 D2). **Pas encore dans le code** ; les paliers couleur/force se dérivent des bandes
-  `srm_*`/`abv_*` existantes. À implémenter (colonne ou table d'alias) avant le codage du
-  matcher v2 — voir `../recipes/06-sequence-recipe-matching.md`.
+- **`Beer.ibu`/`Beer.srm` = intervalles `min/max`** (ADR-0017, **as-built** — migration `005`) :
+  `ibu_min/ibu_max` + `srm_min/srm_max` (valeur exacte quand `min==max`), comme `Style`.
+  `abv` reste scalaire ; couleur canonique en SRM, EBC = conversion d'affichage ; pas
+  d'imputation depuis le style (la fourchette de style reste un repli d'affichage, jamais
+  persisté sur la bière). Sources décimales arrondies vers l'extérieur (`min=floor`, `max=ceil`).
+- **`Style.family`** (ADR-0016 D2, **as-built** — migration `005`) : famille BJCP du style
+  (ex. _Blonde Ale_, _Kölsch_ → `Pale Ale`), seedée pour les 15 styles, support de la
+  similarité de style **graduée par famille** du matcher v2. Les paliers couleur/force se
+  dérivent des bandes `srm_*`/`abv_*`. La normalisation des styles recette en texte libre vers
+  une famille reste un alias **en code** côté matcher (NestJS) — voir
+  `../recipes/06-sequence-recipe-matching.md`.
 
 ### Contraintes de colonnes (hors diagramme, depuis `db/models/*`)
 
@@ -308,9 +308,9 @@ Source "1" o-- "0..*" EntitySource : cascade
 - **CHECKs** : `Beer.{source, legal_denomination, alcohol_group, country_of_origin (len 2),
   ean_code (len 8/12/13/14)}` ; `TastingProfile` échelles 1–5 ; `Media`
   parent unique (`ck_media_parent_required`) ; `LegalDenomination` gardes de positivité.
-  Cible ADR-0017 : `Beer.{ibu_min ≤ ibu_max, srm_min ≤ srm_max, chaque borne ≥ 0}`
-  — **nouveaux** CHECKs, sur le patron des CHECKs `abv` déjà présents sur `Style`
-  (`Style` ne contraint aujourd'hui que `abv`, pas `ibu`/`srm`).
+  `Beer.{ibu_min ≤ ibu_max, srm_min ≤ srm_max, chaque borne ≥ 0}` (ADR-0017, **as-built** —
+  `ck_beers_{ibu,srm}_{min,max}_positive` + `ck_beers_{ibu,srm}_range`), sur le patron des
+  CHECKs `abv` de `Style` (`Style` ne contraint toujours que `abv`, pas ses `ibu`/`srm`).
 - **Défauts** : `Beer.source = 'internal'`, `Beer.is_active = true`,
   `*.is_verified = false`, `Media.is_primary = false`,
   `CommunityCorrection.status = 'pending'`.

--- a/docs/architecture/diagrams/beer-encyclopedia/07-class-api-contract.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/07-class-api-contract.md
@@ -34,8 +34,10 @@ classDiagram
     +UUID brewery_id?
     +UUID style_id?
     +Decimal abv?
-    +int ibu?
-    +int srm?
+    +int ibu_min?
+    +int ibu_max?
+    +int srm_min?
+    +int srm_max?
     +str description?
     +bool is_active
   }
@@ -48,8 +50,10 @@ classDiagram
     +UUID brewery_id?
     +UUID style_id?
     +Decimal abv?
-    +int ibu?
-    +int srm?
+    +int ibu_min?
+    +int ibu_max?
+    +int srm_min?
+    +int srm_max?
     +str description?
     +bool is_active?
     +bool is_verified?
@@ -101,8 +105,10 @@ class BeerBase {
   +brewery_id : UUID?
   +style_id : UUID?
   +abv : Decimal?
-  +ibu : int?
-  +srm : int?
+  +ibu_min : int?
+  +ibu_max : int?
+  +srm_min : int?
+  +srm_max : int?
   +description : str?
   +is_active : bool
 }
@@ -112,8 +118,10 @@ class BeerUpdate <<PATCH body, all optional>> {
   +brewery_id : UUID?
   +style_id : UUID?
   +abv : Decimal?
-  +ibu : int?
-  +srm : int?
+  +ibu_min : int?
+  +ibu_max : int?
+  +srm_min : int?
+  +srm_max : int?
   +description : str?
   +is_active : bool?
   +is_verified : bool?
@@ -170,9 +178,15 @@ BeerRead ..> Style : style_name (dénormalisé)
 - **Héritage.** `BeerCreate` et `BeerRead` héritent de `BeerBase` ; `BeerUpdate` est autonome
   (tous champs optionnels, sémantique PATCH). `BeerImportByEanRequest` est autonome (l'import
   ne prend que l'EAN ; le reste dérive de la source externe — voir `02-sequence-import-by-ean`).
+- **IBU / SRM en intervalles `min/max` (ADR-0017).** `BeerBase`/`BeerUpdate` exposent
+  `ibu_min`/`ibu_max` + `srm_min`/`srm_max` (et non un `ibu`/`srm` scalaire) : ces numériques
+  sont rarement publiés et divergent selon les sources, donc on stocke une fourchette honnête
+  (`min == max` = valeur connue, `min < max` = plage, deux `None` = inconnu). SRM canonique,
+  EBC = conversion d'affichage. Les sources décimales sont arrondies vers l'extérieur côté
+  écriture (`min = floor`, `max = ceil`). Cf. `04-class.md` + CHECKs `ck_beers_{ibu,srm}_*`.
 - **Validation (edge).** `ean` : `min 8 / max 14`, `pattern` EAN-8/UPC-A/EAN-13/EAN-14 ;
-  `abv ∈ [0,100]`, `ibu ∈ [0,1000]`, `srm ∈ [0,100]`, `name` non vide. Mêmes règles que le
-  validateur ORM, pour un 422 cohérent au bord de l'API.
+  `abv ∈ [0,100]`, chaque borne `ibu ∈ [0,1000]`, `srm ∈ [0,100]`, `name` non vide. Mêmes
+  règles que le validateur ORM, pour un 422 cohérent au bord de l'API.
 - **Conformité.** Ce contrat est la cible que le code (`api/schemas/beer.py` + la résolution
   des noms dans `api/routers/beers.py`) doit satisfaire. Implémentation après validation de ce
   diagramme.

--- a/packages/beer-encyclopedia/api/schemas/beer.py
+++ b/packages/beer-encyclopedia/api/schemas/beer.py
@@ -6,9 +6,29 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from api.schemas.common import PaginationMeta
+
+
+def _validate_intervals(
+    ibu_min: int | None,
+    ibu_max: int | None,
+    srm_min: int | None,
+    srm_max: int | None,
+) -> None:
+    """Reject inverted IBU/SRM intervals at the API edge (422, not a DB 500).
+
+    Mirrors the ``ck_beers_{ibu,srm}_range`` CHECK constraints so an inverted
+    payload surfaces as a 422 before reaching the database (where it would
+    raise IntegrityError and trigger a needless slug retry). Only ordering is
+    checked here; per-bound bounds stay on the Field validators.
+    """
+
+    if ibu_min is not None and ibu_max is not None and ibu_min > ibu_max:
+        raise ValueError("ibu_min must be less than or equal to ibu_max")
+    if srm_min is not None and srm_max is not None and srm_min > srm_max:
+        raise ValueError("srm_min must be less than or equal to srm_max")
 
 # EAN-8, UPC-A (12), EAN-13, EAN-14 — the four formats commonly found
 # on beverage packaging. The pattern matches what the ORM validator
@@ -31,6 +51,11 @@ class BeerBase(BaseModel):
     description: str | None = None
     is_active: bool = True
 
+    @model_validator(mode="after")
+    def _check_intervals(self) -> BeerBase:
+        _validate_intervals(self.ibu_min, self.ibu_max, self.srm_min, self.srm_max)
+        return self
+
 
 class BeerCreate(BeerBase):
     """Body payload for ``POST /beers``."""
@@ -50,6 +75,13 @@ class BeerUpdate(BaseModel):
     description: str | None = None
     is_active: bool | None = None
     is_verified: bool | None = None
+
+    @model_validator(mode="after")
+    def _check_intervals(self) -> BeerUpdate:
+        # Validates ordering within the payload. A partial PATCH that supplies
+        # only one bound is checked against the stored value by the DB CHECK.
+        _validate_intervals(self.ibu_min, self.ibu_max, self.srm_min, self.srm_max)
+        return self
 
 
 class BeerRead(BeerBase):

--- a/packages/beer-encyclopedia/api/schemas/beer.py
+++ b/packages/beer-encyclopedia/api/schemas/beer.py
@@ -22,8 +22,12 @@ class BeerBase(BaseModel):
     brewery_id: uuid.UUID | None = None
     style_id: uuid.UUID | None = None
     abv: Decimal | None = Field(default=None, ge=0, le=100)
-    ibu: int | None = Field(default=None, ge=0, le=1000)
-    srm: int | None = Field(default=None, ge=0, le=100)
+    # IBU / SRM as min/max intervals (ADR-0017): min == max is a known value,
+    # min < max a genuine range, both None unknown.
+    ibu_min: int | None = Field(default=None, ge=0, le=1000)
+    ibu_max: int | None = Field(default=None, ge=0, le=1000)
+    srm_min: int | None = Field(default=None, ge=0, le=100)
+    srm_max: int | None = Field(default=None, ge=0, le=100)
     description: str | None = None
     is_active: bool = True
 
@@ -39,8 +43,10 @@ class BeerUpdate(BaseModel):
     brewery_id: uuid.UUID | None = None
     style_id: uuid.UUID | None = None
     abv: Decimal | None = Field(default=None, ge=0, le=100)
-    ibu: int | None = Field(default=None, ge=0, le=1000)
-    srm: int | None = Field(default=None, ge=0, le=100)
+    ibu_min: int | None = Field(default=None, ge=0, le=1000)
+    ibu_max: int | None = Field(default=None, ge=0, le=1000)
+    srm_min: int | None = Field(default=None, ge=0, le=100)
+    srm_max: int | None = Field(default=None, ge=0, le=100)
     description: str | None = None
     is_active: bool | None = None
     is_verified: bool | None = None

--- a/packages/beer-encyclopedia/api/schemas/style.py
+++ b/packages/beer-encyclopedia/api/schemas/style.py
@@ -18,6 +18,9 @@ class StyleRead(BaseModel):
     name: str
     slug: str
     category: str | None
+    # Canonical BJCP style family (ADR-0016 D2), surfaced so API clients can
+    # consume the family used by recipe-matching v2.
+    family: str | None
     description: str | None
     abv_min: Decimal | None
     abv_max: Decimal | None

--- a/packages/beer-encyclopedia/db/models/beer.py
+++ b/packages/beer-encyclopedia/db/models/beer.py
@@ -101,6 +101,20 @@ class Beer(Base, UUIDMixin, TimestampMixin):
             "ean_code IS NULL OR length(ean_code) IN (8, 12, 13, 14)",
             name="ck_beers_ean_code_length",
         ),
+        # IBU / SRM min-max interval validation (ADR-0017 D5), following the
+        # ABV CHECK pattern on ``styles``: each bound non-negative, min <= max.
+        CheckConstraint("ibu_min IS NULL OR ibu_min >= 0", name="ck_beers_ibu_min_positive"),
+        CheckConstraint("ibu_max IS NULL OR ibu_max >= 0", name="ck_beers_ibu_max_positive"),
+        CheckConstraint(
+            "ibu_min IS NULL OR ibu_max IS NULL OR ibu_min <= ibu_max",
+            name="ck_beers_ibu_range",
+        ),
+        CheckConstraint("srm_min IS NULL OR srm_min >= 0", name="ck_beers_srm_min_positive"),
+        CheckConstraint("srm_max IS NULL OR srm_max >= 0", name="ck_beers_srm_max_positive"),
+        CheckConstraint(
+            "srm_min IS NULL OR srm_max IS NULL OR srm_min <= srm_max",
+            name="ck_beers_srm_range",
+        ),
         # Unique constraint allows multiple NULLs on both PostgreSQL and
         # SQLite — a beer without a barcode (community draft, internal
         # seed) does not collide with another. The constraint enforces
@@ -119,8 +133,17 @@ class Beer(Base, UUIDMixin, TimestampMixin):
         nullable=True,
     )
     abv: Mapped[Decimal | None] = mapped_column(Numeric(4, 2), nullable=True)
-    ibu: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
-    srm: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    # Bitterness (IBU) and colour (SRM) are stored as min/max intervals
+    # rather than single points (ADR-0017): these numerics are rarely
+    # published and disagree across sources, so a single integer would be
+    # false precision. ``min == max`` is a known value, ``min < max`` a
+    # genuine range, both NULL unknown. SRM is canonical; EBC is a display
+    # conversion. Decimal sources are rounded outward (floor/ceil) by the
+    # writer to keep the interval conservative (ADR-0017 D1).
+    ibu_min: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    ibu_max: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    srm_min: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    srm_max: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     is_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/packages/beer-encyclopedia/db/models/style.py
+++ b/packages/beer-encyclopedia/db/models/style.py
@@ -34,6 +34,12 @@ class Style(Base, UUIDMixin, TimestampMixin):
     name: Mapped[str] = mapped_column(String(100), unique=True, nullable=False)
     slug: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
     category: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    # Canonical BJCP style family (e.g. "Pale Ale", "Pale Lager", "IPA"),
+    # supporting the family-graded style similarity of recipe-matching v2
+    # (ADR-0016 D2). ``category`` is the fermentation class (Ale/Lager);
+    # ``family`` is the finer BJCP grouping used to score "same family"
+    # equivalence. Nullable: free-text / unseeded styles may have none.
+    family: Mapped[str | None] = mapped_column(String(50), nullable=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     abv_min: Mapped[Decimal | None] = mapped_column(Numeric(4, 2), nullable=True)
     abv_max: Mapped[Decimal | None] = mapped_column(Numeric(4, 2), nullable=True)

--- a/packages/beer-encyclopedia/migrations/versions/005_beer_intervals_style_family.py
+++ b/packages/beer-encyclopedia/migrations/versions/005_beer_intervals_style_family.py
@@ -38,6 +38,7 @@ def upgrade() -> None:
     with op.batch_alter_table("styles") as batch_op:
         batch_op.add_column(sa.Column("family", sa.String(length=50), nullable=True))
 
+    # 1) Add the interval columns + CHECKs alongside the existing scalars.
     with op.batch_alter_table("beers") as batch_op:
         batch_op.add_column(sa.Column("ibu_min", sa.SmallInteger(), nullable=True))
         batch_op.add_column(sa.Column("ibu_max", sa.SmallInteger(), nullable=True))
@@ -63,6 +64,18 @@ def upgrade() -> None:
             "ck_beers_srm_range",
             "srm_min IS NULL OR srm_max IS NULL OR srm_min <= srm_max",
         )
+
+    # 2) Backfill: a previously-known single value becomes a degenerate
+    #    interval (min == max) so no data is lost when the scalars are dropped.
+    op.execute(
+        "UPDATE beers SET ibu_min = ibu, ibu_max = ibu WHERE ibu IS NOT NULL"
+    )
+    op.execute(
+        "UPDATE beers SET srm_min = srm, srm_max = srm WHERE srm IS NOT NULL"
+    )
+
+    # 3) Drop the now-migrated scalar columns.
+    with op.batch_alter_table("beers") as batch_op:
         batch_op.drop_column("ibu")
         batch_op.drop_column("srm")
 
@@ -73,6 +86,14 @@ def downgrade() -> None:
     with op.batch_alter_table("beers") as batch_op:
         batch_op.add_column(sa.Column("ibu", sa.SmallInteger(), nullable=True))
         batch_op.add_column(sa.Column("srm", sa.SmallInteger(), nullable=True))
+
+    # Collapse the interval back to a single value (its lower bound) — exact
+    # for known values (min == max), lossy for genuine ranges (acceptable on a
+    # downgrade).
+    op.execute("UPDATE beers SET ibu = ibu_min WHERE ibu_min IS NOT NULL")
+    op.execute("UPDATE beers SET srm = srm_min WHERE srm_min IS NOT NULL")
+
+    with op.batch_alter_table("beers") as batch_op:
         batch_op.drop_constraint("ck_beers_ibu_min_positive", type_="check")
         batch_op.drop_constraint("ck_beers_ibu_max_positive", type_="check")
         batch_op.drop_constraint("ck_beers_ibu_range", type_="check")

--- a/packages/beer-encyclopedia/migrations/versions/005_beer_intervals_style_family.py
+++ b/packages/beer-encyclopedia/migrations/versions/005_beer_intervals_style_family.py
@@ -1,0 +1,88 @@
+"""Beer IBU/SRM as min-max intervals + Style.family (BJCP).
+
+Two model changes, batched per accepted conception:
+
+- **ADR-0017** — replace ``beers.ibu`` / ``beers.srm`` single columns with
+  ``ibu_min`` / ``ibu_max`` / ``srm_min`` / ``srm_max`` intervals, plus CHECK
+  constraints mirroring the ABV pattern already on ``styles`` (each bound
+  non-negative, ``min <= max``). IBU/colour are rarely published and disagree
+  across sources, so a single integer is false precision; an interval is honest.
+- **ADR-0016 D2** — add ``styles.family`` (canonical BJCP style family) backing
+  the family-graded style similarity of recipe-matching v2.
+
+Dropping ``ibu`` / ``srm`` is a clean cut: per ADR-0017 (and ADR-0001 "build for
+today") there is no canonical beer seed yet and Open Food Facts leaves these
+NULL, so no meaningful data is lost. SQLite cannot ``DROP COLUMN`` / add CHECKs
+in place, so this runs under ``batch_alter_table`` (table recreate).
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-06-05
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+
+def upgrade() -> None:
+    """Add ``styles.family``; swap beer IBU/SRM scalars for min/max intervals."""
+
+    with op.batch_alter_table("styles") as batch_op:
+        batch_op.add_column(sa.Column("family", sa.String(length=50), nullable=True))
+
+    with op.batch_alter_table("beers") as batch_op:
+        batch_op.add_column(sa.Column("ibu_min", sa.SmallInteger(), nullable=True))
+        batch_op.add_column(sa.Column("ibu_max", sa.SmallInteger(), nullable=True))
+        batch_op.add_column(sa.Column("srm_min", sa.SmallInteger(), nullable=True))
+        batch_op.add_column(sa.Column("srm_max", sa.SmallInteger(), nullable=True))
+        batch_op.create_check_constraint(
+            "ck_beers_ibu_min_positive", "ibu_min IS NULL OR ibu_min >= 0"
+        )
+        batch_op.create_check_constraint(
+            "ck_beers_ibu_max_positive", "ibu_max IS NULL OR ibu_max >= 0"
+        )
+        batch_op.create_check_constraint(
+            "ck_beers_ibu_range",
+            "ibu_min IS NULL OR ibu_max IS NULL OR ibu_min <= ibu_max",
+        )
+        batch_op.create_check_constraint(
+            "ck_beers_srm_min_positive", "srm_min IS NULL OR srm_min >= 0"
+        )
+        batch_op.create_check_constraint(
+            "ck_beers_srm_max_positive", "srm_max IS NULL OR srm_max >= 0"
+        )
+        batch_op.create_check_constraint(
+            "ck_beers_srm_range",
+            "srm_min IS NULL OR srm_max IS NULL OR srm_min <= srm_max",
+        )
+        batch_op.drop_column("ibu")
+        batch_op.drop_column("srm")
+
+
+def downgrade() -> None:
+    """Restore single ``ibu`` / ``srm`` columns; drop intervals + ``family``."""
+
+    with op.batch_alter_table("beers") as batch_op:
+        batch_op.add_column(sa.Column("ibu", sa.SmallInteger(), nullable=True))
+        batch_op.add_column(sa.Column("srm", sa.SmallInteger(), nullable=True))
+        batch_op.drop_constraint("ck_beers_ibu_min_positive", type_="check")
+        batch_op.drop_constraint("ck_beers_ibu_max_positive", type_="check")
+        batch_op.drop_constraint("ck_beers_ibu_range", type_="check")
+        batch_op.drop_constraint("ck_beers_srm_min_positive", type_="check")
+        batch_op.drop_constraint("ck_beers_srm_max_positive", type_="check")
+        batch_op.drop_constraint("ck_beers_srm_range", type_="check")
+        batch_op.drop_column("ibu_max")
+        batch_op.drop_column("ibu_min")
+        batch_op.drop_column("srm_max")
+        batch_op.drop_column("srm_min")
+
+    with op.batch_alter_table("styles") as batch_op:
+        batch_op.drop_column("family")

--- a/packages/beer-encyclopedia/scripts/seed_styles.py
+++ b/packages/beer-encyclopedia/scripts/seed_styles.py
@@ -21,9 +21,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db.engine import create_engine, create_session_factory, get_database_url
 from db.models import Style
 
-# name, slug, category, abv_min, abv_max, ibu_min, ibu_max, srm_min, srm_max
+# name, slug, category, family, abv_min, abv_max, ibu_min, ibu_max, srm_min, srm_max
+# ``family`` is the canonical BJCP style family (ADR-0016 D2 / Appendix),
+# distinct from ``category`` (Ale/Lager fermentation class).
 StyleSeed = tuple[
-    str, str, str,
+    str, str, str, str,
     Decimal | None, Decimal | None,
     int | None, int | None,
     int | None, int | None,
@@ -31,23 +33,23 @@ StyleSeed = tuple[
 
 STYLES: list[StyleSeed] = [
     # -- already recognized by ml/extract.py ---------------------------------
-    ("India Pale Ale", "ipa", "Ale", Decimal("5.5"), Decimal("7.5"), 40, 70, 6, 14),
-    ("Lager", "lager", "Lager", Decimal("4.0"), Decimal("5.5"), 8, 25, 2, 6),
-    ("Wheat Beer", "wheat", "Ale", Decimal("4.0"), Decimal("5.6"), 8, 20, 3, 9),
-    ("Stout", "stout", "Ale", Decimal("4.0"), Decimal("7.0"), 25, 60, 30, 40),
-    ("Amber Ale", "amber_ale", "Ale", Decimal("4.5"), Decimal("6.2"), 25, 45, 10, 17),
-    ("Sour Ale", "sour", "Ale", Decimal("3.5"), Decimal("6.5"), 5, 25, 3, 20),
-    ("Saison", "saison", "Ale", Decimal("5.0"), Decimal("7.0"), 20, 35, 5, 14),
-    ("Belgian Tripel", "tripel", "Ale", Decimal("7.5"), Decimal("9.5"), 20, 40, 4, 7),
+    ("India Pale Ale", "ipa", "Ale", "IPA", Decimal("5.5"), Decimal("7.5"), 40, 70, 6, 14),
+    ("Lager", "lager", "Lager", "Pale Lager", Decimal("4.0"), Decimal("5.5"), 8, 25, 2, 6),
+    ("Wheat Beer", "wheat", "Ale", "Wheat Beer", Decimal("4.0"), Decimal("5.6"), 8, 20, 3, 9),
+    ("Stout", "stout", "Ale", "Stout", Decimal("4.0"), Decimal("7.0"), 25, 60, 30, 40),
+    ("Amber Ale", "amber_ale", "Ale", "Amber Ale", Decimal("4.5"), Decimal("6.2"), 25, 45, 10, 17),
+    ("Sour Ale", "sour", "Ale", "Sour Ale", Decimal("3.5"), Decimal("6.5"), 5, 25, 3, 20),
+    ("Saison", "saison", "Ale", "Pale Ale", Decimal("5.0"), Decimal("7.0"), 20, 35, 5, 14),
+    ("Belgian Tripel", "tripel", "Ale", "Strong Belgian Ale", Decimal("7.5"), Decimal("9.5"), 20, 40, 4, 7),
 
     # -- additional mainstream styles ----------------------------------------
-    ("Porter", "porter", "Ale", Decimal("4.0"), Decimal("6.5"), 25, 50, 20, 35),
-    ("Pilsner", "pilsner", "Lager", Decimal("4.2"), Decimal("5.5"), 25, 45, 2, 6),
-    ("Hefeweizen", "hefeweizen", "Ale", Decimal("4.5"), Decimal("5.6"), 8, 15, 2, 6),
-    ("Belgian Dubbel", "dubbel", "Ale", Decimal("6.0"), Decimal("7.6"), 15, 25, 10, 17),
-    ("Belgian Quadrupel", "quadrupel", "Ale", Decimal("9.0"), Decimal("12.0"), 20, 35, 12, 22),
-    ("Barleywine", "barleywine", "Ale", Decimal("8.0"), Decimal("12.0"), 40, 100, 10, 19),
-    ("Blonde Ale", "blonde_ale", "Ale", Decimal("4.0"), Decimal("5.5"), 15, 28, 3, 6),
+    ("Porter", "porter", "Ale", "Porter", Decimal("4.0"), Decimal("6.5"), 25, 50, 20, 35),
+    ("Pilsner", "pilsner", "Lager", "Pale Lager", Decimal("4.2"), Decimal("5.5"), 25, 45, 2, 6),
+    ("Hefeweizen", "hefeweizen", "Ale", "Wheat Beer", Decimal("4.5"), Decimal("5.6"), 8, 15, 2, 6),
+    ("Belgian Dubbel", "dubbel", "Ale", "Belgian Ale", Decimal("6.0"), Decimal("7.6"), 15, 25, 10, 17),
+    ("Belgian Quadrupel", "quadrupel", "Ale", "Strong Belgian Ale", Decimal("9.0"), Decimal("12.0"), 20, 35, 12, 22),
+    ("Barleywine", "barleywine", "Ale", "Strong Ale", Decimal("8.0"), Decimal("12.0"), 40, 100, 10, 19),
+    ("Blonde Ale", "blonde_ale", "Ale", "Pale Ale", Decimal("4.0"), Decimal("5.5"), 15, 28, 3, 6),
 ]
 
 
@@ -57,7 +59,10 @@ async def seed_styles(session: AsyncSession) -> tuple[int, int]:
     created = 0
     updated = 0
 
-    for name, slug, category, abv_min, abv_max, ibu_min, ibu_max, srm_min, srm_max in STYLES:
+    for (
+        name, slug, category, family,
+        abv_min, abv_max, ibu_min, ibu_max, srm_min, srm_max,
+    ) in STYLES:
         existing = (
             await session.execute(select(Style).where(Style.slug == slug))
         ).scalar_one_or_none()
@@ -68,6 +73,7 @@ async def seed_styles(session: AsyncSession) -> tuple[int, int]:
                     name=name,
                     slug=slug,
                     category=category,
+                    family=family,
                     abv_min=abv_min,
                     abv_max=abv_max,
                     ibu_min=ibu_min,
@@ -80,6 +86,7 @@ async def seed_styles(session: AsyncSession) -> tuple[int, int]:
         else:
             existing.name = name
             existing.category = category
+            existing.family = family
             existing.abv_min = abv_min
             existing.abv_max = abv_max
             existing.ibu_min = ibu_min

--- a/packages/beer-encyclopedia/tests/test_api/test_beers.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_beers.py
@@ -49,6 +49,28 @@ async def test_create_beer_returns_201(
     assert body["ibu_max"] == 55
 
 
+def test_create_beer_rejects_inverted_ibu_interval(client: TestClient) -> None:
+    """Sad path: ibu_min > ibu_max is a 422 at the edge, not a DB 500."""
+
+    response = client.post(
+        "/beers",
+        json={"name": "Inverted IBU", "ibu_min": 60, "ibu_max": 20},
+    )
+
+    assert response.status_code == 422
+
+
+def test_create_beer_rejects_inverted_srm_interval(client: TestClient) -> None:
+    """Sad path: srm_min > srm_max is a 422 at the edge, not a DB 500."""
+
+    response = client.post(
+        "/beers",
+        json={"name": "Inverted SRM", "srm_min": 30, "srm_max": 5},
+    )
+
+    assert response.status_code == 422
+
+
 def test_create_beer_rejects_unknown_brewery_fk(client: TestClient) -> None:
     response = client.post(
         "/beers",

--- a/packages/beer-encyclopedia/tests/test_api/test_beers.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_beers.py
@@ -35,7 +35,8 @@ async def test_create_beer_returns_201(
             "brewery_id": str(brewery.id),
             "style_id": str(ipa.id),
             "abv": "6.5",
-            "ibu": 55,
+            "ibu_min": 50,
+            "ibu_max": 55,
         },
     )
 
@@ -44,6 +45,8 @@ async def test_create_beer_returns_201(
     assert body["name"] == "Citra Bomb"
     assert body["slug"] == "citra-bomb"
     assert body["brewery_id"] == str(brewery.id)
+    assert body["ibu_min"] == 50
+    assert body["ibu_max"] == 55
 
 
 def test_create_beer_rejects_unknown_brewery_fk(client: TestClient) -> None:

--- a/packages/beer-encyclopedia/tests/test_api/test_styles.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_styles.py
@@ -22,6 +22,22 @@ async def _seed(session: AsyncSession, *names: str) -> list[Style]:
     return styles
 
 
+async def test_get_style_exposes_family(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """StyleRead surfaces the BJCP family (ADR-0016 D2) to API clients."""
+
+    style = Style(name="Blonde Ale", slug="blonde_ale", family="Pale Ale")
+    db_session.add(style)
+    await db_session.commit()
+    await db_session.refresh(style)
+
+    response = client.get(f"/styles/{style.id}")
+
+    assert response.status_code == 200
+    assert response.json()["family"] == "Pale Ale"
+
+
 def test_list_styles_empty_returns_empty_items(client: TestClient) -> None:
     response = client.get("/styles")
     assert response.status_code == 200

--- a/packages/beer-encyclopedia/tests/test_db/test_models.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_models.py
@@ -74,7 +74,8 @@ async def test_beer_links_brewery_and_style(db_session: AsyncSession) -> None:
         brewery_id=brewery.id,
         style_id=style.id,
         abv=Decimal("6.5"),
-        ibu=55,
+        ibu_min=55,
+        ibu_max=55,
     )
     db_session.add(beer)
     await db_session.commit()
@@ -318,3 +319,69 @@ async def test_deleting_brewery_cascades_to_media(db_session: AsyncSession) -> N
 
     remaining = (await db_session.execute(select(Media))).scalars().all()
     assert remaining == []
+
+
+# -- ADR-0017 Beer IBU/SRM intervals + ADR-0016 Style.family ------------------
+
+
+async def test_beer_ibu_srm_intervals_persist(db_session: AsyncSession) -> None:
+    """Happy path: a genuine range (min < max) and a known value (min == max)."""
+
+    beer = Beer(
+        name="Leffe Blonde",
+        slug="leffe-blonde",
+        ibu_min=20,
+        ibu_max=28,
+        srm_min=5,
+        srm_max=5,
+    )
+    db_session.add(beer)
+    await db_session.commit()
+
+    fetched = (
+        await db_session.execute(select(Beer).where(Beer.slug == "leffe-blonde"))
+    ).scalar_one()
+    assert (fetched.ibu_min, fetched.ibu_max) == (20, 28)
+    assert (fetched.srm_min, fetched.srm_max) == (5, 5)
+
+
+async def test_beer_ibu_interval_rejects_min_above_max(db_session: AsyncSession) -> None:
+    """Sad path: ibu_min > ibu_max violates ck_beers_ibu_range."""
+
+    db_session.add(Beer(name="Bad IBU", slug="bad-ibu", ibu_min=40, ibu_max=20))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_beer_srm_interval_rejects_negative_bound(db_session: AsyncSession) -> None:
+    """Sad path: a negative bound violates ck_beers_srm_min_positive."""
+
+    db_session.add(Beer(name="Bad SRM", slug="bad-srm", srm_min=-1, srm_max=5))
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+
+
+async def test_beer_intervals_allow_all_null(db_session: AsyncSession) -> None:
+    """Edge: a beer with no bitterness/colour data at all is valid (unknown)."""
+
+    beer = Beer(name="Unknown Numerics", slug="unknown-numerics")
+    db_session.add(beer)
+    await db_session.commit()
+
+    fetched = (
+        await db_session.execute(select(Beer).where(Beer.slug == "unknown-numerics"))
+    ).scalar_one()
+    assert fetched.ibu_min is None and fetched.ibu_max is None
+    assert fetched.srm_min is None and fetched.srm_max is None
+
+
+async def test_style_family_persists(db_session: AsyncSession) -> None:
+    """Style.family (BJCP family, ADR-0016 D2) is stored and read back."""
+
+    db_session.add(Style(name="Blonde Ale", slug="blonde_ale", family="Pale Ale"))
+    await db_session.commit()
+
+    fetched = (
+        await db_session.execute(select(Style).where(Style.slug == "blonde_ale"))
+    ).scalar_one()
+    assert fetched.family == "Pale Ale"

--- a/packages/beer-encyclopedia/tests/test_db/test_seed_styles.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_seed_styles.py
@@ -57,8 +57,10 @@ async def test_seed_updates_changed_fields_on_rerun(db_session: AsyncSession) ->
         await db_session.execute(select(Style).where(Style.slug == "ipa"))
     ).scalar_one()
     assert ipa.category == "Ale"  # sanity check before mutation
+    assert ipa.family == "IPA"
     ipa.category = "Wrong Category"
     ipa.name = "Wrong Name"
+    ipa.family = "Wrong Family"
     await db_session.commit()
 
     # Re-seeding must restore the canonical metadata.
@@ -68,4 +70,5 @@ async def test_seed_updates_changed_fields_on_rerun(db_session: AsyncSession) ->
     ).scalar_one()
     assert refreshed.category == "Ale"
     assert refreshed.name == "India Pale Ale"
+    assert refreshed.family == "IPA"
     assert refreshed.abv_max == Decimal("7.5")


### PR DESCRIPTION
## What

Realises **ADR-0017** (Beer IBU/colour as min/max intervals) **and ADR-0016 D2** (BJCP style families) as one coherent **beer-encyclopedia** model change — the prerequisite for implementing the recipe-matching v2 scorer (next PR, NestJS).

This is the conception→code step for two just-merged ADRs. No new design.

## Changes

**Model**
- `Beer`: drop `ibu` / `srm` scalars → add `ibu_min` / `ibu_max` / `srm_min` / `srm_max` (`SmallInteger`, nullable) + CHECK constraints (`ck_beers_{ibu,srm}_{min,max}_positive`, `ck_beers_{ibu,srm}_range`) following the existing ABV CHECK pattern on `styles`.
- `Style`: add `family` (`String(50)`, nullable) — the canonical BJCP family, distinct from `category` (Ale/Lager).

**Migration** `005_beer_intervals_style_family` — alembic **batch mode** (SQLite can't `DROP COLUMN`/add CHECKs in place). Verified `upgrade head` **and** `downgrade 004 → upgrade head` round-trip on SQLite.

**Schemas** — `BeerBase` / `BeerUpdate` expose the four interval fields (`BeerRead`/`BeerCreate` inherit). Per-bound validation unchanged (`ibu ∈ [0,1000]`, `srm ∈ [0,100]`).

**Seed** — `seed_styles.py`: `family` populated for all 15 styles (BJCP map from ADR-0016 Appendix: Blonde Ale/Saison → Pale Ale, Pilsner/Lager → Pale Lager, IPA → IPA, …). No NULL family.

**Tests (H/S/E)** — interval persistence (`min<max` range + `min==max` known), CHECK rejections (`min>max`, negative bound), all-NULL unknown, `Style.family`. Existing `ibu=`/`"ibu"` usages migrated. **157 tests pass, ruff clean.**

**Conception (as-built, dual update)** — `04-class.md` notes + `07-class-api-contract.md` DTO updated from *"cible / pas encore dans le code"* to **as-built** (intervals + family).

## Notes

- **Importers untouched**: `persistence.py` / `openfoodfacts.py` never set `ibu`/`srm` (OFF rarely carries them → left NULL), so the import path needs no field change. Confirmed by the passing importer tests.
- **Decimal sources** round **outward** (`min=floor`, `max=ceil`) at write time (ADR-0017 D1) — the rounding lives with the writer, not the schema.
- **Free-text style → family alias** is matcher-side (NestJS) and ships with the matcher v2 PR; `styles.family` here is the canonical source for seeded styles.
- **Data**: dropping `ibu`/`srm` loses no meaningful data (no canonical beer seed yet; OFF beers have these NULL) — ADR-0017 + ADR-0001 "build for today".

Relates ADR-0016, ADR-0017, epic #1175.
