### PR TITLE
fix(encyclopedia): assert exposed routes via OpenAPI, not app.routes (FastAPI 0.137)

### DIFF
--- a/packages/beer-encyclopedia/tests/test_api/test_scan.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_scan.py
@@ -67,7 +67,13 @@ def test_app_exposes_scan_router_routes() -> None:
     """The scan router must be mounted at the root, not under a prefix —
     backward compatibility with consumers of /health and /scan."""
 
-    paths = {route.path for route in app.routes if hasattr(route, "methods")}
+    # Assert against the OpenAPI schema (the public path contract) rather
+    # than `app.routes`: FastAPI 0.137 stores included routers as opaque
+    # `_IncludedRouter` wrappers in `app.routes` (lazy resolution), so
+    # introspecting that internal structure is brittle and broke this test
+    # on the FastAPI upgrade. `openapi()["paths"]` reflects the
+    # actually-exposed routes regardless of the internal representation.
+    paths = app.openapi()["paths"]
     assert "/health" in paths
     assert "/scan" in paths
 


### PR DESCRIPTION
## Summary

`test_app_exposes_scan_router_routes` started failing on **every** CI run (repo-wide, `main` included) after a recent **FastAPI 0.137** release — unrelated to any feature work.

## Root cause

FastAPI 0.137 changed `include_router`: included routers are now stored as opaque `_IncludedRouter` wrappers in `app.routes` (lazy resolution) instead of flattened `APIRoute`s. The test read `app.routes` and filtered on `hasattr(route, "methods")`, so it saw only the `/docs` routes:

```
AssertionError: assert '/health' in {'/docs', '/docs/oauth2-redirect', '/openapi.json', '/redoc'}
```

CI installs the latest FastAPI (no upper pin in `pyproject`), so the failure is deterministic on CI even though it passed locally on the older pinned-in-venv version. **The app itself is fine** — `TestClient GET /health` → 200 and `app.openapi()["paths"]` lists `/health`, `/scan`, `/beers`, …

## Fix

Assert against `app.openapi()["paths"]` — the public path contract — instead of the internal `app.routes` structure. Robust to FastAPI's internal route representation; still verifies the scan router is mounted at root (`/health`, `/scan`, not under a prefix).

## Verification

Reproduced locally by upgrading to `fastapi==0.137.1` / `starlette==1.3.1` (the failure appears; the fix makes it pass). Full suite green under 0.137: **176 passed**. `ruff` clean.

## Checklist

- [x] Reproduced the failure with FastAPI 0.137; fix verified.
- [x] No runtime change (test-only).
- [x] Unblocks the open PRs (e.g. #1222) once they rebase on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test validation to verify API routes using OpenAPI schema rather than internal framework implementation, improving test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->