### PR TITLE
feat(recipe): recipe-matching v2 — BJCP-family-graded scorer + completeness + threshold (ADR-0016)

### DIFF
--- a/docs/architecture/decisions/0016-recipe-equivalence-matching-v2.md
+++ b/docs/architecture/decisions/0016-recipe-equivalence-matching-v2.md
@@ -69,7 +69,7 @@ A candidate is shown only when **both** `matchStrength ≥ S_min` **and** `compl
 
 ### D6 — Official-recipe promotion stays style-gated (from #1193)
 
-Unchanged: the official shortcut applies only to a **style-compatible** official (style similarity > 0). It does not bypass D5.
+The official shortcut applies only to a **style-compatible** official, and it does not bypass D5. With D2's graded scale, "style-compatible" is refined to **same BJCP family or better** (style similarity ≥ 0.7) — *not* merely the same colour/strength tier (0.4). Otherwise a 0.4 tier match (e.g. an IPA for a Blonde Ale — both pale/standard) would re-promote an off-family official to the top, reintroducing the exact #1193 bug this gate exists to prevent. (Implementation note, 2026-06-06: the original ">0" wording predated the graded scale; ≥ 0.7 is the faithful intent.)
 
 ## Out of scope (deferred, captured)
 

--- a/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
+++ b/docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md
@@ -114,10 +114,11 @@ M --> M : render "recettes équivalentes" + completeness / honest empty state
   not a misleading closest match. `low_confidence` is retained in the envelope for
   backward-compatibility but the empty-state replaces the old "show closest + banner".
 - **Style-gated official promotion (#1193, ADR-0016 D6).** The official-recipe shortcut
-  (matchStrength = 1.0) applies **only when the official is style-compatible** (style local
-  similarity > 0). An off-style official (e.g. an IPA for a Leffe Blonde) is ranked on its
-  honest similarity instead, and does not bypass the D5 threshold. Style-compatible officials
-  stay promoted.
+  (matchStrength = 1.0) applies **only when the official is style-compatible** — refined to
+  **same BJCP family or better** (style local similarity ≥ 0.7), not merely the same
+  colour/strength tier (0.4). An off-family official (e.g. an IPA for a Leffe Blonde — same
+  pale/standard tier, 0.4) is ranked on its honest similarity instead and does not bypass the
+  D5 threshold. Same-family officials stay promoted.
 - **Backward compatibility.** `GET /recipes/match/:beerId` stays (same request/response
   contract): it loads the `scan_catalog_items` row, then calls `rankByCharacteristics(row)`.
   Removed when the NestJS scan path is retired (#1186 step 2). The **interface** is unchanged;

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -23,3 +23,10 @@ SWAGGER_ENABLED=true
 # Hubeau (water quality provider) — runtime tunables
 HUBEAU_TIMEOUT_MS=8000
 HUBEAU_CACHE_TTL_SECONDS=3600
+
+# Recipe-matching v2 acceptance thresholds (ADR-0016 D5) — a scanned beer's
+# equivalent recipe is shown only when its match strength (0..100) AND its
+# completeness (0..1) both clear these. Out-of-range values fall back to the
+# defaults shown. Calibrate on real OpenFoodFacts coverage.
+SCAN_MATCH_S_MIN=45
+SCAN_MATCH_C_MIN=0.5

--- a/packages/api/src/recipe/controllers/recipe.controller.spec.ts
+++ b/packages/api/src/recipe/controllers/recipe.controller.spec.ts
@@ -441,8 +441,12 @@ describe('RecipeController', () => {
     it('happy: returns the ranked envelope straight from the matching service', async () => {
       const envelope = {
         rankings: [
-          { recipe: mockRecipeOrm, score: 87.5 },
-          { recipe: { ...mockRecipeOrm, name: 'Other' }, score: 60 },
+          { recipe: mockRecipeOrm, score: 87.5, completeness: 0.54 },
+          {
+            recipe: { ...mockRecipeOrm, name: 'Other' },
+            score: 60,
+            completeness: 0.54,
+          },
         ],
         low_confidence: false,
       };
@@ -458,7 +462,7 @@ describe('RecipeController', () => {
 
     it('happy: surfaces low_confidence=true when the best match is weak', async () => {
       const envelope = {
-        rankings: [{ recipe: mockRecipeOrm, score: 28 }],
+        rankings: [{ recipe: mockRecipeOrm, score: 28, completeness: 0.4 }],
         low_confidence: true,
       };
       jest.spyOn(matching, 'rankForBeer').mockResolvedValue(envelope);
@@ -482,7 +486,7 @@ describe('RecipeController', () => {
   describe('matchByCharacteristics() - POST /recipes/match', () => {
     it('happy: maps the body characteristics to the matcher and returns the envelope', async () => {
       const envelope = {
-        rankings: [{ recipe: mockRecipeOrm, score: 80 }],
+        rankings: [{ recipe: mockRecipeOrm, score: 80, completeness: 0.54 }],
         low_confidence: false,
       };
       const spy = jest

--- a/packages/api/src/recipe/dtos/ranked-recipe.dto.ts
+++ b/packages/api/src/recipe/dtos/ranked-recipe.dto.ts
@@ -1,31 +1,31 @@
 import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
 
 /**
- * Single ranked-recipe item — recipe row plus its computed match
- * score (0..100). Score breakdown is intentionally NOT exposed; the
- * client only needs the ordering and the headline number.
+ * Single ranked-recipe item — recipe row plus its computed **match strength**
+ * (`score`, 0..100, ADR-0016) and its **completeness** (0..1, ADR-0016 D4: how
+ * much of the full picture the comparison used — a separate confidence signal,
+ * distinct from the match strength). The per-criterion breakdown is
+ * intentionally NOT exposed; the client needs the ordering, the headline number
+ * and the completeness.
  */
 export interface RankedRecipeDto {
   recipe: RecipeOrmEntity;
   score: number;
+  completeness: number;
 }
 
 /**
- * Response envelope for `GET /recipes/match/:beerId` (Issue #699 +
- * brainstorm scan-2026-04-24 §3 "low_confidence" annotation).
+ * Response envelope for `POST /recipes/match` and the legacy
+ * `GET /recipes/match/:beerId` (Issue #699, matcher v2 ADR-0016).
  *
- * - `rankings` — top-N matched recipes ordered by descending score
- *   (with deterministic tie-breakers on `avg_rating` then `id`).
- * - `low_confidence` — `true` when the best match scores below the
- *   40-point threshold. The mobile UI uses this flag to display a
- *   discreet warning *"Aucune recette très similaire dans la base.
- *   Voici les plus proches."* above the equivalent recipes section.
- *
- * The threshold (40) is the inflection point below which the
- * editorial value of the suggestion drops sharply — recipes with
- * neither matching style nor similar ABV nor a strong rating land
- * here, and the user is better served by being told the truth than
- * by being shown a confident-looking but irrelevant top-3.
+ * - `rankings` — the candidates that cleared the acceptance thresholds
+ *   (ADR-0016 D5: match strength ≥ `SCAN_MATCH_S_MIN` AND completeness ≥
+ *   `SCAN_MATCH_C_MIN`), ordered by descending match strength with
+ *   deterministic tie-breakers on `avg_rating` then `id`. Each carries its
+ *   `completeness`.
+ * - `low_confidence` — `true` when **nothing** cleared the thresholds (empty
+ *   `rankings`). The mobile renders an honest *"no reliable equivalent"* empty
+ *   state rather than a misleading closest match.
  */
 export interface RankedRecipeResponseDto {
   rankings: RankedRecipeDto[];

--- a/packages/api/src/recipe/services/bjcp-style-family.spec.ts
+++ b/packages/api/src/recipe/services/bjcp-style-family.spec.ts
@@ -1,0 +1,93 @@
+import {
+  foldStyleKey,
+  normalizeStyle,
+  styleSimilarity,
+} from './bjcp-style-family';
+
+describe('bjcp-style-family (ADR-0016 D2)', () => {
+  // ---------------------------------------------------------------
+  // foldStyleKey
+  // ---------------------------------------------------------------
+  describe('foldStyleKey', () => {
+    it('happy: lowercases, trims and collapses inner whitespace', () => {
+      expect(foldStyleKey('  India   Pale  Ale ')).toBe('india pale ale');
+    });
+
+    it('edge: strips accents (NFD diacritic folding)', () => {
+      expect(foldStyleKey("Bière Blonde à l'Ancienne")).toBe(
+        "biere blonde a l'ancienne",
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // normalizeStyle
+  // ---------------------------------------------------------------
+  describe('normalizeStyle', () => {
+    it('happy: resolves a canonical style to family + tiers', () => {
+      expect(normalizeStyle('Blonde Ale')).toEqual({
+        canonical: 'blonde_ale',
+        family: 'Pale Ale',
+        colourTier: 'pale',
+        strengthTier: 'standard',
+      });
+    });
+
+    it('happy: resolves an FR/accented synonym to the same style', () => {
+      expect(normalizeStyle("Bière Blonde à l'Ancienne")?.canonical).toBe(
+        'blonde_ale',
+      );
+    });
+
+    it('happy: NEIPA resolves into the IPA family', () => {
+      const ipa = normalizeStyle('NEIPA');
+      expect(ipa?.family).toBe('IPA');
+      expect(ipa?.canonical).toBe('ipa');
+    });
+
+    it('sad: an unknown / free-text label returns null', () => {
+      expect(normalizeStyle('Quantum Hazy Sludge')).toBeNull();
+    });
+
+    it('edge: null / blank input returns null', () => {
+      expect(normalizeStyle(null)).toBeNull();
+      expect(normalizeStyle('   ')).toBeNull();
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // styleSimilarity — graded scale {1, 0.7, 0.4, 0, null}
+  // ---------------------------------------------------------------
+  describe('styleSimilarity', () => {
+    it('happy: same canonical style scores 1', () => {
+      expect(styleSimilarity('Blonde Ale', 'blonde')).toBe(1);
+    });
+
+    it('happy: same BJCP family scores 0.7 (Blonde Ale ≈ Kölsch)', () => {
+      expect(styleSimilarity('Blonde Ale', 'Kölsch')).toBe(0.7);
+    });
+
+    it('happy: same family — Blonde Ale ≈ Saison (both Pale Ale)', () => {
+      expect(styleSimilarity('Blonde Ale', 'Saison')).toBe(0.7);
+    });
+
+    it('edge: different family but same colour+strength tier scores 0.4 (Blonde Ale vs NEIPA)', () => {
+      // Blonde Ale = Pale Ale / pale+standard ; NEIPA = IPA / pale+standard.
+      expect(styleSimilarity('Blonde Ale', 'NEIPA')).toBe(0.4);
+    });
+
+    it('sad: unrelated families and tiers score 0 (Blonde Ale vs Stout)', () => {
+      // Stout = dark+standard ; Blonde Ale = pale+standard → no shared tier.
+      expect(styleSimilarity('Blonde Ale', 'Stout')).toBe(0);
+    });
+
+    it('edge: an unclassifiable side drops the criterion (null)', () => {
+      expect(styleSimilarity('Blonde Ale', 'Quantum Sludge')).toBeNull();
+      expect(styleSimilarity(null, 'Stout')).toBeNull();
+    });
+
+    it('edge: two unclassifiable but identical labels still match (1)', () => {
+      expect(styleSimilarity('Quantum Sludge', 'quantum  sludge')).toBe(1);
+    });
+  });
+});

--- a/packages/api/src/recipe/services/bjcp-style-family.spec.ts
+++ b/packages/api/src/recipe/services/bjcp-style-family.spec.ts
@@ -13,9 +13,9 @@ describe('bjcp-style-family (ADR-0016 D2)', () => {
       expect(foldStyleKey('  India   Pale  Ale ')).toBe('india pale ale');
     });
 
-    it('edge: strips accents (NFD diacritic folding)', () => {
+    it('edge: strips accents and folds apostrophes to a space', () => {
       expect(foldStyleKey("Bière Blonde à l'Ancienne")).toBe(
-        "biere blonde a l'ancienne",
+        'biere blonde a l ancienne',
       );
     });
   });
@@ -35,6 +35,14 @@ describe('bjcp-style-family (ADR-0016 D2)', () => {
 
     it('happy: resolves an FR/accented synonym to the same style', () => {
       expect(normalizeStyle("Bière Blonde à l'Ancienne")?.canonical).toBe(
+        'blonde_ale',
+      );
+    });
+
+    it('happy: apostrophe-less seed form resolves too ("à l Ancienne" == "à l\'Ancienne")', () => {
+      // The scan-catalog seed stores "Bière Blonde à l Ancienne" (no apostrophe);
+      // apostrophe folding makes it resolve to the same Blonde Ale family.
+      expect(normalizeStyle('Bière Blonde à l Ancienne')?.canonical).toBe(
         'blonde_ale',
       );
     });

--- a/packages/api/src/recipe/services/bjcp-style-family.ts
+++ b/packages/api/src/recipe/services/bjcp-style-family.ts
@@ -156,7 +156,13 @@ const STYLE_DEFINITIONS: readonly StyleDefinition[] = [
     family: 'Amber Ale',
     colourTier: 'amber',
     strengthTier: 'standard',
-    aliases: ['amber ale', 'ambree', 'biere ambree', 'red ale', 'irish red ale'],
+    aliases: [
+      'amber ale',
+      'ambree',
+      'biere ambree',
+      'red ale',
+      'irish red ale',
+    ],
   },
   {
     canonical: 'dubbel',

--- a/packages/api/src/recipe/services/bjcp-style-family.ts
+++ b/packages/api/src/recipe/services/bjcp-style-family.ts
@@ -44,6 +44,7 @@ export const foldStyleKey = (style: string): string =>
   style
     .normalize('NFD')
     .replace(/\p{Diacritic}/gu, '') // strip combining diacritics (accent folding)
+    .replace(/['’`]/g, ' ') // apostrophe variants → space ("l'Ancienne" == "l Ancienne")
     .toLowerCase()
     .trim()
     .replace(/\s+/g, ' ');

--- a/packages/api/src/recipe/services/bjcp-style-family.ts
+++ b/packages/api/src/recipe/services/bjcp-style-family.ts
@@ -1,0 +1,295 @@
+/**
+ * BJCP style-family classification for recipe-matching v2 (ADR-0016 D2).
+ *
+ * The matcher receives **free-text style strings** (from the scanned beer and
+ * from community recipes), not catalog ids — so the family/tier grouping lives
+ * here in code (the "alias en code" decision), NOT as a DB lookup. The family
+ * and tier values **mirror** the encyclopedia seed
+ * (`packages/beer-encyclopedia/scripts/seed_styles.py`, PR #1204) so both sides
+ * agree on what "same family" means; this module adds free-text synonyms
+ * (FR/EN) and accent folding on top.
+ *
+ * Graded similarity replaces the old name-only `scoreStyle` (exact/substring):
+ *   1.0  same canonical style
+ *   0.7  same BJCP family       (e.g. Blonde Ale ≈ Kölsch ≈ Saison → Pale Ale)
+ *   0.4  same colour + strength tier (a pale-standard ale vs a pale-standard lager)
+ *   0    otherwise
+ *   null when either side is unclassifiable/absent → the criterion drops out of
+ *        the weighted match (Gower renormalisation), never a penalty.
+ */
+
+export type ColourTier = 'pale' | 'amber' | 'dark';
+export type StrengthTier = 'standard' | 'strong';
+
+export interface StyleClassification {
+  /** Canonical style key — distinct styles in the same family differ here. */
+  readonly canonical: string;
+  /** BJCP family (mirrors seed_styles.py). */
+  readonly family: string;
+  readonly colourTier: ColourTier;
+  readonly strengthTier: StrengthTier;
+}
+
+interface StyleDefinition extends StyleClassification {
+  /** Folded synonyms (lowercase, accent-free) that resolve to this style. */
+  readonly aliases: readonly string[];
+}
+
+/**
+ * Fold a free-text style to a comparison key: NFD-decompose, strip diacritics,
+ * lowercase, trim, collapse inner whitespace. So "Bière Blonde à l'Ancienne"
+ * and "biere blonde a l'ancienne" compare equal.
+ */
+export const foldStyleKey = (style: string): string =>
+  style
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '') // strip combining diacritics (accent folding)
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ');
+
+/**
+ * Style catalogue. Families + tiers track seed_styles.py for the 15 seeded
+ * styles; `kolsch` and `witbier` are added as distinct canonicals for common
+ * free-text labels (same family as their cousins → graded 0.7, not 1.0).
+ */
+const STYLE_DEFINITIONS: readonly StyleDefinition[] = [
+  {
+    canonical: 'blonde_ale',
+    family: 'Pale Ale',
+    colourTier: 'pale',
+    strengthTier: 'standard',
+    aliases: [
+      'blonde ale',
+      'blonde',
+      'biere blonde',
+      "biere blonde a l'ancienne",
+      'golden ale',
+      'belgian blonde',
+      'blonde belge',
+    ],
+  },
+  {
+    canonical: 'saison',
+    family: 'Pale Ale',
+    colourTier: 'pale',
+    strengthTier: 'standard',
+    aliases: ['saison', 'farmhouse', 'farmhouse ale'],
+  },
+  {
+    canonical: 'kolsch',
+    family: 'Pale Ale',
+    colourTier: 'pale',
+    strengthTier: 'standard',
+    aliases: ['kolsch', 'koelsch'],
+  },
+  {
+    canonical: 'ipa',
+    family: 'IPA',
+    colourTier: 'pale',
+    strengthTier: 'standard',
+    aliases: [
+      'ipa',
+      'india pale ale',
+      'neipa',
+      'ne ipa',
+      'new england ipa',
+      'hazy ipa',
+      'american ipa',
+      'double ipa',
+      'dipa',
+      'session ipa',
+      'white ipa',
+    ],
+  },
+  {
+    canonical: 'pilsner',
+    family: 'Pale Lager',
+    colourTier: 'pale',
+    strengthTier: 'standard',
+    aliases: [
+      'pilsner',
+      'pils',
+      'pilsener',
+      'bohemian pilsner',
+      'czech pilsner',
+      'german pilsner',
+    ],
+  },
+  {
+    canonical: 'lager',
+    family: 'Pale Lager',
+    colourTier: 'pale',
+    strengthTier: 'standard',
+    aliases: [
+      'lager',
+      'pale lager',
+      'international pale lager',
+      'helles',
+      'munich helles',
+      'blonde lager',
+    ],
+  },
+  {
+    canonical: 'hefeweizen',
+    family: 'Wheat Beer',
+    colourTier: 'pale',
+    strengthTier: 'standard',
+    aliases: ['hefeweizen', 'weissbier', 'weizen', 'hefe', 'weiss'],
+  },
+  {
+    canonical: 'wheat',
+    family: 'Wheat Beer',
+    colourTier: 'pale',
+    strengthTier: 'standard',
+    aliases: ['wheat', 'wheat beer', 'american wheat', 'biere de ble'],
+  },
+  {
+    canonical: 'witbier',
+    family: 'Wheat Beer',
+    colourTier: 'pale',
+    strengthTier: 'standard',
+    aliases: ['witbier', 'wit', 'blanche', 'biere blanche', 'belgian white'],
+  },
+  {
+    canonical: 'amber_ale',
+    family: 'Amber Ale',
+    colourTier: 'amber',
+    strengthTier: 'standard',
+    aliases: ['amber ale', 'ambree', 'biere ambree', 'red ale', 'irish red ale'],
+  },
+  {
+    canonical: 'dubbel',
+    family: 'Belgian Ale',
+    colourTier: 'amber',
+    strengthTier: 'standard',
+    aliases: ['belgian dubbel', 'dubbel', 'abbey dubbel'],
+  },
+  {
+    canonical: 'tripel',
+    family: 'Strong Belgian Ale',
+    colourTier: 'pale',
+    strengthTier: 'strong',
+    aliases: ['belgian tripel', 'tripel', 'triple', 'abbey tripel'],
+  },
+  {
+    canonical: 'quadrupel',
+    family: 'Strong Belgian Ale',
+    colourTier: 'dark',
+    strengthTier: 'strong',
+    aliases: ['belgian quadrupel', 'quadrupel', 'quad', 'abt'],
+  },
+  {
+    canonical: 'barleywine',
+    family: 'Strong Ale',
+    colourTier: 'dark',
+    strengthTier: 'strong',
+    aliases: ['barleywine', 'barley wine', "vin d'orge"],
+  },
+  {
+    canonical: 'porter',
+    family: 'Porter',
+    colourTier: 'dark',
+    strengthTier: 'standard',
+    aliases: ['porter', 'baltic porter', 'brown porter', 'robust porter'],
+  },
+  {
+    canonical: 'stout',
+    family: 'Stout',
+    colourTier: 'dark',
+    strengthTier: 'standard',
+    aliases: [
+      'stout',
+      'dry stout',
+      'irish stout',
+      'imperial stout',
+      'russian imperial stout',
+      'oatmeal stout',
+      'milk stout',
+    ],
+  },
+  {
+    canonical: 'sour',
+    family: 'Sour Ale',
+    colourTier: 'amber',
+    strengthTier: 'standard',
+    aliases: [
+      'sour ale',
+      'sour',
+      'gose',
+      'berliner weisse',
+      'lambic',
+      'gueuze',
+      'acidulee',
+    ],
+  },
+];
+
+const ALIAS_INDEX: ReadonlyMap<string, StyleClassification> = (() => {
+  const index = new Map<string, StyleClassification>();
+  for (const def of STYLE_DEFINITIONS) {
+    const classification: StyleClassification = {
+      canonical: def.canonical,
+      family: def.family,
+      colourTier: def.colourTier,
+      strengthTier: def.strengthTier,
+    };
+    for (const alias of def.aliases) {
+      index.set(foldStyleKey(alias), classification);
+    }
+  }
+  return index;
+})();
+
+/**
+ * Resolve a free-text style to its BJCP classification, or `null` when the
+ * label is empty or matches no known style/alias.
+ */
+export const normalizeStyle = (
+  style: string | null | undefined,
+): StyleClassification | null => {
+  if (!style) {
+    return null;
+  }
+  const key = foldStyleKey(style);
+  if (!key) {
+    return null;
+  }
+  return ALIAS_INDEX.get(key) ?? null;
+};
+
+/**
+ * Graded style similarity in `{1.0, 0.7, 0.4, 0}`, or `null` when either side
+ * is absent/unclassifiable (so the caller drops the criterion rather than
+ * penalising an unknown style). When both sides are unclassifiable but their
+ * folded labels are identical, returns `1.0` (a literal match still counts).
+ */
+export const styleSimilarity = (
+  beerStyle: string | null | undefined,
+  recipeStyle: string | null | undefined,
+): number | null => {
+  const a = normalizeStyle(beerStyle);
+  const b = normalizeStyle(recipeStyle);
+
+  if (a && b) {
+    if (a.canonical === b.canonical) {
+      return 1;
+    }
+    if (a.family === b.family) {
+      return 0.7;
+    }
+    if (a.colourTier === b.colourTier && a.strengthTier === b.strengthTier) {
+      return 0.4;
+    }
+    return 0;
+  }
+
+  // At least one side is unclassifiable: don't penalise an unknown style —
+  // only honour a literal (folded) match, otherwise drop the criterion.
+  const foldedBeer = beerStyle ? foldStyleKey(beerStyle) : '';
+  const foldedRecipe = recipeStyle ? foldStyleKey(recipeStyle) : '';
+  if (foldedBeer && foldedRecipe && foldedBeer === foldedRecipe) {
+    return 1;
+  }
+  return null;
+};

--- a/packages/api/src/recipe/services/recipe-matching.constants.ts
+++ b/packages/api/src/recipe/services/recipe-matching.constants.ts
@@ -1,0 +1,47 @@
+/**
+ * Acceptance thresholds for recipe-matching v2 (ADR-0016 D5).
+ *
+ * A candidate recipe is shown only when its match strength **and** its
+ * completeness both clear these bars — otherwise the section renders an honest
+ * "no reliable equivalent" empty state rather than a misleading closest match.
+ *
+ * Both are env-tunable (calibrate on real OpenFoodFacts coverage); the defaults
+ * are a starting point. Parsing mirrors the `water.config` convention: an
+ * out-of-range or non-numeric value falls back to the default rather than
+ * throwing.
+ */
+
+const DEFAULT_S_MIN = 45; // on the 0..100 match-strength scale
+const DEFAULT_C_MIN = 0.5; // on the 0..1 completeness scale
+
+const parseBoundedNumber = (
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number => {
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed) || parsed < min || parsed > max) {
+    return fallback;
+  }
+  return parsed;
+};
+
+/** Minimum match strength (0..100) for a candidate to be shown. */
+export const SCAN_MATCH_S_MIN = parseBoundedNumber(
+  process.env.SCAN_MATCH_S_MIN,
+  DEFAULT_S_MIN,
+  0,
+  100,
+);
+
+/** Minimum completeness ratio (0..1) for a candidate to be shown. */
+export const SCAN_MATCH_C_MIN = parseBoundedNumber(
+  process.env.SCAN_MATCH_C_MIN,
+  DEFAULT_C_MIN,
+  0,
+  1,
+);

--- a/packages/api/src/recipe/services/recipe-matching.service.spec.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.spec.ts
@@ -18,7 +18,15 @@ import { ScanCatalogItemOrmEntity } from '../../scan/entities/scan-catalog-item.
 import { ScanCatalogSource } from '../../scan/domain/enums/scan-catalog-source.enum';
 import { ScanFermentationType } from '../../scan/domain/enums/scan-fermentation-type.enum';
 
-describe('RecipeMatchingService (Issue #699)', () => {
+/**
+ * Recipe matching **v2** (ADR-0016). Match strength = weighted, completeness-
+ * aware similarity only (style 40 BJCP-graded, colour 22, IBU 18, ABV 14;
+ * Gower renorm). A candidate is shown only when matchStrength ≥ SCAN_MATCH_S_MIN
+ * (default 45) AND completeness ≥ SCAN_MATCH_C_MIN (default 0.5) — D5. The test
+ * fixtures never set IBU/colour, so completeness is 0.54 (style + ABV) or 0.40
+ * (style only, which is filtered out by C_min).
+ */
+describe('RecipeMatchingService (matcher v2, ADR-0016)', () => {
   let module: TestingModule;
   let service: RecipeMatchingService;
   let recipeRepo: Repository<RecipeOrmEntity>;
@@ -63,37 +71,7 @@ describe('RecipeMatchingService (Issue #699)', () => {
   });
 
   // ---------------------------------------------------------------
-  // scoreStyle
-  // ---------------------------------------------------------------
-  describe('scoreStyle', () => {
-    it('happy: exact case-insensitive match scores 100', () => {
-      expect(service.scoreStyle('IPA', 'IPA')).toBe(100);
-      expect(service.scoreStyle('ipa', 'IPA')).toBe(100);
-      expect(service.scoreStyle('  Belgian Tripel ', 'belgian tripel')).toBe(
-        100,
-      );
-    });
-
-    it('happy: same-family substring containment scores 70', () => {
-      expect(service.scoreStyle('IPA', 'Session IPA')).toBe(70);
-      expect(service.scoreStyle('Imperial Stout', 'Stout')).toBe(70);
-    });
-
-    it('sad: unrelated styles score 0', () => {
-      expect(service.scoreStyle('IPA', 'Belgian Tripel')).toBe(0);
-      expect(service.scoreStyle('Pilsner', 'Imperial Stout')).toBe(0);
-    });
-
-    it('edge: null / undefined / empty either side scores 0', () => {
-      expect(service.scoreStyle(null, 'IPA')).toBe(0);
-      expect(service.scoreStyle('IPA', undefined)).toBe(0);
-      expect(service.scoreStyle('', 'IPA')).toBe(0);
-      expect(service.scoreStyle('   ', 'IPA')).toBe(0);
-    });
-  });
-
-  // ---------------------------------------------------------------
-  // scoreAbv
+  // scoreAbv (local similarity, unchanged)
   // ---------------------------------------------------------------
   describe('scoreAbv', () => {
     it('happy: zero gap scores 100', () => {
@@ -118,42 +96,60 @@ describe('RecipeMatchingService (Issue #699)', () => {
   });
 
   // ---------------------------------------------------------------
-  // scoreQuality
+  // scoreBitterness (local similarity, unchanged)
   // ---------------------------------------------------------------
-  describe('scoreQuality', () => {
-    it('happy: 5.0 maps to 100, 1.0 to 20, 3.0 to 60', () => {
-      expect(service.scoreQuality(5)).toBe(100);
-      expect(service.scoreQuality(1)).toBe(20);
-      expect(service.scoreQuality(3)).toBe(60);
+  describe('scoreBitterness', () => {
+    it('happy: same band scores 100', () => {
+      expect(service.scoreBitterness(30, 35)).toBe(100);
     });
 
-    it('sad: null avg_rating scores 0 (do not crowd out rated peers)', () => {
-      expect(service.scoreQuality(null)).toBe(0);
-      expect(service.scoreQuality(undefined)).toBe(0);
+    it('happy: neighbouring band scores 60', () => {
+      expect(service.scoreBitterness(15, 25)).toBe(60);
     });
 
-    it('edge: out-of-range ratings clamp safely', () => {
-      // Ratings outside 1..5 are not expected from the schema
-      // (numeric(3,2) avg) but the helper must not crash.
-      expect(service.scoreQuality(0.5)).toBe(20);
-      expect(service.scoreQuality(7)).toBe(100);
+    it('sad: two-or-more bands apart scores 0', () => {
+      expect(service.scoreBitterness(10, 70)).toBe(0);
+    });
+
+    it('edge: missing values score 0', () => {
+      expect(service.scoreBitterness(null, 30)).toBe(0);
+      expect(service.scoreBitterness(30, undefined)).toBe(0);
     });
   });
 
   // ---------------------------------------------------------------
-  // computeFinalScore
+  // scoreColor (local similarity, unchanged)
   // ---------------------------------------------------------------
-  describe('computeFinalScore', () => {
+  describe('scoreColor', () => {
+    it('happy: same EBC band scores 100', () => {
+      expect(service.scoreColor(18, 25)).toBe(100);
+    });
+
+    it('happy: neighbouring band scores 60', () => {
+      expect(service.scoreColor(6, 12)).toBe(60);
+    });
+
+    it('sad: pale vs noir is two-bands-apart-or-more, scores 0', () => {
+      expect(service.scoreColor(4, 80)).toBe(0);
+    });
+
+    it('edge: missing values score 0', () => {
+      expect(service.scoreColor(null, 18)).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // computeFinalScore — match strength = similarity only (no quality blend)
+  // ---------------------------------------------------------------
+  describe('computeFinalScore (match strength)', () => {
     let beer: ScanCatalogItemOrmEntity;
     beforeEach(() => {
       beer = makeBeer({ style: 'IPA', abv: 5.5 });
     });
 
-    it('happy: blended score = similarity*0.7 + quality*0.3 with renormalization', () => {
-      // Style 100 + ABV 100, bitterness/color null → similarity renorm
-      // = (100*50 + 100*25)/75 = 100. avg_rating 5 → quality 100,
-      // brew_count/recency null → quality renorm = 100. Final =
-      // 100*0.7 + 100*0.3 = 100.
+    it('happy: weighted similarity with renorm — exact style + exact ABV = 100', () => {
+      // style 1.0 → 100 (weight 40), ABV 100 (weight 14), IBU/colour absent.
+      // matchStrength = (40·100 + 14·100) / 54 = 100. No quality term.
       const recipe = makeRecipe({
         style: 'IPA',
         abv_estimated: 5.5,
@@ -162,39 +158,51 @@ describe('RecipeMatchingService (Issue #699)', () => {
       expect(service.computeFinalScore(beer, recipe)).toBe(100);
     });
 
-    it('happy: a style-compatible official gets the shortcut (similarity=100)', () => {
-      // Same style → style-compatible → shortcut. Null quality → 70.
+    it('happy: a same-style official gets the shortcut (matchStrength = 100, no quality)', () => {
       const official = makeRecipe({
         style: 'IPA',
         abv_estimated: null,
         avg_rating: null,
         is_official: true,
       });
-      expect(service.computeFinalScore(beer, official)).toBeCloseTo(70, 5);
+      expect(service.computeFinalScore(beer, official)).toBe(100);
     });
 
-    it('#1193: an off-style official does NOT get the shortcut and cannot outrank a genuine style match', () => {
-      // Pilsner official for an IPA beer → style score 0 → not
-      // style-compatible → no shortcut → ranked on its honest (low)
-      // similarity, so a same-style non-official scores higher.
-      const offStyleOfficial = makeRecipe({
-        style: 'Pilsner',
+    it('happy: a same-FAMILY official also gets the shortcut (≥ 0.7)', () => {
+      const pilsnerBeer = makeBeer({ style: 'Pilsner', abv: 5 });
+      // Lager is a different canonical but the same Pale Lager family → 0.7.
+      const lagerOfficial = makeRecipe({
+        style: 'Lager',
         abv_estimated: null,
         avg_rating: null,
         is_official: true,
       });
-      const sameStyleNonOfficial = makeRecipe({
-        style: 'IPA',
-        abv_estimated: 5.5,
-        avg_rating: 4,
-      });
+      expect(service.computeFinalScore(pilsnerBeer, lagerOfficial)).toBe(100);
+    });
 
-      expect(service.computeFinalScore(beer, offStyleOfficial)).toBeLessThan(
-        service.computeFinalScore(beer, sameStyleNonOfficial),
+    it('#1193: a same-tier-only official (IPA for a Blonde) does NOT get the shortcut', () => {
+      const blondeBeer = makeBeer({ style: 'Blonde Ale', abv: 5 });
+      // IPA vs Blonde Ale: different family, both pale+standard → 0.4 (< 0.7).
+      const offFamilyOfficial = makeRecipe({
+        style: 'American IPA',
+        abv_estimated: 5.5,
+        avg_rating: null,
+        is_official: true,
+      });
+      // Same-family non-official (Saison ≈ Blonde, both Pale Ale → 0.7).
+      const sameFamilyNonOfficial = makeRecipe({
+        style: 'Saison',
+        abv_estimated: 5,
+        avg_rating: null,
+      });
+      expect(
+        service.computeFinalScore(blondeBeer, offFamilyOfficial),
+      ).toBeLessThan(
+        service.computeFinalScore(blondeBeer, sameFamilyNonOfficial),
       );
     });
 
-    it('edge: a recipe with no style nor ABV nor rating still scores deterministically (0)', () => {
+    it('edge: a recipe with no comparable criterion scores 0', () => {
       const empty = makeRecipe({
         style: null,
         abv_estimated: null,
@@ -205,10 +213,102 @@ describe('RecipeMatchingService (Issue #699)', () => {
   });
 
   // ---------------------------------------------------------------
+  // computeSimilarity (Gower renormalization)
+  // ---------------------------------------------------------------
+  describe('computeSimilarity (renormalization)', () => {
+    it('renormalizes when IBU and colour are missing — style + ABV split the present weight', () => {
+      const beer = makeBeer({ style: 'IPA', abv: 5.5 });
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: null,
+      });
+      // style 100 (w40) + ABV 100 (w14), IBU/colour null → (4000 + 1400)/54 = 100.
+      expect(service.computeSimilarity(beer, recipe)).toBe(100);
+    });
+
+    it('returns 0 when every similarity component is missing', () => {
+      const beer = makeBeer({ style: '', abv: null });
+      const recipe = makeRecipe({
+        style: null,
+        abv_estimated: null,
+        avg_rating: null,
+      });
+      expect(service.computeSimilarity(beer, recipe)).toBe(0);
+    });
+
+    it('treats a whitespace-only style as absent (renormalised, not a 0 penalty)', () => {
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: 4,
+      });
+      const whitespace = service.computeSimilarity(
+        { style: '  ', abv: 5.5 },
+        recipe,
+      );
+      const absent = service.computeSimilarity(
+        { style: null, abv: 5.5 },
+        recipe,
+      );
+      expect(whitespace).toBe(absent);
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // computeCompleteness (ADR-0016 D4)
+  // ---------------------------------------------------------------
+  describe('computeCompleteness', () => {
+    it('happy: style + ABV present → 0.54 (of the full 100)', () => {
+      const beer = makeBeer({ style: 'IPA', abv: 5.5 });
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5.5,
+        avg_rating: null,
+      });
+      expect(service.computeCompleteness(beer, recipe)).toBeCloseTo(0.54, 5);
+    });
+
+    it('edge: style only → 0.40 (below C_min, so such a match is filtered)', () => {
+      const beer = makeBeer({ style: 'IPA', abv: null });
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: null,
+        avg_rating: null,
+      });
+      expect(service.computeCompleteness(beer, recipe)).toBeCloseTo(0.4, 5);
+    });
+
+    it('edge: all four criteria present → caps at 0.94 (ingredients weight 6 not compared)', () => {
+      const beer = makeBeer({ style: 'IPA', abv: 5 });
+      beer.ibu = 30;
+      beer.color_ebc = 10;
+      const recipe = makeRecipe({
+        style: 'IPA',
+        abv_estimated: 5,
+        avg_rating: null,
+      });
+      recipe.ibu_target = 30;
+      recipe.ebc_target = 10;
+      expect(service.computeCompleteness(beer, recipe)).toBeCloseTo(0.94, 5);
+    });
+
+    it('edge: no comparable criterion → 0', () => {
+      const beer = makeBeer({ style: '', abv: null });
+      const recipe = makeRecipe({
+        style: null,
+        abv_estimated: null,
+        avg_rating: null,
+      });
+      expect(service.computeCompleteness(beer, recipe)).toBe(0);
+    });
+  });
+
+  // ---------------------------------------------------------------
   // rankForBeer (integration with the in-memory DB)
   // ---------------------------------------------------------------
   describe('rankForBeer (integration)', () => {
-    it('happy: top-3 ordering for an IPA-shaped beer puts the closest IPA on top', async () => {
+    it('happy: keeps the same-style IPAs and orders them, drops the off-family styles (D5)', async () => {
       const beerId = await seedBeer(catalogRepo, {
         style: 'Session IPA',
         abv: 4.5,
@@ -242,38 +342,39 @@ describe('RecipeMatchingService (Issue #699)', () => {
 
       const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
 
-      expect(rankings).toHaveLength(3);
-      expect(rankings[0].recipe.name).toBe('Session IPA Citra');
-      // Scores must be strictly decreasing.
+      // Only the two IPAs (same canonical → style 100) clear S_min; the Tripel
+      // and Stout score 0 on style and ABV → filtered.
+      expect(rankings.map((r) => r.recipe.name)).toEqual([
+        'Session IPA Citra',
+        'NEIPA',
+      ]);
       expect(rankings[0].score).toBeGreaterThan(rankings[1].score);
-      expect(rankings[1].score).toBeGreaterThanOrEqual(rankings[2].score);
+      expect(rankings[0].completeness).toBeCloseTo(0.54, 5);
       expect(low_confidence).toBe(false);
     });
 
-    it('happy: a style-compatible official beats non-official peers (#1193)', async () => {
+    it('happy: a style-compatible official beats non-official peers and scores 100 (#1193 / D6)', async () => {
       const beerId = await seedBeer(catalogRepo, {
         style: 'Pilsner',
         abv: 5,
       });
       await seedRecipe(recipeRepo, {
         name: 'Random NEIPA',
-        style: 'NEIPA', // off the beer style
+        style: 'NEIPA', // different family, same pale+standard tier → 0.4
         abv_estimated: 6.5,
         avg_rating: 5,
       });
       await seedRecipe(recipeRepo, {
         name: 'Brewer-Endorsed Pilsner',
-        style: 'Pilsner', // same style → shortcut applies
-        abv_estimated: 9, // ABV off, but the style gate is satisfied
-        avg_rating: null, // no rating
+        style: 'Pilsner', // same canonical → shortcut applies
+        abv_estimated: 9,
+        avg_rating: null,
         is_official: true,
       });
 
       const { rankings } = await service.rankForBeer(beerId, 3);
       expect(rankings[0].recipe.name).toBe('Brewer-Endorsed Pilsner');
-      // Style-compatible → similarity = 100 (shortcut), quality = 0 (no
-      // avg_rating, no brew_count, no recency). Final = 100*0.7 = 70.
-      expect(rankings[0].score).toBeCloseTo(70, 5);
+      expect(rankings[0].score).toBe(100);
     });
 
     it('sad: unknown beerId throws NotFoundException', async () => {
@@ -306,16 +407,7 @@ describe('RecipeMatchingService (Issue #699)', () => {
     });
 
     it('edge: equal scores resolve deterministically by avg_rating desc then id asc', async () => {
-      // Codex P2 on PR #773 — without explicit tie-breakers the
-      // ranking falls back to the DB return order, which is not
-      // guaranteed. The contract: same scores → higher avg_rating
-      // wins ; same rating → lexicographically smaller id wins.
-      const beerId = await seedBeer(catalogRepo, {
-        style: 'IPA',
-        abv: 5,
-      });
-      // Three recipes that score identically on similarity (style
-      // exact, ABV exact). Differentiate only via avg_rating + id.
+      const beerId = await seedBeer(catalogRepo, { style: 'IPA', abv: 5 });
       await seedRecipeWithId(
         recipeRepo,
         '00000000-0000-4000-8000-aaaaaaaaaaaa',
@@ -349,18 +441,14 @@ describe('RecipeMatchingService (Issue #699)', () => {
 
       const { rankings } = await service.rankForBeer(beerId, 3);
       expect(rankings.map((r) => r.recipe.name)).toEqual([
-        'A-high-rating', // 5★ rating, smaller id (bbbb…)
-        'A-high-rating-tie', // 5★ rating, larger id (cccc…)
-        'Z-low-rating', // 3★ rating
+        'A-high-rating', // 5★, smaller id (bbbb…)
+        'A-high-rating-tie', // 5★, larger id (cccc…)
+        'Z-low-rating', // 3★
       ]);
     });
 
     it('edge: caps the limit at 10 even if a larger value is requested', async () => {
-      const beerId = await seedBeer(catalogRepo, {
-        style: 'IPA',
-        abv: 5,
-      });
-      // Seed 12 distinct PUBLIC recipes.
+      const beerId = await seedBeer(catalogRepo, { style: 'IPA', abv: 5 });
       for (let i = 0; i < 12; i += 1) {
         await seedRecipe(recipeRepo, {
           name: `Recipe ${i}`,
@@ -369,22 +457,20 @@ describe('RecipeMatchingService (Issue #699)', () => {
           avg_rating: 4,
         });
       }
-
       const { rankings } = await service.rankForBeer(beerId, 100);
       expect(rankings.length).toBe(10);
     });
 
     // ----------------------------------------------------------------
-    // low_confidence flag (Issue #699 brainstorm §3.4 — full algo)
+    // Acceptance threshold (ADR-0016 D5) → honest empty state
     // ----------------------------------------------------------------
 
-    it('low_confidence: true when the best match scores below 40', async () => {
-      // Beer style + ABV totally off the recipes' style + ABV.
+    it('D5: nothing passes → empty rankings + low_confidence true (no misleading closest match)', async () => {
       const beerId = await seedBeer(catalogRepo, {
         style: 'Pilsner',
         abv: 4.5,
       });
-      // Single recipe far from the beer on every criterion.
+      // Off family AND off ABV → style 0, ABV 0 → matchStrength 0 < S_min.
       await seedRecipe(recipeRepo, {
         name: 'Imperial Stout',
         style: 'Imperial Stout',
@@ -393,16 +479,11 @@ describe('RecipeMatchingService (Issue #699)', () => {
       });
 
       const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
-      expect(rankings).toHaveLength(1);
-      expect(rankings[0].score).toBeLessThan(40);
+      expect(rankings).toHaveLength(0);
       expect(low_confidence).toBe(true);
     });
 
-    it('low_confidence: an off-style official is not inflated by the shortcut and the warning fires (#1193 supersedes #792)', async () => {
-      // Since #1193 the official shortcut applies only to a
-      // style-compatible official. An off-style official no longer
-      // inflates its headline to 70 — it is ranked on its honest (low)
-      // similarity — and the low_confidence warning still fires.
+    it('D5: an off-style official is not promoted and is filtered out too', async () => {
       const beerId = await seedBeer(catalogRepo, {
         style: 'Pilsner',
         abv: 4.5,
@@ -416,18 +497,15 @@ describe('RecipeMatchingService (Issue #699)', () => {
       });
 
       const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
-      // No shortcut for an off-style official → honest (low) headline.
-      expect(rankings[0].score).toBeLessThan(40);
+      expect(rankings).toHaveLength(0);
       expect(low_confidence).toBe(true);
     });
 
-    it('low_confidence: false when the best match scores 40 or above', async () => {
+    it('D5: a strong same-style match passes → low_confidence false', async () => {
       const beerId = await seedBeer(catalogRepo, {
         style: 'IPA',
         abv: 5.5,
       });
-      // Style exact match → similarity ≥ 50 component-wise → final ≥
-      // 35 just from style alone, plus ABV boost → final clearly > 40.
       await seedRecipe(recipeRepo, {
         name: 'Spot-on IPA',
         style: 'IPA',
@@ -436,172 +514,26 @@ describe('RecipeMatchingService (Issue #699)', () => {
       });
 
       const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
-      expect(rankings[0].score).toBeGreaterThanOrEqual(40);
+      expect(rankings).toHaveLength(1);
+      expect(rankings[0].score).toBeGreaterThanOrEqual(45);
       expect(low_confidence).toBe(false);
     });
-  });
 
-  // ------------------------------------------------------------------
-  // Bitterness (full algo extension)
-  // ------------------------------------------------------------------
-  describe('scoreBitterness', () => {
-    it('happy: same band scores 100', () => {
-      // 30 IBU and 35 IBU both fall in the marked band (20-40).
-      expect(service.scoreBitterness(30, 35)).toBe(100);
-    });
-
-    it('happy: neighbouring band scores 60', () => {
-      // 15 IBU = soft (band 0), 25 IBU = marked (band 1) → distance 1.
-      expect(service.scoreBitterness(15, 25)).toBe(60);
-    });
-
-    it('sad: two-or-more bands apart scores 0', () => {
-      // 10 IBU = soft (band 0), 70 IBU = intense (band 3) → distance 3.
-      expect(service.scoreBitterness(10, 70)).toBe(0);
-    });
-
-    it('edge: missing values score 0', () => {
-      expect(service.scoreBitterness(null, 30)).toBe(0);
-      expect(service.scoreBitterness(30, undefined)).toBe(0);
-    });
-  });
-
-  // ------------------------------------------------------------------
-  // Color (full algo extension)
-  // ------------------------------------------------------------------
-  describe('scoreColor', () => {
-    it('happy: same EBC band scores 100', () => {
-      // 18 EBC and 25 EBC both ambré (16-30).
-      expect(service.scoreColor(18, 25)).toBe(100);
-    });
-
-    it('happy: neighbouring band scores 60', () => {
-      // 6 EBC = pale (0), 12 EBC = doré (1) → distance 1.
-      expect(service.scoreColor(6, 12)).toBe(60);
-    });
-
-    it('sad: pale vs noir is two-bands-apart-or-more, scores 0', () => {
-      // 4 EBC = pale (0), 80 EBC = noir (4) → distance 4.
-      expect(service.scoreColor(4, 80)).toBe(0);
-    });
-
-    it('edge: missing values score 0', () => {
-      expect(service.scoreColor(null, 18)).toBe(0);
-    });
-  });
-
-  // ------------------------------------------------------------------
-  // Brew count confidence (full algo extension)
-  // ------------------------------------------------------------------
-  describe('scoreBrewCount', () => {
-    it('happy: monotonic anchors — 0→0, 1→30, 5→60, 20→80, 100→95, 500+→100', () => {
-      expect(service.scoreBrewCount(0)).toBe(0);
-      expect(service.scoreBrewCount(1)).toBe(30);
-      expect(service.scoreBrewCount(5)).toBe(60);
-      expect(service.scoreBrewCount(20)).toBe(80);
-      expect(service.scoreBrewCount(100)).toBe(95);
-      expect(service.scoreBrewCount(500)).toBe(100);
-      expect(service.scoreBrewCount(10000)).toBe(100);
-    });
-
-    it('happy: linear interpolation between anchors', () => {
-      // 3 brews → between 1 (30) and 5 (60), at 50% → 45.
-      expect(service.scoreBrewCount(3)).toBe(45);
-    });
-
-    it('edge: null / negative returns 0', () => {
-      expect(service.scoreBrewCount(null)).toBe(0);
-      expect(service.scoreBrewCount(-3)).toBe(0);
-    });
-  });
-
-  // ------------------------------------------------------------------
-  // Recency decay (full algo extension)
-  // ------------------------------------------------------------------
-  describe('scoreRecency', () => {
-    const daysAgo = (n: number): Date => {
-      const d = new Date();
-      d.setDate(d.getDate() - n);
-      return d;
-    };
-
-    it('happy: <30 days → 100', () => {
-      expect(service.scoreRecency(daysAgo(10))).toBe(100);
-    });
-
-    it('happy: 30-90 days → 80', () => {
-      expect(service.scoreRecency(daysAgo(60))).toBe(80);
-    });
-
-    it('happy: 90-365 days → 60', () => {
-      expect(service.scoreRecency(daysAgo(200))).toBe(60);
-    });
-
-    it('happy: 1-2 years → 40', () => {
-      expect(service.scoreRecency(daysAgo(500))).toBe(40);
-    });
-
-    it('happy: 2+ years → 20', () => {
-      expect(service.scoreRecency(daysAgo(1000))).toBe(20);
-    });
-
-    it('edge: null returns 0', () => {
-      expect(service.scoreRecency(null)).toBe(0);
-    });
-
-    it('edge: invalid date string returns 0', () => {
-      expect(service.scoreRecency('not-a-date')).toBe(0);
-    });
-  });
-
-  // ------------------------------------------------------------------
-  // Similarity / Quality renormalization (full algo extension)
-  // ------------------------------------------------------------------
-  describe('computeSimilarity (renormalization)', () => {
-    it('renormalizes when bitterness and color are missing — style + ABV split the full 100', () => {
-      const beer = makeBeer({ style: 'IPA', abv: 5.5 });
-      // Recipe with only style + ABV present (no IBU, no EBC).
-      const recipe = makeRecipe({
+    it('D5: a style-only beer (completeness 0.40 < C_min) is filtered even on an exact style', async () => {
+      const beerId = await seedBeer(catalogRepo, {
         style: 'IPA',
-        abv_estimated: 5.5,
-        avg_rating: null,
+        abv: null,
       });
-      // Style 100 weighted 50, ABV 100 weighted 25, others null.
-      // Renorm: (100*50 + 100*25) / (50+25) = 100.
-      expect(service.computeSimilarity(beer, recipe)).toBe(100);
-    });
-
-    it('returns 0 when every similarity component is missing', () => {
-      const beer = makeBeer({ style: '', abv: null });
-      const recipe = makeRecipe({
-        style: null,
+      await seedRecipe(recipeRepo, {
+        name: 'Exact-style but ABV unknown',
+        style: 'IPA',
         abv_estimated: null,
-        avg_rating: null,
+        avg_rating: 4,
       });
-      expect(service.computeSimilarity(beer, recipe)).toBe(0);
-    });
-  });
 
-  describe('computeQuality (renormalization)', () => {
-    it('renormalizes when brew_count and recency are missing — avg_rating gets full weight', () => {
-      const recipe = makeRecipe({
-        style: 'IPA',
-        abv_estimated: 5.5,
-        avg_rating: 5,
-      });
-      // brew_count = 0 (default in helper), last_brewed_at = null → both
-      // dropped via maybe* → only avg_rating remains, renorm to 100%.
-      // avg_rating 5 → score 100.
-      expect(service.computeQuality(recipe)).toBe(100);
-    });
-
-    it('returns 0 when every quality component is missing', () => {
-      const recipe = makeRecipe({
-        style: 'IPA',
-        abv_estimated: 5.5,
-        avg_rating: null,
-      });
-      expect(service.computeQuality(recipe)).toBe(0);
+      const { rankings, low_confidence } = await service.rankForBeer(beerId, 3);
+      expect(rankings).toHaveLength(0);
+      expect(low_confidence).toBe(true);
     });
   });
 
@@ -634,7 +566,7 @@ describe('RecipeMatchingService (Issue #699)', () => {
       expect(low_confidence).toBe(false);
     });
 
-    it('edge: still ranks (renormalised) when only a style is provided', async () => {
+    it('D5: a style-only query is filtered (completeness 0.40 < C_min) → empty + low confidence', async () => {
       await seedRecipe(recipeRepo, {
         name: 'IPA',
         style: 'IPA',
@@ -642,16 +574,16 @@ describe('RecipeMatchingService (Issue #699)', () => {
         avg_rating: 4.5,
       });
 
-      const { rankings } = await service.rankByCharacteristics(
+      const { rankings, low_confidence } = await service.rankByCharacteristics(
         { style: 'IPA' },
         3,
       );
 
-      expect(rankings).toHaveLength(1);
-      expect(rankings[0].recipe.name).toBe('IPA');
+      expect(rankings).toHaveLength(0);
+      expect(low_confidence).toBe(true);
     });
 
-    it('edge: empty characteristics still returns the candidates, flagged low confidence', async () => {
+    it('edge: empty characteristics → nothing comparable → empty + low confidence', async () => {
       await seedRecipe(recipeRepo, {
         name: 'Whatever',
         style: 'IPA',
@@ -664,7 +596,7 @@ describe('RecipeMatchingService (Issue #699)', () => {
         3,
       );
 
-      expect(rankings).toHaveLength(1);
+      expect(rankings).toHaveLength(0);
       expect(low_confidence).toBe(true);
     });
 
@@ -696,37 +628,18 @@ describe('RecipeMatchingService (Issue #699)', () => {
       );
     });
 
-    it('treats a whitespace-only style as absent (renormalised, not a 0 penalty)', () => {
-      const recipe = makeRecipe({
-        style: 'IPA',
-        abv_estimated: 5.5,
-        avg_rating: 4,
-      });
-
-      const whitespace = service.computeSimilarity(
-        { style: '  ', abv: 5.5 },
-        recipe,
-      );
-      const absent = service.computeSimilarity(
-        { style: null, abv: 5.5 },
-        recipe,
-      );
-
-      expect(whitespace).toBe(absent);
-    });
-
-    it('#1193: a blonde beer ranks a same-style recipe above an off-style official (the Leffe case)', async () => {
+    it('#1193 (the Leffe case): a blonde beer ranks the genuine blonde above an off-family IPA official', async () => {
       await Promise.all([
         seedRecipe(recipeRepo, {
           name: 'Punk IPA (official)',
-          style: 'American IPA',
+          style: 'American IPA', // IPA family — same tier as Blonde, not promoted
           abv_estimated: 5.4,
           avg_rating: 4.9,
           is_official: true,
         }),
         seedRecipe(recipeRepo, {
           name: 'Belgian Blonde',
-          style: 'Blonde Ale',
+          style: 'Blonde Ale', // exact family → genuine match
           abv_estimated: 6.5,
           avg_rating: 4.2,
         }),

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -60,8 +60,10 @@ export interface BeerCharacteristics {
  *   shows an honest "no reliable equivalent" state).
  *
  * The official-recipe shortcut stays style-gated (#1193 / D6): `is_official`
- * AND a positive style local-similarity → matchStrength 100; an off-style
- * official is ranked on its honest similarity instead and does not bypass D5.
+ * AND a **same-family-or-better** style local-similarity (≥ 70 = 0.7) →
+ * matchStrength 100. A mere same-tier (0.4) or off-style official is ranked on
+ * its honest similarity instead and does not bypass D5 — so an IPA never
+ * floats to the top for a Blonde Ale.
  *
  * Local-similarity scales (0..100):
  * - style — graded by BJCP family (`./bjcp-style-family`): same style 100,
@@ -175,7 +177,13 @@ export class RecipeMatchingService {
     recipe: RecipeOrmEntity,
   ): number {
     const styleScore = this.maybeStyleScore(beer.style, recipe.style);
-    const styleCompatible = styleScore !== null && styleScore > 0;
+    // "Style-compatible" for the official shortcut means **same BJCP family or
+    // better** (local similarity ≥ 70 = 0.7), NOT merely the same colour/strength
+    // tier (0.4). With v2's graded families a 0.4 tier match (e.g. an IPA for a
+    // Blonde — both pale/standard) would otherwise re-promote an off-family
+    // official to the top, reintroducing the exact Leffe-Blonde → Punk-IPA bug
+    // #1193 fixed. So the gate is ≥ same family (ADR-0016 D6, refined).
+    const styleCompatible = styleScore !== null && styleScore >= 70;
     if (recipe.is_official && styleCompatible) {
       return 100;
     }

--- a/packages/api/src/recipe/services/recipe-matching.service.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.ts
@@ -9,6 +9,11 @@ import {
   RankedRecipeDto,
   RankedRecipeResponseDto,
 } from '../dtos/ranked-recipe.dto';
+import { styleSimilarity } from './bjcp-style-family';
+import {
+  SCAN_MATCH_C_MIN,
+  SCAN_MATCH_S_MIN,
+} from './recipe-matching.constants';
 
 /**
  * The beer characteristics the matcher scores against — style, ABV,
@@ -26,45 +31,45 @@ export interface BeerCharacteristics {
 }
 
 /**
- * Score-based recipe matching — full brainstorm scan-2026-04-24 §3
- * formula. Extends the minimal-viable scope shipped in PR #773 with
- * the four remaining components, weight renormalization when a
- * criterion is missing, and the `low_confidence` flag on the
- * response.
+ * Score-based recipe matching — **v2** per ADR-0016
+ * (docs/architecture/diagrams/recipes/06-sequence-recipe-matching.md).
  *
- *   SIMILARITY (70%) = official ? 100 :
- *                      style × 50 + ABV × 25 + bitterness × 15 + color × 10
- *                      (weights renormalized if a criterion is missing)
+ * The headline score is the **match strength**: a weighted, completeness-aware
+ * SIMILARITY only. Community quality (rating) is no longer blended into the
+ * score — `avg_rating` is now purely a tie-break (ADR-0016 ranks on similarity,
+ * rating departages equal matches).
  *
- *   QUALITY    (30%) = avg_rating × 60 + brew_count_confidence × 30 + recency × 10
- *                      (weights renormalized if a criterion is missing)
+ *   matchStrength = official&style-compatible ? 100 :
+ *                   Σ[weight × localSim] / Σ[weight] over present criteria
+ *                   (Gower renormalisation — a missing criterion drops from
+ *                    BOTH numerator and denominator, never a 0 penalty)
  *
- *   FINAL            = similarity × 0.7 + quality × 0.3
+ *   Full-data weights (ADR-0016 D1):
+ *     style 40, colour 22, bitterness 18, ABV 14   (ingredients 6 deferred)
  *
- *   low_confidence   = true when the best match scores below 40
- *                      (response envelope flag, lets the UI display
- *                      a discreet "no very similar recipe" warning).
+ *   completeness  = Σ[present weight] / 100         (ADR-0016 D4)
+ *                   a separate confidence signal — how much of the full picture
+ *                   the comparison used. Caps at 0.94 until ingredients (6) are
+ *                   compared.
  *
- * The official-recipe shortcut applies **only to a style-compatible
- * official** (`is_official=true` AND a positive style sub-score) →
- * similarity 100; an off-style official is ranked on its honest
- * similarity instead (#1193). Quality still varies.
+ *   Acceptance (ADR-0016 D5): a candidate is shown only when
+ *     matchStrength ≥ SCAN_MATCH_S_MIN AND completeness ≥ SCAN_MATCH_C_MIN.
+ *   The filter runs over ALL scored candidates BEFORE the top-N truncation, so
+ *   a reliable match ranked just below an unreliable one is never hidden.
+ *   `low_confidence` is `true` when nothing passes (empty rankings → the mobile
+ *   shows an honest "no reliable equivalent" state).
  *
- * Sub-score scales (0..100):
- * - style — exact match 100, family containment 70, else 0
+ * The official-recipe shortcut stays style-gated (#1193 / D6): `is_official`
+ * AND a positive style local-similarity → matchStrength 100; an off-style
+ * official is ranked on its honest similarity instead and does not bypass D5.
+ *
+ * Local-similarity scales (0..100):
+ * - style — graded by BJCP family (`./bjcp-style-family`): same style 100,
+ *   same family 70, same colour+strength tier 40, else 0 (null when either side
+ *   is unclassifiable → dropped).
  * - ABV — linear `max(0, 100 - 25 × |gap|)` so 0% gap → 100, 4%+ → 0
- * - bitterness — categorical match on soft / marked / very marked
- *   bands derived from the docs/product/vocab-mapping.md table
- * - color — categorical match on pale / amber / brown / black bands
- *   from the same vocab mapping (EBC scale)
- * - avg_rating — linear `((rating - 1) / 4) × 80 + 20` so 1.0 → 20,
- *   5.0 → 100 ; null → 0 (do not crowd out rated peers)
- * - brew_count_confidence — logarithmic: 0 → 0, 1 → 30, 5 → 60,
- *   20 → 80, 100 → 95, 500+ → 100. Prevents a recent excellent
- *   recipe from being unfairly downgraded versus old recipes with
- *   many brews.
- * - recency — decay from `last_brewed_at`: <30d → 100, <90d → 80,
- *   <1yr → 60, <2yr → 40, 2yr+ → 20, null → 0.
+ * - bitterness — categorical match on the IBU bands from vocab-mapping
+ * - colour — categorical match on the EBC bands from vocab-mapping
  */
 @Injectable()
 export class RecipeMatchingService {
@@ -74,6 +79,13 @@ export class RecipeMatchingService {
     @InjectRepository(ScanCatalogItemOrmEntity)
     private readonly catalogRepo: Repository<ScanCatalogItemOrmEntity>,
   ) {}
+
+  /**
+   * Full weight of all five ADR-0016 criteria (style 40 + colour 22 + IBU 18 +
+   * ABV 14 + ingredients 6). The completeness denominator; ingredients are not
+   * compared yet, so completeness currently caps at 94/100.
+   */
+  private static readonly TOTAL_CRITERIA_WEIGHT = 100;
 
   async rankForBeer(
     beerCatalogItemId: string,
@@ -111,16 +123,24 @@ export class RecipeMatchingService {
       (recipe): RankedRecipeDto => ({
         recipe,
         score: this.computeFinalScore(beer, recipe),
+        completeness: this.computeCompleteness(beer, recipe),
       }),
     );
 
-    // Deterministic ordering: primary on score desc, secondary on
-    // avg_rating desc (a higher-rated peer wins ties), tertiary on
-    // recipe id ascending (lexicographic, stable across DBs and
-    // restarts). Without these tie-breakers the ranking falls back
-    // on the DB return order which is not guaranteed — Codex P2 on
-    // PR #773.
-    scored.sort((a, b) => {
+    // ADR-0016 D5: filter the FULL scored set BEFORE truncating to top-N, so a
+    // reliable match ranked just below a high-strength-but-low-completeness
+    // candidate is never hidden by the cut. A candidate is shown only when its
+    // match strength AND its completeness both clear the thresholds.
+    const accepted = scored.filter(
+      (s) => s.score >= SCAN_MATCH_S_MIN && s.completeness >= SCAN_MATCH_C_MIN,
+    );
+
+    // Deterministic ordering: match strength desc, then avg_rating desc (a
+    // higher-rated peer wins ties — rating is a tie-break only since v2,
+    // ADR-0016), then recipe id ascending (lexicographic, stable across DBs and
+    // restarts; without it the ranking falls back on the DB return order which
+    // is not guaranteed — Codex P2 on PR #773).
+    accepted.sort((a, b) => {
       if (b.score !== a.score) return b.score - a.score;
       const ratingDelta =
         (b.recipe.avg_rating ?? 0) - (a.recipe.avg_rating ?? 0);
@@ -128,26 +148,12 @@ export class RecipeMatchingService {
       return a.recipe.id.localeCompare(b.recipe.id);
     });
 
-    const top = scored.slice(0, Math.max(1, Math.min(limit, 10)));
+    const top = accepted.slice(0, Math.max(1, Math.min(limit, 10)));
 
-    // `low_confidence` reflects whether the best match is genuinely
-    // similar to the scanned beer — NOT the headline score after the
-    // official shortcut. Since #1193 the shortcut is style-gated, so an
-    // off-style official is no longer inflated to the top; but a
-    // style-compatible official still scores 100 on similarity, which on
-    // its own (style match, ABV/quality unknown) can sit above the 40
-    // threshold while not being a strong overall match. So we still
-    // compute the "honest" score (similarity WITHOUT the shortcut +
-    // quality) on the top recipe and use THAT for the threshold check
-    // (the original Codex P1 on PR #792), keeping the warning truthful.
-    let honestTopScore = 0;
-    if (top.length > 0) {
-      const best = top[0].recipe;
-      const honestSimilarity = this.computeSimilarity(beer, best);
-      const honestQuality = this.computeQuality(best);
-      honestTopScore = honestSimilarity * 0.7 + honestQuality * 0.3;
-    }
-    const lowConfidence = top.length === 0 || honestTopScore < 40;
+    // `low_confidence` is true when nothing cleared the acceptance thresholds —
+    // the mobile renders an honest "no reliable equivalent" empty state rather
+    // than a misleading closest match (ADR-0016 D5).
+    const lowConfidence = top.length === 0;
 
     return {
       rankings: top,
@@ -156,18 +162,13 @@ export class RecipeMatchingService {
   }
 
   /**
-   * Final score for a single recipe against a beer. Range 0..100.
-   * Combines similarity (70%) and quality (30%), each computed with
-   * weight renormalization if a sub-criterion is missing.
-   *
-   * The official-recipe shortcut (similarity = 100) applies **only when
-   * the official is style-compatible** with the scanned beer — i.e. the
-   * style sub-score is positive (exact or same-family). An off-style
-   * official (e.g. an IPA for a Leffe Blonde) no longer floats above a
-   * genuine style match; it is ranked on its honest similarity instead,
-   * so a same-style non-official can outrank it (#1193). Quality still
-   * varies, so two style-compatible officials are ordered by their
-   * rating/brew_count/recency.
+   * Match strength for a single recipe against a beer (0..100) = SIMILARITY
+   * only (ADR-0016). The style-gated official shortcut (#1193 / D6) returns 100
+   * for a style-compatible official (`is_official` AND a positive style
+   * sub-score); an off-style official is ranked on its honest similarity
+   * instead, so a same-style non-official can outrank it. Community quality is
+   * NOT blended in — `avg_rating` is a tie-break in `rankByCharacteristics`,
+   * not part of the score.
    */
   computeFinalScore(
     beer: BeerCharacteristics,
@@ -175,64 +176,67 @@ export class RecipeMatchingService {
   ): number {
     const styleScore = this.maybeStyleScore(beer.style, recipe.style);
     const styleCompatible = styleScore !== null && styleScore > 0;
-    const similarity =
-      recipe.is_official && styleCompatible
-        ? 100
-        : this.computeSimilarity(beer, recipe);
-    const quality = this.computeQuality(recipe);
-    return similarity * 0.7 + quality * 0.3;
+    if (recipe.is_official && styleCompatible) {
+      return 100;
+    }
+    return this.computeSimilarity(beer, recipe);
   }
 
   /**
-   * Similarity score (0..100). Combines style (50%), ABV (25%),
-   * bitterness (15%) and color (10%). When a criterion is missing
-   * (null on either side), its weight is redistributed pro-rata to
-   * the criteria that ARE present — so a recipe with no IBU still
-   * gets a fair chance instead of an automatic -15 penalty.
-   *
-   * Returns 0 if all four criteria are missing.
+   * The comparable similarity criteria with their ADR-0016 full-data weights
+   * (style 40, colour 22, bitterness 18, ABV 14). Each `score` is the local
+   * similarity (0..100) or `null` when the criterion is absent on either side
+   * (→ dropped by Gower renormalisation). Shared by `computeSimilarity` (the
+   * weighted average) and `computeCompleteness` (the present-weight ratio) so
+   * the two can never drift.
+   */
+  private similarityComponents(
+    beer: BeerCharacteristics,
+    recipe: RecipeOrmEntity,
+  ): { weight: number; score: number | null }[] {
+    return [
+      { weight: 40, score: this.maybeStyleScore(beer.style, recipe.style) },
+      {
+        weight: 22,
+        score: this.maybeColorScore(beer.color_ebc, recipe.ebc_target),
+      },
+      {
+        weight: 18,
+        score: this.maybeBitternessScore(beer.ibu, recipe.ibu_target),
+      },
+      { weight: 14, score: this.maybeAbvScore(beer.abv, recipe.abv_estimated) },
+    ];
+  }
+
+  /**
+   * Similarity (0..100): the renormalised weighted average over the present
+   * criteria (ADR-0016 D3, Gower — a missing criterion drops from both
+   * numerator and denominator). Returns 0 when no criterion is comparable.
    */
   computeSimilarity(
     beer: BeerCharacteristics,
     recipe: RecipeOrmEntity,
   ): number {
-    const components: { weight: number; score: number | null }[] = [
-      { weight: 50, score: this.maybeStyleScore(beer.style, recipe.style) },
-      { weight: 25, score: this.maybeAbvScore(beer.abv, recipe.abv_estimated) },
-      {
-        weight: 15,
-        score: this.maybeBitternessScore(beer.ibu, recipe.ibu_target),
-      },
-      {
-        weight: 10,
-        score: this.maybeColorScore(beer.color_ebc, recipe.ebc_target),
-      },
-    ];
-    return this.weightedAverageWithRenorm(components);
+    return this.weightedAverageWithRenorm(
+      this.similarityComponents(beer, recipe),
+    );
   }
 
   /**
-   * Quality score (0..100). Combines avg_rating (60%),
-   * brew_count_confidence (30%) and recency (10%). Same
-   * renormalization principle as similarity — a recipe without
-   * brew history still gets credit for its rating instead of an
-   * automatic -40 penalty.
-   *
-   * Returns 0 if all three criteria are missing.
+   * Completeness (0..1): how much of the full ADR-0016 picture the comparison
+   * actually used = Σ present weight / 100. The denominator is the full
+   * five-criterion total; the ingredients criterion (weight 6) is not compared
+   * yet, so completeness caps at 0.94 for now — an honest reflection that we
+   * never have the whole picture (ADR-0016 D4).
    */
-  computeQuality(recipe: RecipeOrmEntity): number {
-    const components: { weight: number; score: number | null }[] = [
-      { weight: 60, score: this.maybeRatingScore(recipe.avg_rating) },
-      {
-        weight: 30,
-        score: this.maybeBrewCountScore(recipe.brew_count),
-      },
-      {
-        weight: 10,
-        score: this.maybeRecencyScore(recipe.last_brewed_at),
-      },
-    ];
-    return this.weightedAverageWithRenorm(components);
+  computeCompleteness(
+    beer: BeerCharacteristics,
+    recipe: RecipeOrmEntity,
+  ): number {
+    const presentWeight = this.similarityComponents(beer, recipe)
+      .filter((c) => c.score !== null)
+      .reduce((sum, c) => sum + c.weight, 0);
+    return presentWeight / RecipeMatchingService.TOTAL_CRITERIA_WEIGHT;
   }
 
   /**
@@ -264,19 +268,6 @@ export class RecipeMatchingService {
   // counting it as 0).
   // ------------------------------------------------------------------
 
-  scoreStyle(
-    beerStyle: string | null | undefined,
-    recipeStyle: string | null | undefined,
-  ): number {
-    if (!beerStyle || !recipeStyle) return 0;
-    const a = beerStyle.trim().toLowerCase();
-    const b = recipeStyle.trim().toLowerCase();
-    if (!a || !b) return 0;
-    if (a === b) return 100;
-    if (a.includes(b) || b.includes(a)) return 70;
-    return 0;
-  }
-
   scoreAbv(
     beerAbv: number | null | undefined,
     recipeAbv: number | null | undefined,
@@ -291,13 +282,6 @@ export class RecipeMatchingService {
     }
     const gap = Math.abs(beerAbv - recipeAbv);
     return Math.max(0, 100 - 25 * gap);
-  }
-
-  scoreQuality(avgRating: number | null | undefined): number {
-    if (avgRating === null || avgRating === undefined) return 0;
-    if (avgRating <= 0) return 0;
-    const clamped = Math.max(1, Math.min(5, avgRating));
-    return ((clamped - 1) / 4) * 80 + 20;
   }
 
   /**
@@ -376,61 +360,6 @@ export class RecipeMatchingService {
     return 4;
   }
 
-  /**
-   * Brew count confidence (0..100). Logarithmic so that a recent
-   * excellent recipe with one brew is not unfairly downgraded
-   * versus an old recipe with many brews:
-   *   0 → 0, 1 → 30, 5 → 60, 20 → 80, 100 → 95, 500+ → 100.
-   *
-   * Linear interpolation between the documented anchors. Null /
-   * negative inputs return 0.
-   */
-  scoreBrewCount(brewCount: number | null | undefined): number {
-    if (brewCount === null || brewCount === undefined) return 0;
-    if (brewCount <= 0) return 0;
-    // Anchor table — strictly monotonic.
-    const anchors: { count: number; score: number }[] = [
-      { count: 1, score: 30 },
-      { count: 5, score: 60 },
-      { count: 20, score: 80 },
-      { count: 100, score: 95 },
-      { count: 500, score: 100 },
-    ];
-    const first = anchors[0];
-    const last = anchors.at(-1) ?? first; // `anchors` is a non-empty literal
-    if (brewCount <= first.count) return first.score * brewCount;
-    if (brewCount >= last.count) {
-      return last.score;
-    }
-    for (let i = 0; i < anchors.length - 1; i += 1) {
-      const lo = anchors[i];
-      const hi = anchors[i + 1];
-      if (brewCount >= lo.count && brewCount <= hi.count) {
-        const t = (brewCount - lo.count) / (hi.count - lo.count);
-        return lo.score + t * (hi.score - lo.score);
-      }
-    }
-    return 0;
-  }
-
-  /**
-   * Recency decay (0..100). Penalizes stale recipes:
-   *   <30 days → 100, <90 → 80, <365 → 60, <730 → 40, 2y+ → 20.
-   *   null → 0 (never brewed).
-   */
-  scoreRecency(lastBrewedAt: Date | string | null | undefined): number {
-    if (lastBrewedAt === null || lastBrewedAt === undefined) return 0;
-    const date =
-      lastBrewedAt instanceof Date ? lastBrewedAt : new Date(lastBrewedAt);
-    if (Number.isNaN(date.getTime())) return 0;
-    const ageDays = (Date.now() - date.getTime()) / (1000 * 60 * 60 * 24);
-    if (ageDays < 30) return 100;
-    if (ageDays < 90) return 80;
-    if (ageDays < 365) return 60;
-    if (ageDays < 730) return 40;
-    return 20;
-  }
-
   // ------------------------------------------------------------------
   // Renormalization-friendly wrappers — return null when the input is
   // missing so `weightedAverageWithRenorm` drops the weight rather
@@ -443,11 +372,12 @@ export class RecipeMatchingService {
     beerStyle: string | null | undefined,
     recipeStyle: string | null | undefined,
   ): number | null {
-    // Treat a blank/whitespace style as *absent* (→ null → dropped by
-    // renormalisation) rather than a present criterion scoring 0, which
-    // would unfairly penalise similarity (Copilot review on #1190).
-    if (!beerStyle?.trim() || !recipeStyle?.trim()) return null;
-    return this.scoreStyle(beerStyle, recipeStyle);
+    // Graded by BJCP family (ADR-0016 D2). `styleSimilarity` returns 0..1 — or
+    // `null` when either side is blank/unclassifiable, so the criterion drops
+    // out of the renormalisation rather than scoring a 0 penalty (Copilot
+    // review on #1190). Scale to the 0..100 local-similarity range.
+    const sim = styleSimilarity(beerStyle ?? null, recipeStyle ?? null);
+    return sim === null ? null : sim * 100;
   }
 
   private maybeAbvScore(
@@ -493,28 +423,5 @@ export class RecipeMatchingService {
       return null;
     }
     return this.scoreColor(beerEbc, recipeEbc);
-  }
-
-  private maybeRatingScore(
-    avgRating: number | null | undefined,
-  ): number | null {
-    if (avgRating === null || avgRating === undefined) return null;
-    return this.scoreQuality(avgRating);
-  }
-
-  private maybeBrewCountScore(
-    brewCount: number | null | undefined,
-  ): number | null {
-    if (brewCount === null || brewCount === undefined || brewCount <= 0) {
-      return null;
-    }
-    return this.scoreBrewCount(brewCount);
-  }
-
-  private maybeRecencyScore(
-    lastBrewedAt: Date | string | null | undefined,
-  ): number | null {
-    if (lastBrewedAt === null || lastBrewedAt === undefined) return null;
-    return this.scoreRecency(lastBrewedAt);
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -94,6 +94,10 @@ sonar.coverage.exclusions=\
 # excluded for the same reason: catalogues of malts / hops / yeasts and
 # the fil-rouge batch step arrays are intentionally parallel data
 # definitions, not duplicated logic.
+#
+# bjcp-style-family.ts is the same case: its STYLE_DEFINITIONS array is one
+# parallel data row per BJCP style (canonical + family + tiers + aliases),
+# mirroring the encyclopedia seed — repeated shape, not duplicated logic.
 sonar.cpd.exclusions=\
   packages/api/src/catalog/**/*.module.ts,\
   packages/api/src/catalog/**/services/*.service.ts,\
@@ -101,6 +105,7 @@ sonar.cpd.exclusions=\
   packages/api/src/catalog/**/dtos/*.dto.ts,\
   packages/api/src/catalog/**/entities/*.orm.entity.ts,\
   packages/api/src/database/seeds/*-catalog.seed.ts,\
+  packages/api/src/recipe/services/bjcp-style-family.ts,\
   packages/api/scripts/run-*-catalog-seed.ts,\
   packages/mobile-app/src/mocks/**
 


### PR DESCRIPTION
## What

Realises **recipe-matching v2** (ADR-0016) in the NestJS API — the scorer that ranks community recipes against a scanned beer. This is the conception→code step for the just-merged ADR-0016 (+ the `Style.family`/interval model from #1204). **NestJS only**; the mobile consumption (interval unpacking, `completeness`, honest empty state) is a follow-up PR.

`POST /recipes/match` request contract is **unchanged**; the response gains an additive `completeness` per ranking.

## The fix

Today `scoreStyle` matches by name (exact 100 / substring 70 / else 0), so `"Blonde Ale"` resembles nothing → the ranking collapses onto ABV + rating → a Saison/IPA tops a Leffe Blonde. v2 grades style by **BJCP family**.

## Changes

- **`bjcp-style-family.ts`** (new) — free-text style → `{canonical, family, colourTier, strengthTier}` with graded `styleSimilarity ∈ {1, 0.7, 0.4, 0, null}`. Families/tiers **mirror the encyclopedia seed** (`seed_styles.py`, #1204) + FR/EN synonyms + accent folding. Lives in code (the "alias en code" decision) — the matcher gets style *strings*, not catalog ids.
- **`recipe-matching.service.ts`** — match strength = weighted similarity only (**style 40, colour 22, IBU 18, ABV 14**; Gower renorm). Community quality is **no longer blended** — `avg_rating` is a pure tie-break (ADR-0016). New `computeCompleteness` (Σ present weight / 100, caps at 0.94 until ingredients ship). `rankByCharacteristics` filters by **D5** (matchStrength ≥ `S_min` AND completeness ≥ `C_min`) **before** the top-N cut; `low_confidence` = nothing passed (empty → honest empty state). Drops the dead quality scorers.
- **Official gate refined (D6)** — "style-compatible" now means **same BJCP family or better (≥ 0.7)**, not merely the same colour/strength tier (0.4). Otherwise a 0.4 tier match (an IPA for a Blonde, both pale/standard) would re-promote an off-family official to the top — the exact #1193 bug. ADR-0016 D6 + the 06-sequence note are updated to match.
- **`ranked-recipe.dto.ts`** — `completeness: number` per ranking.
- **Env** — `SCAN_MATCH_S_MIN` (45) / `SCAN_MATCH_C_MIN` (0.5), tunable, documented in `.env.example`.

## Tests / verification

- `bjcp-style-family.spec` + a rewritten `recipe-matching.service.spec` (graded style, new weights, completeness, D5 empty-state, the Leffe Blonde case, official gate). Controller spec updated for `completeness`.
- **746 tests pass, ESLint clean, `nest build` clean, coverage 94% statements / 77% branches** (ran the full `test:cov` gate locally).

## Out of scope (next PR — mobile)

- Fix the #1204 interval breakage in `beers-import.api.ts` (read `ibu_min/max`, `srm_min/max` → representative value). **Urgent once #1204 deploys.**
- Consume `completeness` + render the honest "no reliable equivalent" empty state.
- Interval-overlap colour/IBU localSim + the ingredients criterion (deferred).

Relates ADR-0016, ADR-0017, #1198, epic #1175.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * BJCP-aligned style classification, new completeness metric, and configurable match-strength/completeness thresholds.

* **Documentation**
  * Clarified official-recipe promotion rules (style compatibility now requires graded-family similarity ≥ 0.7) and updated sequence/behavior docs.

* **Tests**
  * Expanded tests for style normalization, similarity tiers, completeness, acceptance thresholds, and updated ranking expectations.

* **Refactor**
  * Matching logic now ranks by match strength + completeness with deterministic ordering.

* **Chores**
  * Updated example config and static analysis exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->