### PR TITLE
docs(mobile-catalog): UML conception study for the mobile beer catalogue (UC1/2/3)

### DIFF
--- a/docs/architecture/diagrams/beer-encyclopedia/07-class-api-contract.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/07-class-api-contract.md
@@ -45,7 +45,7 @@ classDiagram
     <<POST /beers body>>
   }
   class BeerUpdate {
-    <<PATCH /beers/{id} body — tous optionnels>>
+    <<PATCH body — tous optionnels>>
     +str name?
     +UUID brewery_id?
     +UUID style_id?
@@ -78,6 +78,12 @@ classDiagram
     +list~BeerRead~ items
     +PaginationMeta meta
   }
+  class PaginationMeta {
+    <<api/schemas/common.py>>
+    +int total
+    +int page
+    +int per_page
+  }
   class BeerImportByEanRequest {
     <<POST /beers/import-by-ean body>>
     +str ean
@@ -86,6 +92,7 @@ classDiagram
   BeerBase <|-- BeerCreate
   BeerBase <|-- BeerRead
   BeerList "1" o-- "0..*" BeerRead : items
+  BeerList "1" o-- "1" PaginationMeta : meta
   BeerRead ..> Beer : projette (from_attributes)
   BeerRead ..> Brewery : brewery_name (dénormalisé, lecture)
   BeerRead ..> Style : style_name (dénormalisé, lecture)
@@ -145,6 +152,11 @@ class BeerList {
   +items : list<BeerRead>
   +meta : PaginationMeta
 }
+class PaginationMeta <<api/schemas/common.py>> {
+  +total : int
+  +page : int
+  +per_page : int
+}
 class BeerImportByEanRequest <<POST /beers/import-by-ean>> {
   +ean : str
 }
@@ -152,6 +164,7 @@ class BeerImportByEanRequest <<POST /beers/import-by-ean>> {
 BeerBase <|-- BeerCreate
 BeerBase <|-- BeerRead
 BeerList "1" o-- "0..*" BeerRead : items
+BeerList "1" o-- "1" PaginationMeta : meta
 BeerRead ..> Beer : projette (from_attributes)
 BeerRead ..> Brewery : brewery_name (dénormalisé)
 BeerRead ..> Style : style_name (dénormalisé)
@@ -187,6 +200,11 @@ BeerRead ..> Style : style_name (dénormalisé)
 - **Validation (edge).** `ean` : `min 8 / max 14`, `pattern` EAN-8/UPC-A/EAN-13/EAN-14 ;
   `abv ∈ [0,100]`, chaque borne `ibu ∈ [0,1000]`, `srm ∈ [0,100]`, `name` non vide. Mêmes
   règles que le validateur ORM, pour un 422 cohérent au bord de l'API.
+- **`PaginationMeta` (enveloppe de liste).** Défini dans `api/schemas/common.py` :
+  `total ≥ 0`, `page ≥ 1` (1-based), `per_page ∈ [1,100]` (défaut 20). `BeerList.meta` le
+  référençait sans le dessiner — la boîte est désormais explicite. Le client mobile le
+  consomme pour la pagination infinie (cf. `../mobile-catalog/09-class-domain.md`, où il
+  apparaît en camelCase `perPage`).
 - **Conformité.** Ce contrat est la cible que le code (`api/schemas/beer.py` + la résolution
   des noms dans `api/routers/beers.py`) doit satisfaire. Implémentation après validation de ce
   diagramme.

--- a/docs/architecture/diagrams/mobile-catalog/01-use-case.md
+++ b/docs/architecture/diagrams/mobile-catalog/01-use-case.md
@@ -1,0 +1,174 @@
+# Diagramme de cas d'usage — mobile-catalog — catalogue de bières (réalisation mobile)
+
+> **Périmètre :** réalisation **mobile** de UC1/UC2/UC3 (catalogue de bières) — consommation de l'API encyclopédie
+> **Code concerné (cible) :** `packages/mobile-app/src/features/beer-catalog/`, `packages/mobile-app/app/(app)/beer-catalog/`
+> **ADR liés :** repo ADR-0005 (split backend — l'encyclopédie possède la connaissance bière), repo ADR-0013 (la conception fait foi), ADR-0017 (intervalles IBU/SRM)
+> **Voir aussi :** `../beer-encyclopedia/01-use-case.md` (UC1/2/3 — vue backend) · `06-component.md` · `02-sequence-browse.md` · `03-sequence-search.md` · `04-sequence-fiche.md` · `../../traceability-matrix.md`
+
+## Contexte
+
+Ce diagramme **raffine côté mobile** les cas d'usage UC1/UC2/UC3 déjà définis pour
+l'encyclopédie (`../beer-encyclopedia/01-use-case.md`). Le **but de l'acteur ne change pas**
+avec l'appareil — c'est la **réalisation mobile** qui ajoute des extensions absentes de la
+fiche backend : pagination **infinie** (scroll), recherche **debouncée/annulable**, états
+**chargement / vide / erreur / hors-ligne**. Ces réalisations non triviales justifient des
+diagrammes de séquence dédiés (`02`–`05`), cf. la règle révisée de la matrice de traçabilité.
+
+**Périmètre MVP (vue cible)** : **bières** — Parcourir, Rechercher, Consulter la fiche. La
+**fiche brasserie** et la **fiche style** sont atteintes **en tapant** depuis la fiche bière
+(navigation, toujours UC3, `GET /breweries/{id}` · `GET /styles/{id}`). Le **parcours** des
+rubriques brasseries/styles et les **filtres** (style, brasserie, ABV) sont des **`<<fast-follow>>`**
+(endpoints déjà prêts, hors MVP) — marqués pour le contrôle de conformité conception ↔ code.
+
+## Diagramme (Mermaid — aperçu rapide)
+
+```mermaid
+flowchart LR
+  Visitor(("Visiteur — «Léa la curieuse»"))
+
+  subgraph SYSTEM ["Catalogue mobile (React Native) — vue cible MVP"]
+    subgraph Consult ["Domaine Consulter"]
+      UC1(("UC1 — Parcourir les bières (liste infinie)"))
+      UC2(("UC2 — Rechercher une bière par nom"))
+      UC3(("UC3 — Consulter la fiche d'une bière"))
+      UC1b(("UC1b — Parcourir les brasseries"))
+      UC1c(("UC1c — Parcourir les styles"))
+      UC2b(("UC2b — Filtrer le catalogue (style / brasserie / ABV)"))
+    end
+  end
+
+  BreweryFiche["Fiche brasserie (GET /breweries/{id})"]
+  StyleFiche["Fiche style (GET /styles/{id})"]
+
+  Visitor --> UC1
+  Visitor --> UC2
+  Visitor --> UC3
+  Visitor --> UC1b
+  Visitor --> UC1c
+  Visitor --> UC2b
+
+  UC3 -.->|"navigation (tap)"| BreweryFiche
+  UC3 -.->|"navigation (tap)"| StyleFiche
+
+  classDef fastfollow stroke:#e67e22,stroke-width:2px,stroke-dasharray:6 4;
+  class UC1b,UC1c,UC2b fastfollow;
+```
+
+*Même cas d'usage en **PlantUML** (notation magistrale : acteur, ovales, stéréotypes). À garder **synchronisé** avec le bloc Mermaid.*
+
+```plantuml
+@startuml
+left to right direction
+skinparam packageStyle rectangle
+skinparam shadowing false
+
+actor "Visiteur\n«Léa la curieuse»" as Visitor
+
+rectangle "Catalogue mobile (React Native) — vue cible MVP" {
+  package "Consulter" {
+    usecase "UC1 — Parcourir les bières\n(liste infinie)" as UC1
+    usecase "UC2 — Rechercher une bière\npar nom" as UC2
+    usecase "UC3 — Consulter la fiche\nd'une bière" as UC3
+    usecase "UC1b — Parcourir\nles brasseries" as UC1b <<fast-follow>>
+    usecase "UC1c — Parcourir\nles styles" as UC1c <<fast-follow>>
+    usecase "UC2b — Filtrer le catalogue\n(style / brasserie / ABV)" as UC2b <<fast-follow>>
+  }
+}
+
+rectangle "Fiche brasserie\n(GET /breweries/{id})" as BreweryFiche
+rectangle "Fiche style\n(GET /styles/{id})" as StyleFiche
+
+Visitor --> UC1
+Visitor --> UC2
+Visitor --> UC3
+Visitor --> UC1b
+Visitor --> UC1c
+Visitor --> UC2b
+
+UC3 ..> BreweryFiche : navigation (tap)
+UC3 ..> StyleFiche : navigation (tap)
+
+skinparam usecase {
+  BackgroundColor<<fast-follow>> #FDEBD0
+  BorderColor<<fast-follow>> #E67E22
+  BorderThickness<<fast-follow>> 2
+}
+
+legend right
+  Trait plein = MVP
+  <<fast-follow>> = hors MVP (endpoints prêts)
+endlegend
+@enduml
+```
+
+## Relations (récapitulatif)
+
+- **Même acteur, même but** : la réalisation mobile de UC1/UC2/UC3 ne crée pas de nouveaux
+  buts ; elle réalise les buts du Visiteur déjà modélisés côté encyclopédie.
+- **Navigation (non modélisée comme relation)** : depuis la fiche bière (UC3), taper la
+  brasserie ou le style **ouvre leur fiche** — c'est de la **navigation** (toujours UC3 pour
+  une autre entité), pas un «include»/«extend».
+- **`<<fast-follow>>`** : UC1b/UC1c (parcours brasseries/styles) et UC2b (filtres) sont des
+  **sous-buts** de UC1/UC2 différés au MVP+1 ; les endpoints (`GET /breweries`, `GET /styles`,
+  filtres de `GET /beers`) existent déjà (cf. `06-component.md`).
+
+## Notes
+
+- **MVP livrable** : UC1 (bières), UC2 (bières), UC3 (fiche bière + fiches brasserie/style en
+  navigation). Pas de filtres, pas de rubriques brasseries/styles.
+- **UML 2.5** : chaque nœud est un **but initié par le Visiteur** ; groupé **par domaine**
+  (Consulter), jamais par composant — la décomposition route → écran → hook → data → API vit
+  dans `06-component.md`.
+- **Pagination = infinie** (scroll), décision structurante réalisée par `useInfiniteQuery`
+  (`02-sequence-browse.md`, `07-state-list-screen.md`). Un seul hook sert *parcourir* ET
+  *rechercher* (cf. `06-component.md`).
+- **Lecture publique** : ces consultations sont **sans authentification** (`auth:false`,
+  ADR-0005) — aucune PII envoyée (cf. `11-data-flow.md`).
+
+## Spécifications des cas d'usage (Cockburn) — extensions mobiles
+
+> Les buts, préconditions et garanties restent ceux de `../beer-encyclopedia/01-use-case.md`.
+> Seules sont détaillées ici les **extensions propres à la réalisation mobile** (états d'écran).
+
+### UC1 — Parcourir les bières (réalisation mobile) — *cible MVP*
+
+- **Acteur principal :** Visiteur · **Garantie de succès :** liste **infinie** affichée, pages chargées au défilement
+- **Scénario nominal**
+    1. Le Visiteur ouvre l'écran catalogue.
+    2. Le système charge la 1ʳᵉ page (`GET /beers?page=1&per_page=20`) et affiche la liste.
+    3. En approchant du bas, le système charge la page suivante et l'ajoute à la liste.
+- **Extensions (mobiles)**
+  - 2a. Chargement initial → **squelette / indicateur**.
+  - 2b. Rubrique vide (aucune bière) → message « aucune bière » + invite au scan (UC4).
+  - 2c. Erreur réseau au chargement initial → écran d'erreur + **« Réessayer »**.
+  - 3a. Dernière page atteinte (`page × per_page ≥ total`) → arrêt du chargement (pas de pied de liste).
+  - 3b. Erreur au chargement de la page suivante → **erreur en pied de liste** (la liste déjà chargée reste visible) + réessai en place.
+  - \*a. Hors-ligne **avec cache** → liste servie depuis le cache (staleTime) + bannière hors-ligne.
+- **Postcondition :** aucune modification. · **Relations :** association Visiteur seule.
+
+### UC2 — Rechercher une bière par nom (réalisation mobile) — *cible MVP*
+
+- **Acteur principal :** Visiteur · **Garantie de succès :** résultats paginés, pertinents au terme saisi
+- **Scénario nominal**
+    1. Le Visiteur saisit un terme.
+    2. Après **debounce (≈300 ms)**, le système interroge `GET /beers/search?q=&page=1`.
+    3. Le système affiche les résultats (mêmes pages infinies que UC1) ; ouvrir un résultat → UC3.
+- **Extensions (mobiles)**
+  - 1a. Terme **trop court** (< 2 caractères) → **aucun appel**, invite à préciser.
+  - 1b. Nouvelle frappe avant réponse → la requête précédente est **annulée** (changement de clé de cache).
+  - 2a. Aucun résultat → message « aucune bière pour « \<terme\> » » + orientation (UC1 / scan UC4).
+  - 2b. Erreur réseau → écran d'erreur + « Réessayer ».
+- **Postcondition :** aucune modification. · **Relations :** association Visiteur seule (recherche sur le **nom de bière**).
+
+### UC3 — Consulter la fiche d'une bière (réalisation mobile) — *cible MVP*
+
+- **Acteur principal :** Visiteur · **Précondition :** la bière existe · **Garantie de succès :** fiche détaillée affichée
+- **Scénario nominal**
+    1. Le Visiteur ouvre une fiche (depuis UC1, UC2, ou l'identification UC4).
+    2. Le système affiche `GET /beers/{id}` : nom, brasserie, style, ABV, intervalles IBU/SRM (→ EBC d'affichage), description, mentions légales, provenance.
+- **Extensions (mobiles)**
+  - 1a. Bière introuvable → message « bière introuvable » (404).
+  - 2a. **Tap brasserie** → ouvre la fiche brasserie (`GET /breweries/{id}`) — navigation.
+  - 2b. **Tap style** → ouvre la fiche style (`GET /styles/{id}`) — navigation.
+  - \*a. Hors-ligne **sans cache** → écran d'erreur + « Réessayer ».
+- **Postcondition :** aucune modification. · **Relations :** point d'arrivée de UC1/UC2 ; inclus par UC4 (scan).

--- a/docs/architecture/diagrams/mobile-catalog/01-use-case.md
+++ b/docs/architecture/diagrams/mobile-catalog/01-use-case.md
@@ -162,7 +162,7 @@ endlegend
 
 ### UC3 — Consulter la fiche d'une bière (réalisation mobile) — *cible MVP*
 
-- **Acteur principal :** Visiteur · **Précondition :** la bière existe · **Garantie de succès :** fiche détaillée affichée
+- **Acteur principal :** Visiteur · **Précondition :** un identifiant de bière est fourni (éventuellement **obsolète/invalide** — voir extension 1a) · **Garantie de succès :** fiche détaillée affichée
 - **Scénario nominal**
     1. Le Visiteur ouvre une fiche (depuis UC1, UC2, ou l'identification UC4).
     2. Le système affiche `GET /beers/{id}` : nom, brasserie, style, ABV, intervalles IBU/SRM (→ EBC d'affichage), description, mentions légales, provenance.

--- a/docs/architecture/diagrams/mobile-catalog/02-sequence-browse.md
+++ b/docs/architecture/diagrams/mobile-catalog/02-sequence-browse.md
@@ -1,0 +1,123 @@
+# Diagramme de séquence — mobile-catalog — Parcourir les bières (UC1, liste infinie)
+
+> **Réalise :** UC1 — Parcourir les bières, **côté mobile** (chargement initial + page suivante + cache)
+> **Code concerné (cible) :** `features/beer-catalog/presentation/BeerCatalogBrowseScreen.tsx`, `application/useBeerCatalogPagination.ts`, `application/computeNextPageParam.ts`, `data/beer-catalog.api.ts`
+> **ADR liés :** repo ADR-0005 (lecture publique chez Python), ADR-0017 (intervalles), repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `01-use-case.md` (UC1) · `06-component.md` · `09-class-domain.md` (`Page<T>`, `PaginationMeta`) · `07-state-list-screen.md` · `03-sequence-search.md` · `../../traceability-matrix.md`
+
+## Contexte
+
+Séquence **cible** du parcours infini des bières. Montre l'**orchestration côté client** que la
+fiche Cockburn ne porte pas : vérification du **cache** TanStack, chargement de la 1ʳᵉ page,
+puis **page suivante au défilement** (`onEndReached` → `fetchNextPage`), avec l'**arrêt** piloté
+par `getNextPageParam` (math 1-based sur `meta`). C'est cette non-trivialité (boucle, branches
+cache/fin de liste) qui justifie une séquence (règle révisée, matrice de traçabilité).
+
+## Diagramme (Mermaid — flux cible)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor U as Visiteur
+  participant S as BrowseScreen (FlatList)
+  participant H as useBeerCatalogPagination (useInfiniteQuery)
+  participant Q as Cache TanStack
+  participant UC as listBeers (use-case)
+  participant API as beer-catalog.api (request, auth:false)
+  participant E as beer-encyclopedia (FastAPI)
+
+  U->>S: Ouvre l'écran catalogue
+  S->>H: monte (queryKey ["beer-catalog","browse"])
+  H->>Q: lit la page initiale
+  alt cache présent et frais (staleTime 30s)
+    Q-->>H: pages en cache
+    H-->>S: flatItems (rendu immédiat)
+  else cache absent / périmé
+    H->>UC: queryFn(pageParam = 1)
+    UC->>API: fetchBeersPage(1)
+    API->>E: GET /beers?page=1&per_page=20
+    E-->>API: 200 BeerList { items, meta:{total,page,per_page} }
+    API->>API: mappe → Page<CatalogBeer>
+    API-->>UC: Page<CatalogBeer>
+    UC-->>H: Page<CatalogBeer>
+    H->>H: getNextPageParam(lastPage) → computeNextPageParam(page,total,perPage)
+    H-->>S: flatItems (page 1)
+  end
+
+  loop défilement vers le bas (onEndReached)
+    S->>H: onEndReached
+    alt hasNextPage (page × per_page < total)
+      H->>UC: fetchNextPage(pageParam = page+1)
+      UC->>API: fetchBeersPage(page+1)
+      API->>E: GET /beers?page=2&per_page=20
+      E-->>API: 200 BeerList
+      API-->>H: Page<CatalogBeer>
+      H-->>S: flatItems (append) + spinner de pied masqué
+    else dernière page (page × per_page ≥ total)
+      H-->>S: hasNextPage=false (aucun appel, fin de liste)
+    end
+  end
+```
+
+*Même flux en **PlantUML** (à garder synchronisé avec le bloc Mermaid).*
+
+```plantuml
+@startuml
+title sd — mobile-catalog — Parcourir les bières (UC1, liste infinie)
+autonumber
+actor Visiteur as U
+participant "BrowseScreen\n(FlatList)" as S
+participant "useBeerCatalogPagination\n(useInfiniteQuery)" as H
+participant "Cache TanStack" as Q
+participant "listBeers\n(use-case)" as UC
+participant "beer-catalog.api\n(request, auth:false)" as API
+participant "beer-encyclopedia" as E
+
+U -> S : Ouvre l'écran catalogue
+S -> H : monte (queryKey ["beer-catalog","browse"])
+H -> Q : lit la page initiale
+alt cache présent et frais (staleTime 30s)
+  Q --> H : pages en cache
+  H --> S : flatItems (rendu immédiat)
+else cache absent / périmé
+  H -> UC : queryFn(pageParam = 1)
+  UC -> API : fetchBeersPage(1)
+  API -> E : GET /beers?page=1&per_page=20
+  E --> API : 200 BeerList { items, meta }
+  API -> API : mappe -> Page<CatalogBeer>
+  API --> UC : Page<CatalogBeer>
+  UC --> H : Page<CatalogBeer>
+  H -> H : getNextPageParam -> computeNextPageParam(page,total,perPage)
+  H --> S : flatItems (page 1)
+end
+
+loop défilement (onEndReached)
+  S -> H : onEndReached
+  alt hasNextPage (page*per_page < total)
+    H -> UC : fetchNextPage(page+1)
+    UC -> API : fetchBeersPage(page+1)
+    API -> E : GET /beers?page=2&per_page=20
+    E --> API : 200 BeerList
+    API --> H : Page<CatalogBeer>
+    H --> S : flatItems (append)
+  else dernière page (page*per_page >= total)
+    H --> S : hasNextPage=false (fin de liste)
+  end
+end
+@enduml
+```
+
+## Notes
+
+- **`getNextPageParam` (1-based).** `computeNextPageParam(page, total, perPage)` :
+  `page × perPage < total ⇒ page + 1`, sinon `undefined` (⇒ `hasNextPage = false`, la boucle
+  s'arrête). Fonction **pure, testée** isolément (cas : page unique, dernière page exacte,
+  `total = 0`). C'est `meta.total` qui borne la pagination — pas de lien `next`/`prev` côté API.
+- **Dé-doublonnage des appels.** TanStack ne lance qu'**une requête par `pageParam`** ;
+  plusieurs `onEndReached` rapprochés ne déclenchent pas d'appels concurrents pour la même page.
+- **Cache.** `queryKey ["beer-catalog","browse"]`, `staleTime 30s`, `gcTime 5min`, `retry 1`
+  (`core/query`). Au remontage avant péremption, la liste s'affiche **sans réseau** (branche
+  haute). Erreurs/hors-ligne : voir `05-sequence-errors.md`. Cycle de vie d'écran : `07`.
+- **Conformité.** Le code (`useBeerCatalogPagination` + `beer-catalog.api`) doit se conformer à
+  cette séquence : `useInfiniteQuery`, `initialPageParam = 1`, `getNextPageParam =
+  computeNextPageParam`. Implémentation après validation.

--- a/docs/architecture/diagrams/mobile-catalog/02-sequence-browse.md
+++ b/docs/architecture/diagrams/mobile-catalog/02-sequence-browse.md
@@ -118,6 +118,9 @@ end
 - **Cache.** `queryKey ["beer-catalog","browse"]`, `staleTime 30s`, `gcTime 5min`, `retry 1`
   (`core/query`). Au remontage avant péremption, la liste s'affiche **sans réseau** (branche
   haute). Erreurs/hors-ligne : voir `05-sequence-errors.md`. Cycle de vie d'écran : `07`.
+- **Noms dénormalisés.** `GET /beers` renvoie `brewery_name`/`style_name` **null** aujourd'hui
+  (résolus seulement sur `import-by-ean`, cf. `09` + `../beer-encyclopedia/07-class-api-contract.md`) ;
+  la carte affiche un libellé de repli en attendant leur résolution côté API (divergence à suivre).
 - **Conformité.** Le code (`useBeerCatalogPagination` + `beer-catalog.api`) doit se conformer à
   cette séquence : `useInfiniteQuery`, `initialPageParam = 1`, `getNextPageParam =
   computeNextPageParam`. Implémentation après validation.

--- a/docs/architecture/diagrams/mobile-catalog/03-sequence-search.md
+++ b/docs/architecture/diagrams/mobile-catalog/03-sequence-search.md
@@ -1,0 +1,103 @@
+# Diagramme de séquence — mobile-catalog — Rechercher une bière (UC2, debounce + annulation)
+
+> **Réalise :** UC2 — Rechercher une bière par nom, **côté mobile** (debounce → annulation in-flight → résultats / vide)
+> **Code concerné (cible) :** `features/beer-catalog/presentation/BeerCatalogSearchScreen.tsx`, `application/useDebouncedValue.ts`, `application/useBeerCatalogPagination.ts`, `data/beer-catalog.api.ts`
+> **ADR liés :** repo ADR-0005 (lecture publique), repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `01-use-case.md` (UC2) · `08-state-search-input.md` (FSM saisie) · `02-sequence-browse.md` (même hook paginé) · `06-component.md` · `../../traceability-matrix.md`
+
+## Contexte
+
+Séquence **cible** de la recherche. Réutilise le **même hook paginé** que le parcours
+(`02-sequence-browse.md`) ; seuls la **clé de cache** et l'endpoint changent. La non-trivialité
+propre à la recherche : **debounce** (≈300 ms) pour ne pas appeler à chaque frappe, et
+**annulation de la requête en vol** quand l'utilisateur tape de nouveau (changement de
+`queryKey` → TanStack abandonne la requête `q` périmée). La FSM de la saisie est détaillée dans
+`08-state-search-input.md`.
+
+## Diagramme (Mermaid — flux cible)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor U as Visiteur
+  participant SB as SearchInput
+  participant D as useDebouncedValue (≈300 ms)
+  participant H as useBeerCatalogPagination (useInfiniteQuery)
+  participant Q as Cache TanStack
+  participant API as beer-catalog.api (request, auth:false)
+  participant E as beer-encyclopedia (FastAPI)
+
+  U->>SB: saisit un terme (frappe)
+  SB->>D: onChange(text)
+  D->>D: attend la fin de frappe (debounce)
+  alt terme trop court (< 2 caractères)
+    D-->>SB: pas d'appel — invite à préciser
+  else terme valide
+    D->>H: q stabilisé → queryKey ["beer-catalog","search",q]
+    Note over H,Q: nouvelle clé ⇒ requête "q" précédente ANNULÉE (in-flight)
+    H->>API: searchBeersPage(q, page=1)
+    API->>E: GET /beers/search?q=<q>&page=1&per_page=20
+    E-->>API: 200 BeerList { items, meta }
+    API->>API: mappe → Page<CatalogBeer>
+    API-->>H: Page<CatalogBeer>
+    alt items.length > 0
+      H-->>SB: résultats (mêmes pages infinies que UC1)
+    else aucun résultat
+      H-->>SB: état vide « aucune bière pour « q » » + orientation (UC1 / scan)
+    end
+  end
+```
+
+*Même flux en **PlantUML** (à garder synchronisé avec le bloc Mermaid).*
+
+```plantuml
+@startuml
+title sd — mobile-catalog — Rechercher une bière (UC2, debounce + annulation)
+autonumber
+actor Visiteur as U
+participant "SearchInput" as SB
+participant "useDebouncedValue\n(~300 ms)" as D
+participant "useBeerCatalogPagination\n(useInfiniteQuery)" as H
+participant "Cache TanStack" as Q
+participant "beer-catalog.api\n(request, auth:false)" as API
+participant "beer-encyclopedia" as E
+
+U -> SB : saisit un terme (frappe)
+SB -> D : onChange(text)
+D -> D : attend la fin de frappe (debounce)
+alt terme trop court (< 2 caractères)
+  D --> SB : pas d'appel — invite à préciser
+else terme valide
+  D -> H : q stabilisé -> queryKey ["beer-catalog","search",q]
+  note over H, Q : nouvelle clé => requête "q" précédente ANNULÉE
+  H -> API : searchBeersPage(q, page=1)
+  API -> E : GET /beers/search?q=<q>&page=1&per_page=20
+  E --> API : 200 BeerList { items, meta }
+  API -> API : mappe -> Page<CatalogBeer>
+  API --> H : Page<CatalogBeer>
+  alt items.length > 0
+    H --> SB : résultats (pages infinies comme UC1)
+  else aucun résultat
+    H --> SB : état vide + orientation (UC1 / scan)
+  end
+end
+@enduml
+```
+
+## Notes
+
+- **Debounce.** Le terme n'est propagé au hook qu'après stabilisation (`useDebouncedValue`,
+  ≈300 ms) → une frappe rapide « ip…pa » ne lance pas 4 requêtes. Le debounce vit au
+  **composant/hook**, pas dans la requête.
+- **Annulation in-flight.** Le changement de `queryKey` (`q` → `q'`) fait que TanStack
+  **abandonne** la requête en vol pour `q` ; seule la dernière `q` se résout. Pas d'annulation
+  manuelle (`AbortController`) à écrire — c'est la clé qui pilote. `placeholderData:
+  keepPreviousData` garde les résultats précédents affichés pendant la nouvelle requête (pas de
+  flash vide).
+- **Garde API.** `q` est requis côté API (`min 1, max 100`) → un `q` vide renverrait 422 ; la
+  garde « < 2 caractères » côté mobile évite l'appel inutile (et le 422).
+- **Même pagination.** Les résultats se paginent comme UC1 (`onEndReached` → page suivante de
+  `/beers/search`). Voir `02-sequence-browse.md` pour la boucle et `getNextPageParam`.
+- **Conformité.** Le code doit réutiliser `useBeerCatalogPagination` en mode recherche
+  (queryKey + endpoint), avec `useDebouncedValue` et `keepPreviousData`. Implémentation après
+  validation.

--- a/docs/architecture/diagrams/mobile-catalog/03-sequence-search.md
+++ b/docs/architecture/diagrams/mobile-catalog/03-sequence-search.md
@@ -34,7 +34,7 @@ sequenceDiagram
     D-->>SB: pas d'appel — invite à préciser
   else terme valide
     D->>H: q stabilisé → queryKey ["beer-catalog","search",q]
-    Note over H,Q: nouvelle clé ⇒ requête "q" précédente ANNULÉE (in-flight)
+    Note over H,Q: nouvelle clé ⇒ résultat "q" précédent ignoré (abort réseau seulement si request() propage le signal)
     H->>API: searchBeersPage(q, page=1)
     API->>E: GET /beers/search?q=<q>&page=1&per_page=20
     E-->>API: 200 BeerList { items, meta }
@@ -69,7 +69,7 @@ alt terme trop court (< 2 caractères)
   D --> SB : pas d'appel — invite à préciser
 else terme valide
   D -> H : q stabilisé -> queryKey ["beer-catalog","search",q]
-  note over H, Q : nouvelle clé => requête "q" précédente ANNULÉE
+  note over H, Q : nouvelle clé => résultat "q" précédent ignoré (abort réseau si request() propage le signal)
   H -> API : searchBeersPage(q, page=1)
   API -> E : GET /beers/search?q=<q>&page=1&per_page=20
   E --> API : 200 BeerList { items, meta }
@@ -89,11 +89,13 @@ end
 - **Debounce.** Le terme n'est propagé au hook qu'après stabilisation (`useDebouncedValue`,
   ≈300 ms) → une frappe rapide « ip…pa » ne lance pas 4 requêtes. Le debounce vit au
   **composant/hook**, pas dans la requête.
-- **Annulation in-flight.** Le changement de `queryKey` (`q` → `q'`) fait que TanStack
-  **abandonne** la requête en vol pour `q` ; seule la dernière `q` se résout. Pas d'annulation
-  manuelle (`AbortController`) à écrire — c'est la clé qui pilote. `placeholderData:
-  keepPreviousData` garde les résultats précédents affichés pendant la nouvelle requête (pas de
-  flash vide).
+- **Annulation in-flight (nuance vérifiée).** Le changement de `queryKey` (`q` → `q'`) rend la
+  requête `q` **inactive** : son **résultat est ignoré** par l'UI et `placeholderData:
+  keepPreviousData` garde les résultats précédents (pas de flash vide). **Mais la requête réseau
+  n'est pas abortée** tant que le `AbortSignal` de TanStack n'est pas propagé jusqu'à
+  `core/http/request()` (qui appelle `fetch` **sans** `signal` aujourd'hui). **Cible** pour une
+  vraie annulation réseau : ajouter le support de `signal` à `request()` et le passer à
+  `searchBeersPage` (petite évolution `core/http`).
 - **Garde API.** `q` est requis côté API (`min 1, max 100`) → un `q` vide renverrait 422 ; la
   garde « < 2 caractères » côté mobile évite l'appel inutile (et le 422).
 - **Même pagination.** Les résultats se paginent comme UC1 (`onEndReached` → page suivante de

--- a/docs/architecture/diagrams/mobile-catalog/04-sequence-fiche.md
+++ b/docs/architecture/diagrams/mobile-catalog/04-sequence-fiche.md
@@ -51,17 +51,13 @@ sequenceDiagram
 
   opt tap brasserie
     U->>FS: tape la brasserie
-    FS->>API: getBrewery(breweryId)
-    API->>E: GET /breweries/{id}
-    E-->>API: 200 BreweryRead
-    API-->>FS: fiche brasserie (navigation)
+    FS->>FS: router.push(/beer-catalog/brewery/[id]) — navigation
+    Note over FS: BreweryDetailScreen charge via useBrewery → getBrewery → API (même couche que useBeer)
   end
   opt tap style
     U->>FS: tape le style
-    FS->>API: getStyle(styleId)
-    API->>E: GET /styles/{id}
-    E-->>API: 200 StyleRead
-    API-->>FS: fiche style (navigation)
+    FS->>FS: router.push(/beer-catalog/style/[id]) — navigation
+    Note over FS: StyleDetailScreen charge via useStyle → getStyle → API
   end
 ```
 
@@ -104,17 +100,13 @@ end
 
 opt tap brasserie
   U -> FS : tape la brasserie
-  FS -> API : getBrewery(breweryId)
-  API -> E : GET /breweries/{id}
-  E --> API : 200 BreweryRead
-  API --> FS : fiche brasserie (navigation)
+  FS -> FS : router.push(/beer-catalog/brewery/[id]) — navigation
+  note over FS : BreweryDetailScreen charge via useBrewery -> getBrewery -> API
 end
 opt tap style
   U -> FS : tape le style
-  FS -> API : getStyle(styleId)
-  API -> E : GET /styles/{id}
-  E --> API : 200 StyleRead
-  API --> FS : fiche style (navigation)
+  FS -> FS : router.push(/beer-catalog/style/[id]) — navigation
+  note over FS : StyleDetailScreen charge via useStyle -> getStyle -> API
 end
 @enduml
 ```
@@ -128,9 +120,14 @@ end
 - **404.** `HttpError(404)` (de `core/http`) → `CatalogNotFoundError` → message « bière
   introuvable ». Les autres erreurs (timeout / hors-ligne) : `05-sequence-errors.md`. Le
   catalogue est **encyclopédie-seule** (pas de secours NestJS, contrairement au scan UC4).
-- **Navigation brasserie/style.** Tap → `getBrewery`/`getStyle` (clés `["brewery", id]` /
-  `["style", id]`). C'est de la **navigation** (UC3 pour une autre entité), pas un «include».
-  Les routes sont portées par `TapTargetVM` (`10-class-view-model.md`).
+- **Navigation brasserie/style.** Le tap **navigue** (router.push) vers `BreweryDetailScreen` /
+  `StyleDetailScreen`, qui chargent via leur propre hook (`useBrewery`/`useStyle`) → use-case →
+  `request()` — **jamais** un appel direct écran→data (règle de couches, `06-component.md`).
+  C'est de la navigation (UC3 pour une autre entité), pas un «include» ; routes portées par
+  `TapTargetVM` (`10`).
+- **Noms brasserie/style (divergence connue).** `GET /beers/{id}` renvoie `brewery_name`/
+  `style_name` **null** aujourd'hui (résolus seulement sur `import-by-ean`, cf. `09` + `07`) → la
+  fiche affiche un libellé de repli ; la résolution sur le détail est **cible** (à suivre).
 - **Affichage couleur.** SRM (bornes) → EBC d'affichage via `srmToEbc`/`ebcToHex` réutilisés du
   **scan** ; calcul au **view-model** (`10`), pas au domaine. Cf. `11-data-flow.md`.
 - **Conformité.** `useBeer` = `useQuery` (pas `useInfiniteQuery`) ; `getBeer`/`getBrewery`/

--- a/docs/architecture/diagrams/mobile-catalog/04-sequence-fiche.md
+++ b/docs/architecture/diagrams/mobile-catalog/04-sequence-fiche.md
@@ -1,0 +1,137 @@
+# Diagramme de séquence — mobile-catalog — Consulter une fiche bière (UC3, + tap brasserie/style)
+
+> **Réalise :** UC3 — Consulter la fiche d'une bière, **côté mobile** (GET by id + amorçage cache + navigation brasserie/style)
+> **Code concerné (cible) :** `features/beer-catalog/presentation/BeerDetailScreen.tsx`, `application/useBeer.ts`, `data/beer-catalog.api.ts`
+> **ADR liés :** repo ADR-0005 (lecture publique), ADR-0017 (intervalles → EBC d'affichage), repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `01-use-case.md` (UC3) · `09-class-domain.md` (`CatalogBeerDetail`) · `10-class-view-model.md` (`BeerDetailVM`) · `05-sequence-errors.md` (404) · `../../traceability-matrix.md`
+
+## Contexte
+
+Séquence **cible** de la fiche bière. Montre l'**amorçage du cache** (la ligne de liste porte
+déjà un `CatalogBeer` → la fiche s'affiche partiellement **avant** la réponse `GET /beers/{id}`),
+la branche **404**, et la **navigation** vers la fiche brasserie/style (tap → `GET /breweries/{id}`
+/ `GET /styles/{id}`). C'est une lecture simple **par entité**, mais les branches (cache /
+404 / navigation) la rendent non triviale côté client.
+
+## Diagramme (Mermaid — flux cible)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor U as Visiteur
+  participant L as Liste (UC1/UC2)
+  participant FS as BeerDetailScreen
+  participant H as useBeer (useQuery)
+  participant Q as Cache TanStack
+  participant API as beer-catalog.api (request, auth:false)
+  participant E as beer-encyclopedia (FastAPI)
+
+  U->>L: tape une bière (id)
+  L->>FS: navigue /(app)/beer-catalog/beer/[id]
+  FS->>H: useQuery(["beer", id]) + placeholderData (CatalogBeer de la liste)
+  H-->>FS: rendu partiel immédiat (depuis la liste)
+  alt fiche complète en cache et fraîche
+    H->>Q: lit ["beer", id]
+    Q-->>H: CatalogBeerDetail
+    H-->>FS: fiche complète (sans réseau)
+  else cache absent / périmé
+    H->>API: getBeer(id)
+    API->>E: GET /beers/{id}
+    alt 200 trouvée
+      E-->>API: 200 BeerRead
+      API->>API: mappe → CatalogBeerDetail
+      API-->>H: CatalogBeerDetail
+      H-->>FS: fiche complète (nom, brasserie, style, ABV, IBU/SRM→EBC, mentions légales, provenance)
+    else 404 introuvable
+      E-->>API: 404
+      API-->>H: HttpError(404) → CatalogNotFoundError
+      H-->>FS: « bière introuvable »
+    end
+  end
+
+  opt tap brasserie
+    U->>FS: tape la brasserie
+    FS->>API: getBrewery(breweryId)
+    API->>E: GET /breweries/{id}
+    E-->>API: 200 BreweryRead
+    API-->>FS: fiche brasserie (navigation)
+  end
+  opt tap style
+    U->>FS: tape le style
+    FS->>API: getStyle(styleId)
+    API->>E: GET /styles/{id}
+    E-->>API: 200 StyleRead
+    API-->>FS: fiche style (navigation)
+  end
+```
+
+*Même flux en **PlantUML** (à garder synchronisé avec le bloc Mermaid).*
+
+```plantuml
+@startuml
+title sd — mobile-catalog — Consulter une fiche bière (UC3)
+autonumber
+actor Visiteur as U
+participant "Liste (UC1/UC2)" as L
+participant "BeerDetailScreen" as FS
+participant "useBeer (useQuery)" as H
+participant "Cache TanStack" as Q
+participant "beer-catalog.api\n(request, auth:false)" as API
+participant "beer-encyclopedia" as E
+
+U -> L : tape une bière (id)
+L -> FS : navigue /(app)/beer-catalog/beer/[id]
+FS -> H : useQuery(["beer", id]) + placeholderData (de la liste)
+H --> FS : rendu partiel immédiat
+alt fiche complète en cache et fraîche
+  H -> Q : lit ["beer", id]
+  Q --> H : CatalogBeerDetail
+  H --> FS : fiche complète (sans réseau)
+else cache absent / périmé
+  H -> API : getBeer(id)
+  API -> E : GET /beers/{id}
+  alt 200 trouvée
+    E --> API : 200 BeerRead
+    API -> API : mappe -> CatalogBeerDetail
+    API --> H : CatalogBeerDetail
+    H --> FS : fiche complète
+  else 404 introuvable
+    E --> API : 404
+    API --> H : HttpError(404) -> CatalogNotFoundError
+    H --> FS : « bière introuvable »
+  end
+end
+
+opt tap brasserie
+  U -> FS : tape la brasserie
+  FS -> API : getBrewery(breweryId)
+  API -> E : GET /breweries/{id}
+  E --> API : 200 BreweryRead
+  API --> FS : fiche brasserie (navigation)
+end
+opt tap style
+  U -> FS : tape le style
+  FS -> API : getStyle(styleId)
+  API -> E : GET /styles/{id}
+  E --> API : 200 StyleRead
+  API --> FS : fiche style (navigation)
+end
+@enduml
+```
+
+## Notes
+
+- **Amorçage du cache (liste → détail).** La ligne de liste porte déjà un `CatalogBeer` ;
+  `useQuery(["beer", id])` reçoit ce `CatalogBeer` en `placeholderData` (ou `initialData`) →
+  la fiche s'affiche **immédiatement** (titre, brasserie, style, ABV) pendant que `GET
+  /beers/{id}` complète les champs lourds (`CatalogBeerDetail` : mentions légales, provenance).
+- **404.** `HttpError(404)` (de `core/http`) → `CatalogNotFoundError` → message « bière
+  introuvable ». Les autres erreurs (timeout / hors-ligne) : `05-sequence-errors.md`. Le
+  catalogue est **encyclopédie-seule** (pas de secours NestJS, contrairement au scan UC4).
+- **Navigation brasserie/style.** Tap → `getBrewery`/`getStyle` (clés `["brewery", id]` /
+  `["style", id]`). C'est de la **navigation** (UC3 pour une autre entité), pas un «include».
+  Les routes sont portées par `TapTargetVM` (`10-class-view-model.md`).
+- **Affichage couleur.** SRM (bornes) → EBC d'affichage via `srmToEbc`/`ebcToHex` réutilisés du
+  **scan** ; calcul au **view-model** (`10`), pas au domaine. Cf. `11-data-flow.md`.
+- **Conformité.** `useBeer` = `useQuery` (pas `useInfiniteQuery`) ; `getBeer`/`getBrewery`/
+  `getStyle` via `request()` `auth:false`. Implémentation après validation.

--- a/docs/architecture/diagrams/mobile-catalog/04-sequence-fiche.md
+++ b/docs/architecture/diagrams/mobile-catalog/04-sequence-fiche.md
@@ -28,10 +28,10 @@ sequenceDiagram
 
   U->>L: tape une bière (id)
   L->>FS: navigue /(app)/beer-catalog/beer/[id]
-  FS->>H: useQuery(["beer", id]) + placeholderData (CatalogBeer de la liste)
+  FS->>H: useQuery(["beer-catalog","beer", id]) + placeholderData (CatalogBeer de la liste)
   H-->>FS: rendu partiel immédiat (depuis la liste)
   alt fiche complète en cache et fraîche
-    H->>Q: lit ["beer", id]
+    H->>Q: lit ["beer-catalog","beer", id]
     Q-->>H: CatalogBeerDetail
     H-->>FS: fiche complète (sans réseau)
   else cache absent / périmé
@@ -77,10 +77,10 @@ participant "beer-encyclopedia" as E
 
 U -> L : tape une bière (id)
 L -> FS : navigue /(app)/beer-catalog/beer/[id]
-FS -> H : useQuery(["beer", id]) + placeholderData (de la liste)
+FS -> H : useQuery(["beer-catalog","beer", id]) + placeholderData (de la liste)
 H --> FS : rendu partiel immédiat
 alt fiche complète en cache et fraîche
-  H -> Q : lit ["beer", id]
+  H -> Q : lit ["beer-catalog","beer", id]
   Q --> H : CatalogBeerDetail
   H --> FS : fiche complète (sans réseau)
 else cache absent / périmé
@@ -114,7 +114,7 @@ end
 ## Notes
 
 - **Amorçage du cache (liste → détail).** La ligne de liste porte déjà un `CatalogBeer` ;
-  `useQuery(["beer", id])` reçoit ce `CatalogBeer` en `placeholderData` (ou `initialData`) →
+  `useQuery(["beer-catalog","beer", id])` reçoit ce `CatalogBeer` en `placeholderData` (ou `initialData`) →
   la fiche s'affiche **immédiatement** (titre, brasserie, style, ABV) pendant que `GET
   /beers/{id}` complète les champs lourds (`CatalogBeerDetail` : mentions légales, provenance).
 - **404.** `HttpError(404)` (de `core/http`) → `CatalogNotFoundError` → message « bière

--- a/docs/architecture/diagrams/mobile-catalog/05-sequence-errors.md
+++ b/docs/architecture/diagrams/mobile-catalog/05-sequence-errors.md
@@ -1,0 +1,124 @@
+# Diagramme de séquence — mobile-catalog — Variantes d'erreur (404 / timeout / hors-ligne)
+
+> **Réalise :** branches d'erreur **transverses** de UC1/UC2/UC3 (réalisation mobile)
+> **Code concerné (cible) :** `features/beer-catalog/data/beer-catalog.api.ts`, `application/*`, `core/http/http-error.ts`, `core/query/QueryClient`
+> **ADR liés :** repo ADR-0005 (encyclopédie-seule, pas de secours NestJS), repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `02-sequence-browse.md` · `03-sequence-search.md` · `04-sequence-fiche.md` · `07-state-list-screen.md` (états error/offline) · `../../traceability-matrix.md`
+
+## Contexte
+
+Séquence **transverse** des cas d'erreur, factorisée pour les trois chemins heureux (`02`–`04`).
+Trois variantes : **404** (introuvable), **timeout / 5xx / réseau** (avec le `retry:1` de
+TanStack), **hors-ligne** (cache périmé servi vs erreur). Distingue l'erreur **au chargement
+initial** (plein écran) de l'erreur **de page suivante** (pied de liste, la liste reste
+visible) — distinction reprise par `07-state-list-screen.md`.
+
+## Diagramme (Mermaid — flux cible)
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant S as Écran (liste / fiche)
+  participant H as Hook (useInfiniteQuery / useQuery)
+  participant Q as Cache TanStack
+  participant API as beer-catalog.api (request, auth:false)
+  participant E as beer-encyclopedia (FastAPI)
+
+  alt 404 introuvable (fiche)
+    H->>API: getBeer(id)
+    API->>E: GET /beers/{id}
+    E-->>API: 404
+    API-->>H: HttpError(404) → CatalogNotFoundError
+    H-->>S: « bière introuvable » (pas de secours NestJS)
+  else timeout / 5xx / réseau
+    H->>API: fetch page / fiche
+    API->>E: GET …
+    E--xAPI: timeout / 503 / échec réseau
+    API-->>H: HttpError → CatalogUnavailableError
+    H->>H: retry:1 (un réessai silencieux)
+    H->>API: re-fetch
+    API->>E: GET …
+    E--xAPI: échec persistant
+    API-->>H: HttpError
+    alt chargement initial (pas de données)
+      H-->>S: écran d'erreur plein + « Réessayer » (refetch)
+    else page suivante (données déjà là)
+      H-->>S: erreur en pied de liste — liste conservée, réessai en place
+    end
+  else hors-ligne
+    H->>API: fetch
+    API--xE: pas de réseau
+    alt cache présent (stale)
+      Q-->>H: pages/fiche périmées
+      H-->>S: contenu servi du cache + bannière « hors-ligne »
+    else cache absent
+      H-->>S: écran hors-ligne + « Réessayer »
+    end
+  end
+```
+
+*Même flux en **PlantUML** (à garder synchronisé avec le bloc Mermaid).*
+
+```plantuml
+@startuml
+title sd — mobile-catalog — Variantes d'erreur (404 / timeout / hors-ligne)
+autonumber
+participant "Écran (liste / fiche)" as S
+participant "Hook\n(useInfiniteQuery / useQuery)" as H
+participant "Cache TanStack" as Q
+participant "beer-catalog.api\n(request, auth:false)" as API
+participant "beer-encyclopedia" as E
+
+alt 404 introuvable (fiche)
+  H -> API : getBeer(id)
+  API -> E : GET /beers/{id}
+  E --> API : 404
+  API --> H : HttpError(404) -> CatalogNotFoundError
+  H --> S : « bière introuvable » (pas de secours NestJS)
+else timeout / 5xx / réseau
+  H -> API : fetch page / fiche
+  API -> E : GET ...
+  E -->x API : timeout / 503 / échec réseau
+  API --> H : HttpError -> CatalogUnavailableError
+  H -> H : retry:1 (un réessai silencieux)
+  H -> API : re-fetch
+  API -> E : GET ...
+  E -->x API : échec persistant
+  API --> H : HttpError
+  alt chargement initial (pas de données)
+    H --> S : écran d'erreur plein + « Réessayer »
+  else page suivante (données déjà là)
+    H --> S : erreur en pied de liste — liste conservée, réessai en place
+  end
+else hors-ligne
+  H -> API : fetch
+  API -->x E : pas de réseau
+  alt cache présent (stale)
+    Q --> H : pages/fiche périmées
+    H --> S : contenu du cache + bannière hors-ligne
+  else cache absent
+    H --> S : écran hors-ligne + « Réessayer »
+  end
+end
+@enduml
+```
+
+## Notes
+
+- **Mapping d'erreurs.** `404 → CatalogNotFoundError` (« introuvable ») ;
+  `503 / timeout / réseau → CatalogUnavailableError` (« service indisponible / réessayer »).
+  Réutilise `HttpError(status, message, details)` de `core/http/http-error.ts`. Le `422`
+  (q vide) est évité en amont par la garde de recherche (`03-sequence-search.md`).
+- **`retry:1`.** Un seul réessai silencieux (config `core/query`) avant de remonter l'erreur à
+  l'UI — absorbe les coupures transitoires sans boucle.
+- **Initial vs page suivante.** Erreur **initiale** (aucune donnée) → écran plein + « Réessayer ».
+  Erreur de **page suivante** (`isFetchingNextPage` en échec) → **pied de liste** en erreur, la
+  liste déjà chargée **reste visible** (ne pas tout jeter). Repris dans `07-state-list-screen.md`
+  (états `Error` vs `NextPageError`).
+- **Hors-ligne.** Cache **en mémoire** uniquement (pas d'`AsyncStorage` en MVP) : « hors-ligne
+  avec contenu » n'existe que si la donnée a déjà été chargée dans la session (`gcTime 5min`).
+  Une vraie persistance hors-ligne est un **fast-follow** (cf. `11-data-flow.md`).
+- **Encyclopédie-seule.** Aucune bascule vers NestJS sur 404 (≠ scan UC4 transitoire) : le
+  catalogue lit uniquement Python (ADR-0005).
+- **Conformité.** Le code doit produire ces mappings d'erreur et distinguer initial/page
+  suivante. Implémentation après validation.

--- a/docs/architecture/diagrams/mobile-catalog/06-component.md
+++ b/docs/architecture/diagrams/mobile-catalog/06-component.md
@@ -1,0 +1,161 @@
+# Diagramme de composant — mobile-catalog — couches mobile ↔ API encyclopédie
+
+> **Périmètre :** structure interne de la feature `beer-catalog` (mobile) + frontière vers l'API encyclopédie
+> **Code concerné (cible) :** `packages/mobile-app/src/features/beer-catalog/{domain,data,application,presentation}/`, `packages/mobile-app/app/(app)/beer-catalog/`, `packages/mobile-app/src/core/{http,query,config}/`
+> **ADR liés :** repo ADR-0005 (split backend — le mobile lit les faits bière chez Python), repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `01-use-case.md` · `09-class-domain.md` · `02-sequence-browse.md` · `../beer-encyclopedia/03-component.md` (vue backend) · `../../traceability-matrix.md`
+
+## Contexte
+
+Décomposition structurelle de la feature mobile `beer-catalog` (couches Clean :
+`app` → `presentation` → `application` → `data` → `core/http`) et **frontière ADR-0005**
+avec le service Python. Répond à « comment c'est structuré », pas « qui veut quoi »
+(ça, c'est `01-use-case.md`).
+
+**Points que ce diagramme rend explicites** : (1) l'**egress unique** est
+`core/http/request()` — aucun `fetch` direct dans la feature (motif interdit projet) ;
+(2) les lectures catalogue sont **`auth:false`** sur `baseUrl: env.encyclopediaUrl`
+(l'encyclopédie est publique, ADR-0005) ; (3) **un seul hook** `useBeerCatalogPagination`
+(`useInfiniteQuery`) sert *parcourir* et *rechercher* ; (4) la `presentation` n'importe
+jamais `data/` en direct — elle passe par `application/`.
+
+## Diagramme (Mermaid — aperçu rapide)
+
+```mermaid
+flowchart TB
+  Enc["beer-encyclopedia (FastAPI) — brasse-bouillon-encyclopedia.fly.dev"]
+
+  subgraph MOBILE ["packages/mobile-app — feature beer-catalog"]
+    subgraph APP ["app (Expo Router)"]
+      Routes["(app)/beer-catalog: index · search · beer/[id] · brewery/[id] · style/[id]"]
+    end
+    subgraph PRES ["presentation"]
+      Browse["BeerCatalogBrowseScreen"]
+      Search["BeerCatalogSearchScreen"]
+      Detail["BeerDetailScreen / BreweryDetailScreen / StyleDetailScreen"]
+      Card["BeerListItem (carte)"]
+    end
+    subgraph APPL ["application"]
+      Hook["useBeerCatalogPagination (useInfiniteQuery)"]
+      Debounce["useDebouncedValue"]
+      UseCases["use-cases: listBeers / searchBeers / getBeer / getBrewery / getStyle"]
+      NextParam["computeNextPageParam (pur, testé)"]
+    end
+    subgraph DATA ["data"]
+      Api["beer-catalog.api.ts (request, auth:false)"]
+      Mapper["beer-catalog.mapper.ts (DTO snake_case → domaine)"]
+    end
+    subgraph DOMAIN ["domain"]
+      Types["beer-catalog.types.ts (CatalogBeer, Page<T>, PaginationMeta)"]
+    end
+    subgraph CORE ["core (transverse)"]
+      HTTP["http/request()"]
+      Query["query/QueryClient (retry 1, staleTime 30s, gcTime 5min)"]
+      Env["config/env (encyclopediaUrl, encyclopediaUrlIsConfigured)"]
+    end
+  end
+
+  Routes --> Browse
+  Routes --> Search
+  Routes --> Detail
+  Browse --> Card
+  Search --> Card
+  Browse --> Hook
+  Search --> Hook
+  Search --> Debounce
+  Detail --> UseCases
+  Hook --> UseCases
+  Hook --> NextParam
+  UseCases --> Api
+  Api --> Mapper
+  Mapper --> Types
+  Api --> HTTP
+  Hook --> Query
+  Api --> Env
+  HTTP -->|"GET /beers · /beers/search · /beers/{id} · /breweries/{id} · /styles/{id} — auth:false (ADR-0005)"| Enc
+```
+
+*Même structure en **PlantUML** (notation magistrale). À garder **synchronisée** avec le bloc Mermaid.*
+
+```plantuml
+@startuml
+title cmp — mobile-catalog (couches mobile <-> API encyclopédie)
+skinparam componentStyle rectangle
+skinparam shadowing false
+
+cloud "beer-encyclopedia (FastAPI)\nbrasse-bouillon-encyclopedia.fly.dev" as Enc
+
+package "packages/mobile-app — feature beer-catalog" as MOBILE {
+  package "app (Expo Router)" {
+    component "(app)/beer-catalog\nindex · search · beer/[id] · brewery/[id] · style/[id]" as Routes
+  }
+  package "presentation" {
+    component "BeerCatalogBrowseScreen" as Browse
+    component "BeerCatalogSearchScreen" as Search
+    component "BeerDetailScreen /\nBreweryDetailScreen / StyleDetailScreen" as Detail
+    component "BeerListItem (carte)" as Card
+  }
+  package "application" {
+    component "useBeerCatalogPagination\n(useInfiniteQuery)" as Hook
+    component "useDebouncedValue" as Debounce
+    component "use-cases\nlistBeers / searchBeers / getBeer / getBrewery / getStyle" as UseCases
+    component "computeNextPageParam\n(pur, testé)" as NextParam
+  }
+  package "data" {
+    component "beer-catalog.api.ts\n(request, auth:false)" as Api
+    component "beer-catalog.mapper.ts\n(DTO snake_case -> domaine)" as Mapper
+  }
+  package "domain" {
+    component "beer-catalog.types.ts\n(CatalogBeer, Page<T>, PaginationMeta)" as Types
+  }
+  package "core (transverse)" {
+    component "http/request()" as HTTP
+    component "query/QueryClient\n(retry 1, staleTime 30s, gcTime 5min)" as Query
+    component "config/env\n(encyclopediaUrl, encyclopediaUrlIsConfigured)" as Env
+  }
+}
+
+Routes --> Browse
+Routes --> Search
+Routes --> Detail
+Browse --> Card
+Search --> Card
+Browse --> Hook
+Search --> Hook
+Search --> Debounce
+Detail --> UseCases
+Hook --> UseCases
+Hook --> NextParam
+UseCases --> Api
+Api --> Mapper
+Mapper --> Types
+Api --> HTTP
+Hook --> Query
+Api --> Env
+HTTP --> Enc : "GET /beers · /beers/search · /beers/{id} · /breweries/{id} · /styles/{id}\nauth:false (ADR-0005)"
+
+note bottom of HTTP
+  Egress unique. Aucun fetch direct dans la feature
+  (motif interdit). baseUrl = env.encyclopediaUrl.
+end note
+@enduml
+```
+
+## Notes
+
+- **Egress unique** : seul `core/http/request()` parle au réseau ; `beer-catalog.api.ts`
+  l'appelle avec `baseUrl: env.encyclopediaUrl` + `auth: false`. Aucun `fetch()` direct (motif
+  interdit, CLAUDE.md). Garde `encyclopediaUrlIsConfigured` → `HttpError(503)` si l'URL n'est
+  pas configurée (même garde que la feature `scan`).
+- **Règle de dépendance (Clean)** : `presentation → application → data → core`. La
+  `presentation` n'importe **jamais** `data/` ; `domain/` n'importe rien. La feature ne dépend
+  pas de `scan` (mappers **dupliqués**, pas partagés — cibles différentes, voir `11-data-flow.md`).
+- **Un seul hook paginé** : `useBeerCatalogPagination` (`useInfiniteQuery`) sert *parcourir*
+  (`listBeers`) et *rechercher* (`searchBeers`) ; seule la **clé de cache** et l'endpoint
+  changent (`["beer-catalog","browse"]` vs `["beer-catalog","search",q]`). `computeNextPageParam`
+  est **pur et testé** isolément (math 1-based, cf. `02-sequence-browse.md`).
+- **Frontière ADR-0005** : le mobile lit les **faits bière** chez Python (catalogue), et garde
+  NestJS pour les **données utilisateur** (hors de ce diagramme). NestJS n'est **pas** sur le
+  chemin catalogue.
+- **Conformité** : le code (cible `features/beer-catalog/`) doit se conformer à cette
+  structure. Implémentation **après** validation de la conception (`Part A`).

--- a/docs/architecture/diagrams/mobile-catalog/07-state-list-screen.md
+++ b/docs/architecture/diagrams/mobile-catalog/07-state-list-screen.md
@@ -1,0 +1,101 @@
+# Diagramme d'états — mobile-catalog — cycle de vie de l'écran liste
+
+> **Périmètre :** machine à états de l'écran liste (parcourir UC1 / résultats UC2), pagination infinie
+> **Code concerné (cible) :** `features/beer-catalog/presentation/BeerCatalogBrowseScreen.tsx` (+ Search), drapeaux dérivés de `useBeerCatalogPagination`
+> **ADR liés :** repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `02-sequence-browse.md` · `05-sequence-errors.md` · `10-class-view-model.md` (`CatalogListVM`) · `08-state-search-input.md` · `../../traceability-matrix.md`
+
+## Contexte
+
+Cycle de vie de l'écran liste : la **pagination infinie** crée de vrais états (on peut être
+« chargé **et** en train de charger plus »). Ces états sont **dérivés** des indicateurs
+TanStack (`isLoading`, `isFetchingNextPage`, `isError`, `data`, `hasNextPage`), **pas** une FSM
+écrite à la main — le diagramme nomme les états pour le contrôle de conformité (ils
+correspondent aux drapeaux de `CatalogListVM`, `10`).
+
+## Diagramme (Mermaid — aperçu rapide)
+
+```mermaid
+stateDiagram-v2
+  [*] --> Loading
+
+  Loading --> Loaded: page 1 reçue (liste non vide)
+  Loading --> LoadedEmpty: page 1 reçue (liste vide)
+  Loading --> Error: échec initial (après un réessai)
+  Loading --> OfflineWithCache: hors-ligne, cache présent
+  Loading --> OfflineNoCache: hors-ligne, cache absent
+
+  Loaded --> LoadingMore: onEndReached (hasNextPage)
+  Loaded --> Loaded: pull-to-refresh (refetch)
+  Loaded --> Idle: aucune page suivante
+
+  LoadingMore --> Loaded: page suivante ajoutée
+  LoadingMore --> NextPageError: échec page suivante
+  LoadingMore --> Idle: dernière page
+
+  NextPageError --> LoadingMore: réessai en pied de liste
+  Error --> Loading: « Réessayer »
+  OfflineWithCache --> Loading: reconnexion / refetch
+  OfflineNoCache --> Loading: « Réessayer »
+
+  LoadedEmpty --> Loading: pull-to-refresh
+
+  Idle --> LoadingMore: onEndReached (si hasNextPage redevient vrai)
+  Loaded --> [*]
+  Idle --> [*]
+```
+
+*Même machine en **PlantUML** (à garder synchronisée avec le bloc Mermaid).*
+
+```plantuml
+@startuml
+title stm — mobile-catalog — cycle de vie de l'écran liste
+[*] --> Loading
+
+Loading --> Loaded : page 1 reçue (liste non vide)
+Loading --> LoadedEmpty : page 1 reçue (liste vide)
+Loading --> Error : échec initial (après un réessai)
+Loading --> OfflineWithCache : hors-ligne, cache présent
+Loading --> OfflineNoCache : hors-ligne, cache absent
+
+Loaded --> LoadingMore : onEndReached (hasNextPage)
+Loaded --> Loaded : pull-to-refresh (refetch)
+Loaded --> Idle : aucune page suivante
+
+LoadingMore --> Loaded : page suivante ajoutée
+LoadingMore --> NextPageError : échec page suivante
+LoadingMore --> Idle : dernière page
+
+NextPageError --> LoadingMore : réessai en pied de liste
+Error --> Loading : « Réessayer »
+OfflineWithCache --> Loading : reconnexion / refetch
+OfflineNoCache --> Loading : « Réessayer »
+
+LoadedEmpty --> Loading : pull-to-refresh
+
+Idle --> LoadingMore : onEndReached (si hasNextPage)
+Loaded --> [*]
+Idle --> [*]
+@enduml
+```
+
+## Notes
+
+- **États dérivés (correspondance TanStack).**
+  - `Loading` = `isLoading` (aucune donnée encore) ;
+  - `Loaded` = `data` présent, items > 0, pas de fetch de page en cours ;
+  - `LoadingMore` = `isFetchingNextPage` ;
+  - `Error` = `isError && !data` (échec initial) ;
+  - `NextPageError` = `isError && data` (échec de page suivante, liste conservée) ;
+  - `LoadedEmpty` = `!isLoading && flatItems.length === 0` ;
+  - `Idle` = chargé sans page suivante (`hasNextPage === false`).
+  - `hasNextPage` **garde** la transition `onEndReached`.
+- **`Error` vs `NextPageError`.** Distinction structurante (cf. `05-sequence-errors.md`) :
+  échec **initial** → écran d'erreur plein ; échec de **page suivante** → erreur **en pied de
+  liste**, la liste déjà chargée reste affichée.
+- **Hors-ligne.** `OfflineWithCache` sert le contenu périmé + bannière ; `OfflineNoCache` →
+  écran hors-ligne. Cache **en mémoire** (`gcTime 5min`) — persistance hors-ligne = fast-follow.
+- **Recherche.** Le même écran liste sert les résultats de recherche ; la saisie a sa propre
+  FSM (`08-state-search-input.md`), qui **alimente** ce cycle de vie une fois la requête lancée.
+- **Conformité.** Les drapeaux de `CatalogListVM` (`10`) doivent refléter ces états. Pas de
+  machine à états codée à la main. Implémentation après validation.

--- a/docs/architecture/diagrams/mobile-catalog/07-state-list-screen.md
+++ b/docs/architecture/diagrams/mobile-catalog/07-state-list-screen.md
@@ -40,7 +40,7 @@ stateDiagram-v2
 
   LoadedEmpty --> Loading: pull-to-refresh
 
-  Idle --> LoadingMore: onEndReached (si hasNextPage redevient vrai)
+  Idle --> LoadingMore: onEndReached (si page suivante)
   Loaded --> [*]
   Idle --> [*]
 ```
@@ -73,7 +73,7 @@ OfflineNoCache --> Loading : « Réessayer »
 
 LoadedEmpty --> Loading : pull-to-refresh
 
-Idle --> LoadingMore : onEndReached (si hasNextPage)
+Idle --> LoadingMore : onEndReached (si page suivante)
 Loaded --> [*]
 Idle --> [*]
 @enduml

--- a/docs/architecture/diagrams/mobile-catalog/07-state-list-screen.md
+++ b/docs/architecture/diagrams/mobile-catalog/07-state-list-screen.md
@@ -40,7 +40,6 @@ stateDiagram-v2
 
   LoadedEmpty --> Loading: pull-to-refresh
 
-  Idle --> LoadingMore: onEndReached (si page suivante)
   Loaded --> [*]
   Idle --> [*]
 ```
@@ -73,7 +72,6 @@ OfflineNoCache --> Loading : « Réessayer »
 
 LoadedEmpty --> Loading : pull-to-refresh
 
-Idle --> LoadingMore : onEndReached (si page suivante)
 Loaded --> [*]
 Idle --> [*]
 @enduml
@@ -86,7 +84,8 @@ Idle --> [*]
   - `Loaded` = `data` présent, items > 0, pas de fetch de page en cours ;
   - `LoadingMore` = `isFetchingNextPage` ;
   - `Error` = `isError && !data` (échec initial) ;
-  - `NextPageError` = `isError && data` (échec de page suivante, liste conservée) ;
+  - `NextPageError` = `isFetchNextPageError` (TanStack v5 — échec **spécifique** de
+    `fetchNextPage`, distinct d'une erreur de refetch/pull-to-refresh ; liste conservée) ;
   - `LoadedEmpty` = `!isLoading && flatItems.length === 0` ;
   - `Idle` = chargé sans page suivante (`hasNextPage === false`).
   - `hasNextPage` **garde** la transition `onEndReached`.

--- a/docs/architecture/diagrams/mobile-catalog/08-state-search-input.md
+++ b/docs/architecture/diagrams/mobile-catalog/08-state-search-input.md
@@ -26,7 +26,7 @@ stateDiagram-v2
 
   Searching --> Results: items > 0
   Searching --> Empty: items = 0
-  Searching --> Searching: nouvelle q debouncée (annule la requête en vol)
+  Searching --> Searching: nouvelle q debouncée (résultat précédent ignoré)
 
   Results --> Typing: édition du terme
   Empty --> Typing: édition du terme
@@ -53,7 +53,7 @@ Debouncing --> Searching : timer écoulé (q >= 2 car.)
 
 Searching --> Results : items > 0
 Searching --> Empty : items = 0
-Searching --> Searching : nouvelle q debouncée (annule la requête en vol)
+Searching --> Searching : nouvelle q debouncée (résultat précédent ignoré)
 
 Results --> Typing : édition du terme
 Empty --> Typing : édition du terme
@@ -73,10 +73,11 @@ Idle --> [*]
   Typing`), évitant une requête par caractère.
 - **Garde « ≥ 2 caractères ».** `Debouncing → Idle` si le terme est trop court → pas d'appel
   (évite aussi le `422` d'un `q` vide côté API).
-- **Annulation in-flight.** `Searching → Searching` sur une nouvelle `q` debouncée : le
-  changement de `queryKey` (`["beer-catalog","search",q]`) fait abandonner la requête
-  précédente par TanStack (cf. `03-sequence-search.md`). `keepPreviousData` maintient les
-  anciens résultats affichés pendant la transition.
+- **Résultat précédent ignoré (pas un abort réseau).** `Searching → Searching` sur une nouvelle
+  `q` debouncée : le changement de `queryKey` (`["beer-catalog","search",q]`) rend la requête
+  précédente **inactive** (son résultat est ignoré) ; `keepPreviousData` garde les anciens
+  résultats affichés. L'**abort réseau** n'a lieu que si `request()` propage le `AbortSignal` de
+  TanStack (à câbler, cf. `03-sequence-search.md`).
 - **Vers la liste.** `Searching` lance le hook paginé ; l'affichage des résultats (chargement /
   page suivante / erreur) suit `07-state-list-screen.md`. `Results`/`Empty` ici ≙
   `Loaded`/`LoadedEmpty` là-bas.

--- a/docs/architecture/diagrams/mobile-catalog/08-state-search-input.md
+++ b/docs/architecture/diagrams/mobile-catalog/08-state-search-input.md
@@ -1,0 +1,84 @@
+# Diagramme d'états — mobile-catalog — saisie de recherche (debounce / annulation)
+
+> **Périmètre :** machine à états de la **saisie** de recherche (UC2), du clavier à la requête
+> **Code concerné (cible) :** `features/beer-catalog/presentation/BeerCatalogSearchScreen.tsx`, `application/useDebouncedValue.ts`
+> **ADR liés :** repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `03-sequence-search.md` (séquence) · `10-class-view-model.md` (`SearchVM.status`) · `07-state-list-screen.md` (cycle de vie alimenté) · `../../traceability-matrix.md`
+
+## Contexte
+
+Cycle de vie de la **saisie** de recherche, en amont de la requête. Capture le **debounce**
+(on n'appelle pas à chaque frappe) et l'**annulation** (une nouvelle frappe pendant une
+requête en vol annule la précédente). Ces états correspondent à `SearchVM.status` (`10`) ;
+une fois `Searching` lancé, la **liste de résultats** suit `07-state-list-screen.md`.
+
+## Diagramme (Mermaid — aperçu rapide)
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+
+  Idle --> Typing: onChangeText
+  Typing --> Debouncing: pause de frappe (timer ≈300 ms armé)
+  Debouncing --> Typing: nouvelle frappe (timer réarmé)
+  Debouncing --> Idle: terme effacé / < 2 caractères
+  Debouncing --> Searching: timer écoulé (q ≥ 2 car.)
+
+  Searching --> Results: items > 0
+  Searching --> Empty: items = 0
+  Searching --> Searching: nouvelle q debouncée (annule la requête en vol)
+
+  Results --> Typing: édition du terme
+  Empty --> Typing: édition du terme
+  Results --> Idle: effacer (onClear)
+  Empty --> Idle: effacer (onClear)
+  Typing --> Idle: effacer (onClear)
+
+  Results --> [*]
+  Idle --> [*]
+```
+
+*Même machine en **PlantUML** (à garder synchronisée avec le bloc Mermaid).*
+
+```plantuml
+@startuml
+title stm — mobile-catalog — saisie de recherche (debounce / annulation)
+[*] --> Idle
+
+Idle --> Typing : onChangeText
+Typing --> Debouncing : pause de frappe (timer ~300 ms)
+Debouncing --> Typing : nouvelle frappe (timer réarmé)
+Debouncing --> Idle : terme effacé / < 2 caractères
+Debouncing --> Searching : timer écoulé (q >= 2 car.)
+
+Searching --> Results : items > 0
+Searching --> Empty : items = 0
+Searching --> Searching : nouvelle q debouncée (annule la requête en vol)
+
+Results --> Typing : édition du terme
+Empty --> Typing : édition du terme
+Results --> Idle : effacer (onClear)
+Empty --> Idle : effacer (onClear)
+Typing --> Idle : effacer (onClear)
+
+Results --> [*]
+Idle --> [*]
+@enduml
+```
+
+## Notes
+
+- **Debounce.** `Typing → Debouncing → Searching` : la requête ne part qu'après stabilisation
+  (`useDebouncedValue`, ≈300 ms). Une frappe continue **réarme** le timer (`Debouncing →
+  Typing`), évitant une requête par caractère.
+- **Garde « ≥ 2 caractères ».** `Debouncing → Idle` si le terme est trop court → pas d'appel
+  (évite aussi le `422` d'un `q` vide côté API).
+- **Annulation in-flight.** `Searching → Searching` sur une nouvelle `q` debouncée : le
+  changement de `queryKey` (`["beer-catalog","search",q]`) fait abandonner la requête
+  précédente par TanStack (cf. `03-sequence-search.md`). `keepPreviousData` maintient les
+  anciens résultats affichés pendant la transition.
+- **Vers la liste.** `Searching` lance le hook paginé ; l'affichage des résultats (chargement /
+  page suivante / erreur) suit `07-state-list-screen.md`. `Results`/`Empty` ici ≙
+  `Loaded`/`LoadedEmpty` là-bas.
+- **Conformité.** `SearchVM.status` (`10`) doit exposer exactement ces états. Implémentation
+  après validation.

--- a/docs/architecture/diagrams/mobile-catalog/09-class-domain.md
+++ b/docs/architecture/diagrams/mobile-catalog/09-class-domain.md
@@ -47,7 +47,6 @@ classDiagram
     +string breweryName?
     +string styleName?
     +number abv?
-    +number ibu?
     +number ibuMin?
     +number ibuMax?
     +number srmMin?
@@ -131,7 +130,6 @@ class CatalogBeer {
   +breweryName : string?
   +styleName : string?
   +abv : number?
-  +ibu : number?
   +ibuMin : number?
   +ibuMax : number?
   +srmMin : number?
@@ -199,10 +197,18 @@ CatalogBeerDetail ..> CatalogStyle : tap (navigation)
   (mentions légales, provenance, horodatage). Permet l'**amorçage du cache** liste → détail
   (`04-sequence-fiche.md`).
 - **Transformations (mapper).** `abv: string → number` (Pydantic Decimal sérialise en chaîne) ;
-  `ibu = milieu(ibuMin, ibuMax)` pour l'affichage scalaire, **bornes conservées** (ADR-0017) ;
-  SRM conservé en bornes (`srmMin`/`srmMax`) — la conversion **SRM → EBC** d'affichage vit au
-  **view-model** (`10`), pas au domaine. Noms `breweryName`/`styleName` **dénormalisés** par
-  l'API (peuvent être `null` → libellé de repli côté VM).
+  **bornes IBU/SRM conservées telles quelles** (`ibuMin/ibuMax`, `srmMin/srmMax`, ADR-0017).
+  **Aucun scalaire dérivé au domaine** : le milieu d'intervalle et la conversion **SRM → EBC**
+  d'affichage vivent au **view-model** (`10`), pas au domaine.
+- **Noms dénormalisés (divergence code↔conception, ADR-0013 clause 6).** `breweryName`/
+  `styleName` ne sont résolus par l'API **que sur `POST /beers/import-by-ean`** ; `GET /beers`,
+  `/beers/search` et `/beers/{id}` les renvoient **`null` aujourd'hui** (`BeerRead.model_validate`
+  sans `_beer_read_with_names`, cf. `../beer-encyclopedia/07-class-api-contract.md`). **Cible** :
+  les résoudre aussi sur list/search/detail (à câbler côté API — **divergence à suivre, issue à
+  ouvrir**). En attendant, le **view-model** (`10`) affiche un libellé de repli (« Brasserie
+  inconnue » / « Style inconnu », motif du scan).
+- **`website` ≡ `BreweryRead.website_url`.** Le mapper **renomme** `website_url → website` (pas
+  seulement un changement de casse).
 - **Distinct de l'ORM.** `../beer-encyclopedia/04-class.md` = entités persistées (snake_case,
   FK, contraintes). Ici, vue **client en lecture seule** : pas de FK exécutable, juste
   `breweryId`/`styleId` pour la **navigation** (tap → fiche).

--- a/docs/architecture/diagrams/mobile-catalog/09-class-domain.md
+++ b/docs/architecture/diagrams/mobile-catalog/09-class-domain.md
@@ -1,0 +1,210 @@
+# Diagramme de classes — mobile-catalog — modèle de domaine mobile
+
+> **Périmètre :** types **domaine** de la feature mobile `beer-catalog` (camelCase, après mapping du DTO)
+> **Code concerné (cible) :** `packages/mobile-app/src/features/beer-catalog/domain/beer-catalog.types.ts`
+> **ADR liés :** repo ADR-0005 (contrat consommé depuis Python), ADR-0017 (intervalles IBU/SRM), repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `../beer-encyclopedia/07-class-api-contract.md` (DTO Pydantic source) · `../beer-encyclopedia/04-class.md` (domaine ORM) · `10-class-view-model.md` (modèle de vue dérivé) · `11-data-flow.md` · `../../traceability-matrix.md`
+
+## Contexte
+
+`../beer-encyclopedia/07-class-api-contract.md` modélise le **DTO** (snake_case, sérialisé par
+l'API). Ce diagramme modélise le **domaine mobile** : les types **camelCase** produits par le
+mapper et manipulés par l'`application`. Distinct du DTO (forme réseau) et du **view-model**
+(`10`, forme d'affichage formatée).
+
+**Décisions modélisées** : (1) `Page~T~` est **générique** — une enveloppe paginée réutilisable
+(bières aujourd'hui, brasseries/styles en fast-follow) ; (2) **`PaginationMeta` est dessiné
+ici** (camelCase `perPage`) — il était référencé sans être défini dans le contrat backend
+(corrigé en parallèle dans `07`) ; (3) `CatalogBeerDetail` **étend** `CatalogBeer` (la liste
+porte un sous-ensemble, la fiche le complet) ; (4) `abv` est **parsé `string → number`**, les
+intervalles IBU/SRM conservent **bornes + milieu** (ADR-0017).
+
+## Diagramme (Mermaid — aperçu rapide)
+
+```mermaid
+classDiagram
+  class PaginationMeta {
+    +number total
+    +number page
+    +number perPage
+  }
+  class Page~T~ {
+    +T[] items
+    +PaginationMeta meta
+  }
+  class PageResult~T~ {
+    +Page~T~[] pages
+    +T[] flatItems
+    +boolean hasNextPage
+    +number nextPage?
+  }
+  class CatalogBeer {
+    +string id
+    +string slug
+    +string name
+    +string breweryId?
+    +string styleId?
+    +string breweryName?
+    +string styleName?
+    +number abv?
+    +number ibu?
+    +number ibuMin?
+    +number ibuMax?
+    +number srmMin?
+    +number srmMax?
+    +string description?
+  }
+  class CatalogBeerDetail {
+    +string eanCode?
+    +string legalDenomination?
+    +string countryOfOrigin?
+    +string[] allergens?
+    +number alcoholGroup?
+    +boolean isVerified
+    +string source
+    +string createdAt
+    +string updatedAt
+  }
+  class CatalogBrewery {
+    +string id
+    +string slug
+    +string name
+    +string breweryType?
+    +string city?
+    +string country?
+    +number foundedYear?
+    +string website?
+    +string description?
+  }
+  class CatalogStyle {
+    +string id
+    +string slug
+    +string name
+    +string category?
+    +string family?
+    +number abvMin?
+    +number abvMax?
+    +number ibuMin?
+    +number ibuMax?
+    +number srmMin?
+    +number srmMax?
+  }
+
+  CatalogBeer <|-- CatalogBeerDetail
+  Page~T~ "1" o-- "1" PaginationMeta : meta
+  Page~T~ "1" o-- "0..*" CatalogBeer : items (T = CatalogBeer)
+  PageResult~T~ "1" o-- "1..*" Page~T~ : pages
+  CatalogBeerDetail ..> CatalogBrewery : tap (navigation)
+  CatalogBeerDetail ..> CatalogStyle : tap (navigation)
+```
+
+*Même modèle en **PlantUML** (notation magistrale). À garder **synchronisé** avec le bloc Mermaid.*
+
+```plantuml
+@startuml
+title cd — mobile-catalog (domaine mobile, camelCase)
+skinparam classAttributeIconSize 0
+skinparam shadowing false
+hide methods
+
+class PaginationMeta {
+  +total : number
+  +page : number
+  +perPage : number
+}
+class "Page<T>" as Page {
+  +items : T[]
+  +meta : PaginationMeta
+}
+class "PageResult<T>" as PageResult {
+  +pages : Page<T>[]
+  +flatItems : T[]
+  +hasNextPage : boolean
+  +nextPage : number?
+}
+class CatalogBeer {
+  +id : string
+  +slug : string
+  +name : string
+  +breweryId : string?
+  +styleId : string?
+  +breweryName : string?
+  +styleName : string?
+  +abv : number?
+  +ibu : number?
+  +ibuMin : number?
+  +ibuMax : number?
+  +srmMin : number?
+  +srmMax : number?
+  +description : string?
+}
+class CatalogBeerDetail {
+  +eanCode : string?
+  +legalDenomination : string?
+  +countryOfOrigin : string?
+  +allergens : string[]?
+  +alcoholGroup : number?
+  +isVerified : boolean
+  +source : string
+  +createdAt : string
+  +updatedAt : string
+}
+class CatalogBrewery {
+  +id : string
+  +slug : string
+  +name : string
+  +breweryType : string?
+  +city : string?
+  +country : string?
+  +foundedYear : number?
+  +website : string?
+  +description : string?
+}
+class CatalogStyle {
+  +id : string
+  +slug : string
+  +name : string
+  +category : string?
+  +family : string?
+  +abvMin : number?
+  +abvMax : number?
+  +ibuMin : number?
+  +ibuMax : number?
+  +srmMin : number?
+  +srmMax : number?
+}
+
+CatalogBeer <|-- CatalogBeerDetail
+Page "1" o-- "1" PaginationMeta : meta
+Page "1" o-- "0..*" CatalogBeer : items (T = CatalogBeer)
+PageResult "1" o-- "1..*" Page : pages
+CatalogBeerDetail ..> CatalogBrewery : tap (navigation)
+CatalogBeerDetail ..> CatalogStyle : tap (navigation)
+@enduml
+```
+
+## Notes
+
+- **`PaginationMeta` (camelCase).** `≡ api/schemas/common.PaginationMeta` du contrat backend
+  (`07-class-api-contract.md`, où la boîte est dessinée en parallèle) : `perPage` = `per_page`
+  après mapping. Contraintes API : `total ≥ 0`, `page ≥ 1` (1-based), `per_page ∈ [1,100]`
+  (défaut 20). Le mobile ne renvoie pas `meta` ; il le **lit** pour calculer la page suivante.
+- **`Page~T~` / `PageResult~T~`.** `Page~T~` = une page d'API mappée. `PageResult~T~` =
+  l'agrégat accumulé par `useInfiniteQuery` (toutes les pages + items aplatis + `hasNextPage` /
+  `nextPage` dérivés de `meta`). Générique pour réemploi (brasseries/styles en fast-follow).
+  Promotion vers `core/` **seulement** sur un 2ᵉ consommateur (YAGNI).
+- **`CatalogBeer` vs `CatalogBeerDetail`.** La **liste** (`GET /beers`) et le **détail**
+  (`GET /beers/{id}`) renvoient le même `BeerRead`, mais l'écran liste n'utilise qu'un
+  sous-ensemble : `CatalogBeerDetail` **hérite** de `CatalogBeer` et ajoute les champs lourds
+  (mentions légales, provenance, horodatage). Permet l'**amorçage du cache** liste → détail
+  (`04-sequence-fiche.md`).
+- **Transformations (mapper).** `abv: string → number` (Pydantic Decimal sérialise en chaîne) ;
+  `ibu = milieu(ibuMin, ibuMax)` pour l'affichage scalaire, **bornes conservées** (ADR-0017) ;
+  SRM conservé en bornes (`srmMin`/`srmMax`) — la conversion **SRM → EBC** d'affichage vit au
+  **view-model** (`10`), pas au domaine. Noms `breweryName`/`styleName` **dénormalisés** par
+  l'API (peuvent être `null` → libellé de repli côté VM).
+- **Distinct de l'ORM.** `../beer-encyclopedia/04-class.md` = entités persistées (snake_case,
+  FK, contraintes). Ici, vue **client en lecture seule** : pas de FK exécutable, juste
+  `breweryId`/`styleId` pour la **navigation** (tap → fiche).
+- **Conformité.** `beer-catalog.types.ts` doit correspondre à ce diagramme (`interface` pour
+  les formes d'objet, pas de `any`, pas d'export par défaut). Implémentation après validation.

--- a/docs/architecture/diagrams/mobile-catalog/10-class-view-model.md
+++ b/docs/architecture/diagrams/mobile-catalog/10-class-view-model.md
@@ -1,0 +1,228 @@
+# Diagramme de classes — mobile-catalog — modèle de vue (view-model)
+
+> **Périmètre :** modèle de **vue** consommé par les écrans (formaté, prêt à afficher), distinct du domaine
+> **Code concerné (cible) :** `packages/mobile-app/src/features/beer-catalog/presentation/*` + formateurs `application/`
+> **ADR liés :** ADR-0017 (intervalles → libellés `20–28`), repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `09-class-domain.md` (domaine source) · `07-state-list-screen.md` · `08-state-search-input.md` · `11-data-flow.md` · `../../traceability-matrix.md`
+
+## Contexte
+
+`09-class-domain.md` donne le **domaine** (camelCase, champs optionnels bruts issus du mapper).
+Ce diagramme donne le **view-model** : ce que les écrans **affichent réellement**, après
+formatage (libellés `%`, intervalles `20–28`, couleur EBC → hex) et **drapeaux d'UI**
+(chargement, vide, erreur, hors-ligne, page suivante).
+
+**Pourquoi un modèle de vue séparé** : le domaine est *nullable/brut* (logique métier) ; la vue
+est *formatée/non-null* (présentation). Les **drapeaux** de `CatalogListVM` reflètent
+exactement les états de `07-state-list-screen.md`, ceux de `SearchVM` ceux de
+`08-state-search-input.md` — la machine à états et le view-model sont **deux vues du même
+cycle de vie**. Le formatage réutilise les utilitaires du **scan** (`srmToEbc`, `ebcToHex`,
+`formatInterval`).
+
+## Diagramme (Mermaid — aperçu rapide)
+
+```mermaid
+classDiagram
+  class BeerListItemVM {
+    +string id
+    +string title
+    +string subtitle
+    +string abvLabel
+    +string ibuLabel
+    +string heroColorHex
+    +string foregroundHex
+  }
+  class BeerDetailVM {
+    +string title
+    +string breweryName
+    +string styleName
+    +string abvLabel
+    +string ibuLabel
+    +string colorLabel
+    +string heroColorHex
+    +string foregroundHex
+    +string description?
+    +LegalBlockVM legal
+    +boolean isVerifiedBadge
+    +string sourceLabel
+    +TapTargetVM breweryTap?
+    +TapTargetVM styleTap?
+  }
+  class LegalBlockVM {
+    +string denomination?
+    +string country?
+    +string[] allergens
+    +string alcoholGroupLabel?
+  }
+  class TapTargetVM {
+    +string id
+    +string label
+    +string route
+  }
+  class BreweryFicheVM {
+    +string title
+    +string typeLabel?
+    +string locationLabel?
+    +string foundedLabel?
+    +string website?
+    +string description?
+  }
+  class StyleFicheVM {
+    +string title
+    +string categoryLabel?
+    +string familyLabel?
+    +string abvRangeLabel?
+    +string ibuRangeLabel?
+    +string colorRangeLabel?
+  }
+  class CatalogListVM {
+    +BeerListItemVM[] items
+    +boolean isLoading
+    +boolean isLoadingMore
+    +boolean isEmpty
+    +boolean isError
+    +boolean isOffline
+    +boolean hasNextPage
+    +onEndReached() void
+    +onRetry() void
+  }
+  class SearchVM {
+    +string query
+    +SearchStatus status
+    +onChange(text) void
+    +onClear() void
+    +CatalogListVM list
+  }
+  class SearchStatus {
+    <<enumeration>>
+    idle
+    typing
+    debouncing
+    searching
+    results
+    empty
+  }
+
+  CatalogListVM "1" o-- "0..*" BeerListItemVM : items
+  SearchVM "1" o-- "1" CatalogListVM : list
+  SearchVM ..> SearchStatus : status
+  BeerDetailVM "1" o-- "1" LegalBlockVM : legal
+  BeerDetailVM ..> TapTargetVM : breweryTap / styleTap
+```
+
+*Même modèle en **PlantUML** (notation magistrale). À garder **synchronisé** avec le bloc Mermaid.*
+
+```plantuml
+@startuml
+title cd — mobile-catalog (view-model, prêt à afficher)
+skinparam classAttributeIconSize 0
+skinparam shadowing false
+hide methods
+
+class BeerListItemVM {
+  +id : string
+  +title : string
+  +subtitle : string
+  +abvLabel : string
+  +ibuLabel : string
+  +heroColorHex : string
+  +foregroundHex : string
+}
+class BeerDetailVM {
+  +title : string
+  +breweryName : string
+  +styleName : string
+  +abvLabel : string
+  +ibuLabel : string
+  +colorLabel : string
+  +heroColorHex : string
+  +foregroundHex : string
+  +description : string?
+  +legal : LegalBlockVM
+  +isVerifiedBadge : boolean
+  +sourceLabel : string
+  +breweryTap : TapTargetVM?
+  +styleTap : TapTargetVM?
+}
+class LegalBlockVM {
+  +denomination : string?
+  +country : string?
+  +allergens : string[]
+  +alcoholGroupLabel : string?
+}
+class TapTargetVM {
+  +id : string
+  +label : string
+  +route : string
+}
+class BreweryFicheVM {
+  +title : string
+  +typeLabel : string?
+  +locationLabel : string?
+  +foundedLabel : string?
+  +website : string?
+  +description : string?
+}
+class StyleFicheVM {
+  +title : string
+  +categoryLabel : string?
+  +familyLabel : string?
+  +abvRangeLabel : string?
+  +ibuRangeLabel : string?
+  +colorRangeLabel : string?
+}
+class CatalogListVM {
+  +items : BeerListItemVM[]
+  +isLoading : boolean
+  +isLoadingMore : boolean
+  +isEmpty : boolean
+  +isError : boolean
+  +isOffline : boolean
+  +hasNextPage : boolean
+  +onEndReached() : void
+  +onRetry() : void
+}
+enum SearchStatus {
+  idle
+  typing
+  debouncing
+  searching
+  results
+  empty
+}
+class SearchVM {
+  +query : string
+  +status : SearchStatus
+  +onChange(text) : void
+  +onClear() : void
+  +list : CatalogListVM
+}
+
+CatalogListVM "1" o-- "0..*" BeerListItemVM : items
+SearchVM "1" o-- "1" CatalogListVM : list
+SearchVM ..> SearchStatus : status
+BeerDetailVM "1" o-- "1" LegalBlockVM : legal
+BeerDetailVM ..> TapTargetVM : breweryTap / styleTap
+@enduml
+```
+
+## Notes
+
+- **Domaine → VM = un formateur de l'`application`.** Entrée : `CatalogBeer`/`CatalogBeerDetail`
+  (`09`). Sortie : VM non-null prêt à rendre. Exemples : `abvLabel = "5,5 %"` (ou `"—"` si
+  null) ; `ibuLabel = formatInterval(ibuMin, ibuMax)` → `"20–28"` / `"22"` / `"—"` ;
+  `heroColorHex = ebcToHex(srmToEbc(milieu(srm)))`, `foregroundHex = foregroundOnEbc(...)`
+  (réutilisés du **scan**, cf. `11-data-flow.md`) ; `subtitle = "<brasserie> · <style>"` avec
+  libellés de repli si `breweryName`/`styleName` null.
+- **Drapeaux ≙ machines à états.** `CatalogListVM.{isLoading,isLoadingMore,isEmpty,isError,
+  isOffline,hasNextPage}` reflètent les états de `07-state-list-screen.md` ;
+  `SearchVM.status` reflète `08-state-search-input.md`. Les drapeaux sont **dérivés** des
+  indicateurs TanStack (`isLoading`, `isFetchingNextPage`, `isError`, `data`), pas une FSM
+  écrite à la main.
+- **`TapTargetVM`** porte le `route` Expo Router (`/(app)/beer-catalog/brewery/<id>` ou
+  `/style/<id>`) — la **navigation** UC3 (tap brasserie/style), résolue à la construction du VM
+  pour que l'écran ne calcule pas d'URL.
+- **`BreweryFicheVM` / `StyleFicheVM`** : fiches secondaires atteintes par navigation.
+  `locationLabel = "<ville>, <pays>"`, `colorRangeLabel = "EBC <a>–<b>"`, etc.
+- **Conformité.** Le code de `presentation/` consomme ces VM ; le formatage vit en
+  `application/`. Implémentation après validation. Pas d'export par défaut, pas de `any`.

--- a/docs/architecture/diagrams/mobile-catalog/10-class-view-model.md
+++ b/docs/architecture/diagrams/mobile-catalog/10-class-view-model.md
@@ -212,8 +212,14 @@ BeerDetailVM ..> TapTargetVM : breweryTap / styleTap
   (`09`). Sortie : VM non-null prêt à rendre. Exemples : `abvLabel = "5,5 %"` (ou `"—"` si
   null) ; `ibuLabel = formatInterval(ibuMin, ibuMax)` → `"20–28"` / `"22"` / `"—"` ;
   `heroColorHex = ebcToHex(srmToEbc(milieu(srm)))`, `foregroundHex = foregroundOnEbc(...)`
-  (réutilisés du **scan**, cf. `11-data-flow.md`) ; `subtitle = "<brasserie> · <style>"` avec
-  libellés de repli si `breweryName`/`styleName` null.
+  (helpers du **scan** : `ebcToHex`/`foregroundOnEbc`/`formatInterval` **exportés**, `srmToEbc`/
+  `intervalMidpoint` **à extraire** car privés — cf. `11-data-flow.md`) ;
+  `subtitle = "<brasserie> · <style>"`.
+- **Repli des noms (divergence connue).** `breweryName`/`styleName` sont **`null` aujourd'hui**
+  sur `GET /beers`, `/beers/search`, `/beers/{id}` (l'API ne les résout que sur
+  `POST /beers/import-by-ean`, cf. `09-class-domain.md` +
+  `../beer-encyclopedia/07-class-api-contract.md`). Le VM affiche donc un **libellé de repli**
+  (« Brasserie inconnue » / « Style inconnu ») tant que l'API ne les résout pas sur list/search/detail.
 - **Drapeaux ≙ machines à états.** `CatalogListVM.{isLoading,isLoadingMore,isEmpty,isError,
   isOffline,hasNextPage}` reflètent les états de `07-state-list-screen.md` ;
   `SearchVM.status` reflète `08-state-search-input.md`. Les drapeaux sont **dérivés** des

--- a/docs/architecture/diagrams/mobile-catalog/11-data-flow.md
+++ b/docs/architecture/diagrams/mobile-catalog/11-data-flow.md
@@ -34,7 +34,7 @@ flowchart LR
 ```mermaid
 flowchart LR
   Req["request() (core/http)"] -->|"réponse"| Cache["QueryClient — cache mémoire"]
-  Cache -->|"queryKey [beer-catalog,browse] / [...,search,q] / [beer,id]"| Pages["pages[] accumulées (useInfiniteQuery)"]
+  Cache -->|"queryKey [beer-catalog,browse] / [beer-catalog,search,q] / [beer-catalog,beer,id]"| Pages["pages[] accumulées (useInfiniteQuery)"]
   Cache -->|"staleTime 30s / gcTime 5min / retry 1"| Policy["politique de fraîcheur"]
   Policy -->|"frais → sans réseau"| Screen2["Écran"]
   Policy -->|"périmé → refetch (focus / pull-to-refresh)"| Req
@@ -55,14 +55,15 @@ rectangle "beer-catalog.mapper.ts" as Mapper
 rectangle "CatalogBeer / CatalogBeerDetail\n(domaine)" as Domain
 rectangle "BeerListItemVM / BeerDetailVM" as VM
 rectangle "Écran (FlatList / fiche)" as Screen
-rectangle "features/scan (helpers)" as ScanUtil
+rectangle "features/scan (couleur/format)" as ScanColor
+rectangle "features/scan (helpers privés)" as ScanUtil
 
 E --> Api : "BeerRead / BeerList (snake_case) — aucune PII"
 Api --> Mapper : "BeerRead snake_case"
 Mapper --> Domain : "abv string->number ; bornes IBU/SRM conservées"
 Domain --> VM : "formateur (application) : milieu, SRM->EBC, libellés"
 VM --> Screen : "props"
-VM ..> ScanUtil : "importable (exportés) : ebcToHex, foregroundOnEbc, formatInterval"
+VM ..> ScanColor : "importable (exportés) : ebcToHex, foregroundOnEbc, formatInterval"
 VM ..> ScanUtil : "à extraire (privés) : srmToEbc, intervalMidpoint"
 Api ..> E : "requête sortante : AUCUNE PII (auth:false, pas de jeton)"
 
@@ -71,12 +72,14 @@ rectangle "QueryClient — cache mémoire" as Cache
 rectangle "pages[] (useInfiniteQuery)" as Pages
 rectangle "politique fraîcheur\nstaleTime 30s / gcTime 5min / retry 1" as Policy
 rectangle "état hors-ligne (07)" as Offline
+rectangle "computeNextPageParam" as NextParam
 
 Req --> Cache : "réponse"
-Cache --> Pages : "queryKey [browse] / [search,q] / [beer,id]"
+Cache --> Pages : "queryKey [beer-catalog,browse] / [beer-catalog,search,q] / [beer-catalog,beer,id]"
 Cache --> Policy
 Policy --> Req : "périmé -> refetch"
 Cache ..> Offline : "hors-ligne : périmé si présent, sinon erreur"
+Pages --> NextParam : "getNextPageParam lit meta.total/page/per_page"
 @enduml
 ```
 

--- a/docs/architecture/diagrams/mobile-catalog/11-data-flow.md
+++ b/docs/architecture/diagrams/mobile-catalog/11-data-flow.md
@@ -1,0 +1,101 @@
+# Data-flow — mobile-catalog — DTO → mapper → domaine → vue + cache / hors-ligne
+
+> **Périmètre :** circulation des données du catalogue (transformation + cache), marquage PII
+> **Code concerné (cible) :** `features/beer-catalog/data/beer-catalog.{api,mapper}.ts`, `application/*` (formateurs VM), `core/query`
+> **ADR liés :** repo ADR-0005 (lecture publique, sans auth), ADR-0017 (intervalles), repo ADR-0013 (la conception fait foi)
+> **Voir aussi :** `09-class-domain.md` (domaine) · `10-class-view-model.md` (VM) · `02-sequence-browse.md` · `05-sequence-errors.md` · `../../traceability-matrix.md`
+
+## Contexte
+
+Deux flux complémentaires : **(A) transformation** (forme réseau → forme d'affichage) et
+**(B) cache / hors-ligne** (TanStack). Le data-flow **force le marquage PII** : ici la lecture
+catalogue **ne transporte aucune PII** (`auth:false`, **aucun jeton, aucune identité**
+envoyée) — c'est le point à vérifier en revue. Les conversions SRM→EBC et milieu d'intervalle
+sont **réutilisées du scan** (pas de duplication d'algorithme).
+
+## Diagramme A — transformation (Mermaid)
+
+```mermaid
+flowchart LR
+  E["beer-encyclopedia (FastAPI)"] -->|"BeerRead / BeerList (snake_case) — aucune PII en réponse"| Api["beer-catalog.api.ts"]
+  Api -->|"BeerRead snake_case"| Mapper["beer-catalog.mapper.ts"]
+  Mapper -->|"abv string→number ; ibu=milieu(min,max) ; bornes conservées"| Domain["CatalogBeer / CatalogBeerDetail (domaine)"]
+  Domain -->|"formateur (application)"| VM["BeerListItemVM / BeerDetailVM"]
+  VM -->|"props"| Screen["Écran (FlatList / fiche)"]
+
+  Mapper -.->|"réutilisé du scan : srmToEbc (×1.97), intervalMidpoint"| ScanUtil["features/scan (helpers)"]
+  VM -.->|"réutilisé du scan : ebcToHex, foregroundOnEbc, formatInterval"| ScanColor["features/scan (couleur/format)"]
+
+  Api -.->|"requête sortante : aucune PII (auth:false, pas de jeton)"| E
+```
+
+## Diagramme B — cache / hors-ligne (Mermaid)
+
+```mermaid
+flowchart LR
+  Req["request() (core/http)"] -->|"réponse"| Cache["QueryClient — cache mémoire"]
+  Cache -->|"queryKey [beer-catalog,browse] / [...,search,q] / [beer,id]"| Pages["pages[] accumulées (useInfiniteQuery)"]
+  Cache -->|"staleTime 30s / gcTime 5min / retry 1"| Policy["politique de fraîcheur"]
+  Policy -->|"frais → sans réseau"| Screen2["Écran"]
+  Policy -->|"périmé → refetch (focus / pull-to-refresh)"| Req
+  Cache -.->|"hors-ligne : sert le périmé si présent, sinon erreur"| Offline["état hors-ligne (07)"]
+  Pages -->|"getNextPageParam lit meta.total/page/per_page"| NextParam["computeNextPageParam"]
+```
+
+*Mêmes flux en **PlantUML** (à garder synchronisés avec les blocs Mermaid).*
+
+```plantuml
+@startuml
+title dfd — mobile-catalog — transformation + cache/hors-ligne
+skinparam shadowing false
+
+rectangle "beer-encyclopedia (FastAPI)" as E
+rectangle "beer-catalog.api.ts" as Api
+rectangle "beer-catalog.mapper.ts" as Mapper
+rectangle "CatalogBeer / CatalogBeerDetail\n(domaine)" as Domain
+rectangle "BeerListItemVM / BeerDetailVM" as VM
+rectangle "Écran (FlatList / fiche)" as Screen
+rectangle "features/scan (helpers)" as ScanUtil
+
+E --> Api : "BeerRead / BeerList (snake_case) — aucune PII"
+Api --> Mapper : "BeerRead snake_case"
+Mapper --> Domain : "abv string->number ; ibu=milieu ; bornes conservées"
+Domain --> VM : "formateur (application)"
+VM --> Screen : "props"
+Mapper ..> ScanUtil : "réutilisé : srmToEbc, intervalMidpoint"
+VM ..> ScanUtil : "réutilisé : ebcToHex, foregroundOnEbc, formatInterval"
+Api ..> E : "requête sortante : AUCUNE PII (auth:false, pas de jeton)"
+
+rectangle "request() (core/http)" as Req
+rectangle "QueryClient — cache mémoire" as Cache
+rectangle "pages[] (useInfiniteQuery)" as Pages
+rectangle "politique fraîcheur\nstaleTime 30s / gcTime 5min / retry 1" as Policy
+rectangle "état hors-ligne (07)" as Offline
+
+Req --> Cache : "réponse"
+Cache --> Pages : "queryKey [browse] / [search,q] / [beer,id]"
+Cache --> Policy
+Policy --> Req : "périmé -> refetch"
+Cache ..> Offline : "hors-ligne : périmé si présent, sinon erreur"
+@enduml
+```
+
+## Notes
+
+- **PII : aucune.** La lecture catalogue est **publique** (`auth:false`, ADR-0005) : la requête
+  sortante **ne porte ni jeton ni identité utilisateur**, la réponse ne contient que des faits
+  bière publics. Aucune arête `PII:` — contrairement aux flux authentifiés (recettes, brassins)
+  qui restent hors de cette feature. Point de **revue de confidentialité** : vérifier qu'aucun
+  en-tête d'auth ne fuit (la garde `auth:false` de `request()` l'assure).
+- **Réutilisation du scan (pas de duplication d'algorithme).** `srmToEbc` (×1.97) et
+  `intervalMidpoint` (`features/scan/data/beers-import.api.ts`) ; `ebcToHex` / `foregroundOnEbc`
+  (`features/scan/application/lookup-color.ts`) ; `formatInterval` (#1209). Seuls les **types**
+  diffèrent (mappers dupliqués vers `CatalogBeer`, pas `ScanCatalogItem`) — les **helpers** de
+  calcul/format sont partagés.
+- **Cache en mémoire.** `staleTime 30s`, `gcTime 5min`, `retry 1` (`core/query`). Pas
+  d'`AsyncStorage` : « hors-ligne avec contenu » n'existe que dans la session. Persistance
+  hors-ligne = **fast-follow** (déclencherait un court ADR si elle devient une garantie produit).
+- **Pagination.** `getNextPageParam` lit `meta` (`total/page/per_page`) → `computeNextPageParam`
+  (1-based). Cf. `02-sequence-browse.md`, `09-class-domain.md`.
+- **Conformité.** Mapper et formateurs doivent suivre ce flux ; aucun `fetch` direct (egress
+  unique `request()`, `06-component.md`). Implémentation après validation.

--- a/docs/architecture/diagrams/mobile-catalog/11-data-flow.md
+++ b/docs/architecture/diagrams/mobile-catalog/11-data-flow.md
@@ -19,12 +19,12 @@ sont **réutilisées du scan** (pas de duplication d'algorithme).
 flowchart LR
   E["beer-encyclopedia (FastAPI)"] -->|"BeerRead / BeerList (snake_case) — aucune PII en réponse"| Api["beer-catalog.api.ts"]
   Api -->|"BeerRead snake_case"| Mapper["beer-catalog.mapper.ts"]
-  Mapper -->|"abv string→number ; ibu=milieu(min,max) ; bornes conservées"| Domain["CatalogBeer / CatalogBeerDetail (domaine)"]
-  Domain -->|"formateur (application)"| VM["BeerListItemVM / BeerDetailVM"]
+  Mapper -->|"abv string→number ; bornes IBU/SRM conservées"| Domain["CatalogBeer / CatalogBeerDetail (domaine)"]
+  Domain -->|"formateur (application) : milieu, SRM→EBC, libellés"| VM["BeerListItemVM / BeerDetailVM"]
   VM -->|"props"| Screen["Écran (FlatList / fiche)"]
 
-  Mapper -.->|"réutilisé du scan : srmToEbc (×1.97), intervalMidpoint"| ScanUtil["features/scan (helpers)"]
-  VM -.->|"réutilisé du scan : ebcToHex, foregroundOnEbc, formatInterval"| ScanColor["features/scan (couleur/format)"]
+  VM -.->|"importable (exportés) : ebcToHex, foregroundOnEbc, formatInterval"| ScanColor["features/scan (couleur/format)"]
+  VM -.->|"à extraire/réimplémenter (privés au scan) : srmToEbc ×1.97, intervalMidpoint"| ScanUtil["features/scan (helpers privés)"]
 
   Api -.->|"requête sortante : aucune PII (auth:false, pas de jeton)"| E
 ```
@@ -59,11 +59,11 @@ rectangle "features/scan (helpers)" as ScanUtil
 
 E --> Api : "BeerRead / BeerList (snake_case) — aucune PII"
 Api --> Mapper : "BeerRead snake_case"
-Mapper --> Domain : "abv string->number ; ibu=milieu ; bornes conservées"
-Domain --> VM : "formateur (application)"
+Mapper --> Domain : "abv string->number ; bornes IBU/SRM conservées"
+Domain --> VM : "formateur (application) : milieu, SRM->EBC, libellés"
 VM --> Screen : "props"
-Mapper ..> ScanUtil : "réutilisé : srmToEbc, intervalMidpoint"
-VM ..> ScanUtil : "réutilisé : ebcToHex, foregroundOnEbc, formatInterval"
+VM ..> ScanUtil : "importable (exportés) : ebcToHex, foregroundOnEbc, formatInterval"
+VM ..> ScanUtil : "à extraire (privés) : srmToEbc, intervalMidpoint"
 Api ..> E : "requête sortante : AUCUNE PII (auth:false, pas de jeton)"
 
 rectangle "request() (core/http)" as Req
@@ -87,11 +87,14 @@ Cache ..> Offline : "hors-ligne : périmé si présent, sinon erreur"
   bière publics. Aucune arête `PII:` — contrairement aux flux authentifiés (recettes, brassins)
   qui restent hors de cette feature. Point de **revue de confidentialité** : vérifier qu'aucun
   en-tête d'auth ne fuit (la garde `auth:false` de `request()` l'assure).
-- **Réutilisation du scan (pas de duplication d'algorithme).** `srmToEbc` (×1.97) et
-  `intervalMidpoint` (`features/scan/data/beers-import.api.ts`) ; `ebcToHex` / `foregroundOnEbc`
-  (`features/scan/application/lookup-color.ts`) ; `formatInterval` (#1209). Seuls les **types**
-  diffèrent (mappers dupliqués vers `CatalogBeer`, pas `ScanCatalogItem`) — les **helpers** de
-  calcul/format sont partagés.
+- **Réutilisation des helpers du scan — deux cas (vérifié).** **Importables tels quels**
+  (exportés) : `ebcToHex` / `foregroundOnEbc` (`features/scan/application/lookup-color.ts`) et
+  `formatInterval` (`features/scan/application/lookup-formatters.ts`). **À extraire ou
+  réimplémenter** (actuellement **privés**, non exportés, dans
+  `features/scan/data/beers-import.api.ts`) : `srmToEbc` (×1.97) et `intervalMidpoint`.
+  Réutilisation **algorithmique** (même formule), pas un import d'un symbole privé. Ces
+  dérivations (milieu, SRM→EBC, libellés) vivent au **view-model** (`10`), pas au mapper ;
+  les mappers restent dupliqués vers `CatalogBeer` (pas `ScanCatalogItem`).
 - **Cache en mémoire.** `staleTime 30s`, `gcTime 5min`, `retry 1` (`core/query`). Pas
   d'`AsyncStorage` : « hors-ligne avec contenu » n'existe que dans la session. Persistance
   hors-ligne = **fast-follow** (déclencherait un court ADR si elle devient une garantie produit).

--- a/docs/architecture/traceability-matrix.md
+++ b/docs/architecture/traceability-matrix.md
@@ -8,8 +8,11 @@
 
 ## Périmètre actuel
 
-Couvre le domaine **beer-encyclopedia** (backend). S'étendra aux autres packages au fil des revues.
-Étude de cas d'usage : [`01-use-case.md`](diagrams/beer-encyclopedia/01-use-case.md).
+Couvre le domaine **beer-encyclopedia** (backend) et la **réalisation mobile du catalogue**
+(`mobile-catalog` — consommation de l'API encyclopédie). S'étendra aux autres packages au fil
+des revues. Études de cas d'usage :
+[`beer-encyclopedia/01-use-case.md`](diagrams/beer-encyclopedia/01-use-case.md) (backend) ·
+[`mobile-catalog/01-use-case.md`](diagrams/mobile-catalog/01-use-case.md) (mobile).
 
 ## État des diagrammes — beer-encyclopedia
 
@@ -25,15 +28,34 @@ Couvre le domaine **beer-encyclopedia** (backend). S'étendra aux autres package
 | Data-flow | [`06-data-flow.md`](diagrams/beer-encyclopedia/06-data-flow.md) | ✅ (import EAN + PII) |
 | Séquence mobile — UC4 (scan + affichage) | [`08-sequence-mobile-scan.md`](diagrams/beer-encyclopedia/08-sequence-mobile-scan.md) | 🎯 cible (encyclopedia-first ; cutover #1186 ; code à conformer) |
 
+## État des diagrammes — mobile-catalog
+
+Réalisation **mobile** de UC1/UC2/UC3 (catalogue de bières) consommant l'API encyclopédie.
+Étude **conçue avant code** (ADR-0013) : tous les diagrammes sont 🎯 cible (code à conformer).
+
+| Diagramme | Fichier | État |
+|-----------|---------|------|
+| Cas d'usage (mobile) | [`01-use-case.md`](diagrams/mobile-catalog/01-use-case.md) | 🎯 cible (UC1/2/3 mobile + extensions ; rubriques/filtres `<<fast-follow>>`) |
+| Séquence — UC1 Parcourir | [`02-sequence-browse.md`](diagrams/mobile-catalog/02-sequence-browse.md) | 🎯 cible (scroll infini, `getNextPageParam`) |
+| Séquence — UC2 Rechercher | [`03-sequence-search.md`](diagrams/mobile-catalog/03-sequence-search.md) | 🎯 cible (debounce + annulation) |
+| Séquence — UC3 Fiche | [`04-sequence-fiche.md`](diagrams/mobile-catalog/04-sequence-fiche.md) | 🎯 cible (404 + amorçage cache + nav brasserie/style) |
+| Séquence — variantes d'erreur | [`05-sequence-errors.md`](diagrams/mobile-catalog/05-sequence-errors.md) | 🎯 cible (404 / timeout / hors-ligne) |
+| Composant | [`06-component.md`](diagrams/mobile-catalog/06-component.md) | 🎯 cible (couches mobile ↔ API ; frontière ADR-0005) |
+| États — écran liste | [`07-state-list-screen.md`](diagrams/mobile-catalog/07-state-list-screen.md) | 🎯 cible (cycle de vie pagination, dérivé TanStack) |
+| États — saisie recherche | [`08-state-search-input.md`](diagrams/mobile-catalog/08-state-search-input.md) | 🎯 cible (FSM debounce/cancel) |
+| Classes — domaine | [`09-class-domain.md`](diagrams/mobile-catalog/09-class-domain.md) | 🎯 cible (`CatalogBeer`, `Page<T>`, `PaginationMeta`) |
+| Classes — view-model | [`10-class-view-model.md`](diagrams/mobile-catalog/10-class-view-model.md) | 🎯 cible (`BeerListItemVM`, `CatalogListVM`, `SearchVM`) |
+| Data-flow | [`11-data-flow.md`](diagrams/mobile-catalog/11-data-flow.md) | 🎯 cible (DTO→mapper→VM + cache ; aucune PII) |
+
 ## Matrice — cas d'usage → réalisations
 
 Légende : ✅ fait · ⬜ à venir · — non applicable.
 
 | UC | Domaine | Séquence | Composant | Classes | États | Data-flow | Statut | Suivi |
 |----|---------|----------|-----------|---------|-------|-----------|--------|-------|
-| UC1 Parcourir le catalogue | Consulter | — (lecture simple) | 03 ⬜ (api→db) | Beer, Brewery, Style | — | — | livré | — |
-| UC2 Rechercher | Consulter | — | 03 ⬜ | Beer, Brewery | — | — | livré | — |
-| UC3 Consulter une fiche | Consulter | — | 03 ⬜ | Beer, Brewery, Style, TastingProfile, Media | — | — | livré | — |
+| UC1 Parcourir le catalogue | Consulter | backend — · **mobile** ✅ `mobile-catalog/02` | 03 ⬜ · `mobile-catalog/06` | Beer, Brewery, Style · `mobile-catalog/09,10` | `mobile-catalog/07` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
+| UC2 Rechercher | Consulter | backend — · **mobile** ✅ `mobile-catalog/03` | 03 ⬜ · `mobile-catalog/06` | Beer, Brewery · `mobile-catalog/09,10` | `mobile-catalog/08` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
+| UC3 Consulter une fiche | Consulter | backend — · **mobile** ✅ `mobile-catalog/04` (+`05`) | 03 ⬜ · `mobile-catalog/06` | Beer, Brewery, Style, TastingProfile, Media · `mobile-catalog/09,10` | — | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
 | UC4 Identifier par code-barres | Acquérir | **backend** ✅ `02-sequence-import-by-ean` **+** mobile ⬜ | 03 ⬜ (api, importers, db) | Beer, Brewery, Source, EntitySource | provenance Beer (05 ⬜) | import OFF / PII (06 ⬜) | livré (backend) | #878 (rate-limit) |
 | UC5 Identifier par scan d'étiquette | Acquérir | ✅ `02-sequence-scan` (délègue à `scan/02b`) | 03 ⬜ | Beer (source=scan), BeerDataSuggestion (étude `scan/`) | — | 06 ⬜ | planifié | #1156 (divergence /scan), #1149, étude `scan/` |
 | UC6 Proposer une correction | Contribuer | — (texte) | 03 ⬜ | CommunityCorrection | pending→… (05 ⬜) | — | planifié | #1149 |
@@ -43,9 +65,16 @@ Légende : ✅ fait · ⬜ à venir · — non applicable.
 
 ## Règles de traçabilité
 
-- **Séquence seulement si non-trivial** : un diagramme de séquence n'existe que pour les
-  scénarios traversant 2+ composants ou à branches conditionnelles (UC4, UC5, UC9). Les
-  lectures/écritures simples (UC1/2/3/7/8) restent au niveau de la fiche Cockburn.
+- **Séquence seulement si non-trivial — jugé par réalisation.** Un diagramme de séquence
+  n'existe que pour les scénarios traversant 2+ composants ou à branches conditionnelles.
+  **Côté backend**, les lectures/écritures simples (UC1/2/3/7/8) restent au niveau de la fiche
+  Cockburn — un `GET` paginé direct sur la DB est trivial. **Côté mobile**, la réalisation de
+  UC1/UC2/UC3 n'est **plus** triviale : paginée (scroll infini, `useInfiniteQuery` +
+  `onEndReached`), debouncée/annulable (recherche), orchestrée sur 5+ composants (route → écran
+  → hook → use-case → data → `core/http` → API), avec branches erreur/cache/hors-ligne. Ces
+  réalisations mobiles **ont donc des séquences dédiées** (`mobile-catalog/02..05`), exactement
+  comme UC4 a une séquence mobile (`08-sequence-mobile-scan`) distincte de sa séquence backend.
+  **La trivialité se juge par réalisation (backend vs mobile), pas par cas d'usage.**
 - **Réalisation collaborative** : un cas d'usage peut être réalisé par **plusieurs séquences**
   sur plusieurs composants. Ex. **UC4 = séquence mobile (scan + affichage) + séquence backend
   (`import-by-ean`)**. La matrice est ce qui les recoud.

--- a/docs/architecture/traceability-matrix.md
+++ b/docs/architecture/traceability-matrix.md
@@ -53,9 +53,9 @@ Légende : ✅ fait · ⬜ à venir · — non applicable.
 
 | UC | Domaine | Séquence | Composant | Classes | États | Data-flow | Statut | Suivi |
 |----|---------|----------|-----------|---------|-------|-----------|--------|-------|
-| UC1 Parcourir le catalogue | Consulter | backend — · **mobile** ✅ `mobile-catalog/02` | 03 ⬜ · `mobile-catalog/06` | Beer, Brewery, Style · `mobile-catalog/09,10` | `mobile-catalog/07` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
-| UC2 Rechercher | Consulter | backend — · **mobile** ✅ `mobile-catalog/03` | 03 ⬜ · `mobile-catalog/06` | Beer, Brewery · `mobile-catalog/09,10` | `mobile-catalog/08` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
-| UC3 Consulter une fiche | Consulter | backend — · **mobile** ✅ `mobile-catalog/04` (+`05`) | 03 ⬜ · `mobile-catalog/06` | Beer, Brewery, Style, TastingProfile, Media · `mobile-catalog/09,10` | — | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
+| UC1 Parcourir le catalogue | Consulter | backend — · **mobile** ✅ `mobile-catalog/02` | `beer-encyclopedia/03` ⬜ · `mobile-catalog/06` | Beer, Brewery, Style · `mobile-catalog/09,10` | `mobile-catalog/07` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
+| UC2 Rechercher | Consulter | backend — · **mobile** ✅ `mobile-catalog/03` | `beer-encyclopedia/03` ⬜ · `mobile-catalog/06` | Beer, Brewery · `mobile-catalog/09,10` | `mobile-catalog/08` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
+| UC3 Consulter une fiche | Consulter | backend — · **mobile** ✅ `mobile-catalog/04` (+`05`) | `beer-encyclopedia/03` ⬜ · `mobile-catalog/06` | Beer, Brewery, Style, TastingProfile, Media · `mobile-catalog/09,10` | — | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
 | UC4 Identifier par code-barres | Acquérir | **backend** ✅ `02-sequence-import-by-ean` **+** mobile ⬜ | 03 ⬜ (api, importers, db) | Beer, Brewery, Source, EntitySource | provenance Beer (05 ⬜) | import OFF / PII (06 ⬜) | livré (backend) | #878 (rate-limit) |
 | UC5 Identifier par scan d'étiquette | Acquérir | ✅ `02-sequence-scan` (délègue à `scan/02b`) | 03 ⬜ | Beer (source=scan), BeerDataSuggestion (étude `scan/`) | — | 06 ⬜ | planifié | #1156 (divergence /scan), #1149, étude `scan/` |
 | UC6 Proposer une correction | Contribuer | — (texte) | 03 ⬜ | CommunityCorrection | pending→… (05 ⬜) | — | planifié | #1149 |

--- a/docs/architecture/traceability-matrix.md
+++ b/docs/architecture/traceability-matrix.md
@@ -49,13 +49,13 @@ Réalisation **mobile** de UC1/UC2/UC3 (catalogue de bières) consommant l'API e
 
 ## Matrice — cas d'usage → réalisations
 
-Légende : ✅ fait · ⬜ à venir · — non applicable.
+Légende : ✅ fait · 🎯 conçu (cible, code à venir) · ⬜ à venir · — non applicable.
 
 | UC | Domaine | Séquence | Composant | Classes | États | Data-flow | Statut | Suivi |
 |----|---------|----------|-----------|---------|-------|-----------|--------|-------|
-| UC1 Parcourir le catalogue | Consulter | backend — · **mobile** ✅ `mobile-catalog/02` | `beer-encyclopedia/03` ⬜ · `mobile-catalog/06` | Beer, Brewery, Style · `mobile-catalog/09,10` | `mobile-catalog/07` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
-| UC2 Rechercher | Consulter | backend — · **mobile** ✅ `mobile-catalog/03` | `beer-encyclopedia/03` ⬜ · `mobile-catalog/06` | Beer, Brewery · `mobile-catalog/09,10` | `mobile-catalog/08` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
-| UC3 Consulter une fiche | Consulter | backend — · **mobile** ✅ `mobile-catalog/04` (+`05`) | `beer-encyclopedia/03` ⬜ · `mobile-catalog/06` | Beer, Brewery, Style, TastingProfile, Media · `mobile-catalog/09,10` | — | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
+| UC1 Parcourir le catalogue | Consulter | backend — · **mobile** 🎯 `mobile-catalog/02` | `beer-encyclopedia/03` ⬜ · `mobile-catalog/06` | Beer, Brewery, Style · `mobile-catalog/09,10` | `mobile-catalog/07` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
+| UC2 Rechercher | Consulter | backend — · **mobile** 🎯 `mobile-catalog/03` | `beer-encyclopedia/03` ⬜ · `mobile-catalog/06` | Beer, Brewery · `mobile-catalog/09,10` | `mobile-catalog/08` | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
+| UC3 Consulter une fiche | Consulter | backend — · **mobile** 🎯 `mobile-catalog/04` (+`05`) | `beer-encyclopedia/03` ⬜ · `mobile-catalog/06` | Beer, Brewery, Style, TastingProfile, Media · `mobile-catalog/09,10` | — | `mobile-catalog/11` | livré backend · mobile 🎯 conçu | — |
 | UC4 Identifier par code-barres | Acquérir | **backend** ✅ `02-sequence-import-by-ean` **+** mobile ⬜ | 03 ⬜ (api, importers, db) | Beer, Brewery, Source, EntitySource | provenance Beer (05 ⬜) | import OFF / PII (06 ⬜) | livré (backend) | #878 (rate-limit) |
 | UC5 Identifier par scan d'étiquette | Acquérir | ✅ `02-sequence-scan` (délègue à `scan/02b`) | 03 ⬜ | Beer (source=scan), BeerDataSuggestion (étude `scan/`) | — | 06 ⬜ | planifié | #1156 (divergence /scan), #1149, étude `scan/` |
 | UC6 Proposer une correction | Contribuer | — (texte) | 03 ⬜ | CommunityCorrection | pending→… (05 ⬜) | — | planifié | #1149 |

--- a/packages/beer-encyclopedia/docs/CONCEPTION-REVIEW-PROGRESS.md
+++ b/packages/beer-encyclopedia/docs/CONCEPTION-REVIEW-PROGRESS.md
@@ -71,6 +71,22 @@ _(Ordre : les **séquences** d'abord — juste après les cas d'usage — puis c
 
 _Rappel : UC1/2/3/7/8 n'ont **pas** de séquence (texte suffit) ; séquences = UC4 ✅, UC5, UC9 (plus tard)._
 
+## Fait le 2026-06-08
+
+- **Réalisation mobile UC1/UC2/UC3** : nouvelle étude `docs/architecture/diagrams/mobile-catalog/`
+  (11 diagrammes : use-case mobile, 4 séquences [browse, search, fiche, variantes d'erreur],
+  composant, 2 machines à états [écran liste + saisie recherche], 2 diagrammes de classes
+  [domaine + view-model], data-flow). Pagination = scroll infini (`useInfiniteQuery`), un seul
+  hook réutilisé browse + search. Périmètre MVP = bières ; rubriques brasseries/styles + filtres
+  = fast-follow. Étude conçue **avant code** (ADR-0013).
+- **Correction `07-class-api-contract`** : la boîte `PaginationMeta` (référencée par `BeerList.meta`
+  sans être dessinée) est désormais explicite (Mermaid + PlantUML) ; accolades `{id}` retirées
+  d'une annotation `BeerUpdate` pour que le bloc Mermaid rende sous mmdc 11.
+- **Règle « séquence si non-trivial » affinée** (`traceability-matrix.md`) : la trivialité se juge
+  **par réalisation** (backend trivial vs mobile paginé/debouncé/orchestré), d'où des séquences
+  mobiles dédiées (`mobile-catalog/02..05`) — cf. lignes UC1/2/3 + nouveau bloc d'état mobile-catalog.
+- Rendu Mermaid des 11 nouveaux fichiers validé via `mmdc` 11.12.
+
 ## Issues ouvertes (suivi)
 
 - **#1146** — PR : étude UML + ADR (en cours).


### PR DESCRIPTION
## Summary

Maximal UML conception study for the new **mobile beer-catalogue** feature (UC1 browse / UC2 search / UC3 fiche), consuming the Python encyclopedia API. Conceived **before code** per ADR-0013 — the diagrams are the contract the implementation must satisfy.

New folder `docs/architecture/diagrams/mobile-catalog/` (11 diagrams, Mermaid + PlantUML twins, French study per the ADR-0013 exception):

- **use-case** — mobile realization of UC1/2/3 + mobile Cockburn extensions (loading / empty / error / next-page / offline); brewery & style browse rubrics and filters marked `<<fast-follow>>`.
- **sequences** — browse (infinite scroll, `getNextPageParam`, cache), search (debounce + in-flight cancellation), beer fiche (404 + cache priming + brewery/style navigation), and a transverse error-variants diagram (404 / timeout / offline).
- **component** — mobile layers (route → screen → hook → use-case → data → `core/http`) bounded against the encyclopedia API; single egress `request()`, `auth:false`, ADR-0005 boundary.
- **state** — list-screen lifecycle (derived from TanStack flags) + a dedicated search-input FSM (debounce / cancel).
- **class** — mobile domain model (`CatalogBeer`, `Page<T>`, `PageResult<T>`, `PaginationMeta`) + a separate view-model diagram.
- **data-flow** — DTO → mapper → domain → view-model (+ cache/offline); no PII (`auth:false`).

Decisions captured: pagination = infinite scroll (`useInfiniteQuery`), one reusable hook for browse and search; MVP scope = beers only (brewery/style browse + filters deferred as fast-follow).

## Context

The mobile app today only wires `POST /beers/import-by-ean` (UC4 scan). UC1/2/3 are designed and the encyclopedia API is deployed, but the mobile screens do not exist. This study is the contract for that build (implementation = follow-up).

Cross-cutting:

- draw the dangling `PaginationMeta` box in `beer-encyclopedia/07-class-api-contract` (was referenced by `BeerList.meta`, never drawn).
- refine the "sequence only if non-trivial" rule in the traceability matrix to judge triviality **per realization** (backend trivial vs mobile orchestrated); add the mobile-catalog status block + UC1/2/3 mobile realizations.

A local pre-push review was run and reconciled (Codex helper could not run — CLI arg incompatibility, noted). Notable fixes: a documented divergence (`GET /beers`, `/search`, `/{id}` return `brewery_name`/`style_name` null today — only `import-by-ean` resolves them, ADR-0013 clause 6), private-helper accuracy (`srmToEbc`/`intervalMidpoint` are not exported), and a layering fix (brewery/style tap = navigation, not a direct screen→data call).

## Checklist

- [x] All 11 diagrams render under `mmdc` (Mermaid blocks validated).
- [x] Mermaid + PlantUML twins per diagram (house style).
- [x] French study (ADR-0013 clause 7 exception); commit/PR in English.
- [x] Conception-first per ADR-0013 — code conforms in the follow-up.
- [ ] CodeRabbit + Codex auto-review addressed.

Relates to #1128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified pagination metadata and envelope semantics in API docs (explicit total/page/per_page and required meta).
  * Added a complete mobile catalog architecture: browse/search/detail flows, infinite-scroll pagination, debounced/cancelable search, error/offline behaviors, and view-model mappings.
  * Expanded traceability matrix to cover backend and mobile realizations and their diagram status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->