### PR TITLE
docs: accept ADR-0020 + record PR #1248

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Currently accepted ADRs (see each file for the `Status` line and full rationale)
 - [ADR-0014 — Website hosting on Cloudflare Pages, DNS authority on Cloudflare](docs/architecture/decisions/0014-website-hosting-cloudflare-pages-dns.md)
 - [ADR-0015 — Beer ingestion & enrichment strategy (staging → human-gated promotion)](docs/architecture/decisions/0015-beer-ingestion-enrichment-strategy.md)
 - [ADR-0018 — Admin/moderation surface: in-app CREATOR moderation, secured at the NestJS API](docs/architecture/decisions/0018-admin-moderation-surface.md)
+- [ADR-0020 — Equipment-driven batch sizing & volume planning (computed in the backend)](docs/architecture/decisions/0020-equipment-driven-volume-planning.md)
 
 When a new ADR is accepted, add its file link here (no dates, no per-ADR summaries — open the file for the live status and content). When reviewing a PR, flag any diff that violates these ADRs and cite the ADR number and clause in the review comment.
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -13,7 +13,7 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 - **Decisions**:
   - `equipment-drives-the-plan` — batch size is derived from the fermenter capacity, not a free target; the kettle picks full-volume vs dunk-sparge. Recorded on ADR-0020 D1/D2.
   - `volume-math-in-backend` — the cascade is computed by a NestJS domain service (single source of truth, reused by a future web client) and persisted on the batch at launch; frontend-only and hybrid rejected for now. Recorded on ADR-0020 D3, implements ADR-0002.
-- Reviews — Codex P2 + Copilot (method-fit formula corrected to the mash-in volume `kettleCapacityL >= strikeWaterL + grainVolumeL` per D2; endpoint unified to `GET /recipes/:id/volume-plan`; cross-doc links to `docs/real-world-test/` resolved by updating the branch from main after #1247), CodeRabbit (Critical formula match + a `Batch` stub added to the class diagram to anchor the snapshot/Memento target); all threads resolved.
+- Reviews — the method-fit formula was corrected to the mash-in volume `kettleCapacityL >= strikeWaterL + grainVolumeL` (per D2, not the pre-boil wort); the volume-plan endpoint was unified to `GET /recipes/:id/volume-plan`; the cross-doc links to `docs/real-world-test/` were resolved by updating the branch from main after #1247; and a `Batch` stub was added to the class diagram to anchor the snapshot/Memento target. All review threads resolved.
 
 ### PR #1247 merged (`f0b4f33`) — docs(brewing): beginner blonde ale recipe + volume cascade (first real-world brew)
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,14 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-06-22
 
+### PR #1248 merged (`2ce799a`) — docs(brew-prep/architecture): UML deliverables + ADR-0020 (equipment-driven volume planning)
+
+- Branch `docs/brew-prep-conception`. Conception for the first real-world brew's reversible **pre-batch** journey: `docs/architecture/decisions/0020-equipment-driven-volume-planning.md` + 5 diagrams under `docs/architecture/diagrams/brew-prep/` (use-case / sequence / component / class / state). ADR-0020 settles two coupled questions — **D1** the fermenter (minus headspace) caps the batch, **D2** the kettle selects the BIAB method, **D3** the volume plan is computed in a NestJS domain service and snapshotted onto the batch, **D4** boil-off/losses are calibratable. Joint diagram review with the founder: all 5 validated. **Design patterns named** (vocabulary, no speculative code): Domain Service (`VolumePlanner`), Value Object (`VolumePlan`, `«value object»`), Snapshot/Memento (launch-time plan freeze), Strategy seam (`Method`, a conditional today). ADR-0020 → **Accepted**; added to the CLAUDE.md ADR list + decisions index.
+- **Decisions**:
+  - `equipment-drives-the-plan` — batch size is derived from the fermenter capacity, not a free target; the kettle picks full-volume vs dunk-sparge. Recorded on ADR-0020 D1/D2.
+  - `volume-math-in-backend` — the cascade is computed by a NestJS domain service (single source of truth, reused by a future web client) and persisted on the batch at launch; frontend-only and hybrid rejected for now. Recorded on ADR-0020 D3, implements ADR-0002.
+- Reviews — Codex P2 + Copilot (method-fit formula corrected to the mash-in volume `kettleCapacityL >= strikeWaterL + grainVolumeL` per D2; endpoint unified to `GET /recipes/:id/volume-plan`; cross-doc links to `docs/real-world-test/` resolved by updating the branch from main after #1247), CodeRabbit (Critical formula match + a `Batch` stub added to the class diagram to anchor the snapshot/Memento target); all threads resolved.
+
 ### PR #1247 merged (`f0b4f33`) — docs(brewing): beginner blonde ale recipe + volume cascade (first real-world brew)
 
 - Branch `docs/blonde-first-brew`. Source-of-truth recipe doc `docs/real-world-test/blonde-ale-5l-first-brew.md` for the first real-world brew: a beginner BIAB Blonde Ale (BJCP 18A) scaled to the **fermenter constraint** (5 L demijohn → ferment ~4.3 L → ~4 L bottled, from ~7 L strike water), the full water cascade (strike → mash → pre-boil → boil-off → post-boil → kettle trub → fermenter → bottled), equipment + shopping lists, step-by-step brew day, and §8 the app requirements (fermenter caps the batch, explicit volume planning, equipment-driven process, readiness checklists, step guide, measurements, bottling). Feeds the seeded public recipe (build A1) and ADR-0020 (#1248).

--- a/docs/architecture/decisions/0020-equipment-driven-volume-planning.md
+++ b/docs/architecture/decisions/0020-equipment-driven-volume-planning.md
@@ -1,6 +1,6 @@
 # ADR-0020 — Equipment-driven batch sizing & volume planning (computed in the backend)
 
-**Status**  Proposed
+**Status**  Accepted
 **Date**    2026-06-19
 **Owners**  @benoit-bremaud
 

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -57,7 +57,7 @@ Every ADR follows the same skeleton (inspired by Michael Nygard's template):
 | [0017](0017-beer-ibu-colour-min-max-intervals.md) | Beer IBU & colour stored as min/max intervals | Proposed | 2026-06-05 |
 | [0018](0018-admin-moderation-surface.md) | Admin/moderation surface (in-app CREATOR, secured at the API) | Accepted | 2026-06-15 |
 | [0019](0019-testing-strategy-and-quality-gates.md) | Testing strategy: test pyramid, e2e tooling per surface, CI quality gates | Proposed | 2026-06-17 |
-| [0020](0020-equipment-driven-volume-planning.md) | Equipment-driven batch sizing & volume planning (computed in the backend) | Proposed | 2026-06-19 |
+| [0020](0020-equipment-driven-volume-planning.md) | Equipment-driven batch sizing & volume planning (computed in the backend) | Accepted | 2026-06-19 |
 
 > **Numbers 0006–0008 are reserved** (not yet drafted) for decisions already
 > referenced by open epics: 0006 — private journal vs. social product (#833),


### PR DESCRIPTION
Follow-up housekeeping after #1248 merged.

- **ADR-0020 → Accepted** — validated in the joint diagram review (all 5 brew-prep diagrams + the ADR content). Status flipped in the ADR file and the decisions index, and added to the CLAUDE.md accepted-ADR list (same pattern as ADR-0011/0015).
- **PROJECT_LOG** — records PR #1248 (brew-prep UML deliverables, the D1-D4 decisions, and the named design patterns: Domain Service, Value Object, Snapshot/Memento, Strategy seam).

Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural decision records to mark ADR-0020 (equipment-driven volume planning) as Accepted
  * Updated project documentation index and logs to reflect the latest architectural decisions and related work

<!-- end of auto-generated comment: release notes by coderabbit.ai -->