### PR TITLE
feat(api): deployable production seeding via a compiled seed CLI

### DIFF
--- a/packages/api/docs/fly-deploy.md
+++ b/packages/api/docs/fly-deploy.md
@@ -105,6 +105,52 @@ apt-get update && apt-get install -y sqlite3  # one-off
 sqlite3 /app/data/brasse-bouillon.db ".tables"
 ```
 
+## Migrations & seeding in production
+
+The flow is **deploy → migrate (automatic) → seed (on demand)**:
+
+1. **Schema / migrations — automatic on boot.** The runtime TypeORM config sets
+   `migrationsRun: true` (see `src/database/typeorm.config.ts`), so the app
+   applies any pending migrations against the volume DB **every time it starts**.
+   A plain `fly deploy` therefore brings both the code and the schema up to date —
+   nothing extra to run.
+
+2. **Seed data — run the seed CLI on the app machine.** The curated PUBLIC
+   recipes (and the system curator user that owns them) are seeded by a compiled
+   entrypoint shipped inside the image at `dist/database/seed-cli.js`. Run it on
+   the **running app machine** (which has the volume mounted at `/app/data`):
+
+   ```bash
+   fly ssh console --app brasse-bouillon-api \
+     -C "node dist/database/seed-cli.js"
+   # logs: Production seed complete: {"systemUser":{...},"publicRecipes":{...}}
+   ```
+
+   It is **idempotent** (rows upsert by id), so it is safe to re-run after every
+   deploy that changes the seed data.
+
+> **Why not a `fly.toml` `release_command`?** Release-command machines run the
+> new image **without the volume mounted**, so a SQLite-on-volume migrate/seed
+> there would write to a throwaway database. Migrations already run at app boot,
+> and the seed CLI runs on the app machine — both reach the real `/app/data` DB.
+>
+> **Why not `scripts/run-public-recipes-seed.ts`?** That script lives outside
+> `src/`, is never copied into the runtime image, and runs via `ts-node` (a dev
+> dependency pruned in production). `seed-cli.ts` lives in `src/`, compiles into
+> `dist/`, and runs on plain `node`.
+
+To verify the blonde (or any seed change) landed, query the volume DB directly on
+the app machine (the `/recipes/public` endpoint is JWT-guarded, so an
+unauthenticated `curl` would `401`):
+
+```bash
+fly ssh console --app brasse-bouillon-api \
+  -C "node dist/database/seed-cli.js"   # re-run: 'updated' counts confirm the rows exist
+# or, with sqlite3 installed on the machine:
+sqlite3 /app/data/brasse-bouillon.db \
+  "SELECT name, batch_size_l FROM recipes WHERE name LIKE 'Blonde Facile%';"
+```
+
 ## Rotating secrets
 
 ```bash

--- a/packages/api/docs/fly-deploy.md
+++ b/packages/api/docs/fly-deploy.md
@@ -139,16 +139,22 @@ The flow is **deploy → migrate (automatic) → seed (on demand)**:
 > dependency pruned in production). `seed-cli.ts` lives in `src/`, compiles into
 > `dist/`, and runs on plain `node`.
 
-To verify the blonde (or any seed change) landed, query the volume DB directly on
-the app machine (the `/recipes/public` endpoint is JWT-guarded, so an
-unauthenticated `curl` would `401`):
+To verify the blonde (or any seed change) landed — both options run **on the app
+machine** (the `/recipes/public` endpoint is JWT-guarded, so an unauthenticated
+`curl` would `401`):
+
+**Option 1 — re-run the seed CLI and read the `updated` counts:**
 
 ```bash
 fly ssh console --app brasse-bouillon-api \
-  -C "node dist/database/seed-cli.js"   # re-run: 'updated' counts confirm the rows exist
-# or, with sqlite3 installed on the machine:
-sqlite3 /app/data/brasse-bouillon.db \
-  "SELECT name, batch_size_l FROM recipes WHERE name LIKE 'Blonde Facile%';"
+  -C "node dist/database/seed-cli.js"
+```
+
+**Option 2 — query the volume DB with sqlite3 (if installed on the machine):**
+
+```bash
+fly ssh console --app brasse-bouillon-api \
+  -C "sqlite3 /app/data/brasse-bouillon.db \"SELECT name, batch_size_l FROM recipes WHERE name LIKE 'Blonde Facile%';\""
 ```
 
 ## Rotating secrets

--- a/packages/api/src/database/seed-cli.spec.ts
+++ b/packages/api/src/database/seed-cli.spec.ts
@@ -1,0 +1,144 @@
+import { DataSource } from 'typeorm';
+
+import { User } from '../user/entities/user.entity';
+import {
+  buildPublicRecipeSubResourceRepos,
+  seedPublicRecipes,
+} from './seeds/public-recipes.seed';
+import { seedSystemUser } from './seeds/system-user.seed';
+import { runProductionSeed } from './seed-cli';
+
+jest.mock('./seeds/system-user.seed', () => ({
+  seedSystemUser: jest.fn(),
+}));
+jest.mock('./seeds/public-recipes.seed', () => ({
+  seedPublicRecipes: jest.fn(),
+  buildPublicRecipeSubResourceRepos: jest.fn(),
+}));
+
+const mockedSeedSystemUser = jest.mocked(seedSystemUser);
+const mockedSeedPublicRecipes = jest.mocked(seedPublicRecipes);
+const mockedBuildSubRepos = jest.mocked(buildPublicRecipeSubResourceRepos);
+
+// Distinct sentinels so we can assert each seed receives the repository
+// resolved from the right entity.
+const userRepo = { __entity: 'user' };
+const recipeRepo = { __entity: 'recipe' };
+const subRepos = {
+  fermentableRepo: {},
+  hopRepo: {},
+  yeastRepo: {},
+  stepRepo: {},
+};
+
+function buildDataSource(isInitialized: boolean): {
+  dataSource: DataSource;
+  initialize: jest.Mock;
+} {
+  const initialize = jest.fn().mockResolvedValue(undefined);
+  const dataSource = {
+    isInitialized,
+    initialize,
+    getRepository: jest.fn((entity: unknown) =>
+      entity === User ? userRepo : recipeRepo,
+    ),
+  } as unknown as DataSource;
+  return { dataSource, initialize };
+}
+
+describe('runProductionSeed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedBuildSubRepos.mockReturnValue(
+      subRepos as unknown as ReturnType<
+        typeof buildPublicRecipeSubResourceRepos
+      >,
+    );
+  });
+
+  describe('happy path', () => {
+    it('seeds the system user then the public recipes and returns the combined summary', async () => {
+      mockedSeedSystemUser.mockResolvedValue({
+        inserted: true,
+        user_id: 'sys',
+      });
+      mockedSeedPublicRecipes.mockResolvedValue({
+        inserted: 12,
+        updated: 0,
+        total: 12,
+      });
+      const { dataSource, initialize } = buildDataSource(true);
+
+      const result = await runProductionSeed(dataSource);
+
+      // Already initialised → must not re-initialise.
+      expect(initialize).not.toHaveBeenCalled();
+      // System user seeded from the User repository.
+      expect(mockedSeedSystemUser).toHaveBeenCalledWith(userRepo);
+      // Public recipes seeded from the Recipe repository, default seed list,
+      // and the sub-resource repos built from the same DataSource.
+      expect(mockedBuildSubRepos).toHaveBeenCalledWith(dataSource);
+      expect(mockedSeedPublicRecipes).toHaveBeenCalledWith(
+        recipeRepo,
+        undefined,
+        subRepos,
+      );
+      expect(result).toEqual({
+        systemUser: { inserted: true, user_id: 'sys' },
+        publicRecipes: { inserted: 12, updated: 0, total: 12 },
+      });
+    });
+
+    it('seeds the system user BEFORE the recipes (FK owner_id -> users.id)', async () => {
+      mockedSeedSystemUser.mockResolvedValue({
+        inserted: true,
+        user_id: 'sys',
+      });
+      mockedSeedPublicRecipes.mockResolvedValue({
+        inserted: 0,
+        updated: 12,
+        total: 12,
+      });
+
+      await runProductionSeed(buildDataSource(true).dataSource);
+
+      expect(mockedSeedSystemUser.mock.invocationCallOrder[0]).toBeLessThan(
+        mockedSeedPublicRecipes.mock.invocationCallOrder[0],
+      );
+    });
+  });
+
+  describe('edge cases', () => {
+    it('initialises the DataSource first when it is not yet connected', async () => {
+      mockedSeedSystemUser.mockResolvedValue({
+        inserted: true,
+        user_id: 'sys',
+      });
+      mockedSeedPublicRecipes.mockResolvedValue({
+        inserted: 12,
+        updated: 0,
+        total: 12,
+      });
+      const { dataSource, initialize } = buildDataSource(false);
+
+      await runProductionSeed(dataSource);
+
+      expect(initialize).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sad path', () => {
+    it('rejects when the recipe seed fails, after the system user was seeded', async () => {
+      mockedSeedSystemUser.mockResolvedValue({
+        inserted: true,
+        user_id: 'sys',
+      });
+      mockedSeedPublicRecipes.mockRejectedValue(new Error('seed boom'));
+
+      await expect(
+        runProductionSeed(buildDataSource(true).dataSource),
+      ).rejects.toThrow('seed boom');
+      expect(mockedSeedSystemUser).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/api/src/database/seed-cli.ts
+++ b/packages/api/src/database/seed-cli.ts
@@ -1,0 +1,96 @@
+import 'reflect-metadata';
+
+import { DataSource } from 'typeorm';
+
+import { RecipeOrmEntity } from '../recipe/entities/recipe.orm.entity';
+import { User } from '../user/entities/user.entity';
+import {
+  buildPublicRecipeSubResourceRepos,
+  seedPublicRecipes,
+  SeedPublicRecipesResult,
+} from './seeds/public-recipes.seed';
+import { SeedSystemUserResult, seedSystemUser } from './seeds/system-user.seed';
+import { buildTypeOrmOptions } from './typeorm.config';
+
+/**
+ * Production seeding entrypoint — compiled into `dist/database/seed-cli.js`
+ * so it ships inside the Fly image and can be run on the **app machine**
+ * (which has the SQLite volume mounted at `/app/data`):
+ *
+ *   fly ssh console --app brasse-bouillon-api \
+ *     -C "node dist/database/seed-cli.js"
+ *
+ * Why not `scripts/run-public-recipes-seed.ts`? That script lives outside
+ * `src/`, is never copied into the runtime image, and runs via ts-node
+ * (a dev dependency pruned in production) — so it cannot execute on Fly.
+ * This entrypoint lives in `src/`, compiles to `dist/`, and runs on plain
+ * `node` with production dependencies only.
+ *
+ * Why not a `fly.toml` `release_command`? Release-command machines run the
+ * new image **without the volume mounted**, so a SQLite-on-volume migrate
+ * /seed there would hit a throwaway database. Migrations already run at app
+ * boot (`migrationsRun: true`, see `typeorm.config.ts`); this entrypoint
+ * covers the remaining gap — seeding — explicitly and on demand.
+ *
+ * Idempotent: `seedSystemUser` and `seedPublicRecipes` upsert by id, so
+ * re-running converges on the declared seed without duplicating rows.
+ */
+
+/** Combined result of the production seed, for logging / verification. */
+export interface ProductionSeedSummary {
+  systemUser: SeedSystemUserResult;
+  publicRecipes: SeedPublicRecipesResult;
+}
+
+/**
+ * Seed the data a freshly-deployed production database needs to serve the
+ * public catalogue: the system curator user (the FK owner of every seeded
+ * recipe) and the curated PUBLIC recipes with their full content.
+ *
+ * Order matters: the system user must exist before the recipes are written
+ * (`recipes.owner_id` -> `users.id`). The caller owns the DataSource
+ * lifecycle; this function initialises it if needed but never destroys it.
+ */
+export async function runProductionSeed(
+  dataSource: DataSource,
+): Promise<ProductionSeedSummary> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const systemUser = await seedSystemUser(dataSource.getRepository(User));
+  const publicRecipes = await seedPublicRecipes(
+    dataSource.getRepository(RecipeOrmEntity),
+    undefined,
+    buildPublicRecipeSubResourceRepos(dataSource),
+  );
+
+  return { systemUser, publicRecipes };
+}
+
+/**
+ * CLI bootstrap: build a runtime DataSource (so `initialize()` also applies
+ * any pending migrations — `migrationsRun: true`), run the seed, and always
+ * release the connection. Exits non-zero on failure so the operator sees it.
+ */
+async function bootstrap(): Promise<void> {
+  const dataSource = new DataSource(buildTypeOrmOptions());
+  try {
+    const summary = await runProductionSeed(dataSource);
+    console.log('Production seed complete:', JSON.stringify(summary));
+  } finally {
+    if (dataSource.isInitialized) {
+      await dataSource.destroy();
+    }
+  }
+}
+
+// Only auto-run when invoked directly (`node dist/database/seed-cli.js`),
+// not when imported by a test — so `runProductionSeed` stays unit-testable
+// without side effects.
+if (require.main === module) {
+  bootstrap().catch((err) => {
+    console.error('Production seed failed:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Why

There was **no working way to seed the production DB** after a deploy: the seed scripts under `packages/api/scripts/` are never copied into the Fly image and run via `ts-node` (a dev dependency pruned in prod). This blocked seeding the blonde (#1251) live and reseeding the stale prod API generally.

## What

- **`src/database/seed-cli.ts`** — `runProductionSeed(dataSource)` seeds the system curator user (FK owner) then the public recipes with full content (idempotent), exposed as a unit-testable function; a `require.main === module` guard runs it as `node dist/database/seed-cli.js`. It lives in `src/` so it **compiles into `dist/`** and runs on plain `node` with production deps only.
- **`src/database/seed-cli.spec.ts`** — H/S/E: seeds the user before the recipes (FK `owner_id -> users.id`), initialises the DataSource when not yet connected, propagates seed errors.
- **`docs/fly-deploy.md`** — new *Migrations & seeding in production* section.

## Deploy model (documented)

**deploy → migrate (automatic) → seed (on demand):**
1. Migrations already run at app boot (`migrationsRun: true` in `typeorm.config.ts`), on the app machine which has the volume — so a plain `fly deploy` brings schema up to date.
2. Seed via `fly ssh console -C "node dist/database/seed-cli.js"` on the app machine.

**Not a `release_command`** — those machines run without the volume mounted, so a SQLite-on-volume migrate/seed there would hit a throwaway DB.

### Note on the dist path
In the **Docker** build only `src/` is copied, so tsc's inferred rootDir is `src/` and the entrypoint lands at `dist/database/seed-cli.js` (same reason the Dockerfile's `CMD ["node", "dist/main"]` works). A local `npm run build` instead emits `dist/src/...` because `scripts/` is also present locally — that's a local-only artifact-path difference, not the prod layout.

## Tests
Full api suite green locally: **777 passed / 2 skipped**, coverage above the gate (functions 89.2 / lines 94.4 / branches 77.1).

Unblocks the ops step for #1251 (seed the blonde live) and the stale-API reseed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fly.io deployment guide with new section on production migrations and database seeding, including verification steps and clarification on idempotent seeding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->