### PR TITLE
docs(testing): testing strategy + ADR-0019 (pyramid, e2e tooling, coverage ratchet, CI security)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ When a new ADR is accepted, add its file link here (no dates, no per-ADR summari
 | Definition of Done | [docs/project-management/definition-of-done.md](docs/project-management/definition-of-done.md) |
 | Definition of Ready | [docs/project-management/definition-of-ready.md](docs/project-management/definition-of-ready.md) |
 | Sprint structure | [docs/project-management/sprint-definition.md](docs/project-management/sprint-definition.md) |
+| Testing strategy | [docs/testing/testing-strategy.md](docs/testing/testing-strategy.md) |
 | API docs | [docs/api/](docs/api/) |
 | Architecture | [docs/architecture/](docs/architecture/) |
 | Architecture Decision Records | [docs/architecture/decisions/](docs/architecture/decisions/) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -500,7 +500,11 @@ What this means in practice:
 
 ## Testing
 
-Tests are mandatory for every new feature.
+Tests are mandatory for every new feature. The full approach — the test pyramid,
+per-package layers and coverage targets, the e2e tooling per surface (Supertest /
+Maestro / Playwright / pytest), and the CI quality gates — is the
+[testing strategy](docs/testing/testing-strategy.md) (contract:
+[ADR-0019](docs/architecture/decisions/0019-testing-strategy-and-quality-gates.md)).
 
 | Package    | Test framework                       | Location                                         |
 | ---------- | ------------------------------------ | ------------------------------------------------ |

--- a/docs/architecture/decisions/0019-testing-strategy-and-quality-gates.md
+++ b/docs/architecture/decisions/0019-testing-strategy-and-quality-gates.md
@@ -1,0 +1,148 @@
+# ADR-0019 — Testing strategy: the test pyramid, e2e tooling per surface, and CI quality gates
+
+**Status**  Proposed
+**Date**    2026-06-17
+**Owners**  @benoit-bremaud
+
+> Formalizes the project's testing approach as a contract. The codebase already
+> has a rich unit/component base but **no written strategy**, an **empty e2e top**
+> (no mobile or browser e2e, no e2e on the matcher v2 endpoint), **non-blocking**
+> coverage, and — now that the repo is **public** — **no security scanning in CI**.
+> This ADR fixes the binding decisions; the living detail lives in
+> [`../../testing/testing-strategy.md`](../../testing/testing-strategy.md) (the
+> "how"), the same way ADR-0016 pairs with its sequence diagram.
+
+---
+
+## Context
+
+- **No unified testing strategy exists.** Conventions are scattered across the
+  Definition of Done, `CONTRIBUTING.md`, and each package's `CLAUDE.md`
+  (happy/sad/edge, "tests mandatory"), but there is no single document describing
+  the test pyramid, coverage targets, or the e2e approach. New contributors (and
+  review agents) have no contract to check against.
+- **The e2e top of the pyramid is nearly empty.** Measured state:
+  - **api** (NestJS): 88 unit specs + **5 e2e** (Jest + Supertest, in-memory
+    SQLite + migrations) — but **no e2e on `POST /recipes/match`**, the matcher v2
+    scoring just shipped (ADR-0016). A regression there silently re-breaks the
+    "Leffe Blonde → Saison/NEIPA" bug the v2 redesign fixed.
+  - **mobile-app** (Expo/RN): 99 Jest + React Native Testing Library files
+    (use-cases, mappers, screens) — but **zero device/UI e2e** (no Detox, no
+    Maestro). The core journey (scan → fiche → equivalents) is only asserted at
+    component level with mocked use-cases.
+  - **beer-encyclopedia** (FastAPI): 18 pytest files (routers, DB, seeds) — but the
+    **ML pipeline is untested** except OCR (`ml/infer`, `ml/pipeline`,
+    `ml/extract`).
+  - **website**: 9 structural checks (`scripts/quality_gate.py`) — **no browser
+    smoke test** that the page actually renders and the feedback form posts.
+- **Coverage is collected but never enforced.** CI generates lcov for all three
+  code packages and warns at `< 70%`, but the warning is **non-blocking**; no
+  `coverageThreshold` is set anywhere. Coverage can silently rot.
+- **The repo is public and CI has no security scanning.** Since the public switch,
+  Actions run free, but the only security job is a non-blocking `npm audit`. There
+  is **no gitleaks, no CodeQL, no dependency-review** — a gap that matters more now
+  that the ~157 Dependabot advisories are publicly visible.
+- **Of the eight browser e2e tools surveyed** (TestCafe, Puppeteer, Playwright,
+  PhantomJS, Selenium, Cucumber, Testim, Cypress), **only browser tools apply, and
+  only to the website** — the mobile app is React Native (native, not a browser),
+  so it needs a mobile-specific runner (Maestro/Detox), not anything on that list.
+
+---
+
+## Decision
+
+Adopt a written, pyramid-shaped testing strategy with package-appropriate e2e
+tooling and **enforced** CI quality gates.
+
+### D1 — Adopt the test pyramid as the shape
+
+Many fast **unit** tests at the base (pure logic, services, use-cases, mappers); a
+middle band of **integration** tests (API↔DB, screen↔use-case, router↔DB); a thin
+top of **e2e** tests covering the **real, high-risk journeys only** — never an
+inverted pyramid of slow end-to-end checks. Each new feature lands tests at the
+lowest layer that can meaningfully assert its behaviour (happy/sad/edge,
+unchanged). The per-package layer mapping is in the strategy doc.
+
+### D2 — One e2e tool per surface, chosen for the surface
+
+| Surface | e2e tool | Rationale |
+|---|---|---|
+| **api** (NestJS) | **Supertest** (Jest) | Already in use (5 e2e specs); boots the Nest app on in-memory SQLite with migrations. No new tooling. |
+| **mobile-app** (Expo/RN) | **Maestro** | React Native is native, not a browser — browser tools cannot drive it. Maestro's YAML flows are lower-friction than Detox for a solo Expo project. |
+| **website** (static) | **Playwright** | The only surface a browser e2e tool fits. Playwright over Cypress/Selenium: multi-browser, auto-wait, first-class TypeScript, lightweight for a static site. |
+| **beer-encyclopedia** (FastAPI) | **pytest** | Already in use; HTTP exercised via `TestClient`. Extend to the untested ML pipeline. |
+
+### D3 — Coverage becomes a blocking CI gate, via a ratchet
+
+Replace the non-blocking `< 70%` warning with an **enforced** per-package
+threshold that **never decreases** (a ratchet): set the floor at the **currently
+measured** coverage, fail CI if a PR drops below it, and raise the floor in steps
+toward the long-term targets (api/mobile **80%**, encyclopedia **75%**). Setting an
+honest floor first (KISS) avoids an across-the-board failure on the first run.
+
+### D4 — Public-repo security scanning is mandatory in CI
+
+Add the security baseline that a public repo warrants: **gitleaks** (secret
+scanning, honouring the existing `.gitleaksignore`), **CodeQL** (SAST for
+JS/TS), and **dependency-review** on PRs. This complements (does not replace) the
+existing `npm audit` job and the local/manual SonarQube analysis.
+
+---
+
+## Consequences
+
+### Positive
+
+- A single contract reviewers (and review agents) can cite, the same way ADRs
+  0001–0018 are cited — testing stops being tribal knowledge.
+- The matcher v2 scoring (ADR-0016) gains a regression guard at the HTTP boundary;
+  the mobile scan journey and the website get their first real e2e safety net.
+- Coverage can no longer silently rot; the ratchet makes "tests mandatory" (DoD)
+  actually enforceable instead of advisory.
+- The public repo gets a defensible security posture in CI.
+
+### Trade-offs
+
+- **New tooling to learn and host in CI** (Maestro, Playwright) — mitigated by
+  starting with a single smoke flow each, and by deferring device-farm/emulator
+  e2e (see strategy doc out-of-scope).
+- **A blocking coverage gate can block legitimate PRs** if set too high — mitigated
+  by the ratchet (floor at current, raised deliberately), not a hard 80% on day one.
+- CodeQL/Maestro/Playwright add CI minutes — acceptable now that the repo is public
+  (Actions are free).
+
+### Rejected alternatives
+
+- **No document, tool e2e ad hoc.** Contradicts the project's conception-first
+  discipline (conception = contract); leaves the same gap this ADR closes.
+- **Detox for mobile e2e.** Heavier setup (native build, device/emulator
+  orchestration) than a solo pre-public project needs; Maestro covers the journey
+  with far less ceremony. Revisit if native-module depth demands it.
+- **Cypress/Selenium for the website.** Cypress is single-origin/heavier and
+  Selenium is verbose/flaky for a tiny static site; Playwright is the lighter,
+  more capable fit. (Puppeteer is not a test framework; Cucumber is a BDD layer,
+  not a runner; TestCafe is declining; Testim is commercial; PhantomJS is
+  abandoned.)
+- **Keep coverage as a warning.** Non-enforcement is why coverage drifts; a ratchet
+  is the minimal enforcement that does not punish the current baseline.
+
+---
+
+## Realization
+
+Tracked by a dedicated **"Testing strategy realization" epic** (one issue per
+surface + one for the CI gates). The living detail — the pyramid diagram,
+per-package layer/target table, the ratchet policy, target CI shape, and
+consolidated conventions — is maintained in
+[`docs/testing/testing-strategy.md`](../../testing/testing-strategy.md). The
+config changes (`coverageThreshold`, new CI jobs, security workflows) are
+**implemented in the backlog issues**, not in this conception PR.
+
+## Relation to other ADRs
+
+- **Guards ADR-0016** (matcher v2): the `POST /recipes/match` e2e is the regression
+  net for the scoring this ADR's epic adds.
+- **Aligns with ADR-0001** (build for today): one smoke flow per surface now,
+  device-farm/visual-regression deferred until justified.
+- **Consistent with ADR-0013** (conception is the contract): the strategy doc is
+  the contract the test code must satisfy.

--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -1,0 +1,169 @@
+# Testing strategy — Brasse-Bouillon
+
+> **Status**: living document. Contract: [ADR-0019 — Testing strategy & quality
+> gates](../architecture/decisions/0019-testing-strategy-and-quality-gates.md).
+> This document is the **"how"** (the detail the test code must satisfy); the ADR
+> is the **"what we commit to"**. Language: English (per `docs/CONVENTIONS.md`).
+
+This is the single reference for how Brasse-Bouillon is tested across its four
+packages. It defines the test pyramid, what each layer covers per package, the
+e2e tooling, the coverage policy, and the target CI gates. It supersedes nothing —
+it **consolidates** the conventions previously scattered across the Definition of
+Done, `CONTRIBUTING.md`, and the per-package `CLAUDE.md` files.
+
+---
+
+## 1. The test pyramid
+
+```mermaid
+graph TD
+    E2E["e2e — few, slow, real journeys<br/>Supertest · Maestro · Playwright · pytest"]
+    INT["Integration — controller↔DB, screen↔use-case, router↔DB"]
+    UNIT["Unit — many, fast<br/>services · domain · use-cases · mappers · pure logic"]
+    E2E --> INT --> UNIT
+    style E2E fill:#f8d7da,stroke:#842029
+    style INT fill:#fff3cd,stroke:#664d03
+    style UNIT fill:#d1e7dd,stroke:#0f5132
+```
+
+- **Base (unit)** — the bulk of tests. Pure logic, services, domain factories,
+  use-cases, API mappers. Fast, no I/O, deterministic. The codebase is already
+  strong here.
+- **Middle (integration)** — a thinner band. Real wiring across a seam:
+  controller↔DB (Supertest on in-memory SQLite), screen↔use-case (React Native
+  Testing Library), router↔DB (FastAPI `TestClient`).
+- **Top (e2e)** — deliberately **few**, covering only the **real, high-risk
+  journeys**. Slow and broad; never the place to assert business-rule branches
+  (those belong at the unit layer).
+
+**Anti-goal**: an inverted pyramid (many slow e2e, few unit). If a behaviour can be
+asserted one layer down, it is tested there.
+
+---
+
+## 2. Per-package map
+
+| Package | Unit | Integration | e2e (tool) | Coverage target (ratchet) |
+|---|---|---|---|---|
+| **api** (NestJS) | services, domain, DTO validators (Jest) | controller↔DB (Supertest, in-memory SQLite + migrations) | `POST /recipes/match` + auth/recipes journeys (**Supertest**) | floor now → **80%** |
+| **mobile-app** (Expo/RN) | use-cases, mappers, pure logic (Jest) | screen↔use-case (React Native Testing Library) | scan → fiche → equivalents / honest empty state (**Maestro**) | floor now → **80%** |
+| **beer-encyclopedia** (FastAPI) | `ml/extract`, recommender, persistence (pytest) | router↔DB (`TestClient`, in-memory SQLite) | import-by-ean via OpenFoodFacts (**pytest**) | floor now → **75%** |
+| **website** (static) | — | structural quality gate (`scripts/quality_gate.py`, existing) | home renders + feedback widget + form posts (**Playwright**) | n/a (structural gate) |
+
+Measured baseline (2026-06-17): api 88 unit + 5 e2e specs; mobile-app 99 test
+files; beer-encyclopedia 18 pytest files; website 9 structural checks.
+
+---
+
+## 3. Per-package detail
+
+### 3.1 api (NestJS)
+
+- **Unit** — co-located `*.spec.ts` under `src/`. Mock TypeORM repositories; test
+  services and domain in isolation. Reuse the existing helpers:
+  `src/recipe/recipe-testing.module.ts` (`buildRecipeTestingTypeOrm()`) and
+  `src/database/seeds/seed-test-utils.ts` (`buildRepoMock()`,
+  `assertCommonCatalogueSeederBehaviours()`).
+- **Integration / e2e** — `test/*.e2e-spec.ts`, run via `test/jest-e2e.json` with
+  `--runInBand`, booting the full `AppModule` on `DATABASE_PATH=:memory:` with
+  `TYPEORM_MIGRATIONS_RUN=true`. Existing specs: `app`, `auth.protected`,
+  `health`, `feedback`, `recipes-public`.
+- **Priority gaps to close** (backlog):
+  - e2e on `POST /recipes/match` — pin matcher v2 (ADR-0016): a real Blonde Ale
+    recipe ranks above a same-family Saison, above an off-family NEIPA; an
+    off-family official does not bypass the D5/D6 gate.
+  - Missing unit specs: the `label` module (3 controllers + 3 services),
+    `recipe.service`, `recipe-ingredients.service`, `scan-storage.service`,
+    `password.service`.
+
+### 3.2 mobile-app (Expo / React Native)
+
+- **Unit** — `src/features/<feature>/application/__tests__/` (use-cases) and
+  `.../data/__tests__/` (API clients/mappers). Mock `@/core/http/http-client` with
+  `jest.fn()`; never hit real HTTP. Reuse fixtures
+  (`features/labels/test-utils/label-test-fixtures.ts`, `src/mocks/demo-data.ts`).
+- **Integration** — `src/features/<feature>/presentation/__tests__/` with React
+  Native Testing Library; mock the use-case layer, render the screen, assert
+  interactions. Wrap in `QueryClientProvider` (`retry: false`).
+- **e2e (Maestro, new)** — YAML flows under `.maestro/`. First flow: scan a known
+  barcode → beer fiche → "recettes équivalentes" populated (or the honest empty
+  state when none clear the threshold).
+- **Priority gaps to close** (backlog): introduce Maestro + the scan flow; add the
+  missing unit test for the `equipment` screen (only untested feature).
+
+### 3.3 beer-encyclopedia (FastAPI)
+
+- **Unit** — pytest under `tests/`, `tests/test_<module>_<behavior>.py`. Async via
+  `pytest-asyncio` (auto mode).
+- **Integration** — `tests/test_api/` using `TestClient` with the `db_session`
+  fixture (in-memory SQLite, FK pragma enabled) from `conftest.py`.
+- **Priority gaps to close** (backlog): cover the ML pipeline currently untested
+  except OCR — `ml/infer.py`, `ml/pipeline.py`, `ml/extract.py`.
+
+### 3.4 website (static site)
+
+- **Structural gate (existing)** — `scripts/quality_gate.py` + `tests/test_quality_gate.py`
+  (Python `unittest`, 9 checks): required files, HTML structure, feedback-widget
+  presence, schema.org rules, sitemap/robots policy, conflict markers.
+- **e2e (Playwright, new)** — flows under `packages/website/e2e/`. Smoke only:
+  the home renders, the feedback widget appears (prod-gated, so test against a
+  built/served bundle, not `localhost` where it is intentionally hidden), and the
+  questionnaire form submits.
+
+---
+
+## 4. Coverage policy — the ratchet
+
+1. **Measure** the current coverage per package (`npm run test:cov` for api,
+   `npm run test:coverage` for mobile, `pytest --cov` for encyclopedia).
+2. **Set the floor** = the measured value (an honest baseline), enforced via
+   `coverageThreshold` (Jest) / `--cov-fail-under` (pytest). CI **fails** below it.
+3. **Raise deliberately** in steps toward the long-term targets (api/mobile 80%,
+   encyclopedia 75%) — never auto-lower.
+
+KISS: do not set 80% on day one (it would fail the first run); ratchet up from the
+real baseline.
+
+---
+
+## 5. Target CI gates
+
+This is the **target** shape of [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+(implemented via the backlog issues, not in the conception PR):
+
+- **Coverage is blocking** — replace the non-blocking `< 70%` warning step with the
+  ratchet threshold per package.
+- **e2e jobs** — add path-filtered jobs: api e2e (`npm run test:e2e`), website
+  Playwright smoke, mobile Maestro (when the runner is wired). Keep them separate
+  from the fast unit jobs so unit feedback stays quick.
+- **Security (public repo)** — add **gitleaks** (honour `.gitleaksignore`),
+  **CodeQL** (JS/TS), **dependency-review** on PRs, alongside the existing
+  `npm audit` job. See the global `security-ci-baseline` skill.
+
+---
+
+## 6. Consolidated conventions
+
+- **Happy / Sad / Edge** for every suite: nominal path, expected errors
+  (validation, missing entity, unauthorised), boundary inputs.
+- **Test locations**:
+  - api unit: `packages/api/src/**/*.spec.ts` — api e2e: `packages/api/test/*.e2e-spec.ts`
+  - mobile: `packages/mobile-app/src/features/<feature>/{application,data,presentation}/__tests__/`
+  - mobile e2e: `packages/mobile-app/.maestro/`
+  - encyclopedia: `packages/beer-encyclopedia/tests/`
+  - website e2e: `packages/website/e2e/`
+- **Mandatory for every new feature** (Definition of Done) — and now enforced by
+  the coverage ratchet, not just advised.
+- **Mock at the boundary**: mobile mocks the http-client; api unit mocks
+  repositories; integration/e2e use a real in-memory DB.
+
+---
+
+## 7. Out of scope (deferred, captured)
+
+- Device-farm / emulator-based mobile e2e in CI (heavy) — Maestro runs locally
+  first; CI execution comes later if it earns its keep.
+- Visual-regression / screenshot testing.
+- Performance / load testing of the API and the matcher.
+- The matcher **ingredients** criterion (ADR-0016, deferred) — no e2e until the
+  criterion exists.


### PR DESCRIPTION
## What

Adds the project's first **unified testing strategy** as a conception-first contract (mirroring how ADR-0016 pairs a decision with its detail doc).

- **ADR-0019** (Proposed) — `docs/architecture/decisions/0019-testing-strategy-and-quality-gates.md`: adopt the test pyramid (**D1**); one e2e tool per surface — Supertest / Maestro / Playwright / pytest (**D2**); coverage becomes a **blocking** CI ratchet (**D3**); public-repo CI security scanning — gitleaks + CodeQL + dependency-review (**D4**).
- **`docs/testing/testing-strategy.md`** — the living detail: Mermaid pyramid, per-package layer/target map, per-package gaps, ratchet policy, target CI shape, consolidated H/S/E conventions and test locations.
- References the strategy from the CLAUDE.md Documentation table and CONTRIBUTING.md § Testing.

## Why

The codebase has a rich unit/component base (api 88 unit + 5 e2e, mobile 99 files, encyclopedia 18, website 9 structural) but **no written strategy**, an **empty e2e top** (no mobile/browser e2e, no e2e on the matcher v2 endpoint), **non-blocking** coverage, and — now that the repo is **public** — **no CI security scanning**.

## Scope

- **In**: documentation only (ADR + strategy doc + two reference links). No code, no config change.
- **Out**: the implementation (e2e suites, coverage ratchet, CI jobs, security workflows) — tracked by epic #1230 (one issue per surface + CI).

## Notes

- ADR-0019 stays **Proposed**; it is intentionally **not** added to the "Currently accepted ADRs" list in CLAUDE.md until accepted (consistent with ADR-0016/0017).
- The `decisions/README.md` index is pre-existingly stale (stops at 0015 — 0016/0017/0018 absent); not touched here.

Realized by #1230.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established formalized testing strategy and CI quality gates
  * Defined test pyramid approach across unit, integration, and e2e test layers
  * Introduced blocking coverage enforcement per package
  * Added security scanning to CI pipeline
  * Updated contribution guidelines with consolidated testing expectations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->