### PR TITLE
fix(mobile-app): catalogue & batches back button goes to the wrong tab (missing nav stack)

### DIFF
--- a/packages/mobile-app/app/(app)/batches/_layout.tsx
+++ b/packages/mobile-app/app/(app)/batches/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from "expo-router";
+
+/**
+ * Navigation stack for the batches tab. Without it the nested routes (list /
+ * [id] / celebration) had no in-tab back-stack, so `router.back()` from the
+ * "Brassin terminé" screen fell through to the Tabs navigator and landed on
+ * the previously focused tab. The stack makes back pop to the batches list,
+ * matching the screen's "Retour à la liste des brassins" label. Screens render
+ * their own header, so the stack header stays hidden (mirrors academy).
+ */
+export default function BatchesLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/packages/mobile-app/app/(app)/beer-catalog/_layout.tsx
+++ b/packages/mobile-app/app/(app)/beer-catalog/_layout.tsx
@@ -1,0 +1,14 @@
+import { Stack } from "expo-router";
+
+/**
+ * Navigation stack for the beer-catalogue tab. Without it the nested routes
+ * (browse / search / beer / brewery / style) had no in-tab back-stack, so
+ * `router.back()` fell through to the Tabs navigator and landed on the
+ * previously focused tab (e.g. the academy). The stack makes back retrace the
+ * real forward path: list → fiche → tap brewery → fiche brewery → back → fiche.
+ * Screens render their own header, so the stack header stays hidden (mirrors
+ * the academy tab layout).
+ */
+export default function BeerCatalogLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/packages/mobile-app/src/features/social/presentation/SocialFeedScreen.tsx
+++ b/packages/mobile-app/src/features/social/presentation/SocialFeedScreen.tsx
@@ -92,7 +92,7 @@ export function SocialFeedScreen() {
   const handleGoBack = () => {
     // "Communauté" is a top-level dock tab (no parent stack to pop), so
     // router.back() would fall through to the previously focused tab. The
-    // back button reads "Retour à l'accueil" — send the user there explicitly.
+    // back button reads "Retour à l’accueil" — send the user there explicitly.
     router.replace("/dashboard");
   };
 

--- a/packages/mobile-app/src/features/social/presentation/SocialFeedScreen.tsx
+++ b/packages/mobile-app/src/features/social/presentation/SocialFeedScreen.tsx
@@ -90,7 +90,10 @@ export function SocialFeedScreen() {
   const router = useRouter();
 
   const handleGoBack = () => {
-    router.back();
+    // "Communauté" is a top-level dock tab (no parent stack to pop), so
+    // router.back() would fall through to the previously focused tab. The
+    // back button reads "Retour à l'accueil" — send the user there explicitly.
+    router.replace("/dashboard");
   };
 
   return (

--- a/packages/mobile-app/src/features/social/presentation/__tests__/SocialFeedScreen.test.tsx
+++ b/packages/mobile-app/src/features/social/presentation/__tests__/SocialFeedScreen.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react-native";
 
 import { SocialFeedScreen } from "@/features/social/presentation/SocialFeedScreen";
 
-const mockBack = jest.fn();
+const mockReplace = jest.fn();
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
@@ -14,15 +14,15 @@ jest.mock("expo-router", () => {
     ...actual,
     useRouter: () => ({
       push: jest.fn(),
-      replace: jest.fn(),
-      back: mockBack,
+      replace: mockReplace,
+      back: jest.fn(),
     }),
   };
 });
 
 describe("SocialFeedScreen", () => {
   beforeEach(() => {
-    mockBack.mockClear();
+    mockReplace.mockClear();
   });
 
   it("renders the weekly banner and the four demo posts (happy path)", () => {
@@ -46,11 +46,13 @@ describe("SocialFeedScreen", () => {
     expect(screen.getByText("💬 6")).toBeOnTheScreen();
   });
 
-  it("navigates back when the header back button is pressed (sad path)", () => {
+  it("returns to the home tab when the header back button is pressed (sad path)", () => {
+    // "Communauté" is a top-level dock tab: back goes home explicitly, not
+    // router.back() (which would fall through to the previous tab).
     render(<SocialFeedScreen />);
 
     fireEvent.press(screen.getByLabelText("Retour à l’accueil"));
 
-    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard");
   });
 });


### PR DESCRIPTION
## Summary

Fixes the reported bug: in the **beer catalogue**, the back button on a beer fiche jumped to the **brewing academy** instead of the catalogue list — and the same happened on other screens.

## Context

**Root cause:** in Expo Router, a tab with nested routes needs its own **navigation stack** (`_layout.tsx` = `<Stack>`). Only `app/(app)/_layout.tsx` (Tabs) and `app/(app)/academy/_layout.tsx` had one. Every other group with nested routes (incl. `beer-catalog`, `batches`) lacked it, so `router.back()` fell through to the Tabs navigator and landed on the previously focused tab — frequently the academy (the only other group with a stack).

## Changes (targeted — additive, low risk)

- **`app/(app)/beer-catalog/_layout.tsx`** — `<Stack screenOptions={{ headerShown: false }} />` (mirrors `academy`). Back now retraces the real path: list → fiche → tap brewery → brewery fiche → back → beer fiche → back → list.
- **`app/(app)/batches/_layout.tsx`** — same stack; the "Brassin terminé" back now pops to the batches list, matching its label.
- **`SocialFeedScreen`** — "Communauté" is a top-level dock tab with no parent stack, so `router.back()` was wrong; its label reads "Retour à l'accueil", so it now `router.replace("/dashboard")` explicitly (+ test updated).

## Scope & follow-up

This is the **targeted fix** for the screens using bare `router.back()` without a stack (the actually-broken ones). The broader migration of the `router.replace("/parent")` workarounds and the ingredients manual return-context system (recipes, ingredients, dashboard/scan/labels, shop, tools) to native stacks is a larger, device-test-heavy refactor tracked as **epic #1217**.

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format).
- [x] 173 tests pass across beer-catalog / batches / social.
- [x] No double header (screens own their header; the stack is `headerShown:false`, like academy).
- [ ] Device test: back retraces the path on each flow (the real validation).

Closes the reported back-navigation bug. Follow-up: #1217.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Community tab back button to consistently return to the Dashboard.
* **Refactor**
  * Improved in-tab navigation behavior for the Batches and Beer Catalog sections by adjusting their route layouts to keep back navigation contained within the tab.
* **Tests**
  * Updated navigation-related tests to reflect the new back-button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->