### PR TITLE
feat(api): single-holder CREATOR role above ADMIN, rank-based RolesGuard (ADR-0011)

### DIFF
--- a/packages/api/src/auth/guards/roles.guard.spec.ts
+++ b/packages/api/src/auth/guards/roles.guard.spec.ts
@@ -1,0 +1,76 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { RolesGuard } from './roles.guard';
+import { UserRole } from '../../common/enums/role.enum';
+import { User } from '../../user/entities/user.entity';
+
+/**
+ * RolesGuard authorizes by privilege RANK (ADR-0011), not by exact-string
+ * match: a higher role automatically satisfies a lower @Roles requirement —
+ * so a CREATOR passes an @Roles(ADMIN) route.
+ */
+describe('RolesGuard — hierarchical authorization (ADR-0011)', () => {
+  let guard: RolesGuard;
+  let reflector: Reflector;
+
+  beforeEach(() => {
+    reflector = new Reflector();
+    guard = new RolesGuard(reflector);
+    jest.spyOn(reflector, 'get');
+  });
+
+  const contextFor = (
+    requiredRoles: UserRole[] | undefined,
+    user: Pick<User, 'role'> | undefined,
+  ): ExecutionContext => {
+    (reflector.get as jest.Mock).mockReturnValue(requiredRoles);
+    return {
+      getHandler: () => () => undefined,
+      switchToHttp: () => ({
+        getRequest: () => ({ user }),
+        getResponse: () => ({}),
+        getNext: () => ({}),
+      }),
+    } as unknown as ExecutionContext;
+  };
+
+  it('allows a route with no @Roles metadata', () => {
+    const ctx = contextFor(undefined, { role: UserRole.USER });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('allows an exact-rank match (ADMIN on @Roles(ADMIN))', () => {
+    const ctx = contextFor([UserRole.ADMIN], { role: UserRole.ADMIN });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('lets a higher role pass (CREATOR on @Roles(ADMIN))', () => {
+    const ctx = contextFor([UserRole.ADMIN], { role: UserRole.CREATOR });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('rejects a lower role (USER on @Roles(ADMIN))', () => {
+    const ctx = contextFor([UserRole.ADMIN], { role: UserRole.USER });
+    expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+
+  it('uses the least-privileged required role (@Roles(ADMIN, MODERATOR) lets MODERATOR pass)', () => {
+    const ctx = contextFor([UserRole.ADMIN, UserRole.MODERATOR], {
+      role: UserRole.MODERATOR,
+    });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('lets @Roles(USER) pass for every authenticated role', () => {
+    for (const role of Object.values(UserRole)) {
+      const ctx = contextFor([UserRole.USER], { role });
+      expect(guard.canActivate(ctx)).toBe(true);
+    }
+  });
+
+  it('throws when no authenticated user is present', () => {
+    const ctx = contextFor([UserRole.ADMIN], undefined);
+    expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
+  });
+});

--- a/packages/api/src/auth/guards/roles.guard.ts
+++ b/packages/api/src/auth/guards/roles.guard.ts
@@ -8,20 +8,22 @@ import {
 import { Reflector } from '@nestjs/core';
 import { Request } from 'express';
 import { User } from '../../user/entities/user.entity';
-import { UserRole } from '../../common/enums/role.enum';
+import { UserRole, hasAtLeast } from '../../common/enums/role.enum';
 
 /**
  * Roles Guard
  *
- * Checks if the authenticated user has the required role(s)
- * to access a protected route.
+ * Authorizes by privilege RANK (ADR-0011), not by exact-string match: the user
+ * passes when their rank is at least the least-privileged required role, so a
+ * higher role automatically satisfies a lower requirement (a CREATOR passes an
+ * @Roles(ADMIN) route).
  *
  * How it works:
  * 1. Extracts role requirements from route metadata (set by @Roles decorator)
  * 2. Gets the authenticated user from request (set by JwtAuthGuard)
- * 3. Compares user's role with required roles
- * 4. If match → allows access (returns true)
- * 5. If no match → throws 403 Forbidden
+ * 3. Computes the least-privileged required role (its minimum rank)
+ * 4. If the user's rank is at least that minimum (hasAtLeast) → allows access
+ * 5. Otherwise → throws 403 Forbidden
  * 6. If no @Roles decorator → allows access (not role-protected)
  *
  * Must be used AFTER JwtAuthGuard (which sets req.user)
@@ -43,7 +45,7 @@ import { UserRole } from '../../common/enums/role.enum';
  * }
  *
  * @example
- * // Allow multiple roles
+ * // Allow MODERATOR or higher (the least-privileged listed role is the floor)
  * @Get('reports')
  * @UseGuards(JwtAuthGuard, RolesGuard)
  * @Roles(UserRole.ADMIN, UserRole.MODERATOR)
@@ -94,14 +96,22 @@ export class RolesGuard implements CanActivate {
       throw new ForbiddenException('User not found in request context');
     }
 
-    // Check if user's role matches any of the required roles
-    if (requiredRoles.includes(user.role)) {
-      return true; // User has required role → allow access
+    // Hierarchy (ADR-0011): the user passes when they hold at least one of the
+    // required roles OR a higher one — a higher rank satisfies a lower @Roles
+    // requirement (a CREATOR passes an @Roles(ADMIN) check). Never an exact
+    // string match.
+    const authorized = requiredRoles.some((role) =>
+      hasAtLeast(user.role, role),
+    );
+    if (authorized) {
+      return true;
     }
 
-    // User doesn't have required role → deny access
+    // User's rank is below every required role → deny access
     throw new ForbiddenException(
-      `You do not have permission to access this resource. Required roles: ${requiredRoles.join(', ')}`,
+      `You do not have permission to access this resource. Required roles: ${requiredRoles.join(
+        ', ',
+      )} (or higher).`,
     );
   }
 }

--- a/packages/api/src/common/enums/role.enum.spec.ts
+++ b/packages/api/src/common/enums/role.enum.spec.ts
@@ -1,0 +1,44 @@
+import { UserRole, ROLE_RANK, hasAtLeast } from './role.enum';
+
+describe('role.enum — privilege ranking (ADR-0011)', () => {
+  describe('ROLE_RANK', () => {
+    it('orders the roles user < moderator < admin < creator', () => {
+      expect(ROLE_RANK[UserRole.USER]).toBeLessThan(
+        ROLE_RANK[UserRole.MODERATOR],
+      );
+      expect(ROLE_RANK[UserRole.MODERATOR]).toBeLessThan(
+        ROLE_RANK[UserRole.ADMIN],
+      );
+      expect(ROLE_RANK[UserRole.ADMIN]).toBeLessThan(
+        ROLE_RANK[UserRole.CREATOR],
+      );
+    });
+  });
+
+  describe('hasAtLeast', () => {
+    it('is true for the same rank', () => {
+      expect(hasAtLeast(UserRole.ADMIN, UserRole.ADMIN)).toBe(true);
+    });
+
+    it('is true for a higher rank (CREATOR satisfies ADMIN)', () => {
+      expect(hasAtLeast(UserRole.CREATOR, UserRole.ADMIN)).toBe(true);
+    });
+
+    it('is false for a lower rank (USER does not satisfy MODERATOR)', () => {
+      expect(hasAtLeast(UserRole.USER, UserRole.MODERATOR)).toBe(false);
+    });
+
+    it('lets CREATOR satisfy every role', () => {
+      for (const role of Object.values(UserRole)) {
+        expect(hasAtLeast(UserRole.CREATOR, role)).toBe(true);
+      }
+    });
+
+    it('lets USER satisfy only USER', () => {
+      expect(hasAtLeast(UserRole.USER, UserRole.USER)).toBe(true);
+      expect(hasAtLeast(UserRole.USER, UserRole.MODERATOR)).toBe(false);
+      expect(hasAtLeast(UserRole.USER, UserRole.ADMIN)).toBe(false);
+      expect(hasAtLeast(UserRole.USER, UserRole.CREATOR)).toBe(false);
+    });
+  });
+});

--- a/packages/api/src/common/enums/role.enum.ts
+++ b/packages/api/src/common/enums/role.enum.ts
@@ -1,20 +1,37 @@
 /**
- * User Role Enum
+ * User Role enum + privilege ranking (ADR-0011).
  *
- * Defines the available roles in the application.
- * Used for Role-Based Access Control (RBAC).
+ * Roles form a strict hierarchy. Privilege is expressed by an explicit rank
+ * map — never by comparing the enum strings or `role === 'admin'`. `CREATOR`
+ * is the single-holder supreme owner above `ADMIN` (seeded once, not grantable
+ * through the normal role-assignment path).
  *
  * @enum {string}
- *
- * @example
- * export enum UserRole {
- *   ADMIN = 'admin',      // Full access to all resources
- *   USER = 'user',        // Limited access (own resources only)
- *   MODERATOR = 'moderator' // Moderate content
- * }
  */
 export enum UserRole {
-  ADMIN = 'admin',
   USER = 'user',
   MODERATOR = 'moderator',
+  ADMIN = 'admin',
+  CREATOR = 'creator',
 }
+
+/**
+ * Privilege rank per role (higher number = more privilege). Drives
+ * {@link hasAtLeast}; every authorization decision must use the rank, never a
+ * raw string comparison (ADR-0011).
+ */
+export const ROLE_RANK: Record<UserRole, number> = {
+  [UserRole.USER]: 0,
+  [UserRole.MODERATOR]: 1,
+  [UserRole.ADMIN]: 2,
+  [UserRole.CREATOR]: 3,
+};
+
+/**
+ * True when `role` has at least the privilege of `minimum` (same rank or
+ * higher). Use this for every authorization check so a higher role
+ * automatically satisfies a lower requirement — e.g. a `CREATOR` passes an
+ * `@Roles(ADMIN)` check (ADR-0011).
+ */
+export const hasAtLeast = (role: UserRole, minimum: UserRole): boolean =>
+  ROLE_RANK[role] >= ROLE_RANK[minimum];

--- a/packages/api/src/database/migrations/1799000000000-AddSingleCreatorConstraint.ts
+++ b/packages/api/src/database/migrations/1799000000000-AddSingleCreatorConstraint.ts
@@ -1,0 +1,106 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds the `CREATOR` role (ADR-0011) at the database level.
+ *
+ * Two changes on the `users` table:
+ * 1. Extend `CHK_users_role` to permit `'creator'` — the initial schema only
+ *    allowed `'admin' | 'user' | 'moderator'`, so persisting `role = 'creator'`
+ *    would otherwise fail with a CHECK violation (caught in review of #1231).
+ * 2. Add the partial unique index `UQ_users_single_creator` enforcing the
+ *    single-holder invariant (at most one `role = 'creator'` row) as a DB
+ *    backstop for `UserService.assignCreatorRole`.
+ *
+ * SQLite cannot ALTER a CHECK constraint in place, so the table is rebuilt
+ * (create → copy → drop → rename → re-index) following the repo's existing
+ * `PRAGMA foreign_keys` pattern. Column set mirrors the schema after
+ * `1778000000000-AddPasswordResetFieldsToUser`.
+ */
+export class AddSingleCreatorConstraint1799000000000 implements MigrationInterface {
+  name = 'AddSingleCreatorConstraint1799000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.rebuildUsers(queryRunner, [
+      'admin',
+      'user',
+      'moderator',
+      'creator',
+    ]);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "UQ_users_single_creator" ON "users" ("role") WHERE "role" = 'creator'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "UQ_users_single_creator"`);
+    // Reverts the CHECK to its original three roles. Fails if a 'creator' row
+    // still exists (it would violate the restored constraint) — demote first.
+    await this.rebuildUsers(queryRunner, ['admin', 'user', 'moderator']);
+  }
+
+  /**
+   * Rebuild the `users` table with the given allowed roles in `CHK_users_role`,
+   * preserving every column, default, row, and index.
+   */
+  private async rebuildUsers(
+    queryRunner: QueryRunner,
+    allowedRoles: string[],
+  ): Promise<void> {
+    const rolesList = allowedRoles.map((r) => `'${r}'`).join(', ');
+    const columns = [
+      'id',
+      'email',
+      'username',
+      'password_hash',
+      'first_name',
+      'last_name',
+      'role',
+      'created_at',
+      'updated_at',
+      'is_active',
+      'password_reset_token_hash',
+      'password_reset_expires_at',
+    ]
+      .map((c) => `"${c}"`)
+      .join(', ');
+
+    await queryRunner.query(`PRAGMA foreign_keys = OFF`);
+    try {
+      await queryRunner.query(`
+      CREATE TABLE "users_new" (
+        "id" varchar PRIMARY KEY NOT NULL,
+        "email" varchar(255) NOT NULL,
+        "username" varchar(100) NOT NULL,
+        "password_hash" varchar(255) NOT NULL,
+        "first_name" varchar(255),
+        "last_name" varchar(255),
+        "role" varchar(20) NOT NULL DEFAULT ('user'),
+        "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        "updated_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        "is_active" boolean NOT NULL DEFAULT (1),
+        "password_reset_token_hash" varchar(255),
+        "password_reset_expires_at" datetime,
+        CONSTRAINT "CHK_users_role" CHECK ("role" IN (${rolesList}))
+      )
+    `);
+      await queryRunner.query(
+        `INSERT INTO "users_new" (${columns}) SELECT ${columns} FROM "users"`,
+      );
+      await queryRunner.query(`DROP TABLE "users"`);
+      await queryRunner.query(`ALTER TABLE "users_new" RENAME TO "users"`);
+      await queryRunner.query(
+        `CREATE UNIQUE INDEX "IDX_users_email_unique" ON "users" ("email")`,
+      );
+      await queryRunner.query(
+        `CREATE UNIQUE INDEX "IDX_users_username_unique" ON "users" ("username")`,
+      );
+      await queryRunner.query(
+        `CREATE INDEX "IDX_users_password_reset_token_hash" ON "users" ("password_reset_token_hash")`,
+      );
+    } finally {
+      // Always restore FK enforcement, even if the rebuild fails mid-way —
+      // otherwise the connection keeps FK checks disabled for the process.
+      await queryRunner.query(`PRAGMA foreign_keys = ON`);
+    }
+  }
+}

--- a/packages/api/src/user/services/user.service.spec.ts
+++ b/packages/api/src/user/services/user.service.spec.ts
@@ -4,10 +4,14 @@ import {
   UsernameAlreadyExistsException,
 } from '../../common/exceptions';
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 
 import { PasswordService } from '../../auth/services/password.service';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 import { User } from '../entities/user.entity';
 import { UserRole } from '../../common/enums/role.enum';
 import { UserService } from './user.service';
@@ -578,6 +582,118 @@ describe('UserService', () => {
       );
       expect(result.role).toBe(UserRole.MODERATOR);
       expect(result.password_hash).toBeUndefined();
+    });
+
+    it('should reject assigning the CREATOR role (ADR-0011)', async () => {
+      const findOneSpy = jest.spyOn(userRepository, 'findOne');
+
+      await expect(
+        userService.updateUserRole(mockUser.id, UserRole.CREATOR),
+      ).rejects.toThrow(ForbiddenException);
+
+      // The guard fires before any DB lookup.
+      expect(findOneSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reject demoting the CREATOR to another role (ADR-0011)', async () => {
+      const creator = { ...mockUser, role: UserRole.CREATOR } as User;
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(creator);
+      const saveSpy = jest.spyOn(userRepository, 'save');
+
+      await expect(
+        userService.updateUserRole(creator.id, UserRole.ADMIN),
+      ).rejects.toThrow(ForbiddenException);
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * Test suite for UserService.assignCreatorRole() method (ADR-0011).
+   */
+  describe('assignCreatorRole()', () => {
+    it('should promote a user to CREATOR when none exists', async () => {
+      const target = { ...mockUser, role: UserRole.ADMIN } as User;
+      const promoted = { ...target, role: UserRole.CREATOR } as User;
+
+      jest
+        .spyOn(userRepository, 'findOne')
+        .mockResolvedValueOnce(target) // lookup by email
+        .mockResolvedValueOnce(null); // no existing CREATOR
+      const saveSpy = jest
+        .spyOn(userRepository, 'save')
+        .mockResolvedValue(promoted);
+
+      const result = await userService.assignCreatorRole(target.email);
+
+      expect(saveSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ role: UserRole.CREATOR }),
+      );
+      expect(result.role).toBe(UserRole.CREATOR);
+      expect(result.password_hash).toBeUndefined();
+    });
+
+    it('should be idempotent when the user is already CREATOR', async () => {
+      const creator = { ...mockUser, role: UserRole.CREATOR } as User;
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(creator);
+      const saveSpy = jest.spyOn(userRepository, 'save');
+
+      const result = await userService.assignCreatorRole(creator.email);
+
+      expect(result.role).toBe(UserRole.CREATOR);
+      expect(saveSpy).not.toHaveBeenCalled(); // no write on a no-op
+    });
+
+    it('should throw when the email is unknown', async () => {
+      jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+
+      await expect(
+        userService.assignCreatorRole('ghost@example.com'),
+      ).rejects.toThrow(UserNotFoundException);
+    });
+
+    it('should refuse a second CREATOR (single-holder, ADR-0011)', async () => {
+      const target = {
+        ...mockUser,
+        id: 'id-target',
+        role: UserRole.ADMIN,
+      } as User;
+      const otherCreator = {
+        ...mockUser,
+        id: 'id-other',
+        email: 'other@example.com',
+        role: UserRole.CREATOR,
+      } as User;
+
+      jest
+        .spyOn(userRepository, 'findOne')
+        .mockResolvedValueOnce(target) // lookup by email
+        .mockResolvedValueOnce(otherCreator); // an existing CREATOR
+      const saveSpy = jest.spyOn(userRepository, 'save');
+
+      await expect(userService.assignCreatorRole(target.email)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
+    it('translates a concurrent unique-index violation into ConflictException', async () => {
+      // Race: the app-level check passed (no creator yet) but the DB index
+      // rejects the save. SQLite reports "UNIQUE constraint failed: users.role".
+      const target = { ...mockUser, role: UserRole.ADMIN } as User;
+      jest
+        .spyOn(userRepository, 'findOne')
+        .mockResolvedValueOnce(target) // lookup by email
+        .mockResolvedValueOnce(null); // no existing CREATOR (lost the race)
+      const dbError = new QueryFailedError(
+        'UPDATE users',
+        [],
+        new Error('UNIQUE constraint failed: users.role'),
+      );
+      jest.spyOn(userRepository, 'save').mockRejectedValue(dbError);
+
+      await expect(userService.assignCreatorRole(target.email)).rejects.toThrow(
+        ConflictException,
+      );
     });
   });
 

--- a/packages/api/src/user/services/user.service.ts
+++ b/packages/api/src/user/services/user.service.ts
@@ -2,13 +2,14 @@ import {
   Injectable,
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   NotFoundException,
   UnauthorizedException,
   Logger,
 } from '@nestjs/common';
 import { randomBytes } from 'node:crypto';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MoreThan, Repository } from 'typeorm';
+import { MoreThan, QueryFailedError, Repository } from 'typeorm';
 
 import { User } from '../entities/user.entity';
 import { UserRole } from '../../common/enums/role.enum';
@@ -702,6 +703,15 @@ export class UserService {
    * // Returns: { ..., role: 'moderator', updated_at: '...' }
    */
   async updateUserRole(userId: string, role: UserRole): Promise<User> {
+    // CREATOR is the single-holder supreme owner (ADR-0011): seeded once via
+    // assignCreatorRole and immutable through the normal role path — neither
+    // grantable (incoming target, here) nor revocable (current holder, below).
+    if (role === UserRole.CREATOR) {
+      throw new ForbiddenException(
+        'The CREATOR role cannot be assigned through updateUserRole (ADR-0011).',
+      );
+    }
+
     // ✅ EXISTENCE CHECK
     const user = await this.userRepository.findOne({
       where: { id: userId },
@@ -709,6 +719,14 @@ export class UserService {
 
     if (!user) {
       throw new UserNotFoundException();
+    }
+
+    // The current CREATOR cannot be demoted through this path either — the role
+    // is sticky once seeded (ADR-0011), or the single-holder invariant breaks.
+    if (user.role === UserRole.CREATOR) {
+      throw new ForbiddenException(
+        'The CREATOR role cannot be revoked through updateUserRole (ADR-0011).',
+      );
     }
 
     // ✅ ROLE UPDATE
@@ -722,6 +740,92 @@ export class UserService {
 
     // ✅ SECURITY: Remove password hash before returning
     return this.formatUserResponse(updatedUser);
+  }
+
+  /**
+   * Promote a user to the single-holder CREATOR role (ADR-0011).
+   *
+   * The ONLY path that grants CREATOR — a deliberate, seed-once provisioning
+   * step (like {@link createAdmin}), never exposed via the public API and
+   * explicitly rejected by {@link updateUserRole}. Idempotent: re-running on the
+   * account that is already CREATOR is a no-op. Enforces the single-holder
+   * invariant at the app layer; the `UQ_users_single_creator` partial unique
+   * index is the DB backstop.
+   *
+   * @param {string} email - Email of the account to promote.
+   * @returns {Promise<User>} The promoted user (password excluded).
+   * @throws {UserNotFoundException} No user with that email.
+   * @throws {ConflictException} Another user already holds CREATOR.
+   */
+  async assignCreatorRole(email: string): Promise<User> {
+    const user = await this.userRepository.findOne({ where: { email } });
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    // Idempotent: already the CREATOR → nothing to do.
+    if (user.role === UserRole.CREATOR) {
+      return this.formatUserResponse(user);
+    }
+
+    // Single-holder (ADR-0011): refuse if someone else already holds CREATOR.
+    const existingCreator = await this.userRepository.findOne({
+      where: { role: UserRole.CREATOR },
+    });
+    if (existingCreator && existingCreator.id !== user.id) {
+      throw new ConflictException(
+        'A CREATOR already exists — the role is single-holder (ADR-0011).',
+      );
+    }
+
+    const previousRole = user.role;
+    user.role = UserRole.CREATOR;
+
+    // Seed-once, not a hot path: the check-then-save above is not transactional.
+    // UQ_users_single_creator is the backstop — a truly concurrent call has its
+    // save rejected by the DB index; translate that into the documented
+    // ConflictException so the caller still gets a deterministic 409.
+    let saved: User;
+    try {
+      saved = await this.userRepository.save(user);
+    } catch (error) {
+      if (this.isSingleCreatorViolation(error)) {
+        throw new ConflictException(
+          'A CREATOR already exists — the role is single-holder (ADR-0011).',
+        );
+      }
+      throw error;
+    }
+
+    this.logger.log(
+      `CREATOR role assigned: ${saved.id} (${previousRole} -> creator)`,
+    );
+
+    return this.formatUserResponse(saved);
+  }
+
+  /**
+   * True when the error is the single-holder UNIQUE violation from
+   * `UQ_users_single_creator`. SQLite surfaces it as
+   * `"UNIQUE constraint failed: users.role"` (table.column, not the index
+   * name), so match on the driver code and the column-qualified message rather
+   * than the index name.
+   */
+  private isSingleCreatorViolation(error: unknown): boolean {
+    if (!(error instanceof QueryFailedError)) {
+      return false;
+    }
+    const driver = error.driverError as {
+      code?: string | number;
+      message?: string;
+    };
+    const code = typeof driver.code === 'string' ? driver.code : '';
+    const message = (driver.message ?? error.message).toLowerCase();
+    return (
+      code === 'SQLITE_CONSTRAINT_UNIQUE' ||
+      message.includes('unique constraint failed: users.role') ||
+      message.includes('uq_users_single_creator')
+    );
   }
 
   /**

--- a/packages/api/test/creator-role.e2e-spec.ts
+++ b/packages/api/test/creator-role.e2e-spec.ts
@@ -1,0 +1,75 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ConflictException } from '@nestjs/common';
+
+import { AppModule } from './../src/app.module';
+import { UserService } from './../src/user/services/user.service';
+import { UserRole } from './../src/common/enums/role.enum';
+
+/**
+ * Exercises the CREATOR role against the REAL migrated SQLite schema (the e2e
+ * runner applies all migrations). Unit tests mock the repository, so they
+ * cannot catch a DB-level CHECK constraint — this is the regression guard for
+ * the `CHK_users_role` fix (a 'creator' row must persist) and the
+ * `UQ_users_single_creator` single-holder backstop (ADR-0011).
+ */
+describe('CREATOR role (e2e — real migrated DB)', () => {
+  let app: INestApplication;
+  let userService: UserService;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+    userService = app.get(UserService);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('persists role = creator through the migrated CHECK constraint', async () => {
+    await userService.create({
+      email: 'founder@example.com',
+      username: 'founder',
+      password: 'SecurePassword123!',
+    });
+
+    const promoted = await userService.assignCreatorRole('founder@example.com');
+
+    expect(promoted.role).toBe(UserRole.CREATOR);
+  });
+
+  it('rejects a second CREATOR at the DB single-holder backstop', async () => {
+    await userService.create({
+      email: 'a@example.com',
+      username: 'usera',
+      password: 'SecurePassword123!',
+    });
+    await userService.create({
+      email: 'b@example.com',
+      username: 'userb',
+      password: 'SecurePassword123!',
+    });
+    await userService.assignCreatorRole('a@example.com');
+
+    await expect(
+      userService.assignCreatorRole('b@example.com'),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('is idempotent — re-assigning the same CREATOR keeps the role', async () => {
+    await userService.create({
+      email: 'c@example.com',
+      username: 'userc',
+      password: 'SecurePassword123!',
+    });
+    await userService.assignCreatorRole('c@example.com');
+
+    const again = await userService.assignCreatorRole('c@example.com');
+
+    expect(again.role).toBe(UserRole.CREATOR);
+  });
+});


### PR DESCRIPTION
## Summary

Foundation of the in-app moderation surface (epic #1175, conception #1224) — implements the single-holder **CREATOR** role decided in **ADR-0011** (#821).

**Why now:** the moderation endpoints (next slice) must be CREATOR-gated, and slice 1's read-gate flagged that `RolesGuard` did exact-match — so a `CREATOR` would be wrongly rejected by `@Roles(ADMIN)`. This slice fixes that and lays the role foundation.

**Change (NestJS, `packages/api`):**
- `role.enum`: `UserRole.CREATOR` + `ROLE_RANK` + `hasAtLeast(role, minimum)`.
- `RolesGuard`: rank-based — `requiredRoles.some(hasAtLeast(user.role, ...))`, so a higher role satisfies a lower `@Roles` requirement (a CREATOR passes `@Roles(ADMIN)`). The 8 existing `@Roles(ADMIN)` usages keep their behavior (ADMIN passes, USER blocked).
- `UserService.assignCreatorRole(email)`: the **only** path that grants CREATOR — deliberate seed-once (like `createAdmin`), idempotent, single-holder (rejects a second CREATOR). `updateUserRole` refuses to **grant or revoke** CREATOR (immutable via the normal path); `UpdateUserDto` exposes no `role`, so the public API stays closed.
- Migration `1799…AddSingleCreatorConstraint`: partial unique index `UQ_users_single_creator ON users(role) WHERE role='creator'` — DB backstop for single-holder.

## Tests (H/S/E)

- `role.enum.spec` — `hasAtLeast` ranks.
- `roles.guard.spec` — CREATOR passes `@Roles(ADMIN)`; USER blocked; `@Roles(USER)` open to all; no `@Roles` open; no user -> 403.
- `user.service.spec` — `assignCreatorRole` (promote / idempotent / 404 / second-creator conflict); `updateUserRole` rejects granting **and** revoking CREATOR.
- 767 unit + 16 e2e green (migration applies on SQLite); `npm run build` clean; `npm run lint:check` exit 0.

## Out of scope (next slices)

- NestJS moderation endpoints (promote/depublish) gated `@Roles(CREATOR)` -> close #1151.
- Mobile creator mode (M1-M4) to validate the 26 staged imports.
- Ops: promoting the founder's account via `assignCreatorRole` at provisioning.

## Checklist

- [x] Happy + sad + edge covered
- [x] `npm test` (767) + `npm run test:e2e` (16) green
- [x] `npm run build` + `npm run lint:check` clean
- [x] No `any`, named exports, domain exceptions, English-only
- [x] Conforms to ADR-0011 (single-holder, seed-once, rank-based, not grantable via normal path)

Refs #821, #1175.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added **CREATOR** as the highest privilege role and introduced rank-hierarchy authorization (higher roles satisfy lower requirements).
  * Added support for **promoting a user to CREATOR** with enforcement that only one CREATOR exists system-wide (including database constraints).
* **Tests**
  * Expanded unit and authorization tests for role ranking and guard behavior.
  * Added end-to-end coverage for CREATOR persistence, single-holder enforcement, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->