### PR TITLE
docs(brewing): beginner blonde ale recipe + volume cascade (first real-world brew)

### DIFF
--- a/docs/real-world-test/blonde-ale-5l-first-brew.md
+++ b/docs/real-world-test/blonde-ale-5l-first-brew.md
@@ -9,8 +9,10 @@
 >
 > **The fermenter is the binding constraint.** The founder ferments in **5 L
 > demijohns (dames-jeannes)**. A 5 L demijohn must **not** be filled with 5 L of
-> wort — the krausen (fermentation foam) needs ~15–20 % headspace or it blows out
-> the airlock. So we target **~4.3 L into the demijohn → ~4.0 L bottled**
+> wort — the krausen (fermentation foam) needs headspace or it blows out the
+> airlock. So we target **~4.3 L into the demijohn → ~4.0 L bottled** (~0.7 L /
+> ~14 % headspace; that's tight for a small demijohn, so a **blow-off tube** is
+> recommended for the vigorous first 2–3 days)
 > (≈ 8 × 50 cl), starting from **~7 L of water**.
 
 ## 1. The recipe (BJCP 18A — Blonde Ale)

--- a/docs/real-world-test/blonde-ale-5l-first-brew.md
+++ b/docs/real-world-test/blonde-ale-5l-first-brew.md
@@ -36,8 +36,9 @@ first brew. Scaled to the 5 L demijohn.
 - 100 g **Vienna malt** (roundness + golden hue)
 
 **Hops — single variety, Cascade** (or Saaz for a more floral/noble character)
-- 10 g **Cascade** @ **60 min** (bitterness)
-- 6 g **Cascade** @ **flameout / whirlpool** (light aroma)
+- 5 g **Cascade** @ **60 min** (bitterness — ~18 IBU for this ~4.3 L batch; small
+  batches concentrate bitterness, so the bittering charge is deliberately small)
+- 4 g **Cascade** @ **flameout / whirlpool** (light aroma, negligible IBU)
 
 **Yeast** — **SafAle US-05** (dry, clean, very tolerant). ~½ sachet is plenty for
 this volume (a whole 11 g sachet is also fine). Ferment **18–20 °C**.
@@ -86,7 +87,7 @@ then dunk-sparge the bag in ~3 L at 75 °C and combine (adds one step). A pot
 ## 4. Shopping list (ingredients)
 
 - 900 g **Pilsner malt** + 100 g **Vienna malt** (≈ 1.0 kg)
-- 16 g **Cascade** hops (10 g + 6 g)
+- ~10 g **Cascade** hops (5 g bittering + 4 g flameout + a small margin)
 - 1 sachet **SafAle US-05**
 - ~22 g **priming sugar** (sucrose) for ~4 L
 - Campden / dechlorinated water
@@ -99,8 +100,8 @@ then dunk-sparge the bag in ~3 L at 75 °C and combine (adds one step). A pot
 3. **Mash** — put the BIAB bag in, stir in the grain, hold **66 °C for 60 min**.
 4. **Remove the bag** — lift, drain, gentle squeeze. *(Scenario B: dunk-sparge
    here.)*
-5. **Boil — 60 min.** At the start of the boil add **10 g Cascade** (60-min);
-   at flameout add **6 g Cascade**.
+5. **Boil — 60 min.** At the start of the boil add **5 g Cascade** (60-min,
+   ~18 IBU); at flameout add **4 g Cascade**.
 6. **Whirlpool** — stir, rest ~10 min.
 7. **Chill** to ~20 °C (ice bath).
 8. **Transfer ~4.3 L** into the sanitized 5 L demijohn (leave trub behind, keep

--- a/docs/real-world-test/blonde-ale-5l-first-brew.md
+++ b/docs/real-world-test/blonde-ale-5l-first-brew.md
@@ -1,0 +1,147 @@
+# First real-world brew — Beginner Blonde Ale (~4 L bottled, 5 L demijohn, BIAB)
+
+> **Purpose.** Recipe + brew guide for Brasse-Bouillon's **first real-world
+> test**: the founder brews his first beer — a simple, good Blonde Ale —
+> *guided by the app*. It is also the **source of truth** for (a) the seeded
+> public recipe the app imports, and (b) the **volume planning** the app must
+> display explicitly. We validate the whole novice journey in a dry run first;
+> the physical brew happens once the app is functional end-to-end.
+>
+> **The fermenter is the binding constraint.** The founder ferments in **5 L
+> demijohns (dames-jeannes)**. A 5 L demijohn must **not** be filled with 5 L of
+> wort — the krausen (fermentation foam) needs ~15–20 % headspace or it blows out
+> the airlock. So we target **~4.3 L into the demijohn → ~4.0 L bottled**
+> (≈ 8 × 50 cl), starting from **~7 L of water**.
+
+## 1. The recipe (BJCP 18A — Blonde Ale)
+
+Simple but good: a clean, lightly-hopped pale golden ale, very forgiving for a
+first brew. Scaled to the 5 L demijohn.
+
+| Target | Value |
+|---|---|
+| Into fermenter (5 L demijohn) | **~4.3 L** (~0.7 L headspace) |
+| Finished (bottled) volume | **~4.0 L** (≈ 8 × 50 cl) |
+| Original Gravity (OG) | **1.044** |
+| Final Gravity (FG) | **1.010** |
+| ABV | **~4.5 %** |
+| Bitterness (IBU) | **~18** |
+| Colour | **~7 EBC** (~3.5 SRM, pale gold) |
+| Boil | **60 min** |
+
+**Fermentables (~1.0 kg total)**
+- 900 g **Pilsner malt** (base)
+- 100 g **Vienna malt** (roundness + golden hue)
+
+**Hops — single variety, Cascade** (or Saaz for a more floral/noble character)
+- 10 g **Cascade** @ **60 min** (bitterness)
+- 6 g **Cascade** @ **flameout / whirlpool** (light aroma)
+
+**Yeast** — **SafAle US-05** (dry, clean, very tolerant). ~½ sachet is plenty for
+this volume (a whole 11 g sachet is also fine). Ferment **18–20 °C**.
+
+**Water** — dechlorinated tap water (Campden tablet, or rest 24 h). Optional
+pinch of gypsum. Kept deliberately simple.
+
+## 2. Volume planning (the water cascade)
+
+Target the **fermenter**, then add back every loss up to the strike water.
+Scenario A (large pot, full-volume BIAB, **no sparge**) is this brew.
+
+| Stage | Volume | Loss |
+|---|---|---|
+| **Strike / mash water (all at once)** | **~7.0 L** | — |
+| − grain absorption (~1 L/kg) | → ~6.0 L | −1.0 L |
+| **Pre-boil** | **~6.0 L** | — |
+| − boil-off (60 min) + cooling shrink¹ | → ~4.8 L | −1.2 L |
+| **Post-boil (cooled)** | **~4.8 L** | — |
+| − kettle trub (hops, break) | → ~4.3 L | −0.5 L |
+| **Into the 5 L demijohn** (~0.7 L headspace) | **~4.3 L** | — |
+| − yeast/trub + bottling loss | → ~4.0 L | −0.3 L |
+| **🍺 Bottled** | **~4.0 L** (≈ 8 × 50 cl) | ✅ |
+
+> ¹ **Boil-off is equipment-dependent** (pot diameter, boil vigour); ~1 L/h is a
+> starting assumption — the app should let the user calibrate it and recompute
+> the cascade. Hot wort also shrinks ~4 % on cooling.
+
+**Scenario B — medium pot (~9–11 L): BIAB + dunk-sparge.** Same recipe, same
+~6 L pre-boil, same ~4 L bottled — only the mash water is split: mash in ~4 L,
+then dunk-sparge the bag in ~3 L at 75 °C and combine (adds one step). A pot
+< ~8 L can't boil ~6 L → out of scope (reduced batch / concentrated boil needed).
+
+## 3. Equipment
+
+- **Fermenter: 5 L demijohn (dame-jeanne)** — filled to ~4.3 L, leaving headspace
+  for krausen (a blow-off tube is a safe optional extra)
+- **Pot ≥ 10–12 L** (holds ~7 L mash + grain + headspace; boils ~6 L)
+- **BIAB bag** (large fine-mesh grain bag)
+- Thermometer · Hydrometer + test jar
+- Airlock + bung for the demijohn
+- Sanitizer (e.g. StarSan / Chemipro) · long spoon · sieve
+- ~8 × 50 cl bottles + caps + capper (or swing-top)
+- Ice bath for chilling · priming sugar (sucrose)
+
+## 4. Shopping list (ingredients)
+
+- 900 g **Pilsner malt** + 100 g **Vienna malt** (≈ 1.0 kg)
+- 16 g **Cascade** hops (10 g + 6 g)
+- 1 sachet **SafAle US-05**
+- ~22 g **priming sugar** (sucrose) for ~4 L
+- Campden / dechlorinated water
+
+## 5. Brew day — step by step (Scenario A, full-volume)
+
+1. **Sanitize** everything that touches the wort after the boil (demijohn,
+   airlock, spoon, hydrometer, funnel).
+2. **Heat strike water** — ~7 L to ~72 °C.
+3. **Mash** — put the BIAB bag in, stir in the grain, hold **66 °C for 60 min**.
+4. **Remove the bag** — lift, drain, gentle squeeze. *(Scenario B: dunk-sparge
+   here.)*
+5. **Boil — 60 min.** At the start of the boil add **10 g Cascade** (60-min);
+   at flameout add **6 g Cascade**.
+6. **Whirlpool** — stir, rest ~10 min.
+7. **Chill** to ~20 °C (ice bath).
+8. **Transfer ~4.3 L** into the sanitized 5 L demijohn (leave trub behind, keep
+   the ~0.7 L headspace). **Measure OG** (~1.044) and aerate.
+9. **Pitch** US-05; fit the bung + airlock.
+
+## 6. Fermentation
+
+- Ferment at **18–20 °C** for **~10–14 days**, demijohn out of direct light.
+- Watch for blow-off in the first 2–3 days (krausen peak) — the headspace should
+  absorb it; a blow-off tube is the safe fallback.
+- Done when gravity is **stable** over 2–3 days near **~1.010**.
+- Record OG and FG → the app computes **ABV = (OG − FG) × 131.25**.
+
+## 7. Bottling + conditioning
+
+1. Sanitize bottles + caps + siphon.
+2. **Priming sugar** — ~**22 g** sucrose for ~4 L (≈ 2.4 vol CO₂); use the app's
+   carbonation calculator for the exact amount.
+3. Dissolve sugar in a little boiled water, mix gently into the beer, bottle,
+   cap (leave the demijohn's yeast sediment behind).
+4. **Condition** ~2 weeks at ~20 °C, then refrigerate. 🍻
+
+## 8. What the app must make explicit (requirements)
+
+This brew surfaces concrete requirements for the novice journey:
+
+- **Fermenter capacity caps the batch** — the fermenter volume **and its
+  headspace** is the binding equipment constraint; the app derives the batch
+  size from it (here: 5 L demijohn → ferment ~4.3 L → ~4 L bottled), not from a
+  free "target".
+- **Volume planning shown explicitly** — recipe screen + brew-day guide display
+  the cascade (water needed → pre-boil → post-boil → fermenter → expected
+  bottles), driven by the user's pot **and** fermenter, with a calibratable
+  boil-off.
+- **Equipment drives the process** — pot size selects Scenario A vs B; the BIAB
+  bag + demijohn are required items.
+- **Pre-brew readiness checklists** — ingredients + equipment "have / missing"
+  before "Start the batch" unlocks.
+- **Step-by-step brew-day guide** — each phase: what to do, duration, next step
+  (no dead-ends), persisted on the real batch.
+- **Measurement entry** — OG / FG / temperature, ABV computed.
+- **Bottling + closure** — bottling step (priming via the calculator), a
+  "bottled" state, a closing screen.
+
+These map to the build phases A1–A4 (pre-batch) and B1–B3 (batch → bottling).

--- a/docs/real-world-test/blonde-ale-5l-first-brew.md
+++ b/docs/real-world-test/blonde-ale-5l-first-brew.md
@@ -75,7 +75,7 @@ then dunk-sparge the bag in ~3 L at 75 °C and combine (adds one step). A pot
 
 - **Fermenter: 5 L demijohn (dame-jeanne)** — filled to ~4.3 L, leaving headspace
   for krausen (a blow-off tube is a safe optional extra)
-- **Pot ≥ 10–12 L** (holds ~7 L mash + grain + headspace; boils ~6 L)
+- **Pot ≥ 12 L** (must hold ~7 L mash + grain + headspace; boils ~6 L)
 - **BIAB bag** (large fine-mesh grain bag)
 - Thermometer · Hydrometer + test jar
 - Airlock + bung for the demijohn

--- a/docs/real-world-test/blonde-ale-5l-first-brew.md
+++ b/docs/real-world-test/blonde-ale-5l-first-brew.md
@@ -43,7 +43,7 @@ first brew. Scaled to the 5 L demijohn.
 **Yeast** — **SafAle US-05** (dry, clean, very tolerant). ~½ sachet is plenty for
 this volume (a whole 11 g sachet is also fine). Ferment **18–20 °C**.
 
-**Water** — dechlorinated tap water (Campden tablet, or rest 24 h). Optional
+**Water** — dechlorinated tap water (Campden tablet, or let it stand 24 h). Optional
 pinch of gypsum. Kept deliberately simple.
 
 ## 2. Volume planning (the water cascade)
@@ -63,9 +63,11 @@ Scenario A (large pot, full-volume BIAB, **no sparge**) is this brew.
 | − yeast/trub + bottling loss | → ~4.0 L | −0.3 L |
 | **🍺 Bottled** | **~4.0 L** (≈ 8 × 50 cl) | ✅ |
 
-> ¹ **Boil-off is equipment-dependent** (pot diameter, boil vigour); ~1 L/h is a
-> starting assumption — the app should let the user calibrate it and recompute
-> the cascade. Hot wort also shrinks ~4 % on cooling.
+> ¹ This **−1.2 L** line bundles two effects: ~1.0 L **boil-off** over the 60-min
+> boil (the ~1 L/h starting assumption) plus ~0.2 L **cooling shrink** (hot wort
+> contracts ~4 % as it cools from boiling to ~20 °C). Boil-off is
+> equipment-dependent (pot diameter, boil vigour); the app should let the user
+> calibrate the rate and recompute the cascade.
 
 **Scenario B — medium pot (~9–11 L): BIAB + dunk-sparge.** Same recipe, same
 ~6 L pre-boil, same ~4 L bottled — only the mash water is split: mash in ~4 L,
@@ -100,7 +102,7 @@ then dunk-sparge the bag in ~3 L at 75 °C and combine (adds one step). A pot
 3. **Mash** — put the BIAB bag in, stir in the grain, hold **66 °C for 60 min**.
 4. **Remove the bag** — lift, drain, gentle squeeze. *(Scenario B: dunk-sparge
    here.)*
-5. **Boil — 60 min.** At the start of the boil add **5 g Cascade** (60-min,
+5. **Boil — 60 min.** At the start of the boil add **5 g Cascade** (60 min,
    ~18 IBU); at flameout add **4 g Cascade**.
 6. **Whirlpool** — stir, rest ~10 min.
 7. **Chill** to ~20 °C (ice bath).


### PR DESCRIPTION
## What

The source-of-truth **recipe + brew guide** for Brasse-Bouillon's **first real-world test brew** (the founder's first beer, app-guided): a beginner **Blonde Ale (BJCP 18A)**, BIAB, scaled to the **binding constraint — a 5 L demijohn fermenter**.

- **Target**: ferment ~4.3 L in the 5 L demijohn (headspace for krausen) → **~4 L bottled** (≈ 8 × 50 cl), from **~7 L** of strike water.
- ~1.0 kg grain (900 Pilsner + 100 Vienna), single **Cascade** hop (10 g @60 + 6 g flameout), **US-05**. OG 1.044 / FG 1.010 / ~4.5 % ABV / ~18 IBU / ~7 EBC.
- Full **volume cascade** (water → pre-boil → post-boil → fermenter → bottles), equipment-dependent (calibratable boil-off); brew-day steps; bottling; fermentation.

## Why

This is the conception-first artifact behind the "minimum-functional novice journey then real brew" plan. It also documents the **requirements it places on the app** (§8): **fermenter capacity caps the batch**, **explicit volume planning**, **equipment-driven process** (pot size → full-volume vs sparge), pre-brew checklists, step-by-step brew-day guide, measurement entry, bottling + closure. These map to build phases A1–A4 and B1–B3.

## Scope

Docs only (`docs/real-world-test/`). The simplest path (large pot, full-volume BIAB) is the primary guide; the sparge variant + larger-batch options are noted for later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new beginner guide for brewing a 5-liter Blonde Ale, including scaled BJCP-style recipe targets, volume planning with water-loss scenarios, equipment and shopping lists, step-by-step brew day instructions, fermentation monitoring and ABV calculation guidance, and bottling/conditioning with priming sugar and carbonation support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->