### PR TITLE
chore(ci): exclude framework-core deps from the weekly Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,12 +22,18 @@ updates:
       # Framework-core deps whose minor/patch bumps still introduce breaking
       # type/lint changes (rxjs dual-instance in the API build, react-native
       # StyleSheet.absoluteFillObject removal, @tanstack/react-query Updater
-      # type change, stricter @typescript-eslint rules). They need deliberate
-      # code fixes, handled in the upgrade audit — not the weekly group.
+      # type change, stricter @typescript-eslint rules). Only minor/patch
+      # VERSION updates are ignored (kept out of the weekly group, handled with
+      # code fixes in the upgrade audit); security updates are still raised.
       - dependency-name: "react-native"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "@types/react-native"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "rxjs"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "@tanstack/react-query"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "@typescript-eslint/*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
     commit-message:
       prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,15 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # Framework-core deps whose minor/patch bumps still introduce breaking
+      # type/lint changes (rxjs dual-instance in the API build, react-native
+      # StyleSheet.absoluteFillObject removal, @tanstack/react-query Updater
+      # type change, stricter @typescript-eslint rules). They need deliberate
+      # code fixes, handled in the upgrade audit — not the weekly group.
+      - dependency-name: "react-native"
+      - dependency-name: "@types/react-native"
+      - dependency-name: "rxjs"
+      - dependency-name: "@tanstack/react-query"
+      - dependency-name: "@typescript-eslint/*"
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

The regenerated `npm-minor-patch` group PR (#1264, follow-up to the closed #1261) fails CI for **four independent reasons**, each from a framework-core dependency whose minor/patch bump ships a breaking type/lint change. This adds targeted `ignore` rules so the weekly group stays green and carries only the genuinely-safe leaf bumps.

## Root causes diagnosed (from #1264 CI logs)

| Failing job | Error | Dependency family |
|-------------|-------|-------------------|
| API build | `TS2416` rxjs dual-instance (root vs `packages/api`) | `rxjs` |
| mobile typecheck | `TS2551` `StyleSheet.absoluteFillObject` removed | `react-native` |
| mobile typecheck | `TS2345` `setQueryData` Updater type changed | `@tanstack/react-query` |
| API lint | stricter `no-unnecessary-type-assertion` | `@typescript-eslint/*` |

## Change

`.github/dependabot.yml` — add five `dependency-name` ignores (the four families + `@types/react-native` for safety). Their upgrades need deliberate code fixes and are handled in the planned upgrade/security audit, not the weekly group.

## After merge

On the next weekly run (or via `@dependabot recreate` on #1264), Dependabot regenerates the group excluding these families → expected green and mergeable.

## Checklist

- [x] Config-only change (`.github/dependabot.yml`)
- [x] YAML validated
- [x] No code or lockfile change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update rules to skip several core and tooling packages from weekly update groups.
  * Added exclusions for framework, type, query, and lint-related packages to keep updates grouped more intentionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->