### PR TITLE
feat(api): seed the beginner blonde as a PUBLIC recipe (first real-world brew, A1)

### DIFF
--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -25,6 +25,13 @@ const NEIPA_ID = '00000000-0000-4000-8000-000000000002';
 const WHITE_IPA_ID = '00000000-0000-4000-8000-000000000003';
 const PUNK_IPA_ID = '00000000-0000-4000-8000-00000000000b';
 const GARNISHED_IDS = [SESSION_IPA_ID, NEIPA_ID, WHITE_IPA_ID, PUNK_IPA_ID];
+/** The first-real-brew beginner Blonde Ale — content-bearing like the
+ * garnished recipes, but NOT scan-reachable (it has no demo-bottle
+ * mapping); it is the recipe the app guides the founder's first brew. */
+const BLONDE_ID = '00000000-0000-4000-8000-00000000000c';
+/** Every recipe that ships full content (ingredients + steps): the
+ * four scan-reachable rows plus the first-real-brew blonde. */
+const CONTENT_BEARING_IDS = [...GARNISHED_IDS, BLONDE_ID];
 /** A recipe that intentionally stays metadata-only (Belgian Tripel). */
 const METADATA_ONLY_ID = '00000000-0000-4000-8000-000000000004';
 
@@ -44,7 +51,7 @@ function buildSubRepos(): {
 
 describe('seedPublicRecipes (Issue #701)', () => {
   describe('happy path', () => {
-    it('inserts all 11 curated recipes when the table is empty', async () => {
+    it('inserts all 12 curated recipes when the table is empty', async () => {
       const repo = buildRepoMock();
       repo.findOne.mockResolvedValue(null);
 
@@ -52,9 +59,9 @@ describe('seedPublicRecipes (Issue #701)', () => {
         repo as unknown as Repository<RecipeOrmEntity>,
       );
 
-      expect(result).toEqual({ inserted: 11, updated: 0, total: 11 });
-      expect(repo.create).toHaveBeenCalledTimes(11);
-      expect(repo.save).toHaveBeenCalledTimes(11);
+      expect(result).toEqual({ inserted: 12, updated: 0, total: 12 });
+      expect(repo.create).toHaveBeenCalledTimes(12);
+      expect(repo.save).toHaveBeenCalledTimes(12);
     });
 
     it('tags every inserted row as PUBLIC + system owner with the seed-declared is_official flag', async () => {
@@ -99,7 +106,7 @@ describe('seedPublicRecipes (Issue #701)', () => {
       const nonOfficials = createdRows.filter(
         (row) => row.is_official === false,
       );
-      expect(nonOfficials).toHaveLength(11);
+      expect(nonOfficials).toHaveLength(12);
     });
   });
 
@@ -118,9 +125,9 @@ describe('seedPublicRecipes (Issue #701)', () => {
         repo as unknown as Repository<RecipeOrmEntity>,
       );
 
-      expect(result).toEqual({ inserted: 0, updated: 11, total: 11 });
+      expect(result).toEqual({ inserted: 0, updated: 12, total: 12 });
       expect(repo.create).not.toHaveBeenCalled();
-      expect(repo.save).toHaveBeenCalledTimes(11);
+      expect(repo.save).toHaveBeenCalledTimes(12);
     });
 
     it('forces visibility back to PUBLIC and is_official back to false when overwriting a drifted row', async () => {
@@ -148,7 +155,7 @@ describe('seedPublicRecipes (Issue #701)', () => {
   describe('edge cases', () => {
     it('mixes inserts and updates when only some IDs already exist', async () => {
       const repo = buildRepoMock();
-      // First three IDs exist, last seven do not.
+      // First three IDs exist, last nine do not.
       let counter = 0;
       repo.findOne.mockImplementation(() => {
         counter += 1;
@@ -161,7 +168,7 @@ describe('seedPublicRecipes (Issue #701)', () => {
         repo as unknown as Repository<RecipeOrmEntity>,
       );
 
-      expect(result).toEqual({ inserted: 8, updated: 3, total: 11 });
+      expect(result).toEqual({ inserted: 9, updated: 3, total: 12 });
     });
 
     it('respects an explicit override list (e.g. tests, alternate demo data)', async () => {
@@ -178,8 +185,8 @@ describe('seedPublicRecipes (Issue #701)', () => {
       expect(result).toEqual({ inserted: 2, updated: 0, total: 2 });
     });
 
-    it('exposes 11 curated recipes covering IPA / Belgian / Strong / Lager families plus the official DIY Dog', () => {
-      expect(PUBLIC_RECIPES_SEED).toHaveLength(11);
+    it('exposes 12 curated recipes covering IPA / Belgian / Strong / Lager families plus the official DIY Dog and the first-real-brew blonde', () => {
+      expect(PUBLIC_RECIPES_SEED).toHaveLength(12);
       const names = PUBLIC_RECIPES_SEED.map((r) => r.name);
       expect(names).toContain('Session IPA Citra');
       expect(names).toContain('Belgian Tripel');
@@ -187,6 +194,7 @@ describe('seedPublicRecipes (Issue #701)', () => {
       expect(names).toContain('Imperial Stout');
       expect(names).toContain('Kölsch Tradition');
       expect(names).toContain('BrewDog DIY Dog Punk IPA');
+      expect(names).toContain('Blonde Facile (premier brassin)');
     });
 
     it('tags every seeded recipe with a non-empty style for the matching algorithm', () => {
@@ -214,21 +222,21 @@ describe('seedPublicRecipes (Issue #701)', () => {
 
 describe('public recipe content (ingredients + steps, #1134)', () => {
   describe('seed data integrity', () => {
-    it('garnishes exactly the four scan-reachable recipes with full content', () => {
+    it('gives full content to exactly the four scan-reachable recipes plus the first-real-brew blonde', () => {
       const withContent = PUBLIC_RECIPES_SEED.filter((r) => r.fermentables);
       expect(withContent.map((r) => r.id).sort()).toEqual(
-        [...GARNISHED_IDS].sort(),
+        [...CONTENT_BEARING_IDS].sort(),
       );
     });
 
-    it('gives every garnished recipe fermentables, hops, yeasts and the 5-step workflow', () => {
-      for (const id of GARNISHED_IDS) {
+    it('gives every content-bearing recipe fermentables, hops, yeasts and the 5-step workflow', () => {
+      for (const id of CONTENT_BEARING_IDS) {
         const recipe = PUBLIC_RECIPES_SEED.find((r) => r.id === id);
         expect(recipe).toBeDefined();
         expect(recipe?.fermentables?.length).toBeGreaterThan(0);
         expect(recipe?.hops?.length).toBeGreaterThan(0);
         expect(recipe?.yeasts?.length).toBeGreaterThan(0);
-        // Every garnished recipe references the shared default workflow.
+        // Every content-bearing recipe references the shared default workflow.
         expect(recipe?.steps).toBe(DEFAULT_WORKFLOW_STEPS);
         expect(recipe?.steps).toHaveLength(5);
       }
@@ -365,5 +373,67 @@ describe('public recipe content (ingredients + steps, #1134)', () => {
 
       expect(result).toEqual({ inserted: total, updated: 0, total });
     });
+  });
+});
+
+describe('first-real-brew blonde (A1)', () => {
+  const blonde = PUBLIC_RECIPES_SEED.find((r) => r.id === BLONDE_ID);
+
+  it('happy: ships the beginner Blonde Ale scaled to the 5 L demijohn', () => {
+    expect(blonde).toBeDefined();
+    expect(blonde?.name).toBe('Blonde Facile (premier brassin)');
+    expect(blonde?.style).toBe('Blonde Ale');
+    // batch_size_l is the ~4.3 L INTO the fermenter — the volume the
+    // ~18 IBU Tinseth target is computed against (ADR-0020 / the doc).
+    expect(blonde?.batch_size_l).toBe(4.3);
+    expect(blonde?.og_target).toBe(1.044);
+    expect(blonde?.ibu_target).toBe(18);
+    expect(blonde?.abv_estimated).toBe(4.5);
+  });
+
+  it('happy: carries the ~1 kg BIAB grain bill, single-Cascade hops and US-05', () => {
+    const grainG = (blonde?.fermentables ?? []).reduce(
+      (sum, f) => sum + f.weight_g,
+      0,
+    );
+    expect(grainG).toBe(1000);
+    // Single hop variety across both additions.
+    const varieties = new Set((blonde?.hops ?? []).map((h) => h.variety));
+    expect([...varieties]).toEqual(['Cascade']);
+    // 5 g bittering @ 60 min, 4 g flameout whirlpool — the ~18 IBU charge.
+    const bittering = blonde?.hops?.find(
+      (h) => h.addition_stage === RecipeHopAdditionStage.BOIL,
+    );
+    expect(bittering?.weight_g).toBe(5);
+    expect(bittering?.addition_time_min).toBe(60);
+    const flameout = blonde?.hops?.find(
+      (h) => h.addition_stage === RecipeHopAdditionStage.WHIRLPOOL,
+    );
+    expect(flameout?.weight_g).toBe(4);
+    const yeast = blonde?.yeasts?.[0];
+    expect(yeast?.name).toBe('Fermentis SafAle US-05');
+    expect(yeast?.type).toBe(RecipeYeastType.ALE);
+  });
+
+  it('sad: is never tagged official (no global-flag matching boost)', () => {
+    // Like every backend seed row, the blonde must stay non-official —
+    // is_official is a GLOBAL matching shortcut and tagging it would
+    // distort rankForBeer for unrelated beers.
+    expect(blonde?.is_official ?? false).toBe(false);
+  });
+
+  it('edge: is content-bearing yet NOT scan-reachable (no demo-bottle mapping)', () => {
+    expect(blonde?.fermentables?.length).toBeGreaterThan(0);
+    expect(GARNISHED_IDS).not.toContain(BLONDE_ID);
+    expect(CONTENT_BEARING_IDS).toContain(BLONDE_ID);
+  });
+
+  it('edge: is the smallest batch in the catalogue (4.3 L vs the 20 L demo recipes)', () => {
+    expect(blonde).toBeDefined();
+    const blondeBatch = blonde?.batch_size_l ?? 0;
+    const others = PUBLIC_RECIPES_SEED.filter((r) => r.id !== BLONDE_ID);
+    for (const recipe of others) {
+      expect(recipe.batch_size_l).toBeGreaterThan(blondeBatch);
+    }
   });
 });

--- a/packages/api/src/database/seeds/public-recipes.seed.spec.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.spec.ts
@@ -26,8 +26,9 @@ const WHITE_IPA_ID = '00000000-0000-4000-8000-000000000003';
 const PUNK_IPA_ID = '00000000-0000-4000-8000-00000000000b';
 const GARNISHED_IDS = [SESSION_IPA_ID, NEIPA_ID, WHITE_IPA_ID, PUNK_IPA_ID];
 /** The first-real-brew beginner Blonde Ale — content-bearing like the
- * garnished recipes, but NOT scan-reachable (it has no demo-bottle
- * mapping); it is the recipe the app guides the founder's first brew. */
+ * garnished recipes; it has no demo-bottle MOCK mapping, but being
+ * PUBLIC it still participates in backend scan matching (Codex P2 on
+ * PR #1251). It is the recipe the app guides the founder's first brew. */
 const BLONDE_ID = '00000000-0000-4000-8000-00000000000c';
 /** Every recipe that ships full content (ingredients + steps): the
  * four scan-reachable rows plus the first-real-brew blonde. */
@@ -422,7 +423,11 @@ describe('first-real-brew blonde (A1)', () => {
     expect(blonde?.is_official ?? false).toBe(false);
   });
 
-  it('edge: is content-bearing yet NOT scan-reachable (no demo-bottle mapping)', () => {
+  it('edge: is content-bearing with no demo-bottle mock mapping (still PUBLIC, so still ranked by matching)', () => {
+    // It carries full content but is absent from the scan-reachable
+    // (demo-bottle) set. Being PUBLIC, the backend matcher still ranks
+    // it for scanned beers — accepted as correct behaviour (Codex P2 on
+    // PR #1251); only the mobile demo mock list excludes it.
     expect(blonde?.fermentables?.length).toBeGreaterThan(0);
     expect(GARNISHED_IDS).not.toContain(BLONDE_ID);
     expect(CONTENT_BEARING_IDS).toContain(BLONDE_ID);

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -754,7 +754,7 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
     ],
     steps: DEFAULT_WORKFLOW_STEPS,
   },
-  // --- First real-world brew (NOT a demo-bottle equivalent) ---
+  // --- First real-world brew (no demo-bottle mock mapping) ---
   // The beginner Blonde Ale scaled to the founder's 5 L demijohn that
   // the app guides the first real brew through end-to-end. Source of
   // truth: docs/real-world-test/blonde-ale-5l-first-brew.md. Carries
@@ -763,8 +763,18 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
   // is the separate phase-B build. `batch_size_l` is the ~4.3 L INTO
   // the fermenter (BeerXML batch-size semantics) — the volume the ~18
   // IBU Tinseth target is computed against, kept consistent with the
-  // doc and RecipeIbuTinsethDomainService. `is_official` stays false
-  // (per the global-flag regression note above).
+  // doc and RecipeIbuTinsethDomainService.
+  //
+  // Scope note (Codex P2 on PR #1251): being PUBLIC, this recipe DOES
+  // participate in backend scan matching — `/recipes/match` ranks every
+  // PUBLIC recipe, so a Blonde Ale scores well for a scanned blonde beer.
+  // That is accepted as correct matcher behaviour (a blonde IS a relevant
+  // equivalent for a blonde); the demo "official recipe" beats are driven
+  // by the mobile `demoEquivalentRecipes` mock — which this row is absent
+  // from — not by the backend ranking, so the demo experience is
+  // unaffected. This entry simply has no demo-bottle mapping. `is_official`
+  // stays false (per the global-flag regression note above) so it never
+  // gets the 100-pt shortcut.
   {
     id: '00000000-0000-4000-8000-00000000000c',
     name: 'Blonde Facile (premier brassin)',

--- a/packages/api/src/database/seeds/public-recipes.seed.ts
+++ b/packages/api/src/database/seeds/public-recipes.seed.ts
@@ -192,10 +192,14 @@ export interface PublicRecipeSeed {
 }
 
 /**
- * The 10 demo public recipes — 3 stylistic neighbours per demo
- * bottle. UUIDs are deterministic (sequential + RFC4122 v4 variant
- * bits) so the mobile `demoEquivalentRecipes` table can reference
- * them statically without a database round-trip.
+ * The curated public recipes. Entries 1–10 are the demo recipes (3
+ * stylistic neighbours per demo bottle); entry 11 (`…b`) is the
+ * brewer-endorsed BrewDog DIY Dog clone for Punk IPA; entry 12 (`…c`)
+ * is the first-real-brew beginner Blonde Ale — NOT a demo-bottle
+ * equivalent, it is the recipe the app guides the founder's first
+ * physical brew through. UUIDs are deterministic (sequential + RFC4122
+ * v4 variant bits) so the mobile `demoEquivalentRecipes` table can
+ * reference the demo ones statically without a database round-trip.
  */
 export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
   // --- IPA family (matches Punk IPA) ---
@@ -746,6 +750,83 @@ export const PUBLIC_RECIPES_SEED: readonly PublicRecipeSeed[] = [
         attenuation_percent: 81,
         temperature_min_c: 15,
         temperature_max_c: 22,
+      },
+    ],
+    steps: DEFAULT_WORKFLOW_STEPS,
+  },
+  // --- First real-world brew (NOT a demo-bottle equivalent) ---
+  // The beginner Blonde Ale scaled to the founder's 5 L demijohn that
+  // the app guides the first real brew through end-to-end. Source of
+  // truth: docs/real-world-test/blonde-ale-5l-first-brew.md. Carries
+  // full content so the imported recipe shows real ingredients + the
+  // default workflow; the detailed instruction/duration brew-day guide
+  // is the separate phase-B build. `batch_size_l` is the ~4.3 L INTO
+  // the fermenter (BeerXML batch-size semantics) — the volume the ~18
+  // IBU Tinseth target is computed against, kept consistent with the
+  // doc and RecipeIbuTinsethDomainService. `is_official` stays false
+  // (per the global-flag regression note above).
+  {
+    id: '00000000-0000-4000-8000-00000000000c',
+    name: 'Blonde Facile (premier brassin)',
+    description:
+      "Blonde Ale de débutant (BJCP 18A), méthode tout-grain BIAB, calibrée pour un fermenteur de 5 L (dame-jeanne) : ~4,3 L au fermenteur pour ~4 L embouteillés. Simple mais bonne — base Pilsner avec une pointe de Vienna, houblon unique Cascade, levure sèche US-05. C'est la recette du premier brassin réel guidé par l'application.",
+    style: 'Blonde Ale',
+    batch_size_l: 4.3,
+    boil_time_min: 60,
+    og_target: 1.044,
+    fg_target: 1.01,
+    abv_estimated: 4.5,
+    ibu_target: 18,
+    ebc_target: 7,
+    efficiency_target: 70,
+    avg_rating: 0,
+    brew_count: 0,
+    // Grain bill ~1.0 kg: Pilsner base + a touch of Vienna for a golden
+    // hue and a little roundness. Scaled to the ~4.3 L batch.
+    fermentables: [
+      {
+        name: 'Pilsner Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 900,
+        color_ebc: 3,
+      },
+      {
+        name: 'Vienna Malt',
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 100,
+        color_ebc: 8,
+      },
+    ],
+    // Single-variety Cascade: a small 5 g bittering charge (~18 IBU on
+    // this concentrated 4.3 L batch at 5.5% AA) + 4 g at flameout for a
+    // light aroma (negligible IBU).
+    hops: [
+      {
+        variety: 'Cascade',
+        type: RecipeHopType.PELLET,
+        weight_g: 5,
+        alpha_acid_percent: 5.5,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 60,
+      },
+      {
+        variety: 'Cascade',
+        type: RecipeHopType.PELLET,
+        weight_g: 4,
+        alpha_acid_percent: 5.5,
+        addition_stage: RecipeHopAdditionStage.WHIRLPOOL,
+      },
+    ],
+    // Half a dry sachet is plenty for ~4 L (a whole 11.5 g sachet is
+    // also fine). Ferment 18-20 °C per the recipe doc.
+    yeasts: [
+      {
+        name: 'Fermentis SafAle US-05',
+        type: RecipeYeastType.ALE,
+        amount_g: 5.75,
+        attenuation_percent: 81,
+        temperature_min_c: 18,
+        temperature_max_c: 20,
       },
     ],
     steps: DEFAULT_WORKFLOW_STEPS,


### PR DESCRIPTION
## What

Build **A1** of the first-real-world-brew journey: add the beginner **Blonde Ale** as a 12th curated **PUBLIC** recipe, so the app can import it for the founder's first guided brew. The recipe content is the source-of-truth doc [`docs/real-world-test/blonde-ale-5l-first-brew.md`](docs/real-world-test/blonde-ale-5l-first-brew.md) (#1247), realised under **ADR-0020** (#1248).

## Details

- **`batch_size_l = 4.3`** — the volume **into the 5 L demijohn** (BeerXML batch-size semantics). This is the volume the **~18 IBU** Tinseth target is computed against, so the displayed IBU stays consistent with the doc and `RecipeIbuTinsethDomainService`.
- **~1 kg grain** (900 g Pilsner + 100 g Vienna), **single-Cascade** hops (5 g @ 60 min ≈ 18 IBU + 4 g flameout), **SafAle US-05**, ferment 18–20 °C.
- **Steps = the canonical 5-step workflow** (`DEFAULT_WORKFLOW_STEPS`) — the detailed instruction/duration brew-day guide is the separate **phase-B** build (B1), out of scope here.
- **Not a demo-bottle equivalent**; `is_official` stays `false` (the global-flag matching regression). Carries full content so the imported recipe is not an empty shell.

## Tests

- Spec: curated count **11 → 12**; generalised the content-bearing set (the blonde is content-bearing but **not** scan-reachable); added blonde **H/S/E** (targets, grain bill, single-Cascade schedule, US-05, non-official, smallest batch).
- Full api suite green locally: **773 passed / 2 skipped**, coverage **94.3 / 77.2 / 89.4 / 94.6** (above the 90/72/85/90 gate).

## Follow-up (not in this PR)

Deploy/reseed on Fly: redeploy `main` + run `scripts/run-public-recipes-seed.ts` — resolves the stale-API blocker and seeds the blonde live.

Refs the first-real-brew initiative (#1247 doc, ADR-0020 / #1248).