### PR TITLE
chore(ci): add Dependabot config for weekly grouped npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types: ["minor", "patch"]
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,16 @@ updates:
     open-pull-requests-limit: 10
     groups:
       npm-minor-patch:
-        update-types: ["minor", "patch"]
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Major bumps (Expo / Jest / NestJS / sqlite3 ...) are deferred to the
+      # planned security audit — suppress them here to keep weekly runs low-noise.
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` to enable account-level Dependabot version updates on the single root workspace lockfile. Minor/patch bumps are grouped into one weekly PR (Monday) to keep noise low, with a Conventional-Commits prefix on the generated PRs.

## Context

A weekly Dependabot security digest flagged transitive vulnerabilities across the monorepo. Investigation on the actual dependency tree showed:

- The repo had **no `.github/dependabot.yml`**, so no automated fix PRs were ever opened — the alerts only surfaced as a weekly email digest to triage by hand.
- A blanket `npm audit fix` (without `--force`) resolves only **6 of 76** advisories on the real Expo SDK 54 + NestJS tree, closes **neither** of the 2 criticals, and only runs with `--legacy-peer-deps` (a `react-native-reanimated` "fix" pulls a `react-native@0.86` peer incompatible with the Expo-pinned `0.81.5`).
- Both "critical" advisories are **dev/build tooling, not runtime**: `handlebars` ← `ts-jest` (API tests), `shell-quote` ← `react-native` → `react-devtools-core` (RN devtools, excluded from the production bundle).

This PR therefore ships only the durable, zero-risk piece — the Dependabot automation. Actual version remediation (the ~42 major bumps across Expo/Jest/NestJS/sqlite3, plus the dev-only criticals via `overrides` if judged worthwhile) is **deferred to the planned security audit**, not handled here.

## Checklist

- [x] Config-only change — no lockfile or dependency modifications
- [x] YAML validated locally
- [x] GitHub artifacts in English (the post-merge FYI comment is the documented French exception)