### PR TITLE
feat(batch): live brew-day step guidance (B1-live)

### DIFF
--- a/docs/architecture/diagrams/brew-day/01-sequence-step-enrichment.md
+++ b/docs/architecture/diagrams/brew-day/01-sequence-step-enrichment.md
@@ -1,0 +1,37 @@
+# Sequence diagram — brew-day — Enrich live batch steps with guidance (B1-live)
+
+> **Feature**: first real brew — making the brew-day step guide work in **LIVE** mode (roadmap P0 "TRACKER → ASSISTANT").
+> **Realizes**: B1-live. **Related**: brew-prep state machine ([`../brew-prep/05-state-readiness.md`](../brew-prep/05-state-readiness.md)).
+
+## Context
+
+In live mode, batch steps were bare (`label` + `description`); the ⓘ pedagogical tip + the countdown timer — **already rendered** by the mobile `StepCard` / `BrewStepTimer` — were **demo-only**. This slice adds, **at batch start**, a per-step-type guidance (a beginner "why" tip + a default duration) persisted onto the batch, so the live brew-day is guided. **MVP source = per-step-type defaults** (no recipe↔guidance link yet; deferred).
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant M as Mobile
+  participant API as Backend (BatchService)
+  participant D as BatchDomainService
+  B->>M: "Lancer le brassage"
+  M->>API: POST /batches (recipeId)
+  API->>API: load recipe steps (order, type, label, description)
+  API->>D: startBatch(steps)
+  loop each step
+    D->>D: getStepGuidance(step.type) gives tip + duration, or none
+  end
+  D-->>API: BatchStep[] enriched (tip + duration)
+  API->>API: persist batch_steps (pedagogical_tip, planned_duration_min)
+  API-->>M: BatchDto (steps carry tip + duration)
+  M-->>B: live brew-day with the i tip + countdown timer
+```
+
+## Notes
+
+- **Per-type defaults (MVP):** `STEP_TYPE_GUIDANCE` maps each `RecipeStepType` to `{ pedagogicalTip, plannedDurationMin }`. Unknown type gives `undefined` (graceful: no tip/timer). `FERMENTATION` / `PACKAGING` carry a tip but a `null` duration (they run over days — no countdown).
+- **Description preserved:** the recipe-authored `description` is untouched; only the tip + duration are added.
+- **Backward compatible:** the new `batch_steps` columns are nullable; batches started before this carry no enrichment.
+- **Mobile already renders:** `StepCard` (ⓘ tip) + `BrewStepTimer` (countdown) consume `pedagogicalTip` + `plannedDurationMin`; only the API mapping (`mapBatchStep`) was un-dropped.
+- **Next (P0):** B2 (measurements OG/FG/ABV) then B3 (bottling + closure). Recipe-level customization (extend `recipe_steps`) and a per-style reference are deferred.

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -141,6 +141,30 @@ describe('BatchService', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
+  it('enriches steps with guidance and preserves it across completion (B1-live)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+
+    const started = await batchService.startMine(ownerId, recipe.id);
+    // mash (step 0) carries a tip + a default duration
+    expect(started.steps[0].pedagogical_tip).toBeTruthy();
+    expect(started.steps[0].planned_duration_min).toBe(60);
+    // fermentation (step 3) carries a tip but no duration (runs over days)
+    expect(started.steps[3].pedagogical_tip).toBeTruthy();
+    expect(started.steps[3].planned_duration_min).toBeNull();
+
+    // completing a step must NOT wipe the guidance on the persisted steps
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    const reloaded = await batchStepRepo.find({
+      where: { batch_id: started.batch.id },
+      order: { step_order: 'ASC' },
+    });
+    expect(reloaded[0].pedagogical_tip).toBeTruthy();
+    expect(reloaded[0].planned_duration_min).toBe(60);
+    expect(reloaded[3].pedagogical_tip).toBeTruthy();
+    expect(reloaded[3].planned_duration_min).toBeNull();
+  });
+
   it('getMineById() should enforce ownership', async () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My IPA' });

--- a/packages/api/src/batch/domain/batch.domain.spec.ts
+++ b/packages/api/src/batch/domain/batch.domain.spec.ts
@@ -44,6 +44,33 @@ describe('BatchDomainService', () => {
     expect(batch.steps[0].startedAt).toEqual(t0);
   });
 
+  it('enriches each step with type-level pedagogical guidance', () => {
+    const t0 = new Date('2026-02-05T09:00:00.000Z');
+    const service = new BatchDomainService(() => t0);
+
+    const batch = service.startBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+      steps: new RecipeWorkflowService().getDefaultWorkflow(),
+    });
+
+    const mash = batch.steps.find((s) => s.type === RecipeStepType.MASH);
+    expect(mash?.pedagogicalTip).toBeTruthy();
+    expect(mash?.plannedDurationMin).toBe(60);
+
+    const ferment = batch.steps.find(
+      (s) => s.type === RecipeStepType.FERMENTATION,
+    );
+    expect(ferment?.pedagogicalTip).toBeTruthy();
+    expect(ferment?.plannedDurationMin ?? null).toBeNull();
+
+    // the recipe-authored description is preserved, not overwritten
+    expect(mash?.description).toBe(
+      'Mash grains to extract fermentable sugars.',
+    );
+  });
+
   it('should complete steps and auto-advance until completion', () => {
     const t0 = new Date('2026-02-05T09:00:00.000Z');
     const t1 = new Date('2026-02-05T09:10:00.000Z');

--- a/packages/api/src/batch/domain/entities/batch-step.entity.ts
+++ b/packages/api/src/batch/domain/entities/batch-step.entity.ts
@@ -29,4 +29,10 @@ export interface BatchStep {
 
   /** Timestamp when this step was completed. */
   readonly completedAt?: Date;
+
+  /** Beginner "why" tip for this step (type-level guidance, B1-live). */
+  readonly pedagogicalTip?: string;
+
+  /** Default planned duration in minutes; null/undefined when not time-boxed. */
+  readonly plannedDurationMin?: number | null;
 }

--- a/packages/api/src/batch/domain/services/batch-domain.service.ts
+++ b/packages/api/src/batch/domain/services/batch-domain.service.ts
@@ -4,6 +4,7 @@ import { BatchStatus } from '../enums/batch-status.enum';
 import { BatchStepStatus } from '../enums/batch-step-status.enum';
 import { BatchStep } from '../entities/batch-step.entity';
 import { Batch, BatchId, RecipeId, UserId } from '../entities/batch.entity';
+import { getStepGuidance } from './step-guidance';
 
 export interface StartBatchInput {
   id: BatchId;
@@ -34,6 +35,7 @@ export class BatchDomainService {
     const sortedSteps = [...input.steps].sort((a, b) => a.order - b.order);
     const steps: BatchStep[] = sortedSteps.map((step) => {
       const isFirst = step.order === 0;
+      const guidance = getStepGuidance(step.type);
       return {
         order: step.order,
         type: step.type,
@@ -42,6 +44,8 @@ export class BatchDomainService {
         status: isFirst ? BatchStepStatus.IN_PROGRESS : BatchStepStatus.PENDING,
         startedAt: isFirst ? createdAt : undefined,
         completedAt: undefined,
+        pedagogicalTip: guidance?.pedagogicalTip,
+        plannedDurationMin: guidance?.plannedDurationMin ?? undefined,
       };
     });
 

--- a/packages/api/src/batch/domain/services/step-guidance.spec.ts
+++ b/packages/api/src/batch/domain/services/step-guidance.spec.ts
@@ -1,0 +1,38 @@
+import { RecipeStepType } from '../../../recipe/domain/enums/recipe-step-type.enum';
+
+import { getStepGuidance } from './step-guidance';
+
+describe('getStepGuidance', () => {
+  it('returns a tip and a default duration for time-boxed steps (happy)', () => {
+    const mash = getStepGuidance(RecipeStepType.MASH);
+    expect(mash?.pedagogicalTip.length).toBeGreaterThan(0);
+    expect(mash?.plannedDurationMin).toBe(60);
+
+    expect(getStepGuidance(RecipeStepType.BOIL)?.plannedDurationMin).toBe(60);
+    expect(getStepGuidance(RecipeStepType.WHIRLPOOL)?.plannedDurationMin).toBe(
+      15,
+    );
+  });
+
+  it('returns a tip but no duration for over-days steps (edge: fermentation, packaging)', () => {
+    const ferment = getStepGuidance(RecipeStepType.FERMENTATION);
+    expect(ferment?.pedagogicalTip.length).toBeGreaterThan(0);
+    expect(ferment?.plannedDurationMin).toBeNull();
+
+    const packaging = getStepGuidance(RecipeStepType.PACKAGING);
+    expect(packaging?.pedagogicalTip.length).toBeGreaterThan(0);
+    expect(packaging?.plannedDurationMin).toBeNull();
+  });
+
+  it('covers every RecipeStepType with a non-empty tip (coverage)', () => {
+    for (const type of Object.values(RecipeStepType)) {
+      const guidance = getStepGuidance(type);
+      expect(guidance).toBeDefined();
+      expect(guidance?.pedagogicalTip.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('returns undefined for an unknown step type (sad/edge)', () => {
+    expect(getStepGuidance('barrel-aging' as RecipeStepType)).toBeUndefined();
+  });
+});

--- a/packages/api/src/batch/domain/services/step-guidance.ts
+++ b/packages/api/src/batch/domain/services/step-guidance.ts
@@ -1,0 +1,59 @@
+import { RecipeStepType } from '../../../recipe/domain/enums/recipe-step-type.enum';
+
+/**
+ * StepGuidance
+ *
+ * Beginner-facing guidance attached to a batch step at start time, keyed by the
+ * brewing step type. Realises the "B1-live" brew-day assistant content: a
+ * vulgarised "why" tip and a default planned duration (minutes) so the mobile
+ * step card can show the ⓘ tip and a countdown timer in **live** mode (not only
+ * demo data). The recipe-authored `description` is left untouched — this only
+ * adds the type-level tip + duration.
+ *
+ * MVP source = per-step-type defaults (no recipe↔guidance link yet; that is a
+ * later iteration). A `null` duration means "no countdown" (fermentation and
+ * packaging run over days, tracked elsewhere).
+ */
+export interface StepGuidance {
+  readonly pedagogicalTip: string;
+  /** Default planned duration in minutes, or `null` when not time-boxed. */
+  readonly plannedDurationMin: number | null;
+}
+
+const STEP_TYPE_GUIDANCE: Readonly<Record<RecipeStepType, StepGuidance>> = {
+  [RecipeStepType.MASH]: {
+    pedagogicalTip:
+      "L'empâtage fait infuser le grain concassé dans l'eau chaude (~65-67°C) : les enzymes y convertissent l'amidon en sucres fermentescibles. Plus chaud donne une bière plus ronde, plus froid une bière plus sèche.",
+    plannedDurationMin: 60,
+  },
+  [RecipeStepType.BOIL]: {
+    pedagogicalTip:
+      "L'ébullition stérilise le moût, isomérise les acides alpha du houblon (l'amertume) et concentre les sucres. Les houblons d'amertume vont tôt, les houblons d'arôme en toute fin d'ébullition.",
+    plannedDurationMin: 60,
+  },
+  [RecipeStepType.WHIRLPOOL]: {
+    pedagogicalTip:
+      "Le whirlpool fait tourner le moût pour rassembler les résidus (le trub) au centre, puis on refroidit vite avant d'ensemencer la levure. À partir d'ici, tout ce qui touche le moût refroidi doit être désinfecté.",
+    plannedDurationMin: 15,
+  },
+  [RecipeStepType.FERMENTATION]: {
+    pedagogicalTip:
+      'La levure transforme les sucres en alcool et CO₂. Maintiens 18-20°C : trop chaud, elle stresse et produit des arômes indésirables. La fermentation est finie quand la densité est stable, pas à une date fixe.',
+    plannedDurationMin: null,
+  },
+  [RecipeStepType.PACKAGING]: {
+    pedagogicalTip:
+      "À l'embouteillage, on ajoute une dose précise de sucre (priming) pour la carbonatation : trop de sucre et les bouteilles explosent. Désinfecte les bouteilles, remplis, capsule, puis laisse conditionner ~2 semaines.",
+    plannedDurationMin: null,
+  },
+};
+
+/**
+ * Returns the pedagogical guidance for a brewing step type, or `undefined` for
+ * an unknown / unsupported type (graceful: the step then carries no tip/timer).
+ */
+export function getStepGuidance(
+  type: RecipeStepType,
+): StepGuidance | undefined {
+  return STEP_TYPE_GUIDANCE[type];
+}

--- a/packages/api/src/batch/dtos/batch-step.dto.spec.ts
+++ b/packages/api/src/batch/dtos/batch-step.dto.spec.ts
@@ -1,0 +1,40 @@
+import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
+
+import { BatchStepStatus } from '../domain/enums/batch-step-status.enum';
+import { BatchStepOrmEntity } from '../entities/batch-step.orm.entity';
+
+import { BatchStepDto } from './batch-step.dto';
+
+function makeEntity(
+  overrides: Partial<BatchStepOrmEntity> = {},
+): BatchStepOrmEntity {
+  return Object.assign(new BatchStepOrmEntity(), {
+    batch_id: 'b1',
+    step_order: 0,
+    type: RecipeStepType.MASH,
+    label: 'Mash',
+    description: 'd',
+    status: BatchStepStatus.IN_PROGRESS,
+    started_at: null,
+    completed_at: null,
+    created_at: new Date('2026-02-05T09:00:00.000Z'),
+    updated_at: new Date('2026-02-05T09:00:00.000Z'),
+    ...overrides,
+  });
+}
+
+describe('BatchStepDto.fromEntity', () => {
+  it('maps the pedagogical tip and planned duration (happy)', () => {
+    const dto = BatchStepDto.fromEntity(
+      makeEntity({ planned_duration_min: 60, pedagogical_tip: 'pourquoi' }),
+    );
+    expect(dto.planned_duration_min).toBe(60);
+    expect(dto.pedagogical_tip).toBe('pourquoi');
+  });
+
+  it('nulls them for legacy steps without enrichment (edge)', () => {
+    const dto = BatchStepDto.fromEntity(makeEntity());
+    expect(dto.planned_duration_min).toBeNull();
+    expect(dto.pedagogical_tip).toBeNull();
+  });
+});

--- a/packages/api/src/batch/dtos/batch-step.dto.ts
+++ b/packages/api/src/batch/dtos/batch-step.dto.ts
@@ -30,6 +30,12 @@ export class BatchStepDto {
   @ApiPropertyOptional({ nullable: true })
   completed_at?: Date | null;
 
+  @ApiPropertyOptional({ nullable: true })
+  planned_duration_min?: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  pedagogical_tip?: string | null;
+
   @ApiProperty()
   created_at: Date;
 
@@ -46,6 +52,8 @@ export class BatchStepDto {
       status: e.status,
       started_at: e.started_at ?? null,
       completed_at: e.completed_at ?? null,
+      planned_duration_min: e.planned_duration_min ?? null,
+      pedagogical_tip: e.pedagogical_tip ?? null,
       created_at: e.created_at,
       updated_at: e.updated_at,
     };

--- a/packages/api/src/batch/entities/batch-step.orm.entity.ts
+++ b/packages/api/src/batch/entities/batch-step.orm.entity.ts
@@ -47,6 +47,12 @@ export class BatchStepOrmEntity {
   @Column({ type: 'datetime', nullable: true })
   completed_at?: Date | null;
 
+  @Column({ type: 'integer', nullable: true })
+  planned_duration_min?: number | null;
+
+  @Column({ type: 'text', nullable: true })
+  pedagogical_tip?: string | null;
+
   @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   created_at: Date;
 

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -278,6 +278,8 @@ export class BatchService {
           status: step.status,
           started_at: step.startedAt ?? null,
           completed_at: step.completedAt ?? null,
+          planned_duration_min: step.plannedDurationMin ?? null,
+          pedagogical_tip: step.pedagogicalTip ?? null,
         }),
       );
 
@@ -317,6 +319,8 @@ export class BatchService {
         status: step.status,
         started_at: step.startedAt ?? null,
         completed_at: step.completedAt ?? null,
+        planned_duration_min: step.plannedDurationMin ?? null,
+        pedagogical_tip: step.pedagogicalTip ?? null,
       }),
     );
 
@@ -352,6 +356,8 @@ export class BatchService {
       status: step.status,
       startedAt: step.started_at ?? undefined,
       completedAt: step.completed_at ?? undefined,
+      pedagogicalTip: step.pedagogical_tip ?? undefined,
+      plannedDurationMin: step.planned_duration_min ?? undefined,
     };
   }
 

--- a/packages/api/src/database/migrations/1800000000000-AddBatchStepGuidance.ts
+++ b/packages/api/src/database/migrations/1800000000000-AddBatchStepGuidance.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `planned_duration_min` + `pedagogical_tip` to `batch_steps` (B1-live).
+ *
+ * These carry the brew-day assistant content onto **live** batches — a beginner
+ * "why" tip and a default step duration for the mobile countdown — so the
+ * guided brew-day is no longer demo-only. Both nullable: existing batches keep
+ * no enrichment, and fermentation/packaging carry a tip but no duration.
+ */
+export class AddBatchStepGuidance1800000000000 implements MigrationInterface {
+  name = 'AddBatchStepGuidance1800000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batch_steps" ADD COLUMN "planned_duration_min" integer`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batch_steps" ADD COLUMN "pedagogical_tip" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batch_steps" DROP COLUMN "pedagogical_tip"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batch_steps" DROP COLUMN "planned_duration_min"`,
+    );
+  }
+}

--- a/packages/mobile-app/src/features/batches/data/__tests__/batches.api.test.ts
+++ b/packages/mobile-app/src/features/batches/data/__tests__/batches.api.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Guards the batch DTO → domain mapping, in particular the B1-live step
+ * enrichment: `planned_duration_min` + `pedagogical_tip` must survive the
+ * mapping so the live step card shows the ⓘ tip and the countdown timer
+ * (previously demo-only).
+ */
+
+import * as httpClient from "@/core/http/http-client";
+
+import { getMineById } from "@/features/batches/data/batches.api";
+
+jest.mock("@/core/http/http-client");
+
+const mockedRequest = httpClient.request as jest.MockedFunction<
+  typeof httpClient.request
+>;
+
+function batchDtoWithStep(stepOverrides: Record<string, unknown> = {}) {
+  return {
+    id: "b1",
+    owner_id: "u1",
+    recipe_id: "r1",
+    status: "in_progress",
+    current_step_order: 0,
+    started_at: "2026-02-05T09:00:00.000Z",
+    created_at: "2026-02-05T09:00:00.000Z",
+    updated_at: "2026-02-05T09:00:00.000Z",
+    steps: [
+      {
+        batch_id: "b1",
+        step_order: 0,
+        type: "mash",
+        label: "Mash",
+        description: "d",
+        status: "in_progress",
+        created_at: "2026-02-05T09:00:00.000Z",
+        updated_at: "2026-02-05T09:00:00.000Z",
+        ...stepOverrides,
+      },
+    ],
+  };
+}
+
+describe("batches.api — mapBatchStep enrichment (B1-live)", () => {
+  beforeEach(() => {
+    mockedRequest.mockReset();
+  });
+
+  it("maps planned duration + pedagogical tip onto a batch step (happy)", async () => {
+    mockedRequest.mockResolvedValue(
+      batchDtoWithStep({
+        planned_duration_min: 60,
+        pedagogical_tip: "pourquoi empâter à 67°C",
+      }),
+    );
+
+    const batch = await getMineById("b1");
+
+    expect(batch.steps[0].plannedDurationMin).toBe(60);
+    expect(batch.steps[0].pedagogicalTip).toBe("pourquoi empâter à 67°C");
+  });
+
+  it("nulls them when the backend omits them (edge: legacy / over-days steps)", async () => {
+    mockedRequest.mockResolvedValue(batchDtoWithStep());
+
+    const batch = await getMineById("b1");
+
+    expect(batch.steps[0].plannedDurationMin).toBeNull();
+    expect(batch.steps[0].pedagogicalTip).toBeNull();
+  });
+});

--- a/packages/mobile-app/src/features/batches/data/batches.api.ts
+++ b/packages/mobile-app/src/features/batches/data/batches.api.ts
@@ -25,6 +25,8 @@ type BatchStepDto = {
   status: BatchStep["status"];
   started_at?: string | null;
   completed_at?: string | null;
+  planned_duration_min?: number | null;
+  pedagogical_tip?: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -61,6 +63,8 @@ function mapBatchStep(dto: BatchStepDto): BatchStep {
     status: dto.status,
     startedAt: dto.started_at ?? null,
     completedAt: dto.completed_at ?? null,
+    plannedDurationMin: dto.planned_duration_min ?? null,
+    pedagogicalTip: dto.pedagogical_tip ?? null,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
   };


### PR DESCRIPTION
## Summary

Make the guided **brew-day work in LIVE mode** (was demo-only) — the first **P0** slice toward "a novice reaches bottling, live" (roadmap: **TRACKER → ASSISTANT**).

Batch steps now carry a per-step-type **pedagogical tip** + a **default planned duration**, so the mobile step card shows the info tip and a countdown timer on real batches — previously only the demo data had them.

- **API**: `STEP_TYPE_GUIDANCE` (a pure domain reference: each `RecipeStepType` → `{ tip, default duration }`), applied at batch start in `BatchDomainService`; two new **nullable** `batch_steps` columns (`pedagogical_tip`, `planned_duration_min`) + a TypeORM migration; DTO + `fromEntity`; persistence in **both** the create and the step-completion paths.
- **Mobile**: `mapBatchStep` stops dropping the two fields (rendering already existed via `StepCard` + `BrewStepTimer`).
- **Conception** (folded in, proportional to this small slice): `docs/architecture/diagrams/brew-day/01-sequence-step-enrichment.md`.

## Decisions / edge cases

- MVP source = **per-step-type defaults** (no recipe↔guidance link yet — deferred).
- Recipe-authored `description` is **preserved** (only the tip + duration are added).
- `FERMENTATION` / `PACKAGING` carry a tip but **no duration** (they run over days); an unknown step type degrades gracefully (no tip/timer).
- New columns are nullable → **legacy batches** keep no enrichment (no backfill).

## Tests

- **API** (785 green): `step-guidance` (happy / edge / every-type coverage / unknown), `batch.domain` enrichment, `BatchStepDto.fromEntity`, and a **persistence roundtrip** asserting guidance survives `completeMineCurrentStep` — this caught and fixed a data-loss bug found in the local pre-review (the two columns were nulled on every step completion).
- **Mobile** (1001 green): `mapBatchStep` carries the fields (happy + null).

## Context

First real-brew journey, P0. The novice-journey audit found the live brew-day was a bare tracker (tips/timers demo-only); this is the enrichment that makes it guided. `Refs` the first real brew.
