### PR TITLE
feat(encyclopedia): resolve brewery_name / style_name on the beer read & write endpoints

### DIFF
--- a/packages/beer-encyclopedia/api/routers/beers.py
+++ b/packages/beer-encyclopedia/api/routers/beers.py
@@ -298,7 +298,7 @@ async def create_beer(
         name=payload.name,
         attributes=payload.model_dump(),
     )
-    return BeerRead.model_validate(beer)
+    return await _beer_read_with_names(session, beer)
 
 
 @router.patch("/{beer_id}", response_model=BeerRead)
@@ -321,7 +321,7 @@ async def update_beer(
         setattr(beer, field, value)
     await session.commit()
     await session.refresh(beer)
-    return BeerRead.model_validate(beer)
+    return await _beer_read_with_names(session, beer)
 
 
 @router.delete("/{beer_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/packages/beer-encyclopedia/api/routers/beers.py
+++ b/packages/beer-encyclopedia/api/routers/beers.py
@@ -18,6 +18,7 @@ from decimal import Decimal
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from api.db_utils import is_postgres
 from api.dependencies import get_db
@@ -102,9 +103,7 @@ async def _beer_read_with_names(session: AsyncSession, beer: Beer) -> BeerRead:
     if beer.style_id is not None:
         style = await session.get(Style, beer.style_id)
         style_name = style.name if style is not None else None
-    return dto.model_copy(
-        update={"brewery_name": brewery_name, "style_name": style_name}
-    )
+    return dto.model_copy(update={"brewery_name": brewery_name, "style_name": style_name})
 
 
 @router.post(
@@ -125,12 +124,7 @@ async def _beer_read_with_names(session: AsyncSession, beer: Beer) -> BeerRead:
                 "created from the Open Food Facts payload."
             )
         },
-        404: {
-            "description": (
-                "EAN is unknown both to the local database and to "
-                "Open Food Facts."
-            )
-        },
+        404: {"description": ("EAN is unknown both to the local database and to Open Food Facts.")},
         503: {
             "description": (
                 "Open Food Facts is unavailable or returned an unexpected "
@@ -205,9 +199,7 @@ async def import_beer_by_ean(
         # the seed script, not to debug the import code.
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 
-    response.status_code = (
-        status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
-    )
+    response.status_code = status.HTTP_201_CREATED if result.created else status.HTTP_200_OK
     return await _beer_read_with_names(session, result.beer)
 
 
@@ -231,21 +223,19 @@ async def list_beers(
     if abv_max is not None:
         filters.append(Beer.abv <= abv_max)
 
-    base_stmt = select(Beer)
+    # Eager-load brewery + style so `_beer_read_with_names` resolves the
+    # denormalised names from the identity map (no per-row query / N+1).
+    base_stmt = select(Beer).options(selectinload(Beer.brewery), selectinload(Beer.style))
     count_stmt = select(func.count()).select_from(Beer)
     for flt in filters:
         base_stmt = base_stmt.where(flt)
         count_stmt = count_stmt.where(flt)
 
     total = (await session.execute(count_stmt)).scalar_one()
-    stmt = (
-        base_stmt.order_by(Beer.name)
-        .offset((page - 1) * per_page)
-        .limit(per_page)
-    )
+    stmt = base_stmt.order_by(Beer.name).offset((page - 1) * per_page).limit(per_page)
     items = (await session.execute(stmt)).scalars().all()
     return BeerList(
-        items=[BeerRead.model_validate(b) for b in items],
+        items=[await _beer_read_with_names(session, b) for b in items],
         meta=PaginationMeta(total=total, page=page, per_page=per_page),
     )
 
@@ -271,6 +261,7 @@ async def search_beers(
 
     stmt = (
         select(Beer)
+        .options(selectinload(Beer.brewery), selectinload(Beer.style))
         .where(where_clause)
         .order_by(order_clause)
         .offset((page - 1) * per_page)
@@ -278,7 +269,7 @@ async def search_beers(
     )
     items = (await session.execute(stmt)).scalars().all()
     return BeerList(
-        items=[BeerRead.model_validate(b) for b in items],
+        items=[await _beer_read_with_names(session, b) for b in items],
         meta=PaginationMeta(total=total, page=page, per_page=per_page),
     )
 
@@ -291,7 +282,7 @@ async def get_beer(
     beer = await session.get(Beer, beer_id)
     if beer is None:
         raise HTTPException(status_code=404, detail="Beer not found.")
-    return BeerRead.model_validate(beer)
+    return await _beer_read_with_names(session, beer)
 
 
 @router.post("", response_model=BeerRead, status_code=status.HTTP_201_CREATED)

--- a/packages/beer-encyclopedia/tests/test_api/test_beers.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_beers.py
@@ -23,9 +23,7 @@ async def _seed_reference_data(
     return brewery, ipa, stout
 
 
-async def test_create_beer_returns_201(
-    client: TestClient, db_session: AsyncSession
-) -> None:
+async def test_create_beer_returns_201(client: TestClient, db_session: AsyncSession) -> None:
     brewery, ipa, _ = await _seed_reference_data(db_session)
 
     response = client.post(
@@ -96,9 +94,7 @@ def test_get_beer_returns_404_for_unknown(client: TestClient) -> None:
     assert response.status_code == 404
 
 
-async def test_list_beers_filters_by_style(
-    client: TestClient, db_session: AsyncSession
-) -> None:
+async def test_list_beers_filters_by_style(client: TestClient, db_session: AsyncSession) -> None:
     brewery, ipa, stout = await _seed_reference_data(db_session)
     db_session.add_all(
         [
@@ -174,9 +170,7 @@ async def test_delete_beer_returns_204_then_404(
     assert client.get(f"/beers/{created['id']}").status_code == 404
 
 
-async def test_search_beers_matches_substring(
-    client: TestClient, db_session: AsyncSession
-) -> None:
+async def test_search_beers_matches_substring(client: TestClient, db_session: AsyncSession) -> None:
     brewery, _, _ = await _seed_reference_data(db_session)
     db_session.add_all(
         [
@@ -192,3 +186,83 @@ async def test_search_beers_matches_substring(
     data = response.json()
     assert data["meta"]["total"] == 2
     assert {item["name"] for item in data["items"]} == {"Citra Bomb", "Citra Sun"}
+
+
+async def test_list_resolves_brewery_and_style_names(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Happy: list rows carry the denormalised brewery/style names (#1220)."""
+
+    brewery, ipa, _ = await _seed_reference_data(db_session)
+    db_session.add(
+        Beer(
+            name="Named IPA",
+            slug="named-ipa",
+            brewery_id=brewery.id,
+            style_id=ipa.id,
+        )
+    )
+    await db_session.commit()
+
+    item = client.get("/beers").json()["items"][0]
+
+    assert item["brewery_name"] == "Reference Brewery"
+    assert item["style_name"] == "India Pale Ale"
+
+
+async def test_list_leaves_names_null_when_fks_are_null(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Edge: a beer with no brewery/style keeps both names null."""
+
+    db_session.add(Beer(name="Orphan", slug="orphan"))
+    await db_session.commit()
+
+    item = client.get("/beers").json()["items"][0]
+
+    assert item["brewery_name"] is None
+    assert item["style_name"] is None
+
+
+async def test_search_resolves_brewery_and_style_names(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Happy: search rows also carry the resolved names (#1220)."""
+
+    brewery, ipa, _ = await _seed_reference_data(db_session)
+    db_session.add(
+        Beer(
+            name="Searchable IPA",
+            slug="searchable-ipa",
+            brewery_id=brewery.id,
+            style_id=ipa.id,
+        )
+    )
+    await db_session.commit()
+
+    item = client.get("/beers/search", params={"q": "searchable"}).json()["items"][0]
+
+    assert item["brewery_name"] == "Reference Brewery"
+    assert item["style_name"] == "India Pale Ale"
+
+
+async def test_get_beer_resolves_brewery_and_style_names(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Happy: the detail endpoint resolves the names too (#1220)."""
+
+    brewery, ipa, _ = await _seed_reference_data(db_session)
+    beer = Beer(
+        name="Detail IPA",
+        slug="detail-ipa",
+        brewery_id=brewery.id,
+        style_id=ipa.id,
+    )
+    db_session.add(beer)
+    await db_session.commit()
+    await db_session.refresh(beer)
+
+    body = client.get(f"/beers/{beer.id}").json()
+
+    assert body["brewery_name"] == "Reference Brewery"
+    assert body["style_name"] == "India Pale Ale"

--- a/packages/beer-encyclopedia/tests/test_api/test_beers.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_beers.py
@@ -45,6 +45,9 @@ async def test_create_beer_returns_201(client: TestClient, db_session: AsyncSess
     assert body["brewery_id"] == str(brewery.id)
     assert body["ibu_min"] == 50
     assert body["ibu_max"] == 55
+    # The write path resolves the denormalised names too (#1220).
+    assert body["brewery_name"] == "Reference Brewery"
+    assert body["style_name"] == "India Pale Ale"
 
 
 def test_create_beer_rejects_inverted_ibu_interval(client: TestClient) -> None:
@@ -148,6 +151,7 @@ async def test_patch_beer_updates_fields_and_validates_fk(
     )
     assert update.status_code == 200
     assert update.json()["style_id"] == str(stout.id)
+    assert update.json()["style_name"] == "Stout"
 
     # Invalid FK rejected
     bad_update = client.patch(
@@ -204,7 +208,9 @@ async def test_list_resolves_brewery_and_style_names(
     )
     await db_session.commit()
 
-    item = client.get("/beers").json()["items"][0]
+    data = client.get("/beers").json()
+    assert data["meta"]["total"] == 1
+    item = data["items"][0]
 
     assert item["brewery_name"] == "Reference Brewery"
     assert item["style_name"] == "India Pale Ale"
@@ -218,7 +224,9 @@ async def test_list_leaves_names_null_when_fks_are_null(
     db_session.add(Beer(name="Orphan", slug="orphan"))
     await db_session.commit()
 
-    item = client.get("/beers").json()["items"][0]
+    data = client.get("/beers").json()
+    assert data["meta"]["total"] == 1
+    item = data["items"][0]
 
     assert item["brewery_name"] is None
     assert item["style_name"] is None
@@ -266,3 +274,19 @@ async def test_get_beer_resolves_brewery_and_style_names(
 
     assert body["brewery_name"] == "Reference Brewery"
     assert body["style_name"] == "India Pale Ale"
+
+
+async def test_brewery_name_becomes_null_after_brewery_deleted(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Edge: deleting a brewery (ON DELETE SET NULL) nulls the resolved name."""
+
+    brewery, _, _ = await _seed_reference_data(db_session)
+    db_session.add(Beer(name="Widow", slug="widow", brewery_id=brewery.id))
+    await db_session.commit()
+
+    assert client.delete(f"/breweries/{brewery.id}").status_code == 204
+
+    data = client.get("/beers").json()
+    assert data["meta"]["total"] == 1
+    assert data["items"][0]["brewery_name"] is None


### PR DESCRIPTION
## Summary

Closes **#1220**. The denormalised `brewery_name` / `style_name` on `BeerRead` (07-class-api-contract) were only populated by `POST /beers/import-by-ean`; every other endpoint serialized `BeerRead.model_validate` directly and left both **null** — so the mobile catalogue (#1215) showed "Brasserie inconnue / Style inconnu" on every list row and fiche.

## Changes (`api/routers/beers.py`)

- **list / search** — eager-load `selectinload(Beer.brewery, Beer.style)` and serialize each row via the existing `_beer_read_with_names` helper. Its `session.get` calls become identity-map hits after the selectinload → **no N+1** (two extra batched queries per page, not one per row).
- **detail** — `get_beer` returns `_beer_read_with_names(...)`.
- **create / update** — also resolve the names (was null even with valid FKs); the FKs are already warmed by `_validate_fks`, so the resolution is free. Keeps the read/write contract uniform.

## Tests (`tests/test_api/test_beers.py`)

- Names resolved on list / search / detail; null-FK keeps both names null.
- POST 201 / PATCH 200 responses carry the resolved names.
- Cascade edge: delete a brewery (`ON DELETE SET NULL`) → `brewery_name` becomes null.
- Existing list tests now assert `meta.total == 1` before indexing (isolation safety).
- Full suite: **181 passed**.

## Deploy

**No schema change, no migration** — code-only. After merge, a redeploy of the encyclopedia (Fly) makes the names appear in the live mobile catalogue.

## Review

Local pre-push (`pr-pre-reviewer`): 0 Must Have. The `get_beer` single-row case keeps the helper (selectinload `options=` on `session.get` would be query-neutral with the helper; 3 bounded queries on a detail endpoint is not N+1). Codex helper could not run (known `scripts/codex-review.sh` CLI-arg bug).

## Checklist

- [x] `ruff check` clean; `py_compile` OK; 181 tests pass.
- [x] No schema change / migration.
- [ ] CodeRabbit + Codex auto-review addressed.
- [ ] Redeploy encyclopedia after merge.

Closes #1220. Relates epic #1128.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Beer listings, search results, and beer detail responses now consistently return brewery and style names (including after create/update).
  * Brewery and style name fields now correctly reflect null values when related records are removed.
  * Improved reliability of API responses by standardizing how beer data is formatted across endpoints.
* **Performance**
  * Optimized data loading for beer listings and fuzzy searches.
* **Tests**
  * Added coverage to verify resolved name behavior across list, search, detail, create, update, and deletion scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->