### PR TITLE
chore: disable CodeRabbit auto-review and log PR #1266

### DIFF
--- a/.claude/skills/pr-create-brasse-bouillon/SKILL.md
+++ b/.claude/skills/pr-create-brasse-bouillon/SKILL.md
@@ -59,8 +59,9 @@ gh api graphql -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{pro
 
 ## Step 4 — Reviewers
 
-CodeRabbit and Codex review **every PR automatically** on push — do **not**
-call `requested_reviewers` for them (the API returns 422 for GitHub-App bots).
+No reviewer runs automatically on GitHub (CodeRabbit was removed 2026-06-24;
+Codex runs in the local pre-push ritual). Do **not** call `requested_reviewers`
+for bot accounts (the API returns 422 for GitHub-App bots).
 
 Copilot is **manual** (it bills premium requests; ×13 per review since
 2026-06-01). Do **not** request it by default. Only when a deliberate Copilot
@@ -124,6 +125,6 @@ gh api repos/benoit-bremaud/brasse-bouillon/issues/$PR/comments \
 2. Open the PR (step 1).
 3. Apply labels + assignee + project + milestone (steps 2–5) — these can run in parallel.
 4. Post the French FYI comment (step 6).
-5. Wait for the automatic reviews (CodeRabbit + Codex) to be **posted** per the global `pr-review-procedure` skill (loaded from `~/.claude/skills/pr-review-procedure/SKILL.md`, user-scoped — invoke by name, no in-repo link possible) before any merge. Add the `needs-copilot` label only if a deliberate Copilot review is also wanted (step 4).
+5. If a Copilot review was requested (the `needs-copilot` label, step 4), wait for it to be **posted** per the global `pr-review-procedure` skill (loaded from `~/.claude/skills/pr-review-procedure/SKILL.md`, user-scoped — invoke by name, no in-repo link possible) before any merge. The substantive review is the local pre-push ritual (Claude + Codex), run before pushing.
 
 Never auto-merge. Never use `--auto` or `--admin`. Per the global merge gate, present a readiness summary in English and wait for explicit textual approval.

--- a/.claude/skills/pr-create-brasse-bouillon/SKILL.md
+++ b/.claude/skills/pr-create-brasse-bouillon/SKILL.md
@@ -59,9 +59,9 @@ gh api graphql -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{pro
 
 ## Step 4 — Reviewers
 
-No reviewer runs automatically on GitHub (CodeRabbit was removed 2026-06-24;
-Codex runs in the local pre-push ritual). Do **not** call `requested_reviewers`
-for bot accounts (the API returns 422 for GitHub-App bots).
+Codex reviews **every PR automatically** on GitHub; CodeRabbit was removed
+2026-06-24. Do **not** call `requested_reviewers` for `Codex` or `Copilot`
+(the API returns 422 for GitHub App bot accounts).
 
 Copilot is **manual** (it bills premium requests; ×13 per review since
 2026-06-01). Do **not** request it by default. Only when a deliberate Copilot
@@ -125,6 +125,6 @@ gh api repos/benoit-bremaud/brasse-bouillon/issues/$PR/comments \
 2. Open the PR (step 1).
 3. Apply labels + assignee + project + milestone (steps 2–5) — these can run in parallel.
 4. Post the French FYI comment (step 6).
-5. If a Copilot review was requested (the `needs-copilot` label, step 4), wait for it to be **posted** per the global `pr-review-procedure` skill (loaded from `~/.claude/skills/pr-review-procedure/SKILL.md`, user-scoped — invoke by name, no in-repo link possible) before any merge. The substantive review is the local pre-push ritual (Claude + Codex), run before pushing.
+5. Wait for the automatic Codex review (and Copilot, if `needs-copilot` was added in step 4) to be **posted** per the global `pr-review-procedure` skill (loaded from `~/.claude/skills/pr-review-procedure/SKILL.md`, user-scoped — invoke by name, no in-repo link possible) before any merge. The substantive review is the local pre-push ritual (Claude + Codex) run before pushing.
 
 Never auto-merge. Never use `--auto` or `--admin`. Per the global merge gate, present a readiness summary in English and wait for explicit textual approval.

--- a/.claude/skills/pre-push-review/SKILL.md
+++ b/.claude/skills/pre-push-review/SKILL.md
@@ -5,11 +5,11 @@ description: Brasse-Bouillon pre-push review ritual — run a local defence-in-d
 
 # Brasse-Bouillon — pre-push review ritual
 
-The default review path on this repo is **local and free, before the push**.
-GitHub-side reviewers are the second layer: CodeRabbit auto-reviews every PR,
-Codex auto-reviews every PR, and Copilot is **manual** (`needs-copilot` label —
-it bills premium requests). See [CONTRIBUTING.md](../../../CONTRIBUTING.md)
-§ AI reviewers.
+The default review path on this repo is **local and free, before the push** —
+it is now the primary reviewer. On the GitHub side, Copilot is **manual**
+(`needs-copilot` label — it bills premium requests); CodeRabbit was removed on
+2026-06-24 (free-tier rate limit + billing nudges). See
+[CONTRIBUTING.md](../../../CONTRIBUTING.md) § AI reviewers.
 
 This skill runs **two independent reviewers locally**, makes them **confront**
 their findings, and only authorises the push once the blocking items are fixed.
@@ -89,7 +89,7 @@ Otherwise, loop back to Step 4. The human triggers the actual `git push`.
 
 ## After the push (for reference, not part of this skill)
 
-- The PR triggers **CodeRabbit** (auto) + **Codex** (auto) on GitHub.
+- On GitHub no reviewer runs automatically (CodeRabbit was removed 2026-06-24; Codex runs locally in this ritual, above).
 - Add the **`needs-copilot`** label only if a deliberate Copilot review is also
   wanted (premium-request cost; ×13 per review since 2026-06-01).
 - Handle posted comments per the global `pr-review-procedure` skill.

--- a/.claude/skills/pre-push-review/SKILL.md
+++ b/.claude/skills/pre-push-review/SKILL.md
@@ -6,9 +6,9 @@ description: Brasse-Bouillon pre-push review ritual — run a local defence-in-d
 # Brasse-Bouillon — pre-push review ritual
 
 The default review path on this repo is **local and free, before the push** —
-it is now the primary reviewer. On the GitHub side, Copilot is **manual**
-(`needs-copilot` label — it bills premium requests); CodeRabbit was removed on
-2026-06-24 (free-tier rate limit + billing nudges). See
+it is the primary reviewer. On the GitHub side, Codex auto-reviews and Copilot
+is **manual** (`needs-copilot` label — it bills premium requests); CodeRabbit
+was removed on 2026-06-24 (free-tier rate limit + billing nudges). See
 [CONTRIBUTING.md](../../../CONTRIBUTING.md) § AI reviewers.
 
 This skill runs **two independent reviewers locally**, makes them **confront**
@@ -89,7 +89,7 @@ Otherwise, loop back to Step 4. The human triggers the actual `git push`.
 
 ## After the push (for reference, not part of this skill)
 
-- On GitHub no reviewer runs automatically (CodeRabbit was removed 2026-06-24; Codex runs locally in this ritual, above).
+- On GitHub, **Codex** auto-reviews the PR; CodeRabbit was removed 2026-06-24.
 - Add the **`needs-copilot`** label only if a deliberate Copilot review is also
   wanted (premium-request cost; ×13 per review since 2026-06-01).
 - Handle posted comments per the global `pr-review-procedure` skill.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,11 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 #
-# CodeRabbit — automatic post-push reviewer for brasse-bouillon.
-# Free tier, private repo. CodeRabbit is the always-on GitHub-side reviewer;
-# Copilot is manual (needs-copilot label), Codex auto-reviews in parallel.
-# See CONTRIBUTING.md § AI reviewers.
+# CodeRabbit — DISABLED for brasse-bouillon (2026-06-24).
+# The free tier hit its PR-review rate limit and posted billing nudges on PRs,
+# so auto-review is turned off here and the GitHub App is being uninstalled.
+# The review pipeline is now the local pre-push ritual (Claude pr-pre-reviewer
+# + /code-review + Codex via scripts/codex-review.sh), with Copilot on demand
+# (needs-copilot label). See CONTRIBUTING.md § AI reviewers.
 
 language: en-US
 
@@ -20,7 +22,7 @@ reviews:
   request_changes_workflow: false
 
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     base_branches:
       - main
@@ -64,4 +66,4 @@ reviews:
         Tests must cover Happy path, Sad path, and Edge cases (H/S/E).
 
 chat:
-  auto_reply: true
+  auto_reply: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,8 +50,8 @@ Closes #
   the relevant team members based on the scope/area labels of the linked
   issue. See CONTRIBUTING.md § 6 "PR notification comment" for the rules.
 
-  CodeRabbit + Codex auto-review on push — do NOT call
-  `requested_reviewers`, the API returns 422 for bot accounts.
-  Copilot is MANUAL: add the `needs-copilot` label to request it
-  (it bills premium requests). See CONTRIBUTING.md § AI reviewers.
+  Review runs locally pre-push (Claude pr-pre-reviewer + /code-review +
+  Codex). On GitHub, Copilot is MANUAL: add the `needs-copilot` label to
+  request it (it bills premium requests) — do NOT call `requested_reviewers`,
+  the API returns 422 for bot accounts. See CONTRIBUTING.md § AI reviewers.
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -50,8 +50,8 @@ Closes #
   the relevant team members based on the scope/area labels of the linked
   issue. See CONTRIBUTING.md § 6 "PR notification comment" for the rules.
 
-  Review runs locally pre-push (Claude pr-pre-reviewer + /code-review +
-  Codex). On GitHub, Copilot is MANUAL: add the `needs-copilot` label to
-  request it (it bills premium requests) — do NOT call `requested_reviewers`,
-  the API returns 422 for bot accounts. See CONTRIBUTING.md § AI reviewers.
+  Review runs locally pre-push (Claude + Codex). On GitHub, Codex auto-reviews
+  and Copilot is MANUAL: add the `needs-copilot` label to request it (it bills
+  premium requests) — do NOT call `requested_reviewers`, the API returns 422
+  for GitHub App bot accounts. See CONTRIBUTING.md § AI reviewers.
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -416,14 +416,15 @@ The list of people to mention should be suggested based on the PR context (scope
 ### 7. Wait for review
 
 - CI must pass (GitHub Actions runs automatically)
-- At least one reviewer must approve
+- Every posted review comment is addressed — bot reviewers (Codex, and Copilot on demand) only comment, and `main` is not branch-protected, so a GitHub approval is **not** required; the local pre-push review (all Must-Have items resolved) is the gate
 - Address review comments before merging
 
 #### AI reviewers — defence-in-depth pipeline
 
 Review on this repository is layered: a **local pre-push ritual** is the
-primary path and catches most issues before anything reaches GitHub, and
-Copilot is kept as a deliberate **on-demand** complement (it bills premium
+primary path and catches most issues before anything reaches GitHub, Codex
+auto-reviews PRs on GitHub, and Copilot is kept as a deliberate **on-demand**
+complement (it bills premium
 requests — 13 per review since 2026-06-01 under the AI-credits model — so it
 is not run on every PR). CodeRabbit was removed on 2026-06-24: its free tier
 hit a PR-review rate limit and posted billing nudges on PRs.
@@ -435,14 +436,15 @@ run the local review ritual: the `pre-push-review` skill drives the
 single Must Have / Should Have / Nice to Have / Disagree action list, and
 gates the push on all Must Have items resolved.
 
-**2. Post-push (GitHub) — on-demand reviewer:**
+**2. Post-push (GitHub) — Codex (automatic) + Copilot (on-demand):**
 
 | Reviewer | Bot account | Trigger | Status |
 |---|---|---|---|
+| Codex | `chatgpt-codex-connector[bot]` | Automatic on every PR | Comments only — never approves |
 | Copilot | `copilot-pull-request-reviewer[bot]` | **Manual** — add the `needs-copilot` label | On-demand only (premium-request quota) |
 
-Codex runs in the **local pre-push** ritual (`scripts/codex-review.sh`), not as
-a GitHub-side auto-reviewer.
+Codex also runs in the **local pre-push** ritual (`scripts/codex-review.sh`).
+No GitHub bot reviewer can *approve* — they only post comments.
 
 What this means in practice:
 
@@ -450,9 +452,10 @@ What this means in practice:
   review on a PR, add the **`needs-copilot`** label — the `Copilot Review`
   workflow then posts `@copilot please review`. Use it sparingly (premium
   requests, ×13 per review).
-- **Do not** call `gh api ... requested_reviewers -X POST` for `Copilot` —
-  the call fails with 422 for GitHub-App bot accounts. Copilot is triggered
-  via the `needs-copilot` label above.
+- **Do not** call `gh api ... requested_reviewers -X POST` for `Codex` or
+  `Copilot` — the call fails with 422 for GitHub App bot accounts (not all
+  `[bot]` users). Codex reviews automatically; Copilot is triggered via the
+  `needs-copilot` label above.
 - **Do** wait for each review to be **posted** (not just "requested")
   before considering the PR ready, per the PR review procedure in
   global `~/.claude/CLAUDE.md`. Verify with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -421,12 +421,12 @@ The list of people to mention should be suggested based on the PR context (scope
 
 #### AI reviewers — defence-in-depth pipeline
 
-Review on this repository is layered: a **local pre-push ritual** catches
-most issues before anything reaches GitHub, an **automatic post-push
-reviewer** (CodeRabbit) reviews every PR for free, and Copilot is kept as a
-deliberate **on-demand** complement (it bills premium requests — 13 per
-review since 2026-06-01 under the AI-credits model — so it is not run on
-every PR).
+Review on this repository is layered: a **local pre-push ritual** is the
+primary path and catches most issues before anything reaches GitHub, and
+Copilot is kept as a deliberate **on-demand** complement (it bills premium
+requests — 13 per review since 2026-06-01 under the AI-credits model — so it
+is not run on every PR). CodeRabbit was removed on 2026-06-24: its free tier
+hit a PR-review rate limit and posted billing nudges on PRs.
 
 **1. Pre-push (local, free) — the primary path.** Before pushing a branch,
 run the local review ritual: the `pre-push-review` skill drives the
@@ -435,13 +435,14 @@ run the local review ritual: the `pre-push-review` skill drives the
 single Must Have / Should Have / Nice to Have / Disagree action list, and
 gates the push on all Must Have items resolved.
 
-**2. Post-push (GitHub) — automatic and on-demand reviewers:**
+**2. Post-push (GitHub) — on-demand reviewer:**
 
 | Reviewer | Bot account | Trigger | Status |
 |---|---|---|---|
-| CodeRabbit | `coderabbitai[bot]` | Automatic on every PR | Always active (free tier, private repos OK) |
-| Codex | `chatgpt-codex-connector[bot]` | Automatic on every PR | Always active |
 | Copilot | `copilot-pull-request-reviewer[bot]` | **Manual** — add the `needs-copilot` label | On-demand only (premium-request quota) |
+
+Codex runs in the **local pre-push** ritual (`scripts/codex-review.sh`), not as
+a GitHub-side auto-reviewer.
 
 What this means in practice:
 
@@ -449,10 +450,9 @@ What this means in practice:
   review on a PR, add the **`needs-copilot`** label — the `Copilot Review`
   workflow then posts `@copilot please review`. Use it sparingly (premium
   requests, ×13 per review).
-- **Do not** call `gh api ... requested_reviewers -X POST` for `Codex` or
-  `Copilot` — the call fails with 422 for GitHub-App bot accounts.
-  CodeRabbit and Codex review automatically; Copilot is triggered via the
-  label above.
+- **Do not** call `gh api ... requested_reviewers -X POST` for `Copilot` —
+  the call fails with 422 for GitHub-App bot accounts. Copilot is triggered
+  via the `needs-copilot` label above.
 - **Do** wait for each review to be **posted** (not just "requested")
   before considering the PR ready, per the PR review procedure in
   global `~/.claude/CLAUDE.md`. Verify with:

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,13 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-06-24
 
+### PR #1266 merged (`6a83aa3`) — feat(mobile): gate batch launch behind a pre-brew preparation screen
+
+- Branch `feat/brew-prep-launch-gate`. Brings the launch gate (**UC6** of the brew-prep conception #1248) forward after terrain testing showed the standalone "Vérifier mes ingrédients" entry point (A2) dead-ended. The recipe sticky CTA is renamed **"Lancer un brassin" → "Préparer mon brassin"** and opens a pre-launch preparation screen `BrewPrepScreen` (route `recipes/[id]/prepare`, replacing `IngredientReadinessScreen` + the `readiness` route). The screen hosts the ingredient checklist and a gated **"Lancer le brassage"** CTA: the `startBatch` mutation moves there, the launch is disabled until the checklist is complete and guarded by a confirmation dialog. The Overview "Vérifier mes ingrédients" button is removed.
+- **Decisions**:
+  - `strict-launch-gate` — the gate blocks (not guidance-with-override) until every ingredient is ticked, deliberately anticipating the future stock/inventory feature where ticking "I have it" becomes a stock movement. Conforms to #1248 UC6 as written; no diagram change. Covers the ingredient checklist only this slice; equipment (A3) will fold into the same screen and extend it.
+- CI green (mobile-app lint/typecheck/tests; full suite 999). One Must-Have from the local pre-push review (a forbidden attribution string in a comment) fixed before push; all threads clear.
+
 ### PR #1256 merged (`5af5b99`) — chore(ci): add Dependabot config for weekly grouped npm updates
 
 - Branch `chore/deps-security-audit-fix`, 2 commits (`424902f`, `f8cfaca`). Response to the weekly Dependabot security digest. Adds `.github/dependabot.yml` (npm ecosystem, root workspace lockfile, weekly Monday, `open-pull-requests-limit: 10`), grouping minor/patch into one PR and ignoring `version-update:semver-major`. Config-only; no lockfile or dependency change. GitHub's `.github/dependabot.yml` validation check passes.


### PR DESCRIPTION
## Summary

Disable CodeRabbit as a PR reviewer on this repository and consolidate the review pipeline on the existing local pre-push ritual.

- `.coderabbit.yaml`: `auto_review.enabled: false` + `chat.auto_reply: false`. The GitHub App is being uninstalled separately; this config disable stops auto-reviews on its own.
- Docs updated to reflect the pipeline: the local pre-push ritual (`pr-pre-reviewer` + `/code-review` + Codex via `scripts/codex-review.sh`) is the **primary** reviewer; Copilot stays **on-demand** (`needs-copilot` label). Also corrects a stale claim that Codex auto-reviews on GitHub — it runs in the local ritual. (CONTRIBUTING.md, PR template, `pre-push-review` / `pr-create-brasse-bouillon` skills.)
- PROJECT_LOG: record PR #1266 (pre-brew launch gate).

## Context

CodeRabbit's free tier hit its PR-review rate limit and started posting billing nudges on PRs instead of actual reviews — including on #1266, where it reviewed nothing. The local pre-push review already mirrors CodeRabbit's rules (the `.coderabbit.yaml` path-instructions were kept in sync with `pr-pre-reviewer.md`) and caught the real Must-Have on #1266, so removing CodeRabbit loses no coverage. `main` is not gated by a CodeRabbit status check, so this does not affect merges.

## Checklist

- [x] Config + docs only; no code change
- [x] Local pre-push review documented as the primary path
- [x] PROJECT_LOG entry for #1266


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated review and contribution guidance to reflect the current PR review workflow.
  - Clarified which reviews happen automatically, which require a manual trigger, and when to wait for them.
  - Removed outdated references to the retired review service and aligned instructions across templates and contributor docs.
  - Added a new project log entry documenting a recent mobile launch flow update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->