### PR TITLE
docs(catalog-moderation): UML moderation study + ADR-0018 (in-app CREATOR, secured at API)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,11 @@ Currently accepted ADRs (see each file for the `Status` line and full rationale)
 - [ADR-0003 — Consent as a single source of truth](docs/architecture/decisions/0003-consent-single-source-of-truth.md)
 - [ADR-0004 — Data locality hybrid principle](docs/architecture/decisions/0004-data-locality-hybrid-principle.md)
 - [ADR-0005 — Backend split (encyclopedia vs product)](docs/architecture/decisions/0005-backend-split-encyclopedia-vs-product.md)
+- [ADR-0011 — Single-holder CREATOR role above ADMIN](docs/architecture/decisions/0011-creator-role-above-admin.md)
 - [ADR-0013 — Canonical beer model, scan-catalog reconciliation, and conception order](docs/architecture/decisions/0013-beer-canonical-model-and-conception-order.md)
 - [ADR-0014 — Website hosting on Cloudflare Pages, DNS authority on Cloudflare](docs/architecture/decisions/0014-website-hosting-cloudflare-pages-dns.md)
+- [ADR-0015 — Beer ingestion & enrichment strategy (staging → human-gated promotion)](docs/architecture/decisions/0015-beer-ingestion-enrichment-strategy.md)
+- [ADR-0018 — Admin/moderation surface: in-app CREATOR moderation, secured at the NestJS API](docs/architecture/decisions/0018-admin-moderation-surface.md)
 
 When a new ADR is accepted, add its file link here (no dates, no per-ADR summaries — open the file for the live status and content). When reviewing a PR, flag any diff that violates these ADRs and cite the ADR number and clause in the review comment.
 

--- a/docs/architecture/decisions/0011-creator-role-above-admin.md
+++ b/docs/architecture/decisions/0011-creator-role-above-admin.md
@@ -1,7 +1,7 @@
 # ADR-0011 — Introduce a single-holder `CREATOR` role above `ADMIN`
 
-**Status**  Proposed
-**Date**    2026-05-25
+**Status**  Accepted
+**Date**    2026-05-25 (accepted 2026-06-15)
 **Owners**  @benoit-bremaud
 
 > Records the RBAC decision surfaced by the account/profile conception

--- a/docs/architecture/decisions/0015-beer-ingestion-enrichment-strategy.md
+++ b/docs/architecture/decisions/0015-beer-ingestion-enrichment-strategy.md
@@ -1,7 +1,7 @@
 # ADR-0015 — Beer ingestion & enrichment strategy (multi-source → staging → human-gated promotion)
 
-**Status**  Proposed
-**Date**    2026-06-04
+**Status**  Accepted
+**Date**    2026-06-04 (accepted 2026-06-15)
 **Owners**  @benoit-bremaud
 
 > Crystallizes the ingestion + enrichment strategy for the beer-encyclopedia:

--- a/docs/architecture/decisions/0018-admin-moderation-surface.md
+++ b/docs/architecture/decisions/0018-admin-moderation-surface.md
@@ -49,16 +49,23 @@ enforced at the NestJS API boundary; moderation actions are reversible
 
 1. **In-app creator surface.** A "creator mode" is visible **only** to a
    `CREATOR` (ADR-0011, via `hasAtLeast(user.role, …)`, never a raw
-   `role === 'creator'`). It exposes **targeted** moderation actions on a single
+   `role === 'creator'`). **Build note:** the current `RolesGuard` does
+   *exact-match* (`requiredRoles.includes(user.role)`), so it must migrate to the
+   rank-based `hasAtLeast` (ADR-0011) — otherwise a `CREATOR` is wrongly rejected
+   by an `@Roles(ADMIN)` route. It exposes **targeted** moderation actions on a single
    catalogue entry: **promote** (`is_verified false → true`, realizes UC9 /
    ADR-0015 D4), **depublish** (hide a non-conforming or erroneous entry), and
    **triage the staging queue**.
 2. **Trust boundary at the API (ADR-0002).** The mobile app calls **NestJS admin
    endpoints only** — it never writes to the encyclopedia directly. NestJS
    authenticates (JWT) and authorizes (`RolesGuard`, `CREATOR` rank), then
-   proxies the write to the encyclopedia service. This closes **#1151** at the
-   correct layer and keeps the mobile→backend contract uniform (ADR-0002,
-   ADR-0005).
+   proxies the write to the encyclopedia service. This is the design that
+   **closes #1151** at the correct layer and keeps the mobile→backend contract
+   uniform (ADR-0002, ADR-0005). **Current state (not yet built):** the
+   encyclopedia `POST`/`PATCH`/`DELETE` are **unauthenticated today** (#1151
+   open) and the NestJS proxy layer does **not** exist yet (the
+   `beer-contribution` approve path is a `501` stub) — readers must not assume
+   the protection is in place; it ships with the build slice that closes #1151.
 3. **Reversible + audited.** A moderation action toggles a **status**
    (publication / verification flag); it is **not** a hard `DELETE`. Each action
    records who / when / old → new in the catalog change history (**#1155**),

--- a/docs/architecture/decisions/0018-admin-moderation-surface.md
+++ b/docs/architecture/decisions/0018-admin-moderation-surface.md
@@ -1,0 +1,130 @@
+# ADR-0018 — Admin/moderation surface: in-app CREATOR moderation, secured at the NestJS API
+
+**Status**  Accepted
+**Date**    2026-06-15 (accepted 2026-06-16)
+**Owners**  @benoit-bremaud
+
+> Settles the one open question left by ADR-0011 (the `CREATOR` role) and
+> ADR-0015 (staging → human-gated promotion): **where** the privileged actor
+> moderates the catalogue. Reconciles the contradiction between #1152
+> ("dedicated web admin, never via mobile") and #940 (a mobile admin review
+> screen), and re-scopes #1152 accordingly. Tracked by epic #1175.
+
+---
+
+## Context
+
+- **The conception already mandates a human moderation step.** ADR-0015 (D1)
+  writes every ingested `Beer` as `is_verified = false` (staging) and keeps it
+  **out of the shared canonical catalogue until promoted**; (D4) the
+  `false → true` promotion is performed **only** by human moderation (UC9).
+  ADR-0011 defines the `CREATOR` role (single-holder, above `ADMIN`) that holds
+  this authority.
+- **The "where" was never reconciled.** The encyclopedia use-case study
+  ([`diagrams/beer-encyclopedia/01-use-case.md`](../diagrams/beer-encyclopedia/01-use-case.md))
+  and **#1152** record an intent — maintenance/moderation via a *dedicated web
+  admin interface, never via mobile*. Yet **#940** already proposes a **mobile**
+  admin review screen for scan suggestions, and the encyclopedia study itself
+  flags scan-suggestion validation as "distinct from UC9, to reconcile". The
+  position is internally contradictory.
+- **"Never mobile" is not a security control.** The encyclopedia write endpoints
+  have **no authentication at all today** (**#1151**, `priority:high`,
+  `area:security`). Hiding a button from the mobile UI provides zero protection
+  while the API is open: a deleted row earlier in this epic was removed by an
+  unauthenticated `DELETE`. Access control must live at the API, not in which
+  client surfaces the action.
+- **The founder works on mobile.** The triggering incident — an OpenFoodFacts
+  import (`is_verified = false`: a bottled water, an energy drink, a red wine)
+  leaking into the public catalogue, in violation of ADR-0015 D1 — was spotted
+  by the `CREATOR` while browsing the catalogue **on his phone**. He needs to act
+  where he sees the problem.
+
+---
+
+## Decision
+
+**Moderation is surfaced in the mobile app for the `CREATOR`, with all authority
+enforced at the NestJS API boundary; moderation actions are reversible
+(depublish, not hard-delete) and audited.**
+
+1. **In-app creator surface.** A "creator mode" is visible **only** to a
+   `CREATOR` (ADR-0011, via `hasAtLeast(user.role, …)`, never a raw
+   `role === 'creator'`). It exposes **targeted** moderation actions on a single
+   catalogue entry: **promote** (`is_verified false → true`, realizes UC9 /
+   ADR-0015 D4), **depublish** (hide a non-conforming or erroneous entry), and
+   **triage the staging queue**.
+2. **Trust boundary at the API (ADR-0002).** The mobile app calls **NestJS admin
+   endpoints only** — it never writes to the encyclopedia directly. NestJS
+   authenticates (JWT) and authorizes (`RolesGuard`, `CREATOR` rank), then
+   proxies the write to the encyclopedia service. This closes **#1151** at the
+   correct layer and keeps the mobile→backend contract uniform (ADR-0002,
+   ADR-0005).
+3. **Reversible + audited.** A moderation action toggles a **status**
+   (publication / verification flag); it is **not** a hard `DELETE`. Each action
+   records who / when / old → new in the catalog change history (**#1155**),
+   compatible with the RGPD audit posture (ADR-0012). Hard delete stays an
+   exceptional maintainer operation, never the default moderation gesture.
+4. **Web admin console deferred, not cancelled.** The dedicated web back-office
+   (#738 / #1152) becomes the home for **bulk / heavy** curation — reference-data
+   seeding (UC8), mass operations, multi-maintainer workflows — and is built when
+   a real need or a second maintainer appears (ADR-0001 "build for today"). The
+   mobile surface covers the founder's **daily targeted** moderation.
+5. **#1152 is re-scoped.** Its "no maintenance via mobile" clause is **revised**:
+   targeted, role-gated, API-secured moderation **is** allowed on mobile.
+   #1152 now reads "heavy/bulk curation belongs on web; security is enforced at
+   the API, not by hiding the UI".
+
+---
+
+## Consequences
+
+### Positive
+
+- The `CREATOR` cleans the catalogue **where the problem is seen** (mobile),
+  matching how a solo founder actually works.
+- Security moves to the **API** (#1151 closed properly), instead of relying on an
+  illusory client-side hiding.
+- Moderation is **safe by construction**: reversible depublish + audit trail
+  (#1155), no destructive default.
+- No premature web-console build (KISS / ADR-0001); the heavy surface arrives
+  only when justified.
+
+### Trade-offs
+
+- The mobile app gains a **privileged surface** → it must be strictly role-gated,
+  and the API must reject **any** write that does not carry `CREATOR` (the UI is
+  not the gate — the API is). Defense lives server-side.
+- A compromised `CREATOR` session is **high-impact**. Mitigations: single-holder
+  `CREATOR` (ADR-0011), reversible depublish + audit (#1155), and a follow-up
+  **step-up confirmation** on destructive actions (tracked under the epic).
+
+### Rejected alternatives
+
+- **Web-admin-only now (#1152 as-is).** Heavy to build / host / secure for a solo
+  pre-public project, does not match where the founder works, and — crucially —
+  does **not** itself fix #1151. Deferred to when bulk curation needs it.
+- **Direct mobile → encyclopedia writes.** Violates ADR-0002 and re-opens #1151;
+  the encyclopedia must trust no unauthenticated caller.
+- **Hard delete as the moderation action.** Not reversible, loses the audit
+  trail; conflicts with #1155 and the RGPD-friendly history posture (ADR-0012).
+
+---
+
+## Realization
+
+Tracked by **epic #1175**. Conception deliverables:
+[`docs/architecture/diagrams/catalog-moderation/`](../diagrams/catalog-moderation/)
+— use-case (Curate domain + `CREATOR`), state (entry publication lifecycle),
+sequence (`CREATOR` promotes / depublishes), component (auth boundary). Build
+slices: enforce ADR-0015 D1 read filter + promote the curated `internal` seed,
+close #1151 (auth on writes), NestJS moderation endpoints + in-app creator mode,
+UC9 queue (#1153 / #1154 / #1155).
+
+## Relation to other ADRs
+
+- **Depends on ADR-0011** (`CREATOR` role) and **ADR-0015** (staging /
+  human-gated promotion) — this ADR decides the *surface* they left open.
+- **Respects ADR-0002** (auth/authz owned by NestJS; mobile talks only to NestJS)
+  and **ADR-0005** (encyclopedia / product backend split).
+- **Aligns with ADR-0001** (build for today: defer the web console) and
+  **ADR-0012** (audited, RGPD-friendly history).

--- a/docs/architecture/diagrams/beer-encyclopedia/01-use-case.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/01-use-case.md
@@ -164,8 +164,11 @@ endlegend
   **source externe** en frontière (cible de UC4 sur absence locale), pas un acteur.
 - **Sécurité / maintenance** : les écritures (UC7/UC8) et la modération (UC9) supposent un
   acteur authentifié/autorisé. Le code Python n'impose aucune auth aujourd'hui (divergence
-  - faille → #1151). La maintenance passera par une **interface web admin dédiée**, jamais
-  par le mobile (#1152).
+  - faille → #1151). **ADR-0018** tranche la surface : la **modération ciblée** (promouvoir
+  / dépublier une entrée, UC9) est exposée **en mobile** au CREATOR, autorisée **au niveau de
+  l'API NestJS** (ferme #1151) ; la **curation lourde** (création/édition de masse UC7,
+  référentiels UC8) reste sur une **console web** différée (#1152 re-cadré, #738). Étude
+  dédiée : `catalog-moderation/`.
 
 ## Spécifications des cas d'usage (Cockburn)
 
@@ -244,7 +247,7 @@ endlegend
   - 3a. Identification incertaine/partielle → création d'une **proposition de fiche** à valider par un Mainteneur ; le Visiteur est informé.
   - 2a. Étiquette illisible / analyse en échec → message d'erreur ; proposer une nouvelle capture.
 - **Postcondition :** si succès, bière identifiée (fiche) ou proposition en attente ; sinon aucun changement.
-- **Relations :** **«extend» UC4**. La validation des suggestions de scan est une modération distincte de UC9 (à réconcilier via l'étude `scan/` + l'interface admin #1152).
+- **Relations :** **«extend» UC4**. La validation des suggestions de scan est une modération distincte de UC9 (à réconcilier via l'étude `scan/` + la surface de modération ADR-0018, étude `catalog-moderation/`).
 
 ### UC6 — Proposer une correction — *planifié*
 
@@ -266,7 +269,7 @@ endlegend
 ### UC7 — Gérer le catalogue : créer / modifier / supprimer (bières & brasseries) — *livré*
 
 - **Acteur principal :** Mainteneur
-- **Précondition :** Mainteneur authentifié et autorisé, **via l'interface web d'administration** (jamais via le mobile)
+- **Précondition :** Mainteneur authentifié et autorisé. Création / édition de masse **via la console web** (différée, #1152/#738) ; la **dépublication ciblée** d'une entrée est exposée en mobile au CREATOR (ADR-0018, étude `catalog-moderation/`)
 - **Garantie minimale :** intégrité préservée (validations, contraintes) ; pas de doublon slug/EAN
 - **Garantie de succès :** l'entité est créée / modifiée / supprimée comme demandé
 - **Scénario nominal (création)**
@@ -285,7 +288,7 @@ endlegend
 ### UC8 — Alimenter les données de référence (styles, dénominations légales, sources) — *livré*
 
 - **Acteur principal :** Mainteneur
-- **Précondition :** Mainteneur autorisé, **via l'interface web d'administration** (jamais via le mobile) ; jeux de référence d'autorité disponibles
+- **Précondition :** Mainteneur autorisé, **via la console web d'administration** (curation lourde, reste hors mobile — ADR-0018 §4, #1152) ; jeux de référence d'autorité disponibles
 - **Garantie minimale :** opérations **idempotentes** ; vocabulaires contrôlés respectés (CHECK)
 - **Garantie de succès :** les tables de référence contiennent les entrées canoniques
 - **Scénario nominal**
@@ -301,7 +304,7 @@ endlegend
 ### UC9 — Modérer les corrections communautaires — *planifié*
 
 - **Acteur principal :** Mainteneur (rôle existant ; **lui seul** modère ; il a tous les droits)
-- **Précondition :** Mainteneur authentifié **via l'interface web d'administration** ; au moins une correction « pending » (issue de UC6)
+- **Précondition :** Mainteneur authentifié (surface mobile CREATOR ou console web — ADR-0018) ; au moins une correction « pending » (issue de UC6)
 - **Garantie minimale :** aucune donnée publiée modifiée sans décision explicite ; **traçabilité + historique conservés**
 - **Garantie de succès :** la correction (ou le **groupe** de signalements identiques) est traitée → « approved » (valeur appliquée, éventuellement amendée) ou « rejected », et **le(s) contributeur(s) est/sont notifié(s)**
 - **Scénario nominal**
@@ -318,4 +321,4 @@ endlegend
   - **Notifications** (#1154) : le résultat est notifié au contributeur — dépendance inter-service (utilisateurs côté NestJS, ADR-0005).
   - **Historique / audit** (#1155) : journal des changements (qui, quand, ancienne → nouvelle valeur).
 - **Postcondition :** correction(s) « approved »/« rejected », horodatée(s) et attribuée(s) ; décision dans l'historique ; contributeur(s) notifié(s) ; donnée publiée à jour si approuvée.
-- **Relations :** association Mainteneur seule. Cycle de vie UC6 → UC9 (`05-state`). Validation des suggestions de scan = modération distincte (#1152).
+- **Relations :** association Mainteneur seule. Cycle de vie UC6 → UC9 (`05-state`). Surface décidée par ADR-0018 (modération in-app CREATOR ; étude `catalog-moderation/`). Validation des suggestions de scan = modération distincte (étude `scan/`).

--- a/docs/architecture/diagrams/beer-encyclopedia/01-use-case.md
+++ b/docs/architecture/diagrams/beer-encyclopedia/01-use-case.md
@@ -269,7 +269,7 @@ endlegend
 ### UC7 — Gérer le catalogue : créer / modifier / supprimer (bières & brasseries) — *livré*
 
 - **Acteur principal :** Mainteneur
-- **Précondition :** Mainteneur authentifié et autorisé. Création / édition de masse **via la console web** (différée, #1152/#738) ; la **dépublication ciblée** d'une entrée est exposée en mobile au CREATOR (ADR-0018, étude `catalog-moderation/`)
+- **Précondition :** Mainteneur authentifié et autorisé, **via la console web** (curation lourde : création / édition / suppression de masse — différée, ADR-0018 §4, #1152/#738). La **modération ciblée** (dépublier une entrée depuis le mobile) est un geste **distinct**, traité par UC9 / l'étude `catalog-moderation/`, pas par UC7
 - **Garantie minimale :** intégrité préservée (validations, contraintes) ; pas de doublon slug/EAN
 - **Garantie de succès :** l'entité est créée / modifiée / supprimée comme demandé
 - **Scénario nominal (création)**

--- a/docs/architecture/diagrams/catalog-moderation/01-use-case.md
+++ b/docs/architecture/diagrams/catalog-moderation/01-use-case.md
@@ -1,0 +1,149 @@
+# Diagramme de cas d'usage — catalog-moderation — modération du catalogue (mode créateur)
+
+> **Feature :** épic #1175 (réalise ADR-0015) — surface de modération in-app
+> **Code concerné (cible) :** `packages/api/src/` (endpoints admin NestJS), `packages/mobile-app/src/features/` (mode créateur), `packages/beer-encyclopedia/api/routers/` (écritures proxifiées)
+> **ADR liés :** ADR-0018 (surface admin in-app), ADR-0011 (rôle CREATOR), ADR-0015 (staging → promotion humaine), ADR-0002 (auth NestJS), ADR-0012 (audit/RGPD)
+
+## Contexte
+
+**Vue cible (vision)** des buts de modération que le **CREATOR** initie depuis
+l'application mobile, une fois la surface in-app décidée (ADR-0018). Diagramme
+**contractuel** — la conception fait foi, le code s'y conforme.
+
+Regroupement **par domaine** (Curer), jamais par composant : la frontière
+Mobile / NestJS / Encyclopédie vit dans `03-component.md`, pas ici. Le cycle de
+vie d'une entrée (états) est dans `04-state-entry-lifecycle.md`. Tous les cas
+sont **planifiés** (`<<planned>>`) — aucun n'est encore livré.
+
+**Hors périmètre :** la curation lourde (référentiels UC8, opérations de masse)
+reste destinée à une **console web** différée (ADR-0018 §4, #738/#1152) ; la
+contribution communautaire (UC6) et sa modération (UC9 corrections de champs)
+sont l'objet de l'étude `beer-encyclopedia/`.
+
+## Diagramme
+
+```mermaid
+flowchart LR
+  Creator(("CREATOR — «Benoît», détenteur unique"))
+  Admin(("ADMIN"))
+
+  %% Généralisation d'acteurs (ADR-0011, rank map) : l'enfant hérite des buts du parent
+  Creator -.->|"«is a» (rang supérieur)"| Admin
+
+  subgraph SYSTEM ["Brasse-Bouillon — modération du catalogue (vue cible)"]
+    subgraph Curate ["Domaine Curer (mode créateur in-app)"]
+      M1(("M1 — Trier la file de validation"))
+      M2(("M2 — Promouvoir une entrée en attente"))
+      M3(("M3 — Dépublier une entrée non conforme"))
+      M4(("M4 — Republier une entrée dépubliée"))
+    end
+  end
+
+  Creator --> M1
+  Creator --> M2
+  Creator --> M3
+  Creator --> M4
+
+  classDef planned stroke:#e67e22,stroke-width:2px,stroke-dasharray:6 4;
+  class M1,M2,M3,M4 planned;
+```
+
+*Même cas d'usage en **PlantUML** (notation UML 2.5 : acteurs, ovales,
+généralisation native, stéréotype `<<planned>>`). À garder **synchronisé** avec
+le bloc Mermaid ci-dessus.*
+
+```plantuml
+@startuml
+left to right direction
+skinparam packageStyle rectangle
+skinparam shadowing false
+
+actor "CREATOR\n«Benoît», détenteur unique" as Creator
+actor "ADMIN" as Admin
+
+' Généralisation d'acteurs (ADR-0011, rank map) : l'enfant hérite des buts du parent
+Creator --|> Admin
+
+rectangle "Brasse-Bouillon — modération du catalogue (vue cible)" {
+  package "Curer (mode créateur in-app)" {
+    usecase "M1 — Trier la file\nde validation" as M1 <<planned>>
+    usecase "M2 — Promouvoir une\nentrée en attente" as M2 <<planned>>
+    usecase "M3 — Dépublier une\nentrée non conforme" as M3 <<planned>>
+    usecase "M4 — Republier une\nentrée dépubliée" as M4 <<planned>>
+  }
+}
+
+Creator --> M1
+Creator --> M2
+Creator --> M3
+Creator --> M4
+
+skinparam usecase {
+  BackgroundColor<<planned>> #FDEBD0
+  BorderColor<<planned>> #E67E22
+  BorderThickness<<planned>> 2
+}
+
+legend right
+  Trait plein = livré
+  <<planned>> = non encore implémenté (ADR-0018)
+endlegend
+@enduml
+```
+
+## Spécifications des cas d'usage (Cockburn)
+
+> **Acteur principal commun :** CREATOR (détenteur unique, ADR-0011). La surface
+> est visible **uniquement** s'il a le rang requis (`hasAtLeast`), et toute
+> écriture est **autorisée côté API NestJS** (ADR-0018 §2), jamais par le seul
+> masquage de l'UrI. Les actions M2/M3/M4 sont **atteintes depuis la file M1**
+> (navigation), ce n'est pas une relation «include».
+
+### M1 — Trier la file de validation — *planifié*
+
+- **Intérêts :** le CREATOR voit d'un coup les imports en attente (scans, Open Food Facts) à statuer ; Brasse-Bouillon garde le catalogue partagé propre.
+- **Précondition :** CREATOR authentifié et autorisé. · **Garantie minimale :** lecture seule ; aucune donnée publiée modifiée.
+- **Garantie de succès :** liste des entrées `is_verified=false` affichée, triable/filtrable (source, date), priorisée (#1153 à terme).
+- **Scénario nominal**
+    1. Le CREATOR ouvre la file de validation.
+    2. Le système affiche les entrées en attente (nom, source, champs renseignés, provenance).
+    3. Le CREATOR ouvre une entrée → navigue vers M2 ou M3.
+- **Extensions :** 2a. File vide → message « rien à valider ».
+- **Postcondition :** aucune modification. · **Relations :** réalise la consultation de file de UC9 (ADR-0015) ; point de départ de M2/M3.
+
+### M2 — Promouvoir une entrée en attente — *planifié*
+
+- **Précondition :** une entrée `is_verified=false` existe (issue d'un import UC4/UC5). · **Garantie minimale :** aucune promotion sans décision explicite ; traçabilité conservée (#1155).
+- **Garantie de succès :** l'entrée passe `is_verified=false → true` et **rejoint le catalogue partagé**.
+- **Scénario nominal**
+    1. Depuis M1, le CREATOR examine l'entrée (champs, provenance `EntitySource`).
+    2. Il **promeut** (en l'état ou après amendement des champs).
+    3. Le système bascule `is_verified=true`, **consigne** qui/quand/ancien→nouveau (#1155).
+- **Extensions :** 2a. Données insuffisantes/erronées → il **amende** avant de promouvoir, ou rejette (reste en attente / M3). 2b. Doublon détecté (slug/EAN) → propose la fusion plutôt que la promotion.
+- **Postcondition :** entrée publiée et visible (UC1/UC3) ; décision dans l'historique. · **Relations :** **réalise UC9** (ADR-0015 D4 — promotion par modération humaine, jamais d'auto-promotion).
+
+### M3 — Dépublier une entrée non conforme — *planifié*
+
+- **Précondition :** une entrée non conforme est visible (ex. eau, soda, « Vin rouge », doublon, produit erroné). · **Garantie minimale :** action **réversible** ; **pas de suppression dure** par défaut ; traçabilité conservée.
+- **Garantie de succès :** l'entrée est **retirée du catalogue partagé** (statut publication → false) sans perte de donnée.
+- **Scénario nominal**
+    1. Le CREATOR ouvre l'entrée fautive (depuis M1 ou en parcourant le catalogue).
+    2. Il **dépublie** (motif optionnel).
+    3. Le système masque l'entrée des lectures publiques (UC1/UC2/UC3) et **consigne** la décision (#1155).
+- **Extensions :** 2a. L'entrée doit être **détruite** (donnée illégale, RGPD) → suppression dure = opération mainteneur exceptionnelle (UC7), hors geste de modération courant.
+- **Postcondition :** entrée invisible au public, conservée et réversible. · **Relations :** **réalise UC7** (suppression **logique**, réversible) ; respecte ADR-0012 (audit/RGPD).
+
+### M4 — Republier une entrée dépubliée — *planifié*
+
+- **Précondition :** une entrée dépubliée existe (M3). · **Garantie de succès :** l'entrée redevient visible (retour à l'état publié), décision consignée.
+- **Scénario nominal**
+    1. Le CREATOR retrouve l'entrée dépubliée (file/filtre dédié).
+    2. Il **republie** → le système restaure la visibilité et **consigne** l'action.
+- **Postcondition :** entrée de nouveau publiée. · **Relations :** inverse de M3 ; garantit la réversibilité posée par ADR-0018 §3.
+
+## Notes
+
+- **Aucune relation «include»/«extend» artificielle** : M2/M3/M4 sont des buts distincts atteints **depuis** la file M1 par navigation. Seule la généralisation d'acteur (ADR-0011) est une vraie relation UML ici.
+- **Un seul acteur en v1** : le CREATOR. ADR-0011 permet d'étendre la modération à ADMIN/MODERATOR plus tard (`hasAtLeast`) sans changer ces buts.
+- **Traçabilité** : M2 réalise **UC9**, M3 réalise **UC7** (logique) de `beer-encyclopedia/01-use-case.md` — stitching dans `traceability-matrix.md`.
+- **Anti-pattern rendu visible** : ces buts n'apparaissent **pas** dans l'étude encyclopédie car ils traversent NestJS (surface + auth) ; les y mettre mélangerait « ce que veut l'acteur » et « où ça tourne » (cf. `03-component.md`).

--- a/docs/architecture/diagrams/catalog-moderation/01-use-case.md
+++ b/docs/architecture/diagrams/catalog-moderation/01-use-case.md
@@ -96,7 +96,7 @@ endlegend
 > **Acteur principal commun :** CREATOR (détenteur unique, ADR-0011). La surface
 > est visible **uniquement** s'il a le rang requis (`hasAtLeast`), et toute
 > écriture est **autorisée côté API NestJS** (ADR-0018 §2), jamais par le seul
-> masquage de l'UrI. Les actions M2/M3/M4 sont **atteintes depuis la file M1**
+> masquage de l'UI. Les actions M2/M3/M4 sont **atteintes depuis la file M1**
 > (navigation), ce n'est pas une relation «include».
 
 ### M1 — Trier la file de validation — *planifié*

--- a/docs/architecture/diagrams/catalog-moderation/02-sequence-promote-depublish.md
+++ b/docs/architecture/diagrams/catalog-moderation/02-sequence-promote-depublish.md
@@ -1,0 +1,130 @@
+# Diagramme de séquence — catalog-moderation — le CREATOR promeut / dépublie
+
+> **Feature :** épic #1175 (réalise ADR-0015) — surface de modération in-app
+> **Réalise :** M2 (promouvoir) et M3 (dépublier) de `01-use-case.md`
+> **ADR liés :** ADR-0018 (auth à l'API NestJS), ADR-0002 (mobile ↔ NestJS seul), ADR-0015 (D4 promotion humaine), ADR-0012 (#1155 audit)
+
+## Contexte
+
+Scénario critique : la modération traverse **trois composants** (mobile → NestJS
+→ encyclopédie). Cette séquence montre **où l'autorisation est vérifiée**
+(au niveau NestJS, ce qui ferme #1151) et **que le mobile n'écrit jamais
+directement** dans l'encyclopédie (ADR-0002). Le détail structurel est dans
+`03-component.md` ; les états résultants dans `04-state-entry-lifecycle.md`.
+
+## Diagramme
+
+```mermaid
+sequenceDiagram
+  actor C as CREATOR
+  participant M as Mobile (mode créateur)
+  participant N as NestJS API (admin)
+  participant E as Encyclopédie (Python)
+  participant H as Historique (audit #1155)
+
+  Note over M,N: ADR-0002 — le mobile ne parle qu'à NestJS
+
+  C->>M: Ouvrir la file de validation (M1)
+  M->>N: GET /admin/catalog/pending (Bearer JWT)
+  N->>N: Vérifie JWT puis rang CREATOR (RolesGuard)
+  alt rang insuffisant
+    N-->>M: 403 Forbidden
+    M-->>C: Accès refusé
+  else autorisé
+    N->>E: Lire les entrées en attente (is_verified faux)
+    E-->>N: Liste des entrées en attente
+    N-->>M: 200 file en attente
+    M-->>C: Affiche la file (source, champs, provenance)
+  end
+
+  Note over C,E: M2 — Promouvoir une entrée
+
+  C->>M: Tap Promouvoir sur une entrée
+  M->>N: PATCH /admin/catalog/beers/ID/promote (Bearer JWT)
+  N->>N: Vérifie JWT puis rang CREATOR
+  N->>E: Basculer is_verified faux vers vrai
+  E-->>N: 200 entrée promue
+  N->>H: Consigner qui, quand, ancien vers nouveau
+  N-->>M: 200 promue
+  M-->>C: L'entrée rejoint le catalogue partagé
+
+  Note over C,E: M3 — Dépublier une entrée non conforme
+
+  C->>M: Tap Dépublier (ex. bouteille d'eau)
+  M->>N: PATCH /admin/catalog/beers/ID/depublish (Bearer JWT)
+  N->>N: Vérifie JWT puis rang CREATOR
+  N->>E: Basculer la publication off (réversible)
+  E-->>N: 200 entrée dépubliée
+  N->>H: Consigner la décision et le motif
+  N-->>M: 200 dépubliée
+  M-->>C: L'entrée disparaît du catalogue public
+```
+
+*Même séquence en **PlantUML** (notation UML 2.5). À garder **synchronisé** avec
+le bloc Mermaid ci-dessus.*
+
+```plantuml
+@startuml
+actor "CREATOR" as C
+participant "Mobile\n(mode créateur)" as M
+participant "NestJS API\n(admin)" as N
+participant "Encyclopédie\n(Python)" as E
+participant "Historique\n(audit #1155)" as H
+
+note over M, N: ADR-0002 — le mobile ne parle qu'à NestJS
+
+C -> M : Ouvrir la file de validation (M1)
+M -> N : GET /admin/catalog/pending (Bearer JWT)
+N -> N : Vérifie JWT puis rang CREATOR (RolesGuard)
+alt rang insuffisant
+  N --> M : 403 Forbidden
+  M --> C : Accès refusé
+else autorisé
+  N -> E : Lire les entrées en attente (is_verified faux)
+  E --> N : Liste des entrées en attente
+  N --> M : 200 file en attente
+  M --> C : Affiche la file (source, champs, provenance)
+end
+
+note over C, E: M2 — Promouvoir une entrée
+
+C -> M : Tap Promouvoir sur une entrée
+M -> N : PATCH /admin/catalog/beers/ID/promote (Bearer JWT)
+N -> N : Vérifie JWT puis rang CREATOR
+N -> E : Basculer is_verified faux vers vrai
+E --> N : 200 entrée promue
+N -> H : Consigner qui, quand, ancien vers nouveau
+N --> M : 200 promue
+M --> C : L'entrée rejoint le catalogue partagé
+
+note over C, E: M3 — Dépublier une entrée non conforme
+
+C -> M : Tap Dépublier (ex. bouteille d'eau)
+M -> N : PATCH /admin/catalog/beers/ID/depublish (Bearer JWT)
+N -> N : Vérifie JWT puis rang CREATOR
+N -> E : Basculer la publication off (réversible)
+E --> N : 200 entrée dépubliée
+N -> H : Consigner la décision et le motif
+N --> M : 200 dépubliée
+M --> C : L'entrée disparaît du catalogue public
+@enduml
+```
+
+## Notes
+
+- **#1151 fermée au bon endroit.** L'autorisation (`JWT` + rang `CREATOR`) est
+  vérifiée **dans NestJS**, pas dans l'UI mobile. Une requête sans `CREATOR`
+  reçoit `403` avant tout effet de bord — masquer le bouton côté mobile ne
+  suffirait pas (ADR-0018).
+- **L'encyclopédie ne fait confiance qu'à NestJS.** Les écritures
+  (`promote`/`depublish`) arrivent par le canal interne authentifié
+  NestJS→Python ; aucune écriture publique non authentifiée ne subsiste (la
+  suppression directe de la bouteille d'eau, faite à la main via l'endpoint
+  ouvert, était précisément l'exploitation de #1151).
+- **Réversibilité + audit.** `depublish` bascule un statut (réversible via M4),
+  jamais un `DELETE` ; chaque action écrit l'historique (#1155, ADR-0012).
+- **Pas d'auto-promotion (ADR-0015 D4).** `promote` n'est jamais déclenché par
+  le système — toujours par le tap du CREATOR.
+- **Le `GET /admin/catalog/pending` voit le staging ; les lectures publiques
+  non.** La file expose les entrées `is_verified=false` ; `GET /beers` public
+  les filtre (`04-state`).

--- a/docs/architecture/diagrams/catalog-moderation/03-component.md
+++ b/docs/architecture/diagrams/catalog-moderation/03-component.md
@@ -1,0 +1,118 @@
+# Diagramme de composants — catalog-moderation — frontière d'autorisation
+
+> **Feature :** épic #1175 (réalise ADR-0015) — surface de modération in-app
+> **ADR liés :** ADR-0002 (mobile ↔ NestJS seul), ADR-0018 (auth à l'API),
+> ADR-0005 (split backend), ADR-0015 (filtre lecture publique),
+> ADR-0011 (rang CREATOR)
+> **Voir aussi :** `02-sequence-promote-depublish.md` (le même flux dans le temps)
+
+## Contexte
+
+Décomposition structurelle de la modération : **où** chaque responsabilité vit
+et **où passe la frontière d'autorisation**. Le point clé : l'écriture de
+modération franchit la garde NestJS (`JwtAuthGuard` + `RolesGuard CREATOR`) avant
+d'atteindre l'encyclopédie — ce qui **ferme #1151** au bon niveau. Le mobile
+n'écrit jamais directement dans l'encyclopédie (ADR-0002).
+
+## Diagramme
+
+```mermaid
+flowchart LR
+  subgraph Mobile ["packages/mobile-app"]
+    Creator["Mode créateur (M1 à M4)"]
+    Browse["Catalogue (UC1 UC2 UC3)"]
+    HTTP["core/http/http-client"]
+    Creator --> HTTP
+    Browse --> HTTP
+  end
+
+  subgraph Api ["packages/api (NestJS)"]
+    AdminCtrl["CatalogModerationController (/admin/catalog)"]
+    Guard{{"JwtAuthGuard + RolesGuard (CREATOR)"}}
+    Proxy["EncyclopediaModeration (proxy)"]
+    AdminCtrl --> Guard
+    AdminCtrl --> Proxy
+  end
+
+  subgraph Enc ["packages/beer-encyclopedia (Python)"]
+    WriteApi["Écritures /beers (promote, depublish)"]
+    ReadApi["Lectures publiques /beers (filtre is_verified vrai)"]
+    Audit["Historique catalogue (#1155)"]
+    DB[("SQLite, modèle canonique")]
+    WriteApi --> DB
+    WriteApi --> Audit
+    ReadApi --> DB
+  end
+
+  HTTP -->|"écritures modération, Bearer JWT (ADR-0002)"| AdminCtrl
+  Proxy -->|"canal interne authentifié"| WriteApi
+  HTTP -.->|"lecture catalogue (egress à confirmer)"| ReadApi
+
+  classDef gate stroke:#c0392b,stroke-width:2px;
+  class Guard gate;
+```
+
+*Même composant en **PlantUML** (notation UML 2.5). À garder **synchronisé** avec
+le bloc Mermaid ci-dessus.*
+
+```plantuml
+@startuml
+skinparam shadowing false
+skinparam componentStyle rectangle
+
+package "packages/mobile-app" {
+  [Mode créateur\n(M1 à M4)] as Creator
+  [Catalogue\n(UC1 UC2 UC3)] as Browse
+  [core/http/http-client] as HTTP
+  Creator --> HTTP
+  Browse --> HTTP
+}
+
+package "packages/api (NestJS)" {
+  [CatalogModerationController\n/admin/catalog] as AdminCtrl
+  [JwtAuthGuard + RolesGuard (CREATOR)] as Guard #FFCDD2
+  [EncyclopediaModeration (proxy)] as Proxy
+  AdminCtrl --> Guard
+  AdminCtrl --> Proxy
+}
+
+package "packages/beer-encyclopedia (Python)" {
+  [Écritures /beers\n(promote, depublish)] as WriteApi
+  [Lectures publiques /beers\n(filtre is_verified vrai)] as ReadApi
+  [Historique catalogue (#1155)] as Audit
+  database "SQLite\n(modèle canonique)" as DB
+  WriteApi --> DB
+  WriteApi --> Audit
+  ReadApi --> DB
+}
+
+HTTP --> AdminCtrl : écritures modération\nBearer JWT (ADR-0002)
+Proxy --> WriteApi : canal interne authentifié
+HTTP ..> ReadApi : lecture catalogue\n(egress à confirmer, #1186)
+@enduml
+```
+
+## Notes
+
+- **La garde est la frontière de sécurité.** `JwtAuthGuard` +
+  `RolesGuard(CREATOR)` (rouge) s'interpose avant tout effet de bord. Toute
+  écriture sans `CREATOR` → `403`. C'est la fermeture de **#1151** (les
+  écritures encyclopédie sans auth).
+- **ADR-0002 respecté pour les écritures.** Le mobile poste sur NestJS
+  (`/admin/catalog/...`) ; NestJS proxifie vers l'encyclopédie par un **canal
+  interne authentifié** (mécanisme — jeton de service ou isolation réseau —
+  tranché à la tranche qui ferme #1151). Aucun secret ni écriture directe Python
+  depuis le mobile.
+- **Le filtre de lecture est sur l'encyclopédie.** `ReadApi` ne renvoie que les
+  entrées *Published* (`is_verified=true`, ADR-0015 D1 / `04-state`). C'est le
+  correctif de conformité qui empêchera la prochaine bouteille d'eau
+  d'apparaître.
+- **Question ouverte (hors périmètre).** Le chemin de **lecture** du catalogue
+  (arête pointillée) frappe-t-il l'encyclopédie en direct (état actuel) ou via
+  NestJS (idéal ADR-0002) ? À trancher dans la tranche « lecture » (suivi
+  **#1186** — cutover encyclopedia-first ; référencer ADR-0002/0005) — cette
+  étude ne traite que la **modération** (écritures + auth).
+- **Nouveaux composants à créer (cible).** `CatalogModerationController` + le
+  service proxy côté NestJS, les endpoints `promote`/`depublish` + l'`Historique`
+  côté encyclopédie. Réutilisent l'existant : `RolesGuard`/`JwtAuthGuard`
+  (livrés) et le rang `CREATOR` (ADR-0011).

--- a/docs/architecture/diagrams/catalog-moderation/04-state-entry-lifecycle.md
+++ b/docs/architecture/diagrams/catalog-moderation/04-state-entry-lifecycle.md
@@ -1,0 +1,120 @@
+# Diagramme d'états — catalog-moderation — cycle de vie de publication d'une entrée
+
+> **Feature :** épic #1175 (réalise ADR-0015) — surface de modération in-app
+> **ADR liés :** ADR-0015 (staging → promotion humaine, D1/D4),
+> ADR-0018 (dépublication réversible), ADR-0012 (audit/RGPD)
+> **Voir aussi :** `01-use-case.md` (M1–M4), `beer-encyclopedia/05-state.md`
+> (lifecycle provenance `Imported → Verified`)
+
+## Contexte
+
+Cycle de vie d'une **entrée de catalogue** (`Beer`) du point de vue
+**publication** : quand est-elle dans le catalogue **partagé** (lisible par
+tous) et quand n'y est-elle pas. C'est le contrat que la lecture publique doit
+respecter — et que le code **viole aujourd'hui** (toutes les entrées sont
+visibles quel que soit `is_verified`, cf. la bouteille d'eau / « Vin rouge »
+apparues dans le catalogue).
+
+Ne couvre **pas** : la provenance multi-source (`EntitySource`, voir ADR-0015 §5
+et `beer-encyclopedia/05-state.md`), ni la frontière technique (`03-component.md`).
+
+## Diagramme
+
+```mermaid
+stateDiagram-v2
+  [*] --> Staged: import UC4 ou UC5
+  [*] --> Published: seed corpus internal
+
+  Staged --> Published: M2 Promouvoir
+
+  Published --> Depublished: M3 Depublier
+  Depublished --> Published: M4 Republier
+
+  Published --> Deleted: suppression dure
+  Depublished --> Deleted: suppression dure
+  Staged --> Deleted: suppression dure
+
+  Deleted --> [*]
+
+  Staged: En attente, hors catalogue partage
+  Published: Publiee, visible dans le catalogue partage
+  Depublished: Depubliee, masquee mais conservee et reversible
+  Deleted: Supprimee, destruction exceptionnelle
+
+  note right of Published
+    Seul cet etat est dans le catalogue partage.
+    Lecture publique filtree sur is_verified true (ADR-0015 D1).
+  end note
+
+  note left of Staged
+    Toute entree importee nait ici (is_verified false).
+    Le seed curate internal, lui, nait deja Publiee.
+  end note
+```
+
+*Même machine à états en **PlantUML** (accents possibles, contrairement à
+Mermaid `stateDiagram-v2`). À garder **synchronisé** avec le bloc Mermaid
+ci-dessus.*
+
+```plantuml
+@startuml
+hide empty description
+
+[*] --> Staged : import UC4 ou UC5
+[*] --> Published : seed corpus internal
+
+Staged --> Published : M2 Promouvoir
+Published --> Depublished : M3 Dépublier
+Depublished --> Published : M4 Republier
+
+Published --> Deleted : suppression dure
+Depublished --> Deleted : suppression dure
+Staged --> Deleted : suppression dure
+Deleted --> [*]
+
+Staged : En attente, hors catalogue partagé
+Published : Publiée, visible dans le catalogue partagé
+Depublished : Dépubliée, masquée mais conservée et réversible
+Deleted : Supprimée, destruction exceptionnelle
+
+note right of Published
+  Seul cet état est dans le catalogue partagé.
+  Lecture publique filtrée sur is_verified vrai (ADR-0015 D1).
+end note
+
+note left of Staged
+  Toute entrée importée naît ici (is_verified faux).
+  Le seed curaté internal naît déjà Publiée.
+end note
+@enduml
+```
+
+## Notes
+
+- **Mapping états ↔ champs (cible).**
+  - *Staged* = `is_verified = false`. Utilisable par l'utilisateur
+    contributeur, **hors** catalogue partagé (ADR-0015 D1).
+  - *Published* = `is_verified = true` **et** visible. Le **seul** état renvoyé
+    par les lectures publiques (`GET /beers`, `/beers/search`).
+  - *Depublished* = entrée promue puis **masquée** délibérément (M3). Distincte
+    de *Staged* : ce n'est pas « à valider », c'est « retirée volontairement ».
+    Le drapeau de publication exact (réutiliser `is_active` vs un champ dédié)
+    est un détail d'implémentation tranché à la tranche de code, **pas** par ce
+    diagramme.
+  - *Deleted* = suppression **dure** (`DELETE`), réservée aux cas exceptionnels
+    (donnée illégale, RGPD — ADR-0012). Jamais le geste de modération courant.
+- **Le bug que ce diagramme rend visible.** La lecture publique ne filtre pas
+  sur *Published* → des entrées *Staged* (la bouteille d'eau, « Monster
+  Energy », « Vin rouge ») fuitent dans le catalogue partagé. **Conformer le
+  code** = filtrer `is_verified=true` sur les lectures publiques + exposer le
+  staging uniquement à la file de modération (M1).
+- **Le bug de seed que ce diagramme rend visible.** Les 41 bières curatées
+  `internal` sont nées *Staged* au lieu de *Published* → un filtre naïf viderait
+  le catalogue. **Conformer la donnée** = seeder/migrer le corpus `internal`
+  directement en *Published* (transition `[*] --> Published`).
+- **Réversibilité (ADR-0018 §3).** *Depublished ⇄ Published* (M3/M4) garantit
+  qu'aucune modération courante ne détruit de donnée ; chaque transition est
+  **auditée** (#1155).
+- **Pas d'auto-promotion (ADR-0015 D4).** La seule entrée vers *Published*
+  depuis *Staged* est **M2**, déclenchée par un humain (CREATOR). Aucune
+  transition automatique `Staged → Published`.

--- a/docs/architecture/diagrams/catalog-moderation/04-state-entry-lifecycle.md
+++ b/docs/architecture/diagrams/catalog-moderation/04-state-entry-lifecycle.md
@@ -27,7 +27,7 @@ stateDiagram-v2
 
   Staged --> Published: M2 Promouvoir
 
-  Published --> Depublished: M3 Depublier
+  Published --> Depublished: M3 Dépublier
   Depublished --> Published: M4 Republier
 
   Published --> Deleted: suppression dure
@@ -36,19 +36,19 @@ stateDiagram-v2
 
   Deleted --> [*]
 
-  Staged: En attente, hors catalogue partage
-  Published: Publiee, visible dans le catalogue partage
-  Depublished: Depubliee, masquee mais conservee et reversible
-  Deleted: Supprimee, destruction exceptionnelle
+  Staged: En attente, hors catalogue partagé
+  Published: Publiée, visible dans le catalogue partagé
+  Depublished: Dépubliée, masquée mais conservée et réversible
+  Deleted: Supprimée, destruction exceptionnelle
 
   note right of Published
-    Seul cet etat est dans le catalogue partage.
-    Lecture publique filtree sur is_verified true (ADR-0015 D1).
+    Seul cet état est dans le catalogue partagé.
+    Publié = vérifié ET non dépublié ; lecture publique filtrée sur ce statut (ADR-0015 D1).
   end note
 
   note left of Staged
-    Toute entree importee nait ici (is_verified false).
-    Le seed curate internal, lui, nait deja Publiee.
+    Toute entrée importée naît ici (is_verified false).
+    Le seed curaté internal, lui, naît déjà Publiée.
   end note
 ```
 
@@ -94,8 +94,8 @@ end note
 - **Mapping états ↔ champs (cible).**
   - *Staged* = `is_verified = false`. Utilisable par l'utilisateur
     contributeur, **hors** catalogue partagé (ADR-0015 D1).
-  - *Published* = `is_verified = true` **et** visible. Le **seul** état renvoyé
-    par les lectures publiques (`GET /beers`, `/beers/search`).
+  - *Published* = `is_verified = true` **et non dépubliée**. Le **seul** statut
+    renvoyé par les lectures publiques (`GET /beers`, `/beers/search`).
   - *Depublished* = entrée promue puis **masquée** délibérément (M3). Distincte
     de *Staged* : ce n'est pas « à valider », c'est « retirée volontairement ».
     Le drapeau de publication exact (réutiliser `is_active` vs un champ dédié)
@@ -106,8 +106,9 @@ end note
 - **Le bug que ce diagramme rend visible.** La lecture publique ne filtre pas
   sur *Published* → des entrées *Staged* (la bouteille d'eau, « Monster
   Energy », « Vin rouge ») fuitent dans le catalogue partagé. **Conformer le
-  code** = filtrer `is_verified=true` sur les lectures publiques + exposer le
-  staging uniquement à la file de modération (M1).
+  code** = ne renvoyer sur les lectures publiques que le statut **publié**
+  (`is_verified=true` **et** non dépubliée) + exposer le staging uniquement à la
+  file de modération (M1).
 - **Le bug de seed que ce diagramme rend visible.** Les 41 bières curatées
   `internal` sont nées *Staged* au lieu de *Published* → un filtre naïf viderait
   le catalogue. **Conformer la donnée** = seeder/migrer le corpus `internal`

--- a/docs/architecture/traceability-matrix.md
+++ b/docs/architecture/traceability-matrix.md
@@ -8,11 +8,13 @@
 
 ## Périmètre actuel
 
-Couvre le domaine **beer-encyclopedia** (backend) et la **réalisation mobile du catalogue**
-(`mobile-catalog` — consommation de l'API encyclopédie). S'étendra aux autres packages au fil
-des revues. Études de cas d'usage :
+Couvre le domaine **beer-encyclopedia** (backend), la **réalisation mobile du catalogue**
+(`mobile-catalog` — consommation de l'API encyclopédie) et la **modération du catalogue**
+(`catalog-moderation` — surface mode créateur in-app, ADR-0018). S'étendra aux autres packages
+au fil des revues. Études de cas d'usage :
 [`beer-encyclopedia/01-use-case.md`](diagrams/beer-encyclopedia/01-use-case.md) (backend) ·
-[`mobile-catalog/01-use-case.md`](diagrams/mobile-catalog/01-use-case.md) (mobile).
+[`mobile-catalog/01-use-case.md`](diagrams/mobile-catalog/01-use-case.md) (mobile) ·
+[`catalog-moderation/01-use-case.md`](diagrams/catalog-moderation/01-use-case.md) (modération).
 
 ## État des diagrammes — beer-encyclopedia
 
@@ -47,6 +49,19 @@ Réalisation **mobile** de UC1/UC2/UC3 (catalogue de bières) consommant l'API e
 | Classes — view-model | [`10-class-view-model.md`](diagrams/mobile-catalog/10-class-view-model.md) | 🎯 cible (`BeerListItemVM`, `CatalogListVM`, `SearchVM`) |
 | Data-flow | [`11-data-flow.md`](diagrams/mobile-catalog/11-data-flow.md) | 🎯 cible (DTO→mapper→VM + cache ; aucune PII) |
 
+## État des diagrammes — catalog-moderation
+
+Réalisation **mode créateur in-app** de la modération du catalogue (domaine Curer), décidée par
+ADR-0018. Étude **conçue avant code** : tous les diagrammes sont 🎯 cible. Réalise la **promotion**
+(M2 → UC9 / ADR-0015 D4) et la **dépublication réversible** (M3 → UC7 suppression logique).
+
+| Diagramme | Fichier | État |
+|-----------|---------|------|
+| Cas d'usage (modération) | [`01-use-case.md`](diagrams/catalog-moderation/01-use-case.md) | 🎯 cible (M1 trier · M2 promouvoir · M3 dépublier · M4 republier) |
+| Séquence — promouvoir / dépublier | [`02-sequence-promote-depublish.md`](diagrams/catalog-moderation/02-sequence-promote-depublish.md) | 🎯 cible (Mobile → NestJS admin → encyclopédie ; ferme #1151) |
+| Composant — frontière d'auth | [`03-component.md`](diagrams/catalog-moderation/03-component.md) | 🎯 cible (`JwtAuthGuard` + `RolesGuard CREATOR` ; ADR-0002) |
+| États — cycle de publication | [`04-state-entry-lifecycle.md`](diagrams/catalog-moderation/04-state-entry-lifecycle.md) | 🎯 cible (staged → published → depublished ; correctif conformité ADR-0015 D1) |
+
 ## Matrice — cas d'usage → réalisations
 
 Légende : ✅ fait · 🎯 conçu (cible, code à venir) · ⬜ à venir · — non applicable.
@@ -59,9 +74,9 @@ Légende : ✅ fait · 🎯 conçu (cible, code à venir) · ⬜ à venir · —
 | UC4 Identifier par code-barres | Acquérir | **backend** ✅ `02-sequence-import-by-ean` **+** mobile ⬜ | 03 ⬜ (api, importers, db) | Beer, Brewery, Source, EntitySource | provenance Beer (05 ⬜) | import OFF / PII (06 ⬜) | livré (backend) | #878 (rate-limit) |
 | UC5 Identifier par scan d'étiquette | Acquérir | ✅ `02-sequence-scan` (délègue à `scan/02b`) | 03 ⬜ | Beer (source=scan), BeerDataSuggestion (étude `scan/`) | — | 06 ⬜ | planifié | #1156 (divergence /scan), #1149, étude `scan/` |
 | UC6 Proposer une correction | Contribuer | — (texte) | 03 ⬜ | CommunityCorrection | pending→… (05 ⬜) | — | planifié | #1149 |
-| UC7 Gérer le catalogue (C/U/D) | Curer | — | 03 ⬜ | Beer, Brewery | — | — | livré | #1151 (auth), #1152 (admin web) |
+| UC7 Gérer le catalogue (C/U/D) | Curer | 🎯 `catalog-moderation/02` (M3 dépublier = suppression logique) | `catalog-moderation/03` 🎯 | Beer, Brewery | `catalog-moderation/04` 🎯 | — | livré (CRUD) · modération in-app 🎯 | #1151 (auth), #1152 (re-cadré ADR-0018), #1175 |
 | UC8 Alimenter les référentiels | Curer | — | 03 ⬜ | Style, LegalDenomination, Source | — | — | livré | #1152 |
-| UC9 Modérer les corrections | Curer | ⬜ (plus tard) | 03 ⬜ | CommunityCorrection (+ audit) | pending→approved/rejected (05 ⬜) | — | planifié | #1153, #1154, #1155 |
+| UC9 Modérer les corrections / promouvoir | Curer | 🎯 `catalog-moderation/02` (M2 promouvoir) · corrections ⬜ | `catalog-moderation/03` 🎯 | CommunityCorrection, Beer (is_verified) | `catalog-moderation/04` 🎯 · corrections (05 ⬜) | — | planifié · promotion in-app 🎯 | #1153, #1154, #1155, ADR-0015 D4 |
 
 ## Règles de traçabilité
 

--- a/docs/architecture/traceability-matrix.md
+++ b/docs/architecture/traceability-matrix.md
@@ -58,9 +58,9 @@ ADR-0018. Étude **conçue avant code** : tous les diagrammes sont 🎯 cible. R
 | Diagramme | Fichier | État |
 |-----------|---------|------|
 | Cas d'usage (modération) | [`01-use-case.md`](diagrams/catalog-moderation/01-use-case.md) | 🎯 cible (M1 trier · M2 promouvoir · M3 dépublier · M4 republier) |
-| Séquence — promouvoir / dépublier | [`02-sequence-promote-depublish.md`](diagrams/catalog-moderation/02-sequence-promote-depublish.md) | 🎯 cible (Mobile → NestJS admin → encyclopédie ; ferme #1151) |
+| Séquence — promouvoir / dépublier | [`02-sequence-promote-depublish.md`](diagrams/catalog-moderation/02-sequence-promote-depublish.md) | 🎯 cible (Mobile → NestJS admin → encyclopédie ; fermera #1151 — cible, non livré) |
 | Composant — frontière d'auth | [`03-component.md`](diagrams/catalog-moderation/03-component.md) | 🎯 cible (`JwtAuthGuard` + `RolesGuard CREATOR` ; ADR-0002) |
-| États — cycle de publication | [`04-state-entry-lifecycle.md`](diagrams/catalog-moderation/04-state-entry-lifecycle.md) | 🎯 cible (staged → published → depublished ; correctif conformité ADR-0015 D1) |
+| États — cycle de publication | [`04-state-entry-lifecycle.md`](diagrams/catalog-moderation/04-state-entry-lifecycle.md) | 🎯 cible (staged → published → depublished → deleted ; correctif conformité ADR-0015 D1) |
 
 ## Matrice — cas d'usage → réalisations
 


### PR DESCRIPTION
## Summary

Conception-first UML study (UML before code) for the **in-app CREATOR moderation** of the beer catalogue, plus the ADR that settles the admin surface. Triggered by a non-beer (bottled water, "Monster Energy", "Vin rouge") leaking into the public mobile catalogue.

**Root cause found** — not a design gap but a **conformance bug vs ADR-0015 D1** (staged `is_verified=false` rows must stay out of the shared catalogue) **+ a seed bug** (the 41 curated `internal` beers were never promoted). The role model (ADR-0011) and the staging/promotion strategy (ADR-0015) were already designed; this PR formalizes the missing piece — **where** the privileged actor moderates.

### Decisions

- **ADR-0018 (Accepted)** — moderation surfaced **in-app for the CREATOR**, authority enforced at the **NestJS API boundary** (addresses #1151 — design, not shipped), **reversible depublish + audit** (not hard-delete); **revises** the "never via mobile" clause of #1152; defers the web console (#738).
- **ADR-0011 & ADR-0015** promoted `Proposed -> Accepted` (now the contract we build on); indexed in `CLAUDE.md`.

### Diagrams — `docs/architecture/diagrams/catalog-moderation/` (Mermaid + PlantUML twins, FR)

- `01-use-case` — Curate domain + CREATOR (M1 triage / M2 promote / M3 depublish / M4 republish)
- `02-sequence-promote-depublish` — Mobile -> NestJS admin -> encyclopedia (addresses #1151 at the right layer)
- `03-component` — auth boundary (ADR-0002)
- `04-state-entry-lifecycle` — `staged -> published -> depublished` (the contract the public read path must honour)

### Coherence

- `beer-encyclopedia/01-use-case` — UC7/UC8/UC9 reconciled with ADR-0018 (targeted moderation on mobile; bulk curation stays web).
- `traceability-matrix` — new catalog-moderation section; UC7/UC9 linked to M3/M2.

## Checklist

- [x] Conception-first — no implementation code in this PR
- [x] Mermaid renders (mmdc) + PlantUML valid (`plantuml -checkonly`)
- [x] No CI-blocking markdownlint errors
- [x] ADR consistency reviewed (pr-pre-reviewer)

Refs #1175.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated and approved architectural decisions related to moderation capabilities, role-based access, and enrichment strategy (including acceptance updates to existing ADRs and a new moderation-surface ADR).
  * Added catalog moderation architecture documentation, including updated “Beer Encyclopedia” security/maintenance wording and new diagram pages (use case, sequences, components, and reversible publication lifecycle).
  * Refreshed the architecture traceability matrix to include catalog-moderation realizations and diagram coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->