### PR TITLE
chore(claude-tooling): add local pre-push review ritual (Claude + Codex)

### DIFF
--- a/.claude/skills/pre-push-review/SKILL.md
+++ b/.claude/skills/pre-push-review/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: pre-push-review
+description: Brasse-Bouillon pre-push review ritual — run a local defence-in-depth review BEFORE pushing a branch. Drives the Claude reviewer (`pr-pre-reviewer` agent + `/code-review`) and the Codex reviewer (`scripts/codex-review.sh`), reconciles both into one Must Have / Should Have / Nice to Have / Disagree action list, implements the blocking fixes, and gates the push on all Must Have resolved. Use whenever about to push a feature/fix/chore/docs branch on this repo, or before opening a PR.
+---
+
+# Brasse-Bouillon — pre-push review ritual
+
+The default review path on this repo is **local and free, before the push**.
+GitHub-side reviewers are the second layer: CodeRabbit auto-reviews every PR,
+Codex auto-reviews every PR, and Copilot is **manual** (`needs-copilot` label —
+it bills premium requests). See [CONTRIBUTING.md](../../../CONTRIBUTING.md)
+§ AI reviewers.
+
+This skill runs **two independent reviewers locally**, makes them **confront**
+their findings, and only authorises the push once the blocking items are fixed.
+It never pushes by itself — the human gives the final go.
+
+## When to run
+
+Before pushing any branch, or before `gh pr create`. Skip only for empty diffs
+(no commits between `origin/main` and `HEAD`).
+
+## Inputs
+
+- Current branch ≠ `main`, with commits ahead of `origin/main`.
+- Base branch: `main` (default).
+
+## Procedure
+
+### Step 1 — Claude review (Report C)
+
+Run the local Claude reviewer on the diff `origin/main...HEAD`:
+
+1. Launch the **`pr-pre-reviewer`** agent (`.claude/agents/pr-pre-reviewer.md`) —
+   it loads the ADRs + per-package `CLAUDE.md` and returns a Must Have /
+   Should Have / Nice to Have / Disagree report with `file:line` anchors.
+2. Optionally also run **`/code-review`** for a second Claude pass focused on
+   correctness/simplification.
+
+Keep the combined output as **Report C**.
+
+### Step 2 — Codex review (Report X)
+
+Run the Codex reviewer via the helper (read-only, mirrors the same checklist):
+
+```bash
+scripts/codex-review.sh --base main --out /tmp/codex-review.md
+```
+
+Keep the result as **Report X**. If the helper fails (Codex CLI missing or
+quota exhausted), note it explicitly and continue with Report C alone — do not
+silently skip it.
+
+### Step 3 — Confrontation & reconciliation
+
+Merge Report C and Report X into **one** action list. For each finding:
+
+- **Both agree** → keep it, consolidated, with the agreed fix.
+- **Only one raised it** → keep it, attributed; judge it on its merits.
+- **They conflict** (one flags, the other explicitly disagrees, or they propose
+  incompatible fixes) → resolve it: state both positions in one line each, then
+  **one rebuttal round** to converge on a reliable, durable compromise. If still
+  unresolved after one round, escalate to the human with the trade-off, do not
+  guess.
+
+Output a single table, each row tagged **Must Have / Should Have / Nice to Have
+/ Disagree**, with the agreed resolution and a `file:line` anchor. This is the
+**reconciled action list**.
+
+Reconciliation depth is deliberately bounded: **1 confrontation pass + at most 1
+rebuttal per conflict**. Do not loop indefinitely.
+
+### Step 4 — Implement & respond
+
+- Implement **every Must Have** (and every Should Have the reconciliation kept).
+- Record a one-line **response per finding** (done / deferred-with-reason /
+  disagreed-with-rationale). Nothing in the list is left unanswered.
+- Re-run lint/tests for the touched packages (`npm run ci:check` / `lint:check`
+  + `test:cov` as per the package `CLAUDE.md`).
+
+### Step 5 — Push gate
+
+Authorise the push **only if both hold**:
+
+- Every finding in the reconciled list has a response, **and**
+- Every Must Have is implemented and verified.
+
+Otherwise, loop back to Step 4. The human triggers the actual `git push`.
+
+## After the push (for reference, not part of this skill)
+
+- The PR triggers **CodeRabbit** (auto) + **Codex** (auto) on GitHub.
+- Add the **`needs-copilot`** label only if a deliberate Copilot review is also
+  wanted (premium-request cost; ×13 per review since 2026-06-01).
+- Handle posted comments per the global `pr-review-procedure` skill.
+
+## Rules
+
+- **Read-only reviewers.** Steps 1–2 never mutate the working tree. Fixes happen
+  in Step 4, attributed to the reconciled list.
+- **No silent skips.** If a reviewer could not run, say so in the output.
+- **English** in all review artefacts and commit messages; **no AI attribution**.
+- **Never push automatically.** Step 5 authorises; the human pushes.

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# codex-review.sh — local, read-only Codex (GPT) review of the current branch.
+#
+# Part of the brasse-bouillon defence-in-depth review pipeline. This is the
+# "Codex side" of the pre-push ritual driven by the `pre-push-review` skill
+# (.claude/skills/pre-push-review/SKILL.md): Claude reviews via the
+# `pr-pre-reviewer` agent + /code-review, Codex reviews here, and the two
+# reports are reconciled before any push.
+#
+# It wraps `codex exec review`, which reviews the diff against a base branch
+# without mutating the working tree. It replays the same checklist as the
+# `pr-pre-reviewer` agent so both reviewers judge against the same rules.
+#
+# Cost note: each run consumes the OpenAI/ChatGPT quota tied to your Codex
+# CLI auth — a quota SEPARATE from GitHub Copilot premium requests.
+#
+# Usage:
+#   scripts/codex-review.sh                 # review HEAD vs main, print report
+#   scripts/codex-review.sh --base develop  # review against another base
+#   scripts/codex-review.sh --out report.md # also save the report to a file
+#
+# Requirements: codex CLI on PATH (`codex --version`), run from inside the repo.
+
+set -euo pipefail
+
+BASE="main"
+OUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      BASE="${2:?--base requires a branch name}"
+      shift 2
+      ;;
+    --out)
+      OUT="${2:?--out requires a file path}"
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "error: codex CLI not found on PATH. Install it or check your asdf/node setup." >&2
+  exit 127
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: not inside a git repository." >&2
+  exit 1
+fi
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" == "$BASE" ]]; then
+  echo "error: current branch is '$BASE'; nothing to review against itself." >&2
+  exit 1
+fi
+
+# Keep the comparison honest against the latest remote base (read-only fetch).
+git fetch origin "$BASE" --quiet 2>/dev/null || true
+
+# The review instructions mirror the pr-pre-reviewer checklist so Claude and
+# Codex grade against the same bar. Keep this in sync with
+# .claude/agents/pr-pre-reviewer.md.
+read -r -d '' INSTRUCTIONS <<'PROMPT' || true
+You are a strict, read-only reviewer for the brasse-bouillon monorepo.
+Review ONLY the diff against the base branch. Output English, no AI attribution.
+
+Group findings as Must Have / Should Have / Nice to Have / Disagree, each with
+a `path/to/file.ts:line` anchor and a one-line suggested fix.
+
+Must Have (blocking) — flag any of:
+- `any` TypeScript type introduced anywhere.
+- Default export for a screen, use-case, controller, service, module, or DTO.
+- Direct `fetch()` outside packages/mobile-app/src/core/http/http-client.ts.
+- Raw SQL string outside repository / query-builder methods in packages/api.
+- Hardcoded secret, token, or credential.
+- Hardcoded color/spacing/font in packages/mobile-app (must use theme tokens).
+- Inline `style={{...}}` in React Native (must use StyleSheet.create()).
+- Bypass of the NestJS response envelope in packages/api.
+- Missing TypeORM migration when an entity adds/removes/renames a column.
+- ADR violations (read docs/architecture/decisions/0001..0005 and 0013): e.g.
+  mobile calling a third-party HTTP service directly instead of via the API.
+
+Should Have — tests not following Happy/Sad/Edge, missing Swagger decorator on a
+new endpoint, naming/import-order deviations, Conventional Commits not respected,
+any AI attribution in commit messages or files.
+
+Nice to Have — readability, extraction, WHY-not-WHAT comments.
+
+Disagree — anything that looks off but is justified by a tolerated ADR-0001
+exception or an established pattern; give a one-line rationale.
+
+End with a Summary: ADRs honoured (y/n), forbidden patterns present (y/n),
+H/S/E covered for new units (y/n), Ready for push (y/n).
+PROMPT
+
+echo "Running Codex review of '$CURRENT_BRANCH' against '$BASE'..." >&2
+
+if [[ -n "$OUT" ]]; then
+  codex exec review --base "$BASE" --output-last-message "$OUT" "$INSTRUCTIONS"
+  echo "Report written to: $OUT" >&2
+  cat "$OUT"
+else
+  codex exec review --base "$BASE" "$INSTRUCTIONS"
+fi


### PR DESCRIPTION
## Summary

- Add **`scripts/codex-review.sh`** — a read-only wrapper around `codex exec review --base main` that runs a local Codex (GPT) review, mirroring the `pr-pre-reviewer` checklist. No working-tree mutation.
- Add the **`pre-push-review`** skill (`.claude/skills/pre-push-review/SKILL.md`) — drives both local reviewers (Claude via `pr-pre-reviewer` + `/code-review`, Codex via the script), **confronts** their findings into a single Must/Should/Nice/Disagree action list (1 pass + 1 rebuttal on conflicts), implements blocking fixes, and gates the push.

## Context

Third of three PRs reworking the review service (after #1202, #1203). This is the **pre-push, local, free** layer of the defence-in-depth pipeline documented in CONTRIBUTING § AI reviewers (#1202): catch issues before they ever reach GitHub, then CodeRabbit/Codex review post-push, with Copilot on-demand.

Cost note: each Codex run consumes the OpenAI/ChatGPT quota tied to the Codex CLI — separate from Copilot premium requests.

## Checklist

- [x] `scripts/codex-review.sh` passes `bash -n` and is executable
- [x] No code changes to packages (tooling only)
- [x] No secrets, no `any`, no default exports
- [ ] `PROJECT_LOG.md` updated after merge