### PR TITLE
docs(brew-prep/architecture): UML deliverables + ADR-0020 (equipment-driven volume planning)

### DIFF
--- a/docs/architecture/decisions/0020-equipment-driven-volume-planning.md
+++ b/docs/architecture/decisions/0020-equipment-driven-volume-planning.md
@@ -1,0 +1,75 @@
+# ADR-0020 — Equipment-driven batch sizing & volume planning (computed in the backend)
+
+**Status**  Proposed
+**Date**    2026-06-19
+**Owners**  @benoit-bremaud
+
+> Settles, for the novice brew-preparation journey, two coupled questions that
+> Brasse-Bouillon's **first real-world brew** surfaced: (1) **what sets the batch
+> volume**, and (2) **where the volume math runs**. Conception:
+> [`../diagrams/brew-prep/`](../diagrams/brew-prep/). Recipe content:
+> [`../../real-world-test/blonde-ale-5l-first-brew.md`](../../real-world-test/blonde-ale-5l-first-brew.md).
+> Relates: ADR-0002 (centralized NestJS backend), ADR-0001 (build for today).
+
+## Context
+
+The first real brew (a 5 L demijohn) showed that a brewer's **equipment**, not a
+free "target volume", determines the batch:
+
+- a **5 L fermenter** minus krausen headspace caps the wort (~4.3 L → ~4 L
+  bottled);
+- the **pot (kettle) size** decides the BIAB method (full-volume vs dunk-sparge);
+- boil-off + grain absorption + kettle/fermenter losses set the **water cascade**
+  (strike → pre-boil → post-boil → fermenter → bottled).
+
+The plan must be shown **pre-batch** (reversible) and **persisted into the batch**
+at launch (the brew runs against it). Two decisions follow: how the volume is
+set, and where the math lives — mobile or API.
+
+## Decision
+
+**D1 — The fermenter capacity (minus headspace) caps the batch.** Batch size is
+*derived from equipment*, not entered as a fixed target:
+`intoFermenter = fermenterCapacity × (1 − headspaceRatio)`;
+`bottled = intoFermenter − fermenterLoss`; the recipe scales to that volume.
+
+**D2 — The pot (kettle) capacity selects the method.** If the kettle holds the
+full-volume mash (strike water + grain) → **full-volume BIAB, no sparge**; else →
+**BIAB + dunk-sparge** (split mash + rinse). Pots too small to boil the pre-boil
+volume are out of scope (reduced batch / concentrated boil deferred).
+
+**D3 — The volume plan is computed in the backend and snapshotted into the
+batch.** A pure NestJS **domain service** computes the cascade from the recipe
+targets + the brewer's equipment profile, exposed via an endpoint for the
+pre-batch preview, and **persisted on the batch** at launch.
+
+**D4 — Boil-off and the loss constants are calibratable inputs**, defaulted and
+stored on the equipment profile; the plan recomputes when they change.
+
+## Consequences
+
+- Single source of truth for the brewing math (tested once, reused by a future
+  web client); consistent with **ADR-0002**.
+- The batch carries a reproducible, authoritative volume plan.
+- **Equipment becomes a first-class input** (capacities), not just an ownership
+  checklist — this reshapes the equipment feature (build phase A3).
+- Cost: a network round-trip for the pre-batch preview — acceptable (inputs
+  change rarely, not per-keystroke). A mobile mirror for instant slider feedback
+  is a deferred optimisation (YAGNI).
+
+### Rejected (for now)
+
+- **Frontend-only calc** — simplest today (mobile-only app), instant, offline;
+  but duplicates domain logic when a web client arrives and forces the backend to
+  trust client-sent numbers when persisting. Re-open if offline brew-day
+  calculation becomes essential.
+- **Hybrid (shared function, backend authoritative + mobile mirror)** — most
+  robust but more complexity/maintenance; adopt only if instant feedback **and**
+  authority both prove necessary.
+
+## Relation to other ADRs
+
+- **Implements ADR-0002** (logic centralized in NestJS; mobile talks only to the
+  API via the http-client).
+- **Respects ADR-0001** (build for today): one canonical backend calc now, mobile
+  mirror deferred.

--- a/docs/architecture/decisions/0020-equipment-driven-volume-planning.md
+++ b/docs/architecture/decisions/0020-equipment-driven-volume-planning.md
@@ -46,6 +46,26 @@ pre-batch preview, and **persisted on the batch** at launch.
 **D4 — Boil-off and the loss constants are calibratable inputs**, defaulted and
 stored on the equipment profile; the plan recomputes when they change.
 
+## Design patterns
+
+The conception **names** the DDD/GoF patterns it already relies on — vocabulary
+to make the contract explicit, not new abstractions (no speculative code;
+ADR-0001 / KISS):
+
+- **Domain Service** — `VolumePlanner`. The cascade depends on *both* the recipe
+  and the equipment, so it belongs to no single entity; a stateless domain
+  service owns it. Realizes D3.
+- **Value Object** — `VolumePlan` is immutable and identity-less: defined
+  entirely by its values (strike → pre-boil → … → bottled + method), recomputed,
+  never mutated in place.
+- **Snapshot / Memento** — at launch the `VolumePlan` is captured and frozen onto
+  the batch (D3), so a batch keeps the exact numbers it was brewed with even if
+  the recipe or the equipment profile changes later.
+- **Strategy (seam, not yet coded)** — the `Method` choice (full-volume vs
+  dunk-sparge, D2) is the natural Strategy point. A single conditional is enough
+  for two methods today; promote to a `MashStrategy` interface only if a third
+  method or per-method divergence appears (YAGNI).
+
 ## Consequences
 
 - Single source of truth for the brewing math (tested once, reused by a future

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -56,6 +56,8 @@ Every ADR follows the same skeleton (inspired by Michael Nygard's template):
 | [0016](0016-recipe-equivalence-matching-v2.md) | Recipe-equivalence matching v2 (weighted criteria + completeness + BJCP families) | Proposed | 2026-06-05 |
 | [0017](0017-beer-ibu-colour-min-max-intervals.md) | Beer IBU & colour stored as min/max intervals | Proposed | 2026-06-05 |
 | [0018](0018-admin-moderation-surface.md) | Admin/moderation surface (in-app CREATOR, secured at the API) | Accepted | 2026-06-15 |
+| [0019](0019-testing-strategy-and-quality-gates.md) | Testing strategy: test pyramid, e2e tooling per surface, CI quality gates | Proposed | 2026-06-17 |
+| [0020](0020-equipment-driven-volume-planning.md) | Equipment-driven batch sizing & volume planning (computed in the backend) | Proposed | 2026-06-19 |
 
 > **Numbers 0006–0008 are reserved** (not yet drafted) for decisions already
 > referenced by open epics: 0006 — private journal vs. social product (#833),

--- a/docs/architecture/diagrams/brew-prep/01-use-case.md
+++ b/docs/architecture/diagrams/brew-prep/01-use-case.md
@@ -1,0 +1,52 @@
+# Use case diagram — brew-prep — Prepare a brew (novice, pre-batch)
+
+> **Feature**: first real-world brew — the reversible pre-batch readiness journey.
+> **Related ADRs**: ADR-0020 (equipment-driven volume planning), ADR-0002.
+> **Recipe**: [`../../../real-world-test/blonde-ale-5l-first-brew.md`](../../../real-world-test/blonde-ale-5l-first-brew.md).
+
+## Context
+
+The **reversible** pre-batch journey: from "I have an imported recipe" to "I'm
+ready to start the batch". Starting the batch is the **non-return point** → owned
+by the brewing-session epic (build phase B), out of scope here. Use cases are
+grouped by the **Brew preparation** domain (UML 2.5: by domain, never by backend
+package).
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Novice brewer<br/>(first brew)"))
+  subgraph SYSTEM ["Brasse-Bouillon"]
+    subgraph Prep ["Brew preparation domain"]
+      UC1(("Choose a recipe"))
+      UC2(("Review recipe & volume plan"))
+      UC3(("Declare my equipment & capacities"))
+      UC4(("Check ingredient readiness"))
+      UC5(("Check equipment readiness"))
+      UC6(("Confirm ready to brew"))
+    end
+  end
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+```
+
+## Notes
+
+- **Relationships (real UML, not navigation):** UC2 **«include»** UC3 — the volume
+  plan is *derived from* the declared equipment (ADR-0020 D1/D2), so reviewing the
+  plan presumes equipment is known. UC6 **«include»** UC4 + UC5 — "ready" requires
+  both checklists complete.
+- **Proportionality:** UC1 (browse/choose) and the recipe-stats part of UC2 are
+  simple reads → stay at the textual spec level. The non-trivial flow (equipment
+  → backend volume plan → checklists → gate) is in the sequence (02).
+- **Cockburn (brief) — UC6 *Confirm ready to brew*:** precondition = a recipe
+  imported + equipment declared; success guarantee = "Start the batch" is enabled
+  **only** when the ingredient and equipment checklists are both satisfied; the
+  confirmation hands off to the irreversible batch start.
+- **Out of scope:** starting the batch + the brew day (brewing-session epic).
+  **Skipped diagram types:** data-flow (no PII in this journey).

--- a/docs/architecture/diagrams/brew-prep/02-sequence-plan-and-confirm.md
+++ b/docs/architecture/diagrams/brew-prep/02-sequence-plan-and-confirm.md
@@ -17,7 +17,7 @@ sequenceDiagram
   autonumber
   actor B as Novice brewer
   participant M as Mobile (Brew-prep screen)
-  participant API as "NestJS /recipes · /equipment · /brew-plan"
+  participant API as "NestJS API (recipes · equipment · volume-plan)"
   participant DB as DB
   B->>M: Open the imported blonde recipe
   M->>API: GET recipe targets + my equipment profile

--- a/docs/architecture/diagrams/brew-prep/02-sequence-plan-and-confirm.md
+++ b/docs/architecture/diagrams/brew-prep/02-sequence-plan-and-confirm.md
@@ -1,0 +1,50 @@
+# Sequence diagram — brew-prep — Plan volumes from equipment & confirm readiness
+
+> **Feature**: first real-world brew — pre-batch volume planning + readiness gate.
+> **Related ADRs**: ADR-0020 (backend-computed plan, fermenter caps batch), ADR-0002.
+
+## Context
+
+The one non-trivial pre-batch flow: the app derives the **volume plan** from the
+recipe targets + the brewer's equipment **in the backend** (ADR-0020 D3), shows
+it with the readiness checklists, and unlocks "Start the batch" only when both
+checklists pass. Batch start itself (the non-return point) is out of scope.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor B as Novice brewer
+  participant M as Mobile (Brew-prep screen)
+  participant API as "NestJS /recipes · /equipment · /brew-plan"
+  participant DB as DB
+  B->>M: Open the imported blonde recipe
+  M->>API: GET recipe targets + my equipment profile
+  API->>DB: load recipe + equipment-profile
+  DB-->>API: targets, capacities (fermenter+headspace, kettle, boil-off, losses)
+  API-->>M: targets + equipment
+  M->>API: "GET /recipes/:id/volume-plan?profile=…"
+  API->>API: "VolumePlanner.compute() — fermenter caps batch (D1),<br/>kettle selects method (D2), cascade strike→…→bottled"
+  API-->>M: VolumePlan (cascade + method)
+  M-->>B: "show cascade + scaled ingredients + required equipment"
+  loop each ingredient / equipment item
+    B->>M: tick "I have it" / leave "missing"
+  end
+  alt both checklists complete
+    M-->>B: enable "Start the batch"
+  else something missing
+    M-->>B: keep disabled + list what's missing
+  end
+  Note over B,API: "Start the batch" = non-return → brewing-session epic (phase B).<br/>At launch the API snapshots the VolumePlan onto the batch (ADR-0020 D3).
+```
+
+## Notes
+
+- **Egress explicit:** the mobile reaches the API only via `core/http/http-client`;
+  the brewing math runs in the API domain service (ADR-0020 D3), never in the
+  screen.
+- The checklists are **client state pre-batch** (reversible); they gate the launch
+  (UC6). The launch handoff persists the plan (single source of truth).
+- The round-trip cost is accepted (ADR-0020): the inputs change rarely (pick a
+  pot, set boil-off), not per-keystroke; a mobile mirror is deferred.

--- a/docs/architecture/diagrams/brew-prep/03-component.md
+++ b/docs/architecture/diagrams/brew-prep/03-component.md
@@ -23,7 +23,7 @@ flowchart LR
   subgraph API ["packages/api (NestJS)"]
     RecipeC["Recipe controller"]
     EquipC["Equipment controller"]
-    PlanC["Brew-plan controller"]
+    PlanC["Volume-plan controller (GET /recipes/:id/volume-plan)"]
     Planner["VolumePlanner (domain service)"]
     BatchC["Batch controller (start → snapshot plan)"]
     PlanC --> Planner

--- a/docs/architecture/diagrams/brew-prep/03-component.md
+++ b/docs/architecture/diagrams/brew-prep/03-component.md
@@ -1,0 +1,46 @@
+# Component diagram — brew-prep — where the brew-prep logic runs
+
+> **Feature**: first real-world brew — pre-batch structural view.
+> **Related ADRs**: ADR-0020 (backend volume planning), ADR-0002 (NestJS egress).
+
+## Context
+
+Structural view of the pre-batch journey: which package owns what, making the
+**backend** the home of the volume math explicit (ADR-0020 D3) and the single
+egress through the http-client (ADR-0002).
+
+## Diagram
+
+```mermaid
+flowchart LR
+  subgraph Mobile ["packages/mobile-app"]
+    Screen["Brew-prep screen"]
+    UCm["use-cases (display + checklists)"]
+    HTTP["core/http/http-client"]
+    Screen --> UCm
+    UCm --> HTTP
+  end
+  subgraph API ["packages/api (NestJS)"]
+    RecipeC["Recipe controller"]
+    EquipC["Equipment controller"]
+    PlanC["Brew-plan controller"]
+    Planner["VolumePlanner (domain service)"]
+    BatchC["Batch controller (start → snapshot plan)"]
+    PlanC --> Planner
+    BatchC --> Planner
+  end
+  HTTP --> RecipeC
+  HTTP --> EquipC
+  HTTP --> PlanC
+  HTTP --> BatchC
+```
+
+## Notes
+
+- The **`VolumePlanner` domain service** is the single source of truth for the
+  cascade (ADR-0020 D3); both the pre-batch preview (`PlanC`) and batch start
+  (`BatchC`, which snapshots it) call it — no duplicate math.
+- **No direct `fetch` in the mobile** — egress only through
+  `core/http/http-client` (ADR-0002, repo forbidden-pattern rule).
+- The equipment profile (capacities) lives in the API (reuses the existing
+  `equipment-profiles`); the mobile reads/edits it.

--- a/docs/architecture/diagrams/brew-prep/04-class.md
+++ b/docs/architecture/diagrams/brew-prep/04-class.md
@@ -66,7 +66,10 @@ classDiagram
   `intoFermenterL = fermenterCapacityL × (1 − fermenterHeadspaceRatio)`;
   `bottledL = intoFermenterL − fermenterLossL`; the cascade is back-calculated up
   to `strikeWaterL`;
-  `method = kettleCapacityL ≥ (preBoilL + grain) ? FULL_VOLUME : DUNK_SPARGE`.
+  `method = kettleCapacityL ≥ (strikeWaterL + grainVolumeL) ? FULL_VOLUME : DUNK_SPARGE`
+  — the kettle must hold the **mash-in volume** (strike water + grain, grain
+  displacing ~0.67 L/kg) *during the mash*, **not** the post-boil wort (the grain
+  is lifted out before the boil). Matches ADR-0020 D2.
 - `VolumePlan` is **computed and persisted by the backend** — not stored on the
   recipe; snapshotted onto the batch at launch (ADR-0020 D3).
 - `BrewReadiness.readyToLaunch = ingredientChecklist.isComplete() && equipmentChecklist.isComplete()` (UC6).

--- a/docs/architecture/diagrams/brew-prep/04-class.md
+++ b/docs/architecture/diagrams/brew-prep/04-class.md
@@ -1,0 +1,73 @@
+# Class diagram — brew-prep — volume planning & readiness model
+
+> **Feature**: first real-world brew — the pre-batch domain model.
+> **Related ADRs**: ADR-0020 (equipment-driven, backend-computed).
+
+## Context
+
+The domain types behind ADR-0020: how an `EquipmentProfile` + a `Recipe`'s
+targets derive a `VolumePlan`, and how readiness gates the launch. Crown jewel:
+**the fermenter caps the batch**.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class Recipe {
+    +UUID id
+    +string style
+    +number ogTarget
+    +number fgTarget
+    +number ibu
+    +number ebc
+  }
+  class EquipmentProfile {
+    +number fermenterCapacityL
+    +number fermenterHeadspaceRatio
+    +number kettleCapacityL
+    +number boilOffRatePerHourL
+    +number grainAbsorptionLPerKg
+    +number kettleLossL
+    +number fermenterLossL
+  }
+  class VolumePlan {
+    +Method method
+    +number strikeWaterL
+    +number spargeWaterL
+    +number preBoilL
+    +number postBoilL
+    +number intoFermenterL
+    +number bottledL
+  }
+  class ChecklistItem {
+    +string name
+    +string qty
+    +boolean required
+    +boolean have
+  }
+  class ReadinessChecklist {
+    +Kind kind
+    +ChecklistItem[] items
+    +isComplete() boolean
+  }
+  class BrewReadiness {
+    +boolean readyToLaunch
+  }
+  Recipe "1" ..> "1" VolumePlan : targets feed
+  EquipmentProfile "1" ..> "1" VolumePlan : caps & method (D1/D2)
+  BrewReadiness "1" o-- "1" VolumePlan
+  BrewReadiness "1" o-- "2" ReadinessChecklist
+  ReadinessChecklist "1" *-- "1..*" ChecklistItem
+```
+
+## Notes
+
+- **Derivation (ADR-0020 D1/D2):**
+  `intoFermenterL = fermenterCapacityL × (1 − fermenterHeadspaceRatio)`;
+  `bottledL = intoFermenterL − fermenterLossL`; the cascade is back-calculated up
+  to `strikeWaterL`;
+  `method = kettleCapacityL ≥ (preBoilL + grain) ? FULL_VOLUME : DUNK_SPARGE`.
+- `VolumePlan` is **computed and persisted by the backend** — not stored on the
+  recipe; snapshotted onto the batch at launch (ADR-0020 D3).
+- `BrewReadiness.readyToLaunch = ingredientChecklist.isComplete() && equipmentChecklist.isComplete()` (UC6).
+- Enums: `Method` = {FULL_VOLUME, DUNK_SPARGE}; `Kind` = {INGREDIENT, EQUIPMENT}.

--- a/docs/architecture/diagrams/brew-prep/04-class.md
+++ b/docs/architecture/diagrams/brew-prep/04-class.md
@@ -54,11 +54,16 @@ classDiagram
   class BrewReadiness {
     +boolean readyToLaunch
   }
+  class Batch {
+    <<brewing-session epic>>
+    +UUID id
+  }
   Recipe "1" ..> "1" VolumePlan : targets feed
   EquipmentProfile "1" ..> "1" VolumePlan : caps & method (D1/D2)
   BrewReadiness "1" o-- "1" VolumePlan
   BrewReadiness "1" o-- "2" ReadinessChecklist
   ReadinessChecklist "1" *-- "1..*" ChecklistItem
+  Batch "1" *-- "1" VolumePlan : snapshot at launch (Memento)
 ```
 
 ## Notes
@@ -72,7 +77,10 @@ classDiagram
   displacing ~0.67 L/kg) *during the mash*, **not** the post-boil wort (the grain
   is lifted out before the boil). Matches ADR-0020 D2.
 - `VolumePlan` is **computed and persisted by the backend** — not stored on the
-  recipe; snapshotted onto the batch at launch (ADR-0020 D3).
+  recipe; snapshotted onto the **`Batch`** at launch (ADR-0020 D3). `Batch` is
+  shown as a stub only: it is owned by the **brewing-session epic (phase B)**,
+  out of this conception's scope — it appears here solely to anchor the snapshot
+  (Memento) target and make the persistence contract explicit.
 - `BrewReadiness.readyToLaunch = ingredientChecklist.isComplete() && equipmentChecklist.isComplete()` (UC6).
 - Enums: `Method` = {FULL_VOLUME, DUNK_SPARGE}; `Kind` = {INGREDIENT, EQUIPMENT}.
 - **Design patterns (named, see ADR-0020 § Design patterns):** `VolumePlan` is a

--- a/docs/architecture/diagrams/brew-prep/04-class.md
+++ b/docs/architecture/diagrams/brew-prep/04-class.md
@@ -31,6 +31,7 @@ classDiagram
     +number fermenterLossL
   }
   class VolumePlan {
+    <<value object>>
     +Method method
     +number strikeWaterL
     +number spargeWaterL
@@ -74,3 +75,10 @@ classDiagram
   recipe; snapshotted onto the batch at launch (ADR-0020 D3).
 - `BrewReadiness.readyToLaunch = ingredientChecklist.isComplete() && equipmentChecklist.isComplete()` (UC6).
 - Enums: `Method` = {FULL_VOLUME, DUNK_SPARGE}; `Kind` = {INGREDIENT, EQUIPMENT}.
+- **Design patterns (named, see ADR-0020 § Design patterns):** `VolumePlan` is a
+  **Value Object** (immutable, identity-less — the `«value object»` stereotype);
+  the derivation `Recipe + EquipmentProfile → VolumePlan` is owned by the
+  **Domain Service** `VolumePlanner` (component 03); the launch snapshot is a
+  **Memento** (state 05); and `Method` is a **Strategy seam** — a plain
+  conditional today, promoted to a `MashStrategy` only if a third method appears
+  (YAGNI).

--- a/docs/architecture/diagrams/brew-prep/05-state-readiness.md
+++ b/docs/architecture/diagrams/brew-prep/05-state-readiness.md
@@ -31,3 +31,6 @@ stateDiagram-v2
   launch again (UC6).
 - `BatchStarted` is **irreversible**: the brew then runs against the snapshotted
   plan (ADR-0020 D3), and the brewing-session epic owns everything after.
+- The `Ready → BatchStarted (snapshot the plan)` transition is a **Memento**: the
+  `VolumePlan` Value Object is captured and frozen onto the batch, so a started
+  batch keeps the exact numbers it was brewed with (ADR-0020 § Design patterns).

--- a/docs/architecture/diagrams/brew-prep/05-state-readiness.md
+++ b/docs/architecture/diagrams/brew-prep/05-state-readiness.md
@@ -1,0 +1,33 @@
+# State diagram — brew-prep — the pre-batch readiness gate
+
+> **Feature**: first real-world brew — the pre-batch lifecycle.
+> **Related ADRs**: ADR-0020.
+
+## Context
+
+The lifecycle of a brew preparation, from recipe chosen to the **irreversible**
+batch start. Everything before `BatchStarted` is reversible/editable;
+`BatchStarted` is the non-return boundary handed to the brewing-session epic.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> RecipeChosen: import a recipe
+  RecipeChosen --> Planned: declare equipment → backend computes the volume plan
+  Planned --> Checking: show ingredient + equipment checklists
+  Checking --> Checking: tick / untick an item
+  Checking --> Ready: both checklists complete
+  Ready --> Checking: an item becomes missing
+  Ready --> BatchStarted: confirm "Start the batch" (snapshot the plan)
+  BatchStarted --> [*]
+```
+
+## Notes
+
+- `Planned` **requires equipment** (ADR-0020 D1/D2): no equipment → no plan, no
+  meaningful volumes.
+- `Ready ⇄ Checking` keeps the gate honest — unchecking an item disables the
+  launch again (UC6).
+- `BatchStarted` is **irreversible**: the brew then runs against the snapshotted
+  plan (ADR-0020 D3), and the brewing-session epic owns everything after.


### PR DESCRIPTION
## What

Conception-first UML for the **pre-batch novice journey** (the reversible "prepare a brew" half of the first real-world brew), plus the ADR that settles the architecture question it raised.

- **ADR-0020** (Proposed) — *Equipment-driven batch sizing & volume planning, computed in the backend*:
  - **D1** the fermenter capacity (− krausen headspace) **caps the batch** — volume is derived from equipment, not a free target;
  - **D2** the pot (kettle) selects the BIAB method (full-volume vs dunk-sparge);
  - **D3** the volume math is a **backend domain service**, exposed for the pre-batch preview and **snapshotted onto the batch** at launch (single source of truth, ADR-0002);
  - **D4** boil-off + losses are calibratable.
  - Rejects (for now) frontend-only and hybrid calc.
- **diagrams/brew-prep/** (Mermaid, all render clean): `01-use-case` (prepare-a-brew domain), `02-sequence` (equipment → backend volume plan → checklists → launch gate), `03-component` (VolumePlanner in the API; single egress via http-client), `04-class` (EquipmentProfile + Recipe → VolumePlan; readiness model), `05-state` (reversible prep → irreversible BatchStarted). data-flow skipped (no PII).
- decisions/README index: adds the missing **0019** + **0020** rows.

## Why

The first real brew showed the brewer's **equipment drives the whole plan** (a 5 L demijohn caps the batch; the pot picks the method). This formalizes that as the contract before any code (UML-first), and answers "front or back?" for the volume math → backend (domain logic, persisted, reused by a future web client).

## Scope

Docs only. Realizes the conception behind build phases **A1–A4** (pre-batch). A full diagram review will be done together with the founder. Refs the first-real-brew effort; closes no issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added/updated architecture materials for brew preparation, including the equipment-driven batch sizing & volume planning decision record.
  * Published new architecture diagrams and flow documentation covering use cases, sequence “plan & confirm,” component ownership, and domain readiness/state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->