### PR TITLE
docs(testing): fix fixture path + feedback-widget host gating (review of #1238)

### DIFF
--- a/docs/testing/testing-strategy.md
+++ b/docs/testing/testing-strategy.md
@@ -81,7 +81,7 @@ files; beer-encyclopedia 18 pytest files; website 9 structural checks.
 - **Unit** — `src/features/<feature>/application/__tests__/` (use-cases) and
   `.../data/__tests__/` (API clients/mappers). Mock `@/core/http/http-client` with
   `jest.fn()`; never hit real HTTP. Reuse fixtures
-  (`features/labels/test-utils/label-test-fixtures.ts`, `src/mocks/demo-data.ts`).
+  (`src/features/labels/test-utils/label-test-fixtures.ts`, `src/mocks/demo-data.ts`).
 - **Integration** — `src/features/<feature>/presentation/__tests__/` with React
   Native Testing Library; mock the use-case layer, render the screen, assert
   interactions. Wrap in `QueryClientProvider` (`retry: false`).
@@ -106,9 +106,10 @@ files; beer-encyclopedia 18 pytest files; website 9 structural checks.
   (Python `unittest`, 9 checks): required files, HTML structure, feedback-widget
   presence, schema.org rules, sitemap/robots policy, conflict markers.
 - **e2e (Playwright, new)** — flows under `packages/website/e2e/`. Smoke only:
-  the home renders, the feedback widget appears (prod-gated, so test against a
-  built/served bundle, not `localhost` where it is intentionally hidden), and the
-  questionnaire form submits.
+  the home renders, the feedback widget appears, and the questionnaire form
+  submits. Note the widget's host gating (`packages/website/feedback-widget.js`):
+  it loads **only on staging + `localhost`/`127.0.0.1`, never on public prod** —
+  so run the widget smoke against a local/staging serve, not the production URL.
 
 ---
 


### PR DESCRIPTION
## What

Follow-up to the already-merged **#1238**, addressing its review (Copilot + Codex) — two factual fixes in `docs/testing/testing-strategy.md`:

- **§3.2 fixture path** — add the missing `src/` prefix: `src/features/labels/test-utils/label-test-fixtures.ts` (the path pointed to a non-existent location).
- **§3.4 feedback-widget smoke** — the earlier guidance was **inverted**. Per `packages/website/feedback-widget.js`, the widget loads **only on staging + `localhost`/`127.0.0.1`, never on public prod**. The doc now says to run the widget smoke against a local/staging serve, not the production URL.

## Why

`#1238` was merged before its review comments were addressed. These are real doc-accuracy defects (a broken path and a backwards instruction that would misdirect the future Playwright smoke). Docs-only, no code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing strategy documentation with clarifications on test environment configurations.
  * Refined guidance for smoke testing to specify supported environments and deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->