### PR TITLE
ci(coverage): blocking coverage ratchet + API e2e in CI (ADR-0019 D3, #1236)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,16 @@
 # Runs path-filtered jobs for mobile-app, api, website, and beer-encyclopedia
 # on every PR to main.
 #
-# Quality gates:
-#   - Mobile App: lint + typecheck + format + tests (70% coverage minimum)
-#   - API: lint + build + tests (70% coverage minimum)
+# Quality gates (ADR-0019):
+#   - Mobile App: lint + typecheck + format + unit tests (blocking coverage ratchet)
+#   - API: lint + build + unit tests (blocking coverage ratchet) + e2e (Supertest)
 #   - Website: Python quality gate
-#   - Beer Encyclopedia: ruff lint + compile check + tests (70% coverage minimum)
-#   - Security: npm audit for Node packages
+#   - Beer Encyclopedia: ruff lint + compile check + tests (blocking coverage ratchet)
+#   - Security: npm audit (here) + gitleaks / CodeQL / dependency-review (dedicated workflows)
+#
+# The coverage floor is enforced by each package's own config (Jest
+# coverageThreshold / coverage.py fail_under), so it gates locally and in CI;
+# the floor sits a few points below the current baseline (raise, never lower).
 # ==============================================================================
 
 name: CI
@@ -78,16 +82,8 @@ jobs:
       - name: Lint + Typecheck + Format check
         run: npm run ci:check
 
-      - name: Run tests with coverage
+      - name: Run tests with coverage (blocking ratchet)
         run: npm run test:coverage
-
-      - name: Check coverage threshold (70%)
-        run: |
-          COVERAGE=$(npx lcov-summary coverage/lcov.info 2>/dev/null | grep -oP 'Lines:\s+\K[\d.]+' || echo "0")
-          echo "Coverage: ${COVERAGE}%"
-          if [ "$(echo "$COVERAGE < 70" | bc -l 2>/dev/null || echo 1)" = "1" ]; then
-            echo "::warning::Coverage is ${COVERAGE}% — below 70% threshold"
-          fi
 
       - name: Upload coverage report
         if: always()
@@ -126,16 +122,11 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Run tests with coverage
+      - name: Run unit tests with coverage (blocking ratchet)
         run: npm run test:cov
 
-      - name: Check coverage threshold (70%)
-        run: |
-          COVERAGE=$(npx lcov-summary coverage/lcov.info 2>/dev/null | grep -oP 'Lines:\s+\K[\d.]+' || echo "0")
-          echo "Coverage: ${COVERAGE}%"
-          if [ "$(echo "$COVERAGE < 70" | bc -l 2>/dev/null || echo 1)" = "1" ]; then
-            echo "::warning::Coverage is ${COVERAGE}% — below 70% threshold"
-          fi
+      - name: Run e2e tests (Supertest, in-memory SQLite + migrations)
+        run: npm run test:e2e
 
       - name: Upload coverage report
         if: always()
@@ -202,23 +193,9 @@ jobs:
             api/routers/*.py api/schemas/*.py \
             ml/*.py db/*.py db/models/*.py scripts/*.py
 
-      - name: Run tests with coverage
+      - name: Run tests with coverage (blocking ratchet via coverage.py fail_under)
         run: |
           pytest tests/ --cov=ml --cov=api --cov=db --cov-report=term --cov-report=lcov:coverage/lcov.info -q
-
-      - name: Check coverage threshold (70%)
-        run: |
-          COVERAGE=$(python -c "
-          import re
-          data = open('coverage/lcov.info').read()
-          covered = sum(1 for m in re.findall(r'^DA:\d+,(\d+)', data, re.M) if int(m) > 0)
-          total = len(re.findall(r'^DA:\d+,', data, re.M))
-          print(f'{100*covered/total:.1f}' if total else '0')
-          " 2>/dev/null || echo "0")
-          echo "Coverage: ${COVERAGE}%"
-          if [ "$(echo "$COVERAGE < 70" | bc -l 2>/dev/null || echo 1)" = "1" ]; then
-            echo "::warning::Coverage is ${COVERAGE}% — below 70% threshold"
-          fi
 
       - name: Upload coverage report
         if: always()

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -104,6 +104,14 @@
       "text",
       "text-summary"
     ],
+    "coverageThreshold": {
+      "global": {
+        "statements": 90,
+        "branches": 72,
+        "functions": 85,
+        "lines": 90
+      }
+    },
     "testEnvironment": "node"
   },
   "overrides": {

--- a/packages/beer-encyclopedia/pyproject.toml
+++ b/packages/beer-encyclopedia/pyproject.toml
@@ -49,6 +49,13 @@ exclude = ["tests*", "scripts*", "configs*", "data*", "docs*", "migrations*"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 
+# Coverage ratchet (ADR-0019 D3, #1236): a `pytest --cov` run fails when total
+# line coverage drops below this floor (current baseline ~75%). Raise
+# deliberately over time; never lower. Only applies when coverage is collected,
+# so partial `pytest <path>` runs without --cov are unaffected.
+[tool.coverage.report]
+fail_under = 70
+
 [tool.ruff]
 target-version = "py312"
 line-length = 100

--- a/packages/mobile-app/jest.config.js
+++ b/packages/mobile-app/jest.config.js
@@ -7,4 +7,15 @@ module.exports = {
   transformIgnorePatterns: [
     "node_modules/(?!((jest-)?react-native|@react-native|expo(nent)?|@expo(nent)?/.*|@expo/.*|expo-router|@react-navigation/.*))",
   ],
+  // Coverage ratchet (ADR-0019 D3, #1236): a floor a few points below the
+  // current baseline so a meaningful drop fails CI without breaking the first
+  // run. Raise deliberately over time; never lower.
+  coverageThreshold: {
+    global: {
+      statements: 82,
+      branches: 72,
+      functions: 80,
+      lines: 82,
+    },
+  },
 };


### PR DESCRIPTION
## What

Makes the testing-strategy contract (ADR-0019 D3) **enforced** instead of advisory, and wires the matcher e2e into CI (realizes the bulk of #1236, epic #1230):

- **API** — adds an **e2e step** (`npm run test:e2e`) to the CI api job, so the matcher v2 regression net from #1243 actually runs in CI (the job ran unit only). Jest `coverageThreshold` global **90/72/85/90** (statements/branches/functions/lines) — current baseline 94.3/77.2/89.4/94.6.
- **Mobile** — Jest `coverageThreshold` global **82/72/80/82** — current 86.4/77.7/86.0/86.2.
- **Encyclopedia** — `coverage.py` `fail_under = 70` in `pyproject.toml` — current ~75%.
- Drops the three non-blocking `< 70% warning` CI steps: enforcement now lives in **each package's own config**, so it gates locally **and** in CI.

The floors sit a few points below the current baseline — a meaningful drop fails CI, but the first run is green. **Ratchet: raise over time, never lower.**

## Why

The e2e from #1243 wasn't enforced (the api CI job ran unit only), and coverage was advisory (a warning that never failed). This closes both.

## Verified

Locally (api): `test:cov` exit 0, `test:e2e` exit 0 (22 e2e pass). Mobile + encyclopedia thresholds are below their measured baselines and run natively in their CI jobs (jest-expo can't run under the local worktree symlink, so CI is the proof here).

## Scope / deferred

Rest of #1236 — **Trivy + OSSF Scorecard** (optional security extras) and the **mobile Maestro / website Playwright** CI jobs (frameworks not set up yet) — deferred to #1233/#1234.
