### PR TITLE
feat(encyclopedia): gate the public catalogue on the published status (ADR-0015 D1)

### DIFF
--- a/packages/beer-encyclopedia/api/routers/beers.py
+++ b/packages/beer-encyclopedia/api/routers/beers.py
@@ -213,7 +213,11 @@ async def list_beers(
     abv_min: Decimal | None = Query(None, ge=0, le=100),
     abv_max: Decimal | None = Query(None, ge=0, le=100),
 ) -> BeerList:
-    filters = []
+    # Public catalogue = the published baseline only: verified (ADR-0015 D1 —
+    # promoted out of staging) AND active (not depublished). Unverified imports
+    # and depublished entries are excluded from browse/search; an unverified row
+    # stays reachable by direct id (`get_beer`) and via moderation.
+    filters = [Beer.is_verified.is_(True), Beer.is_active.is_(True)]
     if style_id is not None:
         filters.append(Beer.style_id == style_id)
     if brewery_id is not None:
@@ -256,13 +260,17 @@ async def search_beers(
         where_clause = func.lower(Beer.name).contains(q.lower())
         order_clause = Beer.name
 
-    count_stmt = select(func.count()).select_from(Beer).where(where_clause)
+    # Same published gate as list_beers: only verified + active rows surface in
+    # public search (ADR-0015 D1). Staged / depublished rows are excluded.
+    published = (Beer.is_verified.is_(True), Beer.is_active.is_(True))
+    count_stmt = select(func.count()).select_from(Beer).where(where_clause).where(*published)
     total = (await session.execute(count_stmt)).scalar_one()
 
     stmt = (
         select(Beer)
         .options(selectinload(Beer.brewery), selectinload(Beer.style))
         .where(where_clause)
+        .where(*published)
         .order_by(order_clause)
         .offset((page - 1) * per_page)
         .limit(per_page)
@@ -279,6 +287,10 @@ async def get_beer(
     beer_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
 ) -> BeerRead:
+    # Deliberately NOT gated on is_verified / is_active: a staged (unverified)
+    # or depublished beer must stay reachable by direct id — the fiche of a
+    # bottle the user just scanned (ADR-0015 D1: usable to the contributing
+    # user) and the moderation surface. Only browse/search hide them.
     beer = await session.get(Beer, beer_id)
     if beer is None:
         raise HTTPException(status_code=404, detail="Beer not found.")
@@ -317,6 +329,11 @@ async def update_beer(
         brewery_id=updates.get("brewery_id"),
         style_id=updates.get("style_id"),
     )
+    # TODO(#1151): this generic PATCH can set is_verified / is_active with no
+    # auth — an unauthenticated caller could self-promote a staged beer or
+    # depublish a live one, bypassing the read gate above. Closing #1151 (auth
+    # on writes) gates it; promotion / depublication then move to dedicated
+    # moderation endpoints (catalog-moderation slice 3) and leave this surface.
     for field, value in updates.items():
         setattr(beer, field, value)
     await session.commit()

--- a/packages/beer-encyclopedia/scripts/seed_beers.py
+++ b/packages/beer-encyclopedia/scripts/seed_beers.py
@@ -10,7 +10,9 @@ rounded outward), and a 1–5 ``TastingProfile``.
 Seeded rows are the curated, founder-vouched baseline → ``is_verified=True``
 (published per ADR-0015 D1 / the catalog-moderation state machine), so they
 surface in the public catalogue. Runtime imports (``/beers/import-by-ean``)
-stay ``is_verified=False`` (staging) until promoted via moderation.
+stay ``is_verified=False`` (staging) and surface only once promoted — either by
+human moderation, or by this seed when an import matches the curated corpus by
+EAN/slug (it is then published as part of the corpus, see ``_find_existing_beer``).
 ``source='openfoodfacts'`` for the three EAN-confirmed beers, ``'internal'``
 otherwise. OpenFoodFacts category errors are NOT propagated: every abbey/blonde
 mis-tagged "lager" by OFF is seeded with its true ale style (scan spec §8.5).

--- a/packages/beer-encyclopedia/scripts/seed_beers.py
+++ b/packages/beer-encyclopedia/scripts/seed_beers.py
@@ -7,8 +7,10 @@
 SRM canonical — EBC estimates converted with SRM = round(EBC / 1.97) and
 rounded outward), and a 1–5 ``TastingProfile``.
 
-Newly inserted rows get ``is_verified=False`` (maintainer validation pending,
-ADR-0015); re-seeding preserves the verification state of existing rows.
+Seeded rows are the curated, founder-vouched baseline → ``is_verified=True``
+(published per ADR-0015 D1 / the catalog-moderation state machine), so they
+surface in the public catalogue. Runtime imports (``/beers/import-by-ean``)
+stay ``is_verified=False`` (staging) until promoted via moderation.
 ``source='openfoodfacts'`` for the three EAN-confirmed beers, ``'internal'``
 otherwise. OpenFoodFacts category errors are NOT propagated: every abbey/blonde
 mis-tagged "lager" by OFF is seeded with its true ale style (scan spec §8.5).
@@ -784,6 +786,12 @@ def _apply_beer_fields(
     beer.country_of_origin = b.country
     beer.ean_code = b.ean
     beer.source = b.source
+    # The curated seed is the founder-vouched baseline → published
+    # (is_verified=True, ADR-0015 D1), so it surfaces in the public catalogue.
+    # Idempotent: re-seeding re-publishes the corpus. Depublication (moderation)
+    # toggles is_active, not is_verified, so a depublished seed beer survives a
+    # re-seed; runtime imports (not in this corpus) stay staged until promoted.
+    beer.is_verified = True
 
 
 async def _upsert_tasting_profile(session: AsyncSession, beer_id: uuid.UUID, b: BeerSeed) -> None:

--- a/packages/beer-encyclopedia/tests/test_api/test_beers.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_beers.py
@@ -101,9 +101,19 @@ async def test_list_beers_filters_by_style(client: TestClient, db_session: Async
     brewery, ipa, stout = await _seed_reference_data(db_session)
     db_session.add_all(
         [
-            Beer(name="A IPA", slug="a-ipa", brewery_id=brewery.id, style_id=ipa.id),
-            Beer(name="B IPA", slug="b-ipa", brewery_id=brewery.id, style_id=ipa.id),
-            Beer(name="C Stout", slug="c-stout", brewery_id=brewery.id, style_id=stout.id),
+            Beer(
+                name="A IPA", slug="a-ipa", brewery_id=brewery.id, style_id=ipa.id, is_verified=True
+            ),
+            Beer(
+                name="B IPA", slug="b-ipa", brewery_id=brewery.id, style_id=ipa.id, is_verified=True
+            ),
+            Beer(
+                name="C Stout",
+                slug="c-stout",
+                brewery_id=brewery.id,
+                style_id=stout.id,
+                is_verified=True,
+            ),
         ]
     )
     await db_session.commit()
@@ -121,9 +131,9 @@ async def test_list_beers_filters_by_abv_range(
     brewery, _, _ = await _seed_reference_data(db_session)
     db_session.add_all(
         [
-            Beer(name="Low", slug="low", brewery_id=brewery.id, abv=3.5),
-            Beer(name="Mid", slug="mid", brewery_id=brewery.id, abv=5.5),
-            Beer(name="Strong", slug="strong", brewery_id=brewery.id, abv=9.0),
+            Beer(name="Low", slug="low", brewery_id=brewery.id, abv=3.5, is_verified=True),
+            Beer(name="Mid", slug="mid", brewery_id=brewery.id, abv=5.5, is_verified=True),
+            Beer(name="Strong", slug="strong", brewery_id=brewery.id, abv=9.0, is_verified=True),
         ]
     )
     await db_session.commit()
@@ -178,9 +188,9 @@ async def test_search_beers_matches_substring(client: TestClient, db_session: As
     brewery, _, _ = await _seed_reference_data(db_session)
     db_session.add_all(
         [
-            Beer(name="Citra Bomb", slug="citra-bomb", brewery_id=brewery.id),
-            Beer(name="Citra Sun", slug="citra-sun", brewery_id=brewery.id),
-            Beer(name="Amber Amber", slug="amber-amber", brewery_id=brewery.id),
+            Beer(name="Citra Bomb", slug="citra-bomb", brewery_id=brewery.id, is_verified=True),
+            Beer(name="Citra Sun", slug="citra-sun", brewery_id=brewery.id, is_verified=True),
+            Beer(name="Amber Amber", slug="amber-amber", brewery_id=brewery.id, is_verified=True),
         ]
     )
     await db_session.commit()
@@ -204,6 +214,7 @@ async def test_list_resolves_brewery_and_style_names(
             slug="named-ipa",
             brewery_id=brewery.id,
             style_id=ipa.id,
+            is_verified=True,
         )
     )
     await db_session.commit()
@@ -221,7 +232,7 @@ async def test_list_leaves_names_null_when_fks_are_null(
 ) -> None:
     """Edge: a beer with no brewery/style keeps both names null."""
 
-    db_session.add(Beer(name="Orphan", slug="orphan"))
+    db_session.add(Beer(name="Orphan", slug="orphan", is_verified=True))
     await db_session.commit()
 
     data = client.get("/beers").json()
@@ -244,6 +255,7 @@ async def test_search_resolves_brewery_and_style_names(
             slug="searchable-ipa",
             brewery_id=brewery.id,
             style_id=ipa.id,
+            is_verified=True,
         )
     )
     await db_session.commit()
@@ -282,7 +294,7 @@ async def test_brewery_name_becomes_null_after_brewery_deleted(
     """Edge: deleting a brewery (ON DELETE SET NULL) nulls the resolved name."""
 
     brewery, _, _ = await _seed_reference_data(db_session)
-    db_session.add(Beer(name="Widow", slug="widow", brewery_id=brewery.id))
+    db_session.add(Beer(name="Widow", slug="widow", brewery_id=brewery.id, is_verified=True))
     await db_session.commit()
 
     assert client.delete(f"/breweries/{brewery.id}").status_code == 204
@@ -290,3 +302,165 @@ async def test_brewery_name_becomes_null_after_brewery_deleted(
     data = client.get("/beers").json()
     assert data["meta"]["total"] == 1
     assert data["items"][0]["brewery_name"] is None
+
+
+async def test_list_excludes_unverified_beers(client: TestClient, db_session: AsyncSession) -> None:
+    """Sad/edge: staged (is_verified=False) imports stay out of the public
+    catalogue (ADR-0015 D1) — only the published row is browsable."""
+
+    brewery, _, _ = await _seed_reference_data(db_session)
+    db_session.add_all(
+        [
+            Beer(name="Published", slug="published", brewery_id=brewery.id, is_verified=True),
+            Beer(name="Staged", slug="staged", brewery_id=brewery.id, is_verified=False),
+        ]
+    )
+    await db_session.commit()
+
+    data = client.get("/beers").json()
+    assert data["meta"]["total"] == 1
+    assert {item["name"] for item in data["items"]} == {"Published"}
+
+
+async def test_search_excludes_unverified_beers(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Sad: search also hides staged rows."""
+
+    brewery, _, _ = await _seed_reference_data(db_session)
+    db_session.add_all(
+        [
+            Beer(
+                name="Verified Saison",
+                slug="verified-saison",
+                brewery_id=brewery.id,
+                is_verified=True,
+            ),
+            Beer(
+                name="Staged Saison",
+                slug="staged-saison",
+                brewery_id=brewery.id,
+                is_verified=False,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    data = client.get("/beers/search", params={"q": "saison"}).json()
+    assert data["meta"]["total"] == 1
+    assert data["items"][0]["name"] == "Verified Saison"
+
+
+async def test_list_excludes_depublished_beers(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Edge: a depublished entry (is_active=False) is hidden even when verified —
+    the read contract is verified AND not depublished (ADR-0018)."""
+
+    brewery, _, _ = await _seed_reference_data(db_session)
+    db_session.add_all(
+        [
+            Beer(
+                name="Active",
+                slug="active",
+                brewery_id=brewery.id,
+                is_verified=True,
+                is_active=True,
+            ),
+            Beer(
+                name="Depublished",
+                slug="depublished",
+                brewery_id=brewery.id,
+                is_verified=True,
+                is_active=False,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    data = client.get("/beers").json()
+    assert data["meta"]["total"] == 1
+    assert {item["name"] for item in data["items"]} == {"Active"}
+
+
+async def test_get_beer_returns_unverified_staged_detail(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Edge: a staged beer is hidden from browse/search but its fiche stays
+    reachable by id — the just-scanned bottle the contributor needs to see
+    (ADR-0015 D1)."""
+
+    beer = Beer(name="Just Scanned", slug="just-scanned", is_verified=False)
+    db_session.add(beer)
+    await db_session.commit()
+    await db_session.refresh(beer)
+
+    response = client.get(f"/beers/{beer.id}")
+    assert response.status_code == 200
+    assert response.json()["name"] == "Just Scanned"
+    assert response.json()["is_verified"] is False
+
+
+async def test_search_excludes_depublished_beers(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Edge: search hides a depublished (is_active=False) row too — same
+    published gate as list (verified AND not depublished)."""
+
+    brewery, _, _ = await _seed_reference_data(db_session)
+    db_session.add_all(
+        [
+            Beer(
+                name="Active Porter",
+                slug="active-porter",
+                brewery_id=brewery.id,
+                is_verified=True,
+                is_active=True,
+            ),
+            Beer(
+                name="Depublished Porter",
+                slug="depublished-porter",
+                brewery_id=brewery.id,
+                is_verified=True,
+                is_active=False,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    data = client.get("/beers/search", params={"q": "porter"}).json()
+    assert data["meta"]["total"] == 1
+    assert data["items"][0]["name"] == "Active Porter"
+
+
+async def test_list_filter_intersects_with_published_gate(
+    client: TestClient, db_session: AsyncSession
+) -> None:
+    """Edge: stacking a column filter (style_id) on the published gate applies
+    BOTH to the count and the items — a staged IPA is excluded from a
+    style-filtered browse (proves count vs items stay consistent)."""
+
+    brewery, ipa, _ = await _seed_reference_data(db_session)
+    db_session.add_all(
+        [
+            Beer(
+                name="Published IPA",
+                slug="published-ipa",
+                brewery_id=brewery.id,
+                style_id=ipa.id,
+                is_verified=True,
+            ),
+            Beer(
+                name="Staged IPA",
+                slug="staged-ipa",
+                brewery_id=brewery.id,
+                style_id=ipa.id,
+                is_verified=False,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    data = client.get("/beers", params={"style_id": str(ipa.id)}).json()
+    assert data["meta"]["total"] == 1
+    assert {item["name"] for item in data["items"]} == {"Published IPA"}

--- a/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
+++ b/packages/beer-encyclopedia/tests/test_api/test_import_by_ean.py
@@ -37,9 +37,7 @@ EAN_PELFORTH: str = "3760231860119"
 # return: a snapshot (success), ``None`` (unknown product), or an
 # Exception instance to raise (transport failure). Typing this once
 # keeps the fixture and the stub class honest without ``# type: ignore``.
-SnapshotBehaviour = Callable[
-    [str], "ExternalBeerSnapshot | None | OpenFoodFactsError"
-]
+SnapshotBehaviour = Callable[[str], "ExternalBeerSnapshot | None | OpenFoodFactsError"]
 
 
 def _build_pelforth_snapshot(ean: str = EAN_PELFORTH) -> ExternalBeerSnapshot:
@@ -107,9 +105,7 @@ async def seeded_source(db_session: AsyncSession) -> Source:
 
     await seed_sources(db_session)
     return (
-        await db_session.execute(
-            select(Source).where(Source.name == "openfoodfacts")
-        )
+        await db_session.execute(select(Source).where(Source.name == "openfoodfacts"))
     ).scalar_one()
 
 
@@ -125,9 +121,7 @@ async def test_first_import_creates_beer_and_returns_201(
     snapshot = _build_pelforth_snapshot()
     stub = stub_off_factory(lambda _: snapshot)
 
-    response = client.post(
-        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
-    )
+    response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
 
     assert response.status_code == 201
     body = response.json()
@@ -139,23 +133,39 @@ async def test_first_import_creates_beer_and_returns_201(
     assert stub.calls == [EAN_PELFORTH]
 
     beer = (
-        await db_session.execute(
-            select(Beer).where(Beer.ean_code == EAN_PELFORTH)
-        )
+        await db_session.execute(select(Beer).where(Beer.ean_code == EAN_PELFORTH))
     ).scalar_one()
     assert beer.name == "Pelforth Brune"
 
     audit = (
         await db_session.execute(
-            select(EntitySource).where(
-                EntitySource.external_id == EAN_PELFORTH
-            )
+            select(EntitySource).where(EntitySource.external_id == EAN_PELFORTH)
         )
     ).scalar_one()
     assert audit.entity_type == "beer"
     assert audit.entity_id == beer.id
     assert audit.raw_data == snapshot.raw_payload
     assert audit.last_synced_at is not None
+
+
+async def test_imported_beer_is_staged_unverified(
+    client: TestClient,
+    db_session: AsyncSession,
+    stub_off_factory,  # type: ignore[no-untyped-def]
+    seeded_source: Source,
+) -> None:
+    """An OFF import lands in staging (is_verified=False, ADR-0015 D1): it is
+    NOT part of the shared catalogue until a human promotes it (browse/search
+    filter it out; only its fiche-by-id is reachable)."""
+
+    stub_off_factory(lambda _: _build_pelforth_snapshot())
+    response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
+    assert response.status_code == 201
+
+    beer = (
+        await db_session.execute(select(Beer).where(Beer.ean_code == EAN_PELFORTH))
+    ).scalar_one()
+    assert beer.is_verified is False
 
 
 async def test_import_links_resolved_style_and_description(
@@ -190,9 +200,7 @@ async def test_import_links_resolved_style_and_description(
     assert body["brewery_name"] == "Some Brewery"
 
     beer = (
-        await db_session.execute(
-            select(Beer).where(Beer.ean_code == EAN_PELFORTH)
-        )
+        await db_session.execute(select(Beer).where(Beer.ean_code == EAN_PELFORTH))
     ).scalar_one()
     assert beer.style_id == ipa.id
     assert beer.description == "Eau, malt d'orge, houblon, levure."
@@ -224,9 +232,7 @@ async def test_import_leaves_style_none_when_slug_not_seeded(
     assert body["brewery_name"] is None
 
     beer = (
-        await db_session.execute(
-            select(Beer).where(Beer.ean_code == EAN_PELFORTH)
-        )
+        await db_session.execute(select(Beer).where(Beer.ean_code == EAN_PELFORTH))
     ).scalar_one()
     assert beer.style_id is None
 
@@ -255,9 +261,7 @@ async def test_invalid_ean_format_is_rejected_by_pydantic(
     seeded_source: Source,
 ) -> None:
     # 7-digit string is too short for any standard barcode.
-    response = client.post(
-        "/beers/import-by-ean", json={"ean": "1234567"}
-    )
+    response = client.post("/beers/import-by-ean", json={"ean": "1234567"})
     assert response.status_code == 422
 
 
@@ -265,9 +269,7 @@ async def test_non_digit_ean_is_rejected_by_pydantic(
     client: TestClient,
     seeded_source: Source,
 ) -> None:
-    response = client.post(
-        "/beers/import-by-ean", json={"ean": "12345abc"}
-    )
+    response = client.post("/beers/import-by-ean", json={"ean": "12345abc"})
     assert response.status_code == 422
 
 
@@ -278,9 +280,7 @@ async def test_unknown_product_returns_404(
 ) -> None:
     stub_off_factory(lambda _: None)
 
-    response = client.post(
-        "/beers/import-by-ean", json={"ean": "0000000000017"}
-    )
+    response = client.post("/beers/import-by-ean", json={"ean": "0000000000017"})
     assert response.status_code == 404
     assert "0000000000017" in response.json()["detail"]
 
@@ -292,9 +292,7 @@ async def test_off_transport_failure_returns_503(
 ) -> None:
     stub_off_factory(lambda _: OpenFoodFactsError("HTTP 502"))
 
-    response = client.post(
-        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
-    )
+    response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
     assert response.status_code == 503
     assert "Open Food Facts unavailable" in response.json()["detail"]
 
@@ -307,9 +305,7 @@ async def test_missing_source_seed_returns_503_with_actionable_message(
     # `openfoodfacts` row is absent.
     stub_off_factory(lambda _: _build_pelforth_snapshot())
 
-    response = client.post(
-        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
-    )
+    response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
     assert response.status_code == 503
     assert "seed_sources.py" in response.json()["detail"]
 
@@ -341,19 +337,21 @@ async def test_second_import_is_idempotent_and_returns_200(
     # Still exactly one beer + one audit row (the first import created
     # both; the second short-circuit added neither).
     beers = (
-        await db_session.execute(
-            select(Beer).where(Beer.ean_code == EAN_PELFORTH)
-        )
-    ).scalars().all()
+        (await db_session.execute(select(Beer).where(Beer.ean_code == EAN_PELFORTH)))
+        .scalars()
+        .all()
+    )
     assert len(beers) == 1
 
     audits = (
-        await db_session.execute(
-            select(EntitySource).where(
-                EntitySource.external_id == EAN_PELFORTH
+        (
+            await db_session.execute(
+                select(EntitySource).where(EntitySource.external_id == EAN_PELFORTH)
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(audits) == 1
 
 
@@ -385,9 +383,7 @@ async def test_db_hit_returns_existing_beer_without_calling_off(
         lambda _: pytest.fail("OFF must not be called on a DB hit")  # type: ignore[arg-type,return-value]
     )
 
-    response = client.post(
-        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
-    )
+    response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
 
     assert response.status_code == 200
     assert response.json()["ean_code"] == EAN_PELFORTH
@@ -405,9 +401,7 @@ async def test_db_miss_still_falls_back_to_off(
 
     stub = stub_off_factory(lambda _: _build_pelforth_snapshot())
 
-    response = client.post(
-        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
-    )
+    response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
 
     assert response.status_code == 201
     assert stub.calls == [EAN_PELFORTH]
@@ -427,14 +421,10 @@ async def test_import_with_snapshot_missing_brand_skips_brewery(
     )
     stub_off_factory(lambda _: snapshot)
 
-    response = client.post(
-        "/beers/import-by-ean", json={"ean": EAN_PELFORTH}
-    )
+    response = client.post("/beers/import-by-ean", json={"ean": EAN_PELFORTH})
     assert response.status_code == 201
     assert response.json()["brewery_id"] is None
 
     # No brewery row should have been created.
-    breweries = (
-        await db_session.execute(select(Brewery))
-    ).scalars().all()
+    breweries = (await db_session.execute(select(Brewery))).scalars().all()
     assert breweries == []

--- a/packages/beer-encyclopedia/tests/test_db/test_seed_corpus.py
+++ b/packages/beer-encyclopedia/tests/test_db/test_seed_corpus.py
@@ -86,6 +86,36 @@ async def test_seed_beers_intervals_and_fk_resolved(db_session: AsyncSession) ->
     assert chouffe.ean_code == "5410769100081"
 
 
+async def test_seed_beers_publishes_corpus_as_verified(db_session: AsyncSession) -> None:
+    # The curated seed is the founder-vouched baseline → published
+    # (is_verified=True, ADR-0015 D1), so it surfaces in the public catalogue.
+    # No seeded row stays in staging.
+    await _seed_prerequisites(db_session)
+
+    unverified = (
+        await db_session.execute(
+            select(func.count()).select_from(Beer).where(Beer.is_verified.is_(False))
+        )
+    ).scalar_one()
+    assert unverified == 0
+
+
+async def test_reseed_preserves_depublication(db_session: AsyncSession) -> None:
+    # Depublication (moderation) toggles is_active, not is_verified. A re-seed
+    # re-publishes is_verified but must NOT resurrect a depublished beer:
+    # is_active stays False across re-runs (ADR-0018 reversible depublish).
+    await _seed_prerequisites(db_session)
+    orval = (await db_session.execute(select(Beer).where(Beer.slug == "orval"))).scalar_one()
+    orval.is_active = False
+    await db_session.commit()
+
+    await seed_beers(db_session)
+
+    orval = (await db_session.execute(select(Beer).where(Beer.slug == "orval"))).scalar_one()
+    assert orval.is_active is False  # depublication survives the re-seed
+    assert orval.is_verified is True  # corpus stays published
+
+
 async def test_seed_beers_missing_brewery_raises(db_session: AsyncSession) -> None:
     # No breweries seeded → the first beer's brewery slug cannot resolve.
     with pytest.raises(ValueError, match="Brewery slug"):
@@ -120,6 +150,7 @@ async def test_seed_beers_matches_existing_by_ean(db_session: AsyncSession) -> N
     assert len(matches) == 1  # no duplicate, no constraint violation
     assert matches[0].slug == "la-chouffe"  # slug normalized to the curated one
     assert matches[0].name == "La Chouffe"
+    assert matches[0].is_verified is True  # a matched staged import is published by the seed
 
 
 # -- ingredients (+ links) --------------------------------------------------


### PR DESCRIPTION
## Summary

**Slice 1** of the catalog-moderation epic (#1175) — implements the conception merged in #1224 (ADR-0015 + ADR-0018). The public beer catalogue now only surfaces **published** rows.

**Problem:** `GET /beers` and `/beers/search` returned every row regardless of verification, so unverified OpenFoodFacts imports (a scanned water bottle, "Monster Energy", "Vin rouge") leaked into browse/search — violating ADR-0015 D1.

**Change:**
- `list_beers` / `search_beers` filter `is_verified=true AND is_active=true` (verified out of staging + not depublished). Applied to both the count and the page query, on both the SQLite `contains` and the Postgres trigram path.
- `get_beer` (detail by id) is **deliberately not gated** — a staged / just-scanned beer must stay reachable by id (ADR-0015 D1: usable to the contributing user) and for moderation.
- `seed_beers` publishes the curated corpus (`is_verified=true`): the seed is the founder-vouched baseline; runtime imports stay staged until promoted. Idempotent re-seed re-publishes; depublication toggles `is_active`, not `is_verified`, so a depublished seed beer survives a re-seed.

**Effect after deploy:** the live catalogue becomes the ~44 curated beers; the 26 runtime OpenFoodFacts imports (legit + junk) drop to staging and become the moderation queue handled in slice 3.

**Known follow-up — `TODO(#1151)`:** the generic `PATCH /beers/{id}` can set `is_verified`/`is_active` unauthenticated (self-promotion bypass) until auth on writes lands; promotion/depublication move to dedicated moderation endpoints in slice 3.

## Tests

- H/S/E: browse + search exclude staged and depublished rows; a column filter intersects correctly with the gate; `get_beer` returns a staged fiche; an import lands staged; the seed publishes its corpus, promotes a matched staged import, and a re-seed preserves depublication.
- `pytest -q tests/` -> 190 passed; `ruff check` clean; `py_compile` ok.
- Note: `test_import_by_ean.py` shows formatting churn from the repo's ruff auto-format hook (line-length=100), not manual edits.

## Checklist

- [x] Happy + sad + edge cases covered
- [x] `pytest -q tests/` green (190)
- [x] `ruff check` clean + `py_compile` ok
- [x] No `any` / no silent failures; English-only
- [x] Conforms to the merged conception (ADR-0015 D1, ADR-0018)

Refs #1175.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the public Beer catalog and search to show only published beers (verified and active) by default, while direct by-id lookup still returns staged/unpublished items.
  * Seeding now publishes the curated corpus as verified, while imported beers remain staged/unverified until promoted.

* **Tests**
  * Expanded visibility-rule coverage for list/search vs by-id behavior.
  * Added/updated seed and import test cases to verify verification, depublishing behavior, and correct counts/filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->