### PR TITLE
docs(equipment-cleaning): conception (UML + ADR-0021) for the equipment + cleaning epic

### DIFF
--- a/docs/architecture/decisions/0021-equipment-readiness-cleaning-and-adaptive-pedagogy.md
+++ b/docs/architecture/decisions/0021-equipment-readiness-cleaning-and-adaptive-pedagogy.md
@@ -1,0 +1,96 @@
+# ADR-0021 — Equipment readiness = reusable profile + capacity fit-check + cleaning ritual; adaptive pedagogy
+
+**Status**  Proposed
+**Date**    2026-06-24
+**Owners**  @benoit-bremaud
+
+> Settles how "equipment readiness" works in the novice brew-preparation journey,
+> after the first-brew debrief showed it is **not** a per-brew possession checklist.
+> Conception: [`../diagrams/equipment-cleaning/`](../diagrams/equipment-cleaning/).
+> Builds on ADR-0020 (equipment-driven volume planning) and refines brew-prep
+> ([`../diagrams/brew-prep/`](../diagrams/brew-prep/)). Relates: ADR-0002, ADR-0001.
+
+## Context
+
+"A3 = an equipment checklist mirroring the ingredient one" proved wrong:
+
+- the backend has **no recipe↔equipment relation** — equipment is the brewer's,
+  stored as reusable **`equipment_profiles`** (per-user CRUD) + an
+  **`equipment_templates`** catalog;
+- equipment is **durable / reusable** (declared once, reused every brew), unlike
+  consumed ingredients — so re-ticking owned gear each brew is meaningless;
+- a live recipe (the blonde) carries no equipment; mobile has only a read-only
+  list (no capture);
+- the product's **maître-mot is education** — a novice must learn to brew on
+  their own, in the app.
+
+## Decision
+
+**D1 — Equipment is a reusable profile, declared once via a guided wizard.** An
+`EquipmentProfile` (on the existing `equipment_profiles` API) is created in a
+**dedicated equipment space**, from a **preset** (`equipment_templates`),
+answering **3 essential questions** (system type, fermenter + size, kettle size);
+losses / evaporation / efficiency are inherited from the preset (editable later).
+Multi-fermenter is out of v1.
+
+**D2 — Equipment readiness for a brew = a capacity fit-check + the cleaning
+ritual, NOT a possession checklist.** Per brew the app does **not** re-tick owned
+gear; it (a) runs a **graded fit-check** (fits / tight-krausen / too-small) **with
+advice** (reduce volume, or dunk-sparge), and (b) gates on the **cleaning** phase.
+Refines brew-prep UC6:
+`readyToLaunch = ingredientChecklist.isComplete() && fitCheck.ok() && preCleaning.isComplete()`.
+
+**D3 — The fermenter caps the batch and the recipe target-volume.** Consistent
+with ADR-0020 D1, the profile's fermenter capacity (minus krausen headspace)
+**caps the recipe target-volume slider**. v1 = a simple UI ceiling + a graded
+fit-check comparing fixed numbers; the full ADR-0020 **VolumePlanner cascade is
+deferred** (not required while the first recipe's volume is fixed).
+
+**D4 — Cleaning is a guided, beginner phase: guide + hybrid checklist, before and
+after the brew.** It distinguishes **cleaning** (residues; e.g. percarbonate)
+from **sanitizing** (microbes, no-rinse; e.g. Star San), teaches the rule
+"post-boil = sanitize", and adapts instructions (dose / contact time / rinse) to
+the **products the brewer declares** (light v1 — *which* products, no stock
+tracking; full inventory deferred, unified with ingredients later). Items =
+curated beginner set + adjustable. Bottle sanitizing belongs to bottling (phase
+B).
+
+**D5 — Pedagogy is everywhere and adaptive.** Every screen teaches (inline
+explanation + a foldable "why?" + glossary, plus links to the academy).
+Intrusiveness adapts to a **brewer level declared at onboarding** (novice /
+intermediate / confirmed), overridable anytime, with guides **always one tap
+away** (guidance + escape hatch). Gamification / **badges** = a future competence
+layer (deferred).
+
+## Consequences
+
+- The equipment feature becomes a **reusable profile + fit-check + cleaning**,
+  decoupled from recipes — matching ADR-0020's "equipment as a first-class input".
+- Cleaning guidance is a **differentiator** vs Brewfather / BeerSmith (which
+  assume the user already knows).
+- v1 stays small (no VolumePlanner, no stock tracking) yet brew-meaningful; the
+  heavier layers (ADR-0020 cascade, unified inventory, badges, wait-tracking) are
+  deferred behind clear seams.
+- Cost: a new mobile equipment-capture surface + a cleaning content set; both
+  serve the educational vocation.
+
+### Rejected (for now)
+
+- **Recipe-declared equipment** — would need a new recipe↔equipment relation +
+  migration + per-recipe seeding; wrong model (equipment is the brewer's, not the
+  recipe's).
+- **Per-brew possession checklist** (re-tick owned gear) — redundant once a
+  profile exists; the meaningful per-brew act is fit + cleaning.
+- **Full quantitative inventory now** (products + ingredients) — deferred as a
+  unified epic; v1 only declares *which* cleaning products.
+
+## Relation to other ADRs
+
+- **Builds on ADR-0020** — D3 defers its VolumePlanner cascade while honouring
+  "the fermenter caps the batch".
+- **Refines brew-prep** — supersedes the placeholder "equipment readiness = a
+  checklist".
+- **Respects ADR-0001 / KISS** — names seams (fit-check, cleaning, level,
+  inventory) without speculative code.
+- **Implements ADR-0002** — equipment profiles and any future volume calc live in
+  the NestJS API; mobile talks via the http-client.

--- a/docs/architecture/decisions/0021-equipment-readiness-cleaning-and-adaptive-pedagogy.md
+++ b/docs/architecture/decisions/0021-equipment-readiness-cleaning-and-adaptive-pedagogy.md
@@ -29,8 +29,11 @@
 **D1 — Equipment is a reusable profile, declared once via a guided wizard.** An
 `EquipmentProfile` (on the existing `equipment_profiles` API) is created in a
 **dedicated equipment space**, from a **preset** (`equipment_templates`),
-answering **3 essential questions** (system type, fermenter + size, kettle size);
-losses / evaporation / efficiency are inherited from the preset (editable later).
+answering **3 essential questions** (system type, fermenter + size, kettle size).
+The create-DTO requires more than those 3 answers (`name`, `mash_tun_volume_l`,
+`evaporation_rate_l_per_hour`, `efficiency_estimated_percent`, plus the losses):
+these are **preset-seeded and hidden from the novice, but still sent** in the
+snake_case `POST /equipment-profiles` body so validation passes (editable later).
 Multi-fermenter is out of v1.
 
 **D2 — Equipment readiness for a brew = a capacity fit-check + the cleaning

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -58,6 +58,7 @@ Every ADR follows the same skeleton (inspired by Michael Nygard's template):
 | [0018](0018-admin-moderation-surface.md) | Admin/moderation surface (in-app CREATOR, secured at the API) | Accepted | 2026-06-15 |
 | [0019](0019-testing-strategy-and-quality-gates.md) | Testing strategy: test pyramid, e2e tooling per surface, CI quality gates | Proposed | 2026-06-17 |
 | [0020](0020-equipment-driven-volume-planning.md) | Equipment-driven batch sizing & volume planning (computed in the backend) | Accepted | 2026-06-19 |
+| [0021](0021-equipment-readiness-cleaning-and-adaptive-pedagogy.md) | Equipment readiness = reusable profile + capacity fit-check + cleaning ritual; adaptive pedagogy | Proposed | 2026-06-24 |
 
 > **Numbers 0006–0008 are reserved** (not yet drafted) for decisions already
 > referenced by open epics: 0006 — private journal vs. social product (#833),

--- a/docs/architecture/diagrams/equipment-cleaning/01-use-case.md
+++ b/docs/architecture/diagrams/equipment-cleaning/01-use-case.md
@@ -1,0 +1,47 @@
+# Use case diagram — equipment-cleaning — Manage gear & clean for a brew (novice)
+
+> **Feature**: first real-world brew (epic) — reusable equipment profile + cleaning ritual.
+> **Refines**: brew-prep ([`../brew-prep/01-use-case.md`](../brew-prep/01-use-case.md)) UC3 (declare equipment) and UC5 (equipment readiness).
+> **Related ADRs**: ADR-0021 (this epic), ADR-0020 (volume planning), ADR-0002.
+
+## Context
+
+Equipment is **durable and reusable** (declared once, reused every brew) — unlike consumed ingredients. This epic covers declaring a reusable **equipment profile** (guided), checking it **fits** a given brew, and the beginner **cleaning / sanitizing** ritual (before and after). Use cases are grouped **by domain** (UML 2.5), never by backend package. Pedagogy is **cross-cutting** (every screen teaches — ADR-0021), surfaced as on-demand help, not modelled as its own goal beyond "consult guidance".
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer<br/>(novice to confirmed)"))
+  subgraph SYSTEM ["Brasse-Bouillon"]
+    subgraph Equip ["Equipment domain"]
+      UC1(("Declare my equipment profile (guided)"))
+      UC2(("Adjust a preset to my gear"))
+    end
+    subgraph Prep ["Brew-preparation domain"]
+      UC3(("Check my equipment fits this brew"))
+      UC4(("Clean and sanitize before brewing"))
+    end
+    subgraph Closure ["Brew-closure domain"]
+      UC5(("Clean and sanitize after brewing"))
+    end
+    subgraph Learn ["Learning domain"]
+      UC6(("Consult a guide or glossary"))
+    end
+  end
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+```
+
+## Notes
+
+- **Relationships (real UML, not navigation):** UC1 **«include»** UC2 — a profile is created *from a preset*, then adjusted (the guided wizard). The brew-prep launch gate (brew-prep UC6 *Confirm ready to brew*) **«include»** UC3 + UC4 — this epic **refines** brew-prep's "Check equipment readiness" (UC5 there) into **fit-check + cleaning**, not a possession checklist (the gear is already declared). UC5 here is an **«extend»** of the bottling step (bottle sanitizing).
+- **Cockburn (brief) — UC1 *Declare my equipment profile*:** primary actor = brewer; precondition = none; success guarantee = a reusable profile saved (`equipment_profiles`). Main success: pick a preset → answer **3 essential questions** (system type, fermenter + size, kettle size) → save; losses/efficiency inherited from the preset. The **fermenter capacity caps the batch** and the recipe target-volume slider (ADR-0020 D1, ADR-0021 D3).
+- **Cockburn (brief) — UC3 *Check my equipment fits*:** success = a **graded verdict** (fits / tight-krausen / too-small) **with advice** (reduce volume, or switch to dunk-sparge), comparing the declared profile to the brew's needs. v1 = comparison of fixed numbers (no ADR-0020 recompute).
+- **Cockburn (brief) — UC4 / UC5 *Clean and sanitize*:** a beginner **guide + a hybrid checklist** (curated set + adjustable) that distinguishes **cleaning** (residues) from **sanitizing** (microbes, no-rinse); product instructions adapt to the products the brewer declares. Pre-brew (post-boil gear) and post-brew (cleanup; bottle sanitizing at bottling).
+- **Actor level (ADR-0021):** the same actor carries a **declared level** (novice → confirmed) that tunes pedagogy intrusiveness; modelled as an actor attribute, not separate actors (avoids actor-explosion).
+- **Proportionality / out of scope:** the fermentation-wait follow-up ("resume tracking from a reminder", "record a gravity reading") is **phase B** — mapped in the needs brief, detailed when built. **Skipped here:** data-flow — the only user data is the owner-scoped profile + declared products (no sensitive PII beyond `owner_id`, already JWT-scoped by the API).

--- a/docs/architecture/diagrams/equipment-cleaning/02-sequence-equipment-wizard.md
+++ b/docs/architecture/diagrams/equipment-cleaning/02-sequence-equipment-wizard.md
@@ -18,7 +18,7 @@ sequenceDiagram
   M->>API: GET /catalog/equipment-templates
   API-->>M: presets (kitchen starter, BIAB 20/30L, all-in-one, ...)
   B->>M: Q1 - choose a preset (system type)
-  M->>M: prefill losses / evaporation / efficiency from the preset
+  M->>M: seed name, mash tun, losses, evaporation, efficiency from the preset
   B->>M: Q2 - fermentation vessel + size (caps the batch)
   B->>M: Q3 - largest kettle / pot size (selects the method)
   M->>M: suggest a name, show a recap
@@ -33,4 +33,5 @@ sequenceDiagram
 - **Guided / progressive (ADR-0021):** one question at a time; the preset prefills everything else, so a beginner answers only **3** essentials (type, fermenter, kettle). Advanced fields (losses, efficiency) stay editable later, hidden by default (adaptive pedagogy).
 - **Reuse, not per-recipe:** a profile is created **once** and reused; it is **not** tied to a recipe (no recipe↔equipment relation — the gear is the brewer's). Multi-fermenter is out of v1 (enter the vessel you ferment in).
 - The **fermenter size** captured here caps the batch and the recipe target-volume slider (ADR-0020 D1, ADR-0021 D3). The **kettle size** selects full-volume vs dunk-sparge (ADR-0020 D2) — consumed by the fit-check (03).
+- **API payload (beyond the 3 answers):** the `POST /equipment-profiles` body is **snake_case**, and the create-DTO **requires more than the 3 essentials** — `name`, `mash_tun_volume_l`, `evaporation_rate_l_per_hour`, `efficiency_estimated_percent` — which the wizard **seeds from the preset** (hidden from the novice) and **still sends** so `ValidationPipe({ whitelist: true })` passes. The `equipment_templates` BeerXML fields (`evap_rate_percent`, `hop_utilization_percent`, …) don't map 1:1, so the wizard applies an explicit template → create-DTO mapping/defaults.
 - Inline help + a glossary explain each term ("fermenteur", "empâtage", "dunk-sparge") in beginner language, with academy links (ADR-0021 D5).

--- a/docs/architecture/diagrams/equipment-cleaning/02-sequence-equipment-wizard.md
+++ b/docs/architecture/diagrams/equipment-cleaning/02-sequence-equipment-wizard.md
@@ -1,0 +1,36 @@
+# Sequence diagram — equipment-cleaning — Declare an equipment profile (guided wizard)
+
+> **Feature**: equipment-cleaning epic — the guided 3-question profile wizard.
+> **Realizes**: UC1 (with «include» UC2). **Related ADRs**: ADR-0021, ADR-0020.
+
+## Context
+
+How a novice creates a **reusable** equipment profile **from a preset** with minimal questions. The API (`equipment_profiles`, CRUD per user) and the **`equipment_templates`** catalog already exist; this is the missing mobile capture. Only 3 essentials are asked; losses / evaporation / efficiency are inherited from the chosen preset (invisible until the ADR-0020 volume calc lands).
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant M as Mobile (Equipment space)
+  participant API as Backend API
+  B->>M: Open "Mes équipements", then "Ajouter un profil"
+  M->>API: GET /catalog/equipment-templates
+  API-->>M: presets (kitchen starter, BIAB 20/30L, all-in-one, ...)
+  B->>M: Q1 - choose a preset (system type)
+  M->>M: prefill losses / evaporation / efficiency from the preset
+  B->>M: Q2 - fermentation vessel + size (caps the batch)
+  B->>M: Q3 - largest kettle / pot size (selects the method)
+  M->>M: suggest a name, show a recap
+  B->>M: Confirm
+  M->>API: POST /equipment-profiles (3 answers + preset defaults)
+  API-->>M: 201 saved profile
+  M-->>B: Profile ready - reusable for every brew
+```
+
+## Notes
+
+- **Guided / progressive (ADR-0021):** one question at a time; the preset prefills everything else, so a beginner answers only **3** essentials (type, fermenter, kettle). Advanced fields (losses, efficiency) stay editable later, hidden by default (adaptive pedagogy).
+- **Reuse, not per-recipe:** a profile is created **once** and reused; it is **not** tied to a recipe (no recipe↔equipment relation — the gear is the brewer's). Multi-fermenter is out of v1 (enter the vessel you ferment in).
+- The **fermenter size** captured here caps the batch and the recipe target-volume slider (ADR-0020 D1, ADR-0021 D3). The **kettle size** selects full-volume vs dunk-sparge (ADR-0020 D2) — consumed by the fit-check (03).
+- Inline help + a glossary explain each term ("fermenteur", "empâtage", "dunk-sparge") in beginner language, with academy links (ADR-0021 D5).

--- a/docs/architecture/diagrams/equipment-cleaning/03-sequence-prep-fit-and-clean.md
+++ b/docs/architecture/diagrams/equipment-cleaning/03-sequence-prep-fit-and-clean.md
@@ -1,0 +1,47 @@
+# Sequence diagram — equipment-cleaning — Fit-check & clean before launch
+
+> **Feature**: equipment-cleaning epic — pre-launch equipment readiness (fit-check + cleaning).
+> **Realizes**: UC3 + UC4; refines the brew-prep ([`../brew-prep/02-sequence-plan-and-confirm.md`](../brew-prep/02-sequence-plan-and-confirm.md)) launch gate.
+> **Related ADRs**: ADR-0021, ADR-0020.
+
+## Context
+
+On the existing `BrewPrepScreen` (PR #1266), "equipment readiness" is **not** a possession checklist — it is a **capacity fit-check** against the declared profile **plus** the **cleaning** ritual. Both, with the ingredient checklist, gate the irreversible launch.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant M as Mobile (BrewPrepScreen)
+  participant API as Backend API
+  B->>M: Open "Préparer mon brassin"
+  M->>API: GET /equipment-profiles (my default profile)
+  API-->>M: profile (fermenter, kettle, ...)
+  Note over M: Fit-check, v1 = compare fixed numbers
+  alt fermenter >= batch + krausen AND kettle >= mash-in
+    M-->>B: GREEN - fits
+  else fermenter only just fits
+    M-->>B: AMBER - tight krausen (advice - reduce volume)
+  else too small
+    M-->>B: RED - too small (advice - smaller batch or dunk-sparge)
+  end
+  loop each cleaning item (curated set + my additions)
+    B->>M: tick "nettoyé" or "désinfecté" (guide + product sheet)
+  end
+  alt ingredients OK AND fit-check OK AND pre-cleaning complete
+    M-->>B: enable "Lancer le brassage"
+  else something missing
+    M-->>B: keep disabled, list what is missing
+  end
+  B->>M: Confirm launch
+  M->>API: POST /batches (start)
+```
+
+## Notes
+
+- **Equipment readiness = fit-check + cleaning, NOT possession (ADR-0021 D2).** The gear is already declared (the profile); re-ticking owned vessels every brew is pointless. The per-brew act is verifying **capacity fit** + **cleaning**.
+- **Graded fit-check + advice (ADR-0021 D2):** green / amber / red with an action, not a binary pass/fail — it educates the novice. v1 compares fixed recipe numbers vs the profile's capacities (no ADR-0020 recompute; deferred).
+- **Cleaning = guide + hybrid checklist (ADR-0021 D4):** a curated beginner set (fermenter, airlock + bung, spoon, funnel, hydrometer, thermometer, ...) + adjustable; clean (residues) vs sanitize (no-rinse, e.g. Star San); instructions adapt to the brewer's **declared products**.
+- **Refines brew-prep UC6:** `readyToLaunch = ingredientChecklist.isComplete() && fitCheck.ok() && preCleaning.isComplete()` — supersedes the placeholder "equipmentChecklist.isComplete()".
+- **Open (ADR-0021):** sanitizing the post-boil gear is ideally **just-in-time** (during cooling, just before transfer) — a brew-day (phase B) placement; the pre-launch gate may instead confirm "ready to sanitize at transfer". Flagged; settled when B1 is built.

--- a/docs/architecture/diagrams/equipment-cleaning/03-sequence-prep-fit-and-clean.md
+++ b/docs/architecture/diagrams/equipment-cleaning/03-sequence-prep-fit-and-clean.md
@@ -16,8 +16,9 @@ sequenceDiagram
   participant M as Mobile (BrewPrepScreen)
   participant API as Backend API
   B->>M: Open "Préparer mon brassin"
-  M->>API: GET /equipment-profiles (my default profile)
-  API-->>M: profile (fermenter, kettle, ...)
+  M->>API: GET /equipment-profiles (list mine)
+  API-->>M: my profiles (fermenter, kettle, ...)
+  M->>M: select a profile (auto if only one; else last-used)
   Note over M: Fit-check, v1 = compare fixed numbers
   alt fermenter >= batch + krausen AND kettle >= mash-in
     M-->>B: GREEN - fits
@@ -44,4 +45,5 @@ sequenceDiagram
 - **Graded fit-check + advice (ADR-0021 D2):** green / amber / red with an action, not a binary pass/fail — it educates the novice. v1 compares fixed recipe numbers vs the profile's capacities (no ADR-0020 recompute; deferred).
 - **Cleaning = guide + hybrid checklist (ADR-0021 D4):** a curated beginner set (fermenter, airlock + bung, spoon, funnel, hydrometer, thermometer, ...) + adjustable; clean (residues) vs sanitize (no-rinse, e.g. Star San); instructions adapt to the brewer's **declared products**.
 - **Refines brew-prep UC6:** `readyToLaunch = ingredientChecklist.isComplete() && fitCheck.ok() && preCleaning.isComplete()` — supersedes the placeholder "equipmentChecklist.isComplete()".
+- **No "default profile" on the backend:** the API exposes only `GET /equipment-profiles` (list mine); **profile selection is client-side** (auto-select if a single profile, else last-used). No default-profile endpoint is implied.
 - **Open (ADR-0021):** sanitizing the post-boil gear is ideally **just-in-time** (during cooling, just before transfer) — a brew-day (phase B) placement; the pre-launch gate may instead confirm "ready to sanitize at transfer". Flagged; settled when B1 is built.

--- a/docs/architecture/diagrams/equipment-cleaning/04-class.md
+++ b/docs/architecture/diagrams/equipment-cleaning/04-class.md
@@ -1,0 +1,82 @@
+# Class diagram — equipment-cleaning — equipment profile, fit-check & cleaning model
+
+> **Feature**: equipment-cleaning epic — the domain model.
+> **Refines**: brew-prep ([`../brew-prep/04-class.md`](../brew-prep/04-class.md)).
+> **Related ADRs**: ADR-0021 (this epic), ADR-0020 (volume planning).
+
+## Context
+
+The durable, reusable **`EquipmentProfile`** (mapped to the `equipment_profiles` API entity), how it produces a **`FitCheck`** for a brew, and the beginner **cleaning** model (`CleaningChecklist` / `CleaningItem` / `CleaningProduct`). Equipment readiness is **redefined** as fit-check + cleaning (not a possession checklist).
+
+## Diagram
+
+```mermaid
+classDiagram
+  class EquipmentProfile {
+    +UUID id
+    +UUID ownerId
+    +string name
+    +SystemType systemType
+    +number fermenterVolumeL
+    +number boilKettleVolumeL
+    +number mashTunVolumeL
+    +number trubLossL
+    +number deadSpaceLossL
+    +number transferLossL
+    +number evaporationRateLPerHour
+    +number efficiencyEstimatedPercent
+    +fermenterCapL() number
+  }
+  class FitCheck {
+    <<value object>>
+    +Verdict fermenterVerdict
+    +Verdict kettleVerdict
+    +Method suggestedMethod
+    +string advice
+    +ok() boolean
+  }
+  class CleaningProduct {
+    +string name
+    +ProductRole role
+    +boolean noRinse
+    +string dosePerLitre
+    +number contactMinutes
+  }
+  class CleaningItem {
+    +string id
+    +string name
+    +CleanKind kind
+    +boolean required
+    +boolean done
+    +UUID productId
+  }
+  class CleaningChecklist {
+    +Phase phase
+    +CleaningItem[] items
+    +isComplete() boolean
+  }
+  class EquipmentReadiness {
+    +boolean ready
+  }
+  class Recipe {
+    <<brew-prep>>
+    +number targetVolumeL
+  }
+  EquipmentProfile "1" ..> "1" FitCheck : caps and method
+  Recipe "1" ..> "1" FitCheck : needs feed
+  EquipmentProfile "1" ..> "1" Recipe : caps target volume
+  EquipmentReadiness "1" o-- "1" FitCheck
+  EquipmentReadiness "1" o-- "1" CleaningChecklist : pre-brew
+  CleaningChecklist "1" *-- "1..*" CleaningItem
+  CleaningItem "0..1" --> "1" CleaningProduct : adaptive sheet
+```
+
+## Notes
+
+- **`EquipmentProfile` maps 1:1 to the API entity** (`equipment_profiles`). The v1 wizard captures `systemType`, `fermenterVolumeL`, `boilKettleVolumeL` (the API field names; brew-prep's conceptual `fermenterCapacityL` / `kettleCapacityL` are these same fields); the rest (losses, evaporation, efficiency) are **inherited from the chosen preset** (`equipment_templates`) and editable later. `fermenterCapL() = fermenterVolumeL × (1 − headspaceRatio)`.
+- **`FitCheck` is a Value Object** (graded verdicts + advice), computed mobile-side in v1 from fixed recipe numbers vs the profile (no ADR-0020 recompute — deferred). `Verdict = {FITS, TIGHT_KRAUSEN, TOO_SMALL}`; `Method = {FULL_VOLUME, DUNK_SPARGE}` (shared with brew-prep / ADR-0020). `ok() = fermenterVerdict ≠ TOO_SMALL && kettleVerdict ≠ TOO_SMALL`.
+- **Cleaning model:** `CleanKind = {CLEAN, SANITIZE}`; `Phase = {PRE_BREW, POST_BREW}`; `ProductRole = {CLEANER, SANITIZER}`. Items = **hybrid** (curated beginner set + user-added). `CleaningProduct` is **declared by the brewer** (light inventory — *which* products, no quantities; full stock deferred, unified with ingredients in a later inventory epic); it drives an **adaptive sheet** (dose / contact time / rinse-or-not). The shared `ChecklistRow` UI primitive renders both ingredient (brew-prep) and cleaning items.
+- **Equipment readiness redefined (ADR-0021 D2):** `EquipmentReadiness.ready = fitCheck.ok() && preCleaning.isComplete()` — replaces the brew-prep placeholder "equipmentChecklist.isComplete()". The launch gate becomes `ingredientChecklist.isComplete() && EquipmentReadiness.ready` (refines brew-prep `BrewReadiness.readyToLaunch`).
+- **Volume cap (ADR-0021 D3):** the profile **caps `Recipe.targetVolumeL`** (≤ `fermenterCapL()`); v1 = a UI ceiling on the existing slider, not the full ADR-0020 cascade (deferred).
+- **No recipe↔equipment relation:** equipment is the **brewer's**, owned via `ownerId`; recipes never declare equipment — the gap that triggered this epic.
+- **Pedagogy** (`BrewerLevel = {NOVICE, INTERMEDIATE, CONFIRMED}`, declared at onboarding) tunes guide intrusiveness — a cross-cutting concern, not drawn here (ADR-0021 D5).

--- a/docs/architecture/diagrams/equipment-cleaning/04-class.md
+++ b/docs/architecture/diagrams/equipment-cleaning/04-class.md
@@ -36,6 +36,7 @@ classDiagram
     +ok() boolean
   }
   class CleaningProduct {
+    +UUID id
     +string name
     +ProductRole role
     +boolean noRinse
@@ -68,14 +69,14 @@ classDiagram
   EquipmentReadiness "1" o-- "1" FitCheck
   EquipmentReadiness "1" o-- "1" CleaningChecklist : pre-brew
   CleaningChecklist "1" *-- "1..*" CleaningItem
-  CleaningItem "0..1" --> "1" CleaningProduct : adaptive sheet
+  CleaningItem "*" --> "0..1" CleaningProduct : adaptive sheet
 ```
 
 ## Notes
 
-- **`EquipmentProfile` maps 1:1 to the API entity** (`equipment_profiles`). The v1 wizard captures `systemType`, `fermenterVolumeL`, `boilKettleVolumeL` (the API field names; brew-prep's conceptual `fermenterCapacityL` / `kettleCapacityL` are these same fields); the rest (losses, evaporation, efficiency) are **inherited from the chosen preset** (`equipment_templates`) and editable later. `fermenterCapL() = fermenterVolumeL × (1 − headspaceRatio)`.
+- **`EquipmentProfile` maps to the API entity** (`equipment_profiles`); this diagram uses camelCase (domain/mobile) but the **API wire format is snake_case** (`system_type`, `fermenter_volume_l`, `boil_kettle_volume_l`, `mash_tun_volume_l`, `evaporation_rate_l_per_hour`, `efficiency_estimated_percent`, `name`). The v1 wizard asks only the **3 essentials** (`system_type`, `fermenter_volume_l`, `boil_kettle_volume_l`); the **other required create-DTO fields** are **preset-seeded (hidden from the novice) and still sent in the `POST /equipment-profiles` body** so `ValidationPipe` passes. The preset comes from `equipment_templates`, whose BeerXML field names (`evap_rate_percent`, `hop_utilization_percent`, …) do **not** map 1:1 — the template → profile mapping is an implementation detail of the wizard. `fermenterCapL() = fermenter_volume_l × (1 − HEADSPACE_RATIO)`, where `HEADSPACE_RATIO` is a **fixed krausen constant** (the API has no headspace column).
 - **`FitCheck` is a Value Object** (graded verdicts + advice), computed mobile-side in v1 from fixed recipe numbers vs the profile (no ADR-0020 recompute — deferred). `Verdict = {FITS, TIGHT_KRAUSEN, TOO_SMALL}`; `Method = {FULL_VOLUME, DUNK_SPARGE}` (shared with brew-prep / ADR-0020). `ok() = fermenterVerdict ≠ TOO_SMALL && kettleVerdict ≠ TOO_SMALL`.
-- **Cleaning model:** `CleanKind = {CLEAN, SANITIZE}`; `Phase = {PRE_BREW, POST_BREW}`; `ProductRole = {CLEANER, SANITIZER}`. Items = **hybrid** (curated beginner set + user-added). `CleaningProduct` is **declared by the brewer** (light inventory — *which* products, no quantities; full stock deferred, unified with ingredients in a later inventory epic); it drives an **adaptive sheet** (dose / contact time / rinse-or-not). The shared `ChecklistRow` UI primitive renders both ingredient (brew-prep) and cleaning items.
+- **Cleaning model:** `CleanKind = {CLEAN, SANITIZE}`; `Phase = {PRE_BREW, POST_BREW}`; `ProductRole = {CLEANER, SANITIZER}`. Items = **hybrid** (curated beginner set + user-added). `CleaningProduct` is **declared by the brewer** (light inventory — *which* products, no quantities; full stock deferred, unified with ingredients in a later inventory epic); it drives an **adaptive sheet** (dose / contact time / rinse-or-not). `CleaningItem.productId` is **optional** (`0..1`): a curated item may not yet map to a declared product, and one product (e.g. Star San) applies to **many** items. The shared `ChecklistRow` UI primitive renders both ingredient (brew-prep) and cleaning items.
 - **Equipment readiness redefined (ADR-0021 D2):** `EquipmentReadiness.ready = fitCheck.ok() && preCleaning.isComplete()` — replaces the brew-prep placeholder "equipmentChecklist.isComplete()". The launch gate becomes `ingredientChecklist.isComplete() && EquipmentReadiness.ready` (refines brew-prep `BrewReadiness.readyToLaunch`).
 - **Volume cap (ADR-0021 D3):** the profile **caps `Recipe.targetVolumeL`** (≤ `fermenterCapL()`); v1 = a UI ceiling on the existing slider, not the full ADR-0020 cascade (deferred).
 - **No recipe↔equipment relation:** equipment is the **brewer's**, owned via `ownerId`; recipes never declare equipment — the gap that triggered this epic.

--- a/docs/architecture/diagrams/equipment-cleaning/05-state-brew-readiness.md
+++ b/docs/architecture/diagrams/equipment-cleaning/05-state-brew-readiness.md
@@ -1,0 +1,33 @@
+# State diagram — equipment-cleaning — readiness gate with cleaning, through bottling
+
+> **Feature**: equipment-cleaning epic — the pre-batch gate (refined) + where cleaning sits across the lifecycle.
+> **Extends**: brew-prep ([`../brew-prep/05-state-readiness.md`](../brew-prep/05-state-readiness.md)).
+> **Related ADRs**: ADR-0021, ADR-0020.
+
+## Context
+
+Refines the brew-prep readiness gate so equipment readiness = **fit-check + pre-cleaning** (not a possession checklist), and maps where **cleaning** sits across the brew lifecycle (pre and post). Everything before `BatchStarted` is reversible; after it is owned by the brewing-session epic (phase B), shown lightly here only to place the cleaning + educational-wait phases.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> RecipeChosen: import a recipe
+  RecipeChosen --> Planned: select equipment profile (caps volume)
+  Planned --> Checking: ingredient checklist + equipment fit-check + pre-cleaning
+  Checking --> Checking: tick an item, sanitize, or re-run the fit-check
+  Checking --> Ready: ingredients OK and fit-check OK and pre-cleaning complete
+  Ready --> Checking: an item becomes missing
+  Ready --> BatchStarted: confirm "Lancer le brassage"
+  BatchStarted --> Fermenting: transfer (sanitize just-in-time), then clean gear
+  Fermenting --> Conditioning: gravity stable, bottle (sanitize bottles), clean fermenter
+  Conditioning --> Bottled: carbonation done
+  Bottled --> [*]
+```
+
+## Notes
+
+- **Readiness gate refined (ADR-0021 D2):** the `Checking → Ready` guard is now `ingredients complete AND fitCheck.ok AND preCleaning complete` — equipment readiness = **fit-check + cleaning**, not a possession checklist (supersedes brew-prep `05` "both checklists complete").
+- **Profile is a precondition** of `Planned`: no profile → no fit-check, no volume cap. Auto-selected if the brewer has a single profile.
+- **Cleaning placement (open, ADR-0021):** sanitizing post-boil gear is best **just-in-time** (during cooling, before transfer) — a phase-B brew-day step; pre-cleaning at the gate covers preparation / availability. **Post-brew cleaning** (kettle after the brew day; fermenter after transfer; bottle sanitizing at bottling) is shown on the later transitions; detailed when phase B is built.
+- **Phase B** (`Fermenting`, `Conditioning`, `Bottled`) belongs to the brewing-session epic — shown only to place the cleaning + educational-wait phases (fermentation end = **gravity stable, not calendar**; ADR-0021 D5). `BatchStarted` remains the **irreversible** boundary (brew-prep).


### PR DESCRIPTION
## Summary

Conception (UML + ADR) for the **equipment + cleaning** epic of the first-real-brew journey. Conception-first (the contract the code will follow); **ADR-0021 is `Proposed`**, pending the planned end-to-end validation review of all brew phases.

- `docs/architecture/diagrams/equipment-cleaning/`: `01-use-case`, `02-sequence-equipment-wizard`, `03-sequence-prep-fit-and-clean`, `04-class`, `05-state-brew-readiness`.
- `docs/architecture/decisions/0021-equipment-readiness-cleaning-and-adaptive-pedagogy.md` (Proposed) + index row.

## Context

"A3 = an equipment checklist mirroring the ingredient one" proved wrong: the backend has **no recipe↔equipment relation** — equipment is the brewer's (`equipment_profiles`, per-user CRUD, + an `equipment_templates` catalog), durable and **reusable** (unlike consumed ingredients). This refines brew-prep (#1248).

## Key decisions captured (ADR-0021)

- **Equipment = a reusable profile**, declared once via a guided **3-question wizard** from a preset; in a dedicated equipment space.
- **Per-brew equipment readiness = a capacity fit-check (graded + advice) + the cleaning ritual** — NOT a per-brew possession checklist.
- **The fermenter caps the batch** and the recipe target-volume; the ADR-0020 volume calculator is **deferred**.
- **Cleaning = guide + hybrid checklist, pre and post**, clean vs sanitize, products declared by the brewer → adaptive sheets.
- **Adaptive pedagogy** (level declared at onboarding; badges deferred).

## Notes

- Docs only; no code. The build slices (E1 wizard → E2 fit-check + volume cap → C1/C2 cleaning) follow, conception-first, after the validation review.
- Refines brew-prep (#1248); builds on ADR-0020.
