### PR TITLE
fix(scan): show ADR-0017 IBU/colour intervals on the beer card

### DIFF
--- a/packages/mobile-app/src/features/scan/application/__tests__/lookup-formatters.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/lookup-formatters.test.ts
@@ -1,6 +1,7 @@
 import {
   abvToStrengthWord,
   ebcToColorWord,
+  formatInterval,
   ibuToBitternessWord,
 } from "@/features/scan/application/lookup-formatters";
 
@@ -102,6 +103,31 @@ describe("lookup-formatters", () => {
 
     it("returns Inconnu for negative input (defensive)", () => {
       expect(abvToStrengthWord(-1)).toBe("Inconnu");
+    });
+  });
+
+  describe("formatInterval", () => {
+    it("joins distinct bounds with an en dash", () => {
+      expect(formatInterval(20, 28, 24)).toBe("20–28");
+    });
+
+    it("renders a single value when the bounds coincide", () => {
+      expect(formatInterval(20, 20, 20)).toBe("20");
+    });
+
+    it("falls back to the scalar when both bounds are absent", () => {
+      expect(formatInterval(undefined, undefined, 35)).toBe("35");
+      expect(formatInterval(null, null, 35)).toBe("35");
+    });
+
+    it("returns null when nothing is known", () => {
+      expect(formatInterval(null, null, null)).toBeNull();
+      expect(formatInterval(undefined, undefined, null)).toBeNull();
+    });
+
+    it("tolerates a single known bound", () => {
+      expect(formatInterval(20, null, null)).toBe("20");
+      expect(formatInterval(null, 28, null)).toBe("28");
     });
   });
 });

--- a/packages/mobile-app/src/features/scan/application/__tests__/lookup-formatters.test.ts
+++ b/packages/mobile-app/src/features/scan/application/__tests__/lookup-formatters.test.ts
@@ -129,5 +129,12 @@ describe("lookup-formatters", () => {
       expect(formatInterval(20, null, null)).toBe("20");
       expect(formatInterval(null, 28, null)).toBe("28");
     });
+
+    it("renders the known bound alone, never paired with the fallback", () => {
+      // A present bound must not be combined with the scalar fallback into
+      // a fabricated range like "20–24".
+      expect(formatInterval(20, undefined, 24)).toBe("20");
+      expect(formatInterval(undefined, 28, 24)).toBe("28");
+    });
   });
 });

--- a/packages/mobile-app/src/features/scan/application/lookup-formatters.ts
+++ b/packages/mobile-app/src/features/scan/application/lookup-formatters.ts
@@ -97,19 +97,21 @@ export function abvToStrengthWord(abv: number | null): string {
 /**
  * Render an ADR-0017 [min, max] interval for display: a single value
  * when the bounds coincide ("20"), a dash-joined range otherwise
- * ("20–28"). Falls back to the representative scalar when the bounds
- * are absent (mock/demo items that carry only a single value), and to
- * null when nothing is known.
+ * ("20–28"). A single known bound renders on its own. The scalar
+ * `fallback` stands in only when neither bound is known (mock/demo
+ * items that carry just a scalar) — never paired with a real bound,
+ * which would fabricate a misleading range. Returns null when nothing
+ * is known.
  */
 export function formatInterval(
   min: number | null | undefined,
   max: number | null | undefined,
   fallback: number | null,
 ): string | null {
-  const lo = min ?? fallback;
-  const hi = max ?? fallback;
-  if (lo == null && hi == null) return null;
-  if (lo == null) return String(hi);
-  if (hi == null) return String(lo);
+  if (min == null && max == null) {
+    return fallback == null ? null : String(fallback);
+  }
+  const lo = min ?? max;
+  const hi = max ?? min;
   return lo === hi ? String(lo) : `${lo}–${hi}`;
 }

--- a/packages/mobile-app/src/features/scan/application/lookup-formatters.ts
+++ b/packages/mobile-app/src/features/scan/application/lookup-formatters.ts
@@ -93,3 +93,23 @@ export function abvToStrengthWord(abv: number | null): string {
   if (abv <= 10) return "Forte";
   return "Très forte";
 }
+
+/**
+ * Render an ADR-0017 [min, max] interval for display: a single value
+ * when the bounds coincide ("20"), a dash-joined range otherwise
+ * ("20–28"). Falls back to the representative scalar when the bounds
+ * are absent (mock/demo items that carry only a single value), and to
+ * null when nothing is known.
+ */
+export function formatInterval(
+  min: number | null | undefined,
+  max: number | null | undefined,
+  fallback: number | null,
+): string | null {
+  const lo = min ?? fallback;
+  const hi = max ?? fallback;
+  if (lo == null && hi == null) return null;
+  if (lo == null) return String(hi);
+  if (hi == null) return String(lo);
+  return lo === hi ? String(lo) : `${lo}–${hi}`;
+}

--- a/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
+++ b/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
@@ -322,6 +322,19 @@ describe("beers-import.api / importBeerByEan", () => {
       expect(item.colorEbc).toBe(12); // srmToEbc(midpoint 6) = round(11.82)
       expect(item.isColorEbcEstimated).toBe(true);
     });
+
+    it("still derives EBC and flags it estimated when only one SRM bound is present", async () => {
+      mockRequest.mockResolvedValueOnce(
+        buildDto({ srm_min: null, srm_max: 8 }),
+      );
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.colorEbc).toBe(16); // srmToEbc(midpoint(null, 8) = 8)
+      expect(item.colorEbcMin).toBeNull();
+      expect(item.colorEbcMax).toBe(16);
+      expect(item.isColorEbcEstimated).toBe(true);
+    });
   });
 
   describe("source → origin mapping", () => {

--- a/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
+++ b/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
@@ -33,8 +33,10 @@ type PythonBeerReadDto = {
   brewery_name: string | null;
   style_name: string | null;
   abv: string | null;
-  ibu: number | null;
-  srm: number | null;
+  ibu_min: number | null;
+  ibu_max: number | null;
+  srm_min: number | null;
+  srm_max: number | null;
   description: string | null;
   is_active: boolean;
   is_verified: boolean;
@@ -60,8 +62,10 @@ function buildDto(
     brewery_name: "Pelforth",
     style_name: "Brune",
     abv: "6.5",
-    ibu: 22,
-    srm: 30,
+    ibu_min: 22,
+    ibu_max: 22,
+    srm_min: 30,
+    srm_max: 30,
     description: "Brune intense",
     is_active: true,
     is_verified: false,
@@ -252,7 +256,7 @@ describe("beers-import.api / importBeerByEan", () => {
     });
 
     it("converts SRM to EBC (factor 1.97, rounded) and flags color as estimated", async () => {
-      mockRequest.mockResolvedValueOnce(buildDto({ srm: 10 }));
+      mockRequest.mockResolvedValueOnce(buildDto({ srm_min: 10, srm_max: 10 }));
 
       const { item } = await importBeerByEan("3760231860119");
 
@@ -261,21 +265,62 @@ describe("beers-import.api / importBeerByEan", () => {
     });
 
     it("returns null colorEbc and unflagged estimation when srm is null", async () => {
-      mockRequest.mockResolvedValueOnce(buildDto({ srm: null }));
+      mockRequest.mockResolvedValueOnce(
+        buildDto({ srm_min: null, srm_max: null }),
+      );
 
       const { item } = await importBeerByEan("3760231860119");
 
       expect(item.colorEbc).toBeNull();
+      expect(item.colorEbcMin).toBeNull();
+      expect(item.colorEbcMax).toBeNull();
       expect(item.isColorEbcEstimated).toBe(false);
     });
 
     it("propagates ibu null without estimation", async () => {
-      mockRequest.mockResolvedValueOnce(buildDto({ ibu: null }));
+      mockRequest.mockResolvedValueOnce(
+        buildDto({ ibu_min: null, ibu_max: null }),
+      );
 
       const { item } = await importBeerByEan("3760231860119");
 
       expect(item.ibu).toBeNull();
+      expect(item.ibuMin).toBeNull();
+      expect(item.ibuMax).toBeNull();
       expect(item.isIbuEstimated).toBe(false);
+    });
+
+    it("collapses an exact IBU interval (min === max) to the value, not estimated", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ ibu_min: 20, ibu_max: 20 }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.ibu).toBe(20);
+      expect(item.ibuMin).toBe(20);
+      expect(item.ibuMax).toBe(20);
+      expect(item.isIbuEstimated).toBe(false);
+    });
+
+    it("keeps IBU bounds and uses the rounded midpoint when min !== max (flagged estimated)", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ ibu_min: 20, ibu_max: 28 }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.ibuMin).toBe(20);
+      expect(item.ibuMax).toBe(28);
+      expect(item.ibu).toBe(24); // round((20 + 28) / 2)
+      expect(item.isIbuEstimated).toBe(true);
+    });
+
+    it("maps an SRM interval to EBC bounds plus a midpoint-derived scalar", async () => {
+      mockRequest.mockResolvedValueOnce(buildDto({ srm_min: 4, srm_max: 8 }));
+
+      const { item } = await importBeerByEan("3760231860119");
+
+      expect(item.colorEbcMin).toBe(8); // round(4 * 1.97)
+      expect(item.colorEbcMax).toBe(16); // round(8 * 1.97)
+      expect(item.colorEbc).toBe(12); // srmToEbc(midpoint 6) = round(11.82)
+      expect(item.isColorEbcEstimated).toBe(true);
     });
   });
 

--- a/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
+++ b/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
@@ -312,6 +312,24 @@ describe("beers-import.api / importBeerByEan", () => {
       expect(item.isIbuEstimated).toBe(true);
     });
 
+    it("does not flag a single-bound IBU as estimated, whichever bound is set", async () => {
+      // A lone bound is not a range — and a valid ADR-0017 interval carries
+      // both bounds. Symmetric: neither (20, null) nor (null, 20) is estimated.
+      mockRequest.mockResolvedValueOnce(
+        buildDto({ ibu_min: 20, ibu_max: null }),
+      );
+      const onlyMin = (await importBeerByEan("3760231860119")).item;
+      expect(onlyMin.ibu).toBe(20);
+      expect(onlyMin.isIbuEstimated).toBe(false);
+
+      mockRequest.mockResolvedValueOnce(
+        buildDto({ ibu_min: null, ibu_max: 20 }),
+      );
+      const onlyMax = (await importBeerByEan("3760231860119")).item;
+      expect(onlyMax.ibu).toBe(20);
+      expect(onlyMax.isIbuEstimated).toBe(false);
+    });
+
     it("maps an SRM interval to EBC bounds plus a midpoint-derived scalar", async () => {
       mockRequest.mockResolvedValueOnce(buildDto({ srm_min: 4, srm_max: 8 }));
 

--- a/packages/mobile-app/src/features/scan/data/beers-import.api.ts
+++ b/packages/mobile-app/src/features/scan/data/beers-import.api.ts
@@ -43,8 +43,12 @@ interface PythonBeerReadDto {
   brewery_name: string | null;
   style_name: string | null;
   abv: string | null; // Pydantic Decimal serialises as string
-  ibu: number | null;
-  srm: number | null;
+  // ADR-0017: IBU and colour are stored as min/max intervals
+  // (min === max when the value is exactly known).
+  ibu_min: number | null;
+  ibu_max: number | null;
+  srm_min: number | null;
+  srm_max: number | null;
   description: string | null;
   is_active: boolean;
   is_verified: boolean;
@@ -80,6 +84,25 @@ function srmToEbc(srm: number | null): number | null {
     return null;
   }
   return Math.round(srm * 1.97);
+}
+
+/**
+ * Representative single value for an ADR-0017 [min, max] interval. The
+ * bucket formatters (bitterness/colour words) and the recipe-matching
+ * scorer work on a scalar, so we collapse the interval to its rounded
+ * midpoint; the bounds themselves are preserved separately for display.
+ */
+function intervalMidpoint(
+  min: number | null,
+  max: number | null,
+): number | null {
+  if (min === null || min === undefined) {
+    return max ?? null;
+  }
+  if (max === null || max === undefined) {
+    return min;
+  }
+  return Math.round((min + max) / 2);
 }
 
 function mapPythonSourceToOrigin(
@@ -137,14 +160,22 @@ function mapPythonBeerToCatalogItem(
     brewery: dto.brewery_name ?? SCAN_BREWERY_PLACEHOLDER,
     style: dto.style_name ?? SCAN_STYLE_PLACEHOLDER,
     abv: dto.abv === null ? null : Number(dto.abv),
-    ibu: dto.ibu,
-    colorEbc: srmToEbc(dto.srm),
+    // Scalar = representative midpoint (formatters/scoring); bounds kept
+    // for range display (ADR-0017).
+    ibu: intervalMidpoint(dto.ibu_min, dto.ibu_max),
+    ibuMin: dto.ibu_min,
+    ibuMax: dto.ibu_max,
+    colorEbc: srmToEbc(intervalMidpoint(dto.srm_min, dto.srm_max)),
+    colorEbcMin: srmToEbc(dto.srm_min),
+    colorEbcMax: srmToEbc(dto.srm_max),
     fermentationType: "",
     aromaticTags: null,
     notesSource: dto.description,
     isAbvEstimated: false,
-    isIbuEstimated: false,
-    isColorEbcEstimated: dto.srm !== null,
+    // A range (min !== max) is by definition an estimate; an exact
+    // single value (min === max) is not.
+    isIbuEstimated: dto.ibu_min !== null && dto.ibu_min !== dto.ibu_max,
+    isColorEbcEstimated: dto.srm_min !== null,
     isStyleEstimated: true,
     origin: mapPythonSourceToOrigin(dto.source),
     // BeerRead does not expose the OFF fetch timestamp; `updated_at`

--- a/packages/mobile-app/src/features/scan/data/beers-import.api.ts
+++ b/packages/mobile-app/src/features/scan/data/beers-import.api.ts
@@ -177,7 +177,7 @@ function mapPythonBeerToCatalogItem(
     // estimate when present, being an approximate SRM→EBC conversion
     // (×1.97, rounded), regardless of whether the SRM bounds coincide.
     isIbuEstimated: dto.ibu_min !== null && dto.ibu_min !== dto.ibu_max,
-    isColorEbcEstimated: dto.srm_min !== null,
+    isColorEbcEstimated: dto.srm_min !== null || dto.srm_max !== null,
     isStyleEstimated: true,
     origin: mapPythonSourceToOrigin(dto.source),
     // BeerRead does not expose the OFF fetch timestamp; `updated_at`

--- a/packages/mobile-app/src/features/scan/data/beers-import.api.ts
+++ b/packages/mobile-app/src/features/scan/data/beers-import.api.ts
@@ -172,8 +172,10 @@ function mapPythonBeerToCatalogItem(
     aromaticTags: null,
     notesSource: dto.description,
     isAbvEstimated: false,
-    // A range (min !== max) is by definition an estimate; an exact
-    // single value (min === max) is not.
+    // IBU is the raw value: a true range (min !== max) is an estimate, an
+    // exact single value is not. EBC differs on purpose — it is always an
+    // estimate when present, being an approximate SRM→EBC conversion
+    // (×1.97, rounded), regardless of whether the SRM bounds coincide.
     isIbuEstimated: dto.ibu_min !== null && dto.ibu_min !== dto.ibu_max,
     isColorEbcEstimated: dto.srm_min !== null,
     isStyleEstimated: true,

--- a/packages/mobile-app/src/features/scan/data/beers-import.api.ts
+++ b/packages/mobile-app/src/features/scan/data/beers-import.api.ts
@@ -172,11 +172,16 @@ function mapPythonBeerToCatalogItem(
     aromaticTags: null,
     notesSource: dto.description,
     isAbvEstimated: false,
-    // IBU is the raw value: a true range (min !== max) is an estimate, an
-    // exact single value is not. EBC differs on purpose — it is always an
-    // estimate when present, being an approximate SRM→EBC conversion
-    // (×1.97, rounded), regardless of whether the SRM bounds coincide.
-    isIbuEstimated: dto.ibu_min !== null && dto.ibu_min !== dto.ibu_max,
+    // IBU is the raw value: a true range (both bounds present and
+    // differing) is an estimate; an exact single value (min === max) is
+    // not. Requiring both bounds keeps the flag symmetric and matches
+    // ADR-0017, where a valid interval always carries both. EBC differs
+    // on purpose — always an estimate when present, being an approximate
+    // SRM→EBC conversion (×1.97, rounded).
+    isIbuEstimated:
+      dto.ibu_min !== null &&
+      dto.ibu_max !== null &&
+      dto.ibu_min !== dto.ibu_max,
     isColorEbcEstimated: dto.srm_min !== null || dto.srm_max !== null,
     isStyleEstimated: true,
     origin: mapPythonSourceToOrigin(dto.source),

--- a/packages/mobile-app/src/features/scan/domain/scan.types.ts
+++ b/packages/mobile-app/src/features/scan/domain/scan.types.ts
@@ -149,7 +149,17 @@ export interface ScanCatalogItem {
   style: string;
   abv: number | null;
   ibu: number | null;
+  /**
+   * ADR-0017 interval bounds, for display ("20–28"). The scalar `ibu`
+   * above stays the representative midpoint consumed by the bucket
+   * formatters and the recipe-matching scorer. Optional: mock/demo
+   * items carry only the scalar.
+   */
+  ibuMin?: number | null;
+  ibuMax?: number | null;
   colorEbc: number | null;
+  colorEbcMin?: number | null;
+  colorEbcMax?: number | null;
   fermentationType: string;
   aromaticTags: string | null;
   notesSource: string | null;

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -30,6 +30,7 @@ import {
 import {
   abvToStrengthWord,
   ebcToColorWord,
+  formatInterval,
   ibuToBitternessWord,
 } from "@/features/scan/application/lookup-formatters";
 import type {
@@ -743,17 +744,23 @@ function TechnicalDetails({ result }: { result: ScanLookupResult }) {
       estimated: item.isAbvEstimated,
     });
   }
-  if (item.ibu != null) {
+  const ibuValue = formatInterval(item.ibuMin, item.ibuMax, item.ibu);
+  if (ibuValue != null) {
     rows.push({
       label: "Amertume (IBU)",
-      value: String(item.ibu),
+      value: ibuValue,
       estimated: item.isIbuEstimated,
     });
   }
-  if (item.colorEbc != null) {
+  const ebcValue = formatInterval(
+    item.colorEbcMin,
+    item.colorEbcMax,
+    item.colorEbc,
+  );
+  if (ebcValue != null) {
     rows.push({
       label: "Couleur (EBC)",
-      value: String(item.colorEbc),
+      value: ebcValue,
       estimated: item.isColorEbcEstimated,
     });
   }


### PR DESCRIPTION
## Summary

After the ADR-0017 deploy, the beer-encyclopedia returns IBU and colour as **min/max intervals** (`ibu_min/ibu_max`, `srm_min/srm_max`), but the mobile DTO still read the removed scalar `ibu`/`srm` fields — so **IBU and EBC rendered blank** on the beer card after a scan.

This propagates ADR-0017 to the mobile consumer:
- `beers-import.api.ts` reads the interval fields; keeps a **representative midpoint** scalar (`ibu`/`colorEbc`) for the bucket formatters and the recipe-matching scorer, and carries the **bounds** (`ibuMin/Max`, `colorEbcMin/Max`) on `ScanCatalogItem`.
- New `formatInterval` helper renders a **range** (`20–28`), or a single value when `min === max`.
- `BeerInfoCardScreen` shows the range in the technical-details rows.
- IBU is flagged **estimated** only when it is a true range.

## Context

- Consequence of ADR-0017 (Beer IBU/colour as min/max intervals), deployed with the corpus seed (#1207, #1208).
- Scalar kept for `lookup-formatters` (bitterness/colour words) and `scan.use-cases` scoring — no ripple to those layers.
- New `ScanCatalogItem` interval fields are **optional**, so mock/demo builders are unaffected.

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format)
- [x] Tests: DTO interval mapping (single / range / null) + `formatInterval` unit cases — **215 scan tests pass**
- [x] No hardcoded values / inline styles introduced; named exports only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Beer details now display IBU and color as intervals (min–max) when available, fall back to a single value when bounds coincide, and hide the row when nothing is known; estimated flags preserved.

* **Data / Import**
  * External lookup now supplies min/max bounds for IBU and colour; the app derives representative scalar values and estimation flags from those intervals.

* **Tests**
  * Added tests for interval formatting and interval-based beer mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->