### PR TITLE
feat(batch): bottling, live closure and first tasting (B3)

### DIFF
--- a/docs/architecture/diagrams/brew-day/03-sequence-bottle-and-close.md
+++ b/docs/architecture/diagrams/brew-day/03-sequence-bottle-and-close.md
@@ -1,0 +1,46 @@
+# Sequence diagram — brew-day — Bottle and close the batch (B3)
+
+> **Feature**: first real brew — making the LIVE journey reach the bottle (roadmap P0 "TRACKER → ASSISTANT", B3).
+> **Realizes**: B3. **Related**: step enrichment ([`01-sequence-step-enrichment.md`](01-sequence-step-enrichment.md)), gravity measurement ([`02-sequence-record-gravity-measurement.md`](02-sequence-record-gravity-measurement.md)), ADR-0020 (volume), ADR-0021 (D4 — bottle sanitizing belongs to this phase).
+
+## Context
+
+In LIVE mode the journey **dead-ends** at the **PACKAGING** step (a disabled "Brassin terminé" button; the celebration screen is demo-only). B3 turns that step into a real **bottling + closure** flow: the app gives a beginner-safe **priming-sugar** dose (to carbonate in-bottle), a **bottle-bomb safety** gate, the bottling gestures, then **closes** the batch live and lets the novice record a first **tasting**. This diagram covers only that interaction; it reuses the existing step engine (`completeCurrentStep`) and the existing volume (ADR-0020) — no recompute.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant M as Mobile (BottlingScreen)
+  participant UC as Use-case (closeBottling / recordTasting)
+  participant API as Backend API
+  B->>M: Reach the "Conditionnement" step, tap "Mettre en bouteille"
+  M->>API: GET /batches/:id/priming
+  API-->>M: sugarGrams, sugarType, targetCo2Vol, volumeL, safetyWarning
+  M-->>B: Show priming dose + bottling gestures + a prominent bottle-bomb warning
+  Note over M,B: simple rule ~6-7 g/L table sugar by default; precise formula (CO2 vol + temperature) is an advanced option
+  B->>M: Tick "j'ai compris le risque" (required), then "Mettre en bouteille / clôturer"
+  M->>UC: closeBottling(batchId)
+  UC->>API: POST /batches/:id/bottling/close
+  API->>API: set bottledAt, then completeCurrentStep(PACKAGING) -> batch COMPLETED
+  API-->>UC: closed batch (COMPLETED, bottledAt set)
+  UC-->>M: batch closed
+  M-->>B: Live closure / celebration (real volume + dates, no mock)
+  opt Record a first tasting
+    B->>M: Open "Noter ma dégustation", rate 1-5 stars + free note
+    M->>UC: recordTasting(batchId, rating, note)
+    UC->>API: POST /batches/:id/tasting
+    API-->>UC: 201 TastingDto
+    UC-->>M: tasting saved -> shown on the closure view
+  end
+```
+
+## Notes
+
+- **Reuses the existing step engine (no rewrite):** the batch already auto-advances and auto-COMPLETES on the final step (`BatchDomainService.completeCurrentStep`); the seeded Blonde recipe already declares a **PACKAGING** step ("Conditionnement"). `POST /bottling/close` sets `bottledAt` AND drives the PACKAGING completion through that proven path — it does **not** duplicate completion logic.
+- **Priming = read-only computation (founder decision):** `GET /priming` returns a **simple ~6-7 g/L table-sugar** dose by default (zero input); a **precise** mode (target CO2 volumes + beer temperature) is an advanced option. Volume comes from the batch / recipe (ADR-0020) — never recomputed here.
+- **Closure = `bottledAt` timestamp, status stays COMPLETED (founder decision):** mirrors `fermentation_completed_at`; no new BOTTLED status (see [`05-state-batch-closure.md`](05-state-batch-closure.md)).
+- **Safety (founder decision):** a prominent bottle-bomb warning **plus a required "j'ai compris" checkbox** — closing is disabled until it is ticked. The only real physical risk of the novice journey (over-priming -> over-pressure).
+- **Tasting (founder decision):** a **1-5 star rating + a free note** (no structured BJCP form in v1); optional, recorded after closure; replaces the placeholder "Noter ma dégustation" that today just navigates back.
+- **Cleaning (ADR-0021 D4):** sanitizing the **bottles** belongs to this bottling phase; the broader pre/post cleaning ritual is the P1 epic.

--- a/docs/architecture/diagrams/brew-day/04-class-tasting-and-priming.md
+++ b/docs/architecture/diagrams/brew-day/04-class-tasting-and-priming.md
@@ -1,0 +1,56 @@
+# Class diagram — brew-day — Tasting entity + priming calculator (B3)
+
+> **Feature**: first real brew — B3 bottling / closure / tasting domain model.
+> **Realizes**: B3. **Related**: [`03-sequence-bottle-and-close.md`](03-sequence-bottle-and-close.md), ADR-0020 (volume source), ADR-0001 (KISS).
+
+## Context
+
+The only **new persisted** concept in B3 is a **`Tasting`** (the novice's first note on their beer). Everything else is computed or reuses existing models: the **`PrimingCalculator`** is a pure, stateless domain service (no entity), and the batch gains a single **`bottledAt`** field. This keeps the B3 contract small.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class Tasting {
+    +UUID id
+    +UUID batchId
+    +int rating
+    +string note
+    +Date createdAt
+  }
+  class CreateTastingDto {
+    <<dto>>
+    +int rating
+    +string note
+  }
+  class PrimingCalculator {
+    <<domain service · pure>>
+    +simple(volumeL) PrimingResult
+    +precise(volumeL, targetCo2Vol, beerTempC) PrimingResult
+  }
+  class PrimingResult {
+    <<value object>>
+    +number sugarGrams
+    +SugarType sugarType
+    +number targetCo2Vol
+    +number volumeL
+    +string safetyWarning
+  }
+  class Batch {
+    <<existing>>
+    +BatchStatus status
+    +Date fermentationCompletedAt
+    +Date bottledAt
+  }
+  Batch "1" --> "0..1" Tasting : first tasting
+  Batch ..> PrimingResult : priming for this volume
+  PrimingCalculator ..> PrimingResult : computes
+  CreateTastingDto ..> Tasting : creates
+```
+
+## Notes
+
+- **`Tasting` = the only new entity/table (founder decision):** `rating` is **1-5** (`@IsInt @Min(1) @Max(5)`), `note` is an optional free string (`@IsOptional @IsString`); **one tasting per batch** in v1. No structured appearance/aroma/flavor/mouthfeel fields (deferred — a future BJCP-lite refinement). Owner-guarded, wrapped by the standard response envelope; `GET /batches/:id/tasting` renders it on the closure view.
+- **`PrimingCalculator` is pure + stateless (KISS, ADR-0001):** no entity, trivially unit-testable. `simple(volumeL)` = `DEFAULT_G_PER_L` (~6.5 g/L of table sugar for ~2.4 CO2 vol) → the zero-input default. `precise(volumeL, targetCo2Vol, beerTempC)` = the standard residual-CO2 formula → the advanced option. `SugarType = {TABLE_SUGAR, DEXTROSE}`, default `TABLE_SUGAR`.
+- **`PrimingResult` is a Value Object** carrying the dose + the mandatory `safetyWarning` string, served by `GET /priming`. `volumeL` comes from the batch / recipe (ADR-0020) — the calculator never sources volume itself.
+- **`Batch` gains only `bottledAt`** (one nullable column + migration), mirroring `fermentationCompletedAt`; status stays `IN_PROGRESS → COMPLETED` (no new state). See [`05-state-batch-closure.md`](05-state-batch-closure.md).

--- a/docs/architecture/diagrams/brew-day/04-class-tasting-and-priming.md
+++ b/docs/architecture/diagrams/brew-day/04-class-tasting-and-priming.md
@@ -29,12 +29,19 @@ classDiagram
     +precise(volumeL, targetCo2Vol, beerTempC) PrimingResult
   }
   class PrimingResult {
-    <<value object>>
+    <<value object · domain>>
     +number sugarGrams
     +SugarType sugarType
     +number targetCo2Vol
     +number volumeL
-    +string safetyWarning
+  }
+  class PrimingDto {
+    <<dto · wire>>
+    +number sugar_grams
+    +SugarType sugar_type
+    +number target_co2_vol
+    +number volume_l
+    +string safety_warning
   }
   class Batch {
     <<existing>>
@@ -45,6 +52,7 @@ classDiagram
   Batch "1" --> "0..1" Tasting : first tasting
   Batch ..> PrimingResult : priming for this volume
   PrimingCalculator ..> PrimingResult : computes
+  PrimingDto ..> PrimingResult : maps + adds safety_warning
   CreateTastingDto ..> Tasting : creates
 ```
 
@@ -52,5 +60,5 @@ classDiagram
 
 - **`Tasting` = the only new entity/table (founder decision):** `rating` is **1-5** (`@IsInt @Min(1) @Max(5)`), `note` is an optional free string (`@IsOptional @IsString`); **one tasting per batch** in v1. No structured appearance/aroma/flavor/mouthfeel fields (deferred — a future BJCP-lite refinement). Owner-guarded, wrapped by the standard response envelope; `GET /batches/:id/tasting` renders it on the closure view.
 - **`PrimingCalculator` is pure + stateless (KISS, ADR-0001):** no entity, trivially unit-testable. `simple(volumeL)` = `DEFAULT_G_PER_L` (~6.5 g/L of table sugar for ~2.4 CO2 vol) → the zero-input default. `precise(volumeL, targetCo2Vol, beerTempC)` = the standard residual-CO2 formula → the advanced option. `SugarType = {TABLE_SUGAR, DEXTROSE}`, default `TABLE_SUGAR`.
-- **`PrimingResult` is a Value Object** carrying the dose + the mandatory `safetyWarning` string, served by `GET /priming`. `volumeL` comes from the batch / recipe (ADR-0020) — the calculator never sources volume itself.
+- **`PrimingResult` is a domain Value Object** carrying only the computed dose (`sugarGrams`, `sugarType`, `targetCo2Vol`, `volumeL`); `volumeL` comes from the batch / recipe (ADR-0020) — the calculator never sources volume itself. The **`safety_warning` is added at the DTO layer**, not in the domain: `PrimingDto.fromResult` maps the domain VO to the snake_case wire shape (`sugar_grams`, `sugar_type`, `target_co2_vol`, `volume_l`) and injects `safety_warning` from the `SAFETY_WARNING` constant. This domain/DTO split keeps the calculator pure and presentation-free; `GET /priming` returns the `PrimingDto`.
 - **`Batch` gains only `bottledAt`** (one nullable column + migration), mirroring `fermentationCompletedAt`; status stays `IN_PROGRESS → COMPLETED` (no new state). See [`05-state-batch-closure.md`](05-state-batch-closure.md).

--- a/docs/architecture/diagrams/brew-day/05-state-batch-closure.md
+++ b/docs/architecture/diagrams/brew-day/05-state-batch-closure.md
@@ -1,0 +1,31 @@
+# State diagram — brew-day — Batch closure at bottling (B3)
+
+> **Feature**: first real brew — B3 batch-lifecycle amendment.
+> **Realizes**: B3 (founder decision Q4). **Related**: [`03-sequence-bottle-and-close.md`](03-sequence-bottle-and-close.md), brew-prep state machine ([`../brew-prep/05-state-readiness.md`](../brew-prep/05-state-readiness.md)), `batch-status.enum.ts`.
+
+## Context
+
+Today a batch is binary: `IN_PROGRESS → COMPLETED`, set **automatically** when the last step completes. B3 needs to mark "bottled" without inventing a parallel lifecycle. **Decision (Q4):** keep the existing `COMPLETED` status and add a `bottledAt` **timestamp** (mirroring `fermentation_completed_at`) — **not** a new `BOTTLED` status. This diagram documents that choice; it is an amendment, not a new study.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> InProgress : startBatch
+  InProgress --> InProgress : completeCurrentStep
+  InProgress --> Completed : close at bottling, sets bottledAt
+  Completed --> Completed : record tasting
+  Completed --> [*]
+  note right of Completed
+    status COMPLETED, unchanged
+    bottledAt set, new nullable column
+    fermentationCompletedAt already exists
+  end note
+```
+
+## Notes
+
+- **No new status (founder decision Q4):** the batch reaches the **existing** `COMPLETED` via the **existing** `completeCurrentStep` path; B3 only adds the `bottledAt` timestamp set by `POST /batches/:id/bottling/close`. Cheapest, mirrors the fermentation lifecycle, and avoids threading a new enum value through every status switch.
+- **`bottledAt` distinguishes "completed because bottled" from any other completion** for the closure / celebration view and future stats, without a parallel state.
+- **The PACKAGING step is the transition trigger:** the bottling action completes the last (PACKAGING) step, which auto-COMPLETES the batch — closure flows through the proven step engine, not a bespoke transition.
+- **Tasting is post-closure + optional:** recorded against the already-COMPLETED batch; it does not change the batch status.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2353,6 +2353,7 @@
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -4280,6 +4281,7 @@
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -4289,6 +4291,7 @@
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
       "version": "7.7.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -4300,6 +4303,7 @@
     },
     "node_modules/@npmcli/move-file": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5666,6 +5670,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5677,6 +5682,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5861,6 +5867,7 @@
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -5936,7 +5943,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -5947,6 +5954,7 @@
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5958,6 +5966,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6117,11 +6126,13 @@
     },
     "node_modules/aproba": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6725,6 +6736,7 @@
     },
     "node_modules/cacache": {
       "version": "15.3.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6753,6 +6765,7 @@
     },
     "node_modules/cacache/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6772,6 +6785,7 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6783,6 +6797,7 @@
     },
     "node_modules/cacache/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6794,6 +6809,7 @@
     },
     "node_modules/cacache/node_modules/tar": {
       "version": "6.2.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -6810,6 +6826,7 @@
     },
     "node_modules/cacache/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "engines": {
@@ -6818,6 +6835,7 @@
     },
     "node_modules/cacache/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -7052,6 +7070,7 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7207,6 +7226,7 @@
     },
     "node_modules/color-support": {
       "version": "1.1.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -7356,6 +7376,7 @@
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -8446,6 +8467,7 @@
     },
     "node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -8665,6 +8687,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8673,6 +8696,7 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -10557,6 +10581,7 @@
     },
     "node_modules/gauge": {
       "version": "4.0.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -10575,6 +10600,7 @@
     },
     "node_modules/gauge/node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -10841,6 +10867,7 @@
     },
     "node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -10901,7 +10928,7 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
@@ -10949,7 +10976,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -10969,6 +10996,7 @@
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11089,6 +11117,7 @@
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -11124,6 +11153,7 @@
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11222,6 +11252,7 @@
     },
     "node_modules/is-lambda": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -14401,6 +14432,7 @@
     },
     "node_modules/make-fetch-happen": {
       "version": "9.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14427,6 +14459,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/@tootallnate/once": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14435,6 +14468,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14448,6 +14482,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14459,6 +14494,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14470,6 +14506,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -15204,6 +15241,7 @@
     },
     "node_modules/minipass-collect": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15215,6 +15253,7 @@
     },
     "node_modules/minipass-collect/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15226,11 +15265,13 @@
     },
     "node_modules/minipass-collect/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/minipass-fetch": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -15247,6 +15288,7 @@
     },
     "node_modules/minipass-fetch/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15258,11 +15300,13 @@
     },
     "node_modules/minipass-fetch/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15274,6 +15318,7 @@
     },
     "node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15285,11 +15330,13 @@
     },
     "node_modules/minipass-flush/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15301,6 +15348,7 @@
     },
     "node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15312,11 +15360,13 @@
     },
     "node_modules/minipass-pipeline/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15328,6 +15378,7 @@
     },
     "node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15339,6 +15390,7 @@
     },
     "node_modules/minipass-sized/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -15580,6 +15632,7 @@
     },
     "node_modules/node-gyp": {
       "version": "8.4.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -15612,6 +15665,7 @@
     },
     "node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15631,6 +15685,7 @@
     },
     "node_modules/node-gyp/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "engines": {
@@ -15639,6 +15694,7 @@
     },
     "node_modules/node-gyp/node_modules/semver": {
       "version": "7.7.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -15650,6 +15706,7 @@
     },
     "node_modules/node-gyp/node_modules/tar": {
       "version": "6.2.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15666,6 +15723,7 @@
     },
     "node_modules/node-gyp/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -15679,6 +15737,7 @@
     },
     "node_modules/nopt": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15749,6 +15808,7 @@
     },
     "node_modules/npmlog": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -15926,6 +15986,7 @@
     },
     "node_modules/p-map": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16459,11 +16520,13 @@
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17534,6 +17597,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -17726,6 +17790,7 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -17973,6 +18038,7 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -17982,6 +18048,7 @@
     },
     "node_modules/socks": {
       "version": "2.8.7",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17995,6 +18062,7 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "6.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -18122,6 +18190,7 @@
     },
     "node_modules/ssri": {
       "version": "8.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -18133,6 +18202,7 @@
     },
     "node_modules/ssri/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -18144,6 +18214,7 @@
     },
     "node_modules/ssri/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true
     },
@@ -19531,6 +19602,7 @@
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -19539,6 +19611,7 @@
     },
     "node_modules/unique-slug": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -20238,6 +20311,7 @@
     },
     "node_modules/wide-align": {
       "version": "1.1.5",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {

--- a/packages/api/src/batch/batch.module.ts
+++ b/packages/api/src/batch/batch.module.ts
@@ -10,6 +10,7 @@ import { BatchOrmEntity } from './entities/batch.orm.entity';
 import { BatchStepOrmEntity } from './entities/batch-step.orm.entity';
 import { MeasurementOrmEntity } from './entities/measurement.orm.entity';
 import { ObservationOrmEntity } from './entities/observation.orm.entity';
+import { TastingOrmEntity } from './entities/tasting.orm.entity';
 import { BatchService } from './services/batch.service';
 
 @Module({
@@ -21,6 +22,7 @@ import { BatchService } from './services/batch.service';
       MeasurementOrmEntity,
       ObservationOrmEntity,
       AlertOrmEntity,
+      TastingOrmEntity,
     ]),
     RecipeModule,
   ],

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -102,6 +102,20 @@ describe('BatchService', () => {
     await recipeRepo.clear();
   });
 
+  // Drive a freshly started batch through its 5 steps to COMPLETED via the
+  // real bottling-close path (advance 4 steps onto PACKAGING, then close).
+  // Tasting is only allowed once the batch is bottled/completed.
+  async function completeBatch(
+    ownerId: string,
+    batchId: string,
+  ): Promise<void> {
+    await batchService.completeMineCurrentStep(ownerId, batchId);
+    await batchService.completeMineCurrentStep(ownerId, batchId);
+    await batchService.completeMineCurrentStep(ownerId, batchId);
+    await batchService.completeMineCurrentStep(ownerId, batchId);
+    await batchService.closeMineBottling(ownerId, batchId);
+  }
+
   it('startMine() should create a batch and snapshot steps', async () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
@@ -705,6 +719,7 @@ describe('BatchService', () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
     const { batch } = await batchService.startMine(ownerId, recipe.id);
+    await completeBatch(ownerId, batch.id);
 
     const saved = await batchService.createMineTasting(ownerId, batch.id, {
       rating: 4,
@@ -725,6 +740,7 @@ describe('BatchService', () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
     const { batch } = await batchService.startMine(ownerId, recipe.id);
+    await completeBatch(ownerId, batch.id);
 
     await batchService.createMineTasting(ownerId, batch.id, { rating: 5 });
 
@@ -738,9 +754,21 @@ describe('BatchService', () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
     const { batch } = await batchService.startMine(ownerId, recipe.id);
+    await completeBatch(ownerId, batch.id);
 
     await expect(
       batchService.createMineTasting(ownerId, batch.id, { rating: 9 }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // B3 — tasting (sad path): an in-progress (non-completed) batch is rejected
+  it('createMineTasting() rejects a tasting on an in-progress batch with BadRequest', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.createMineTasting(ownerId, batch.id, { rating: 4 }),
     ).rejects.toThrow(BadRequestException);
   });
 

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -1,6 +1,10 @@
 jest.setTimeout(20000);
 
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 
@@ -14,6 +18,7 @@ import { BatchStepStatus } from './domain/enums/batch-step-status.enum';
 import { MeasurementOrmEntity } from './entities/measurement.orm.entity';
 import { MeasurementType } from './domain/enums/measurement-type.enum';
 import { ObservationOrmEntity } from './entities/observation.orm.entity';
+import { TastingOrmEntity } from './entities/tasting.orm.entity';
 import { RecipeHopOrmEntity } from '../recipe/entities/recipe-hop.orm.entity';
 import { RecipeOrmEntity } from '../recipe/entities/recipe.orm.entity';
 import { RecipeService } from '../recipe/services/recipe.service';
@@ -33,6 +38,7 @@ describe('BatchService', () => {
   let recipeStepRepo: Repository<RecipeStepOrmEntity>;
   let measurementRepo: Repository<MeasurementOrmEntity>;
   let observationRepo: Repository<ObservationOrmEntity>;
+  let tastingRepo: Repository<TastingOrmEntity>;
 
   beforeAll(async () => {
     module = await Test.createTestingModule({
@@ -49,6 +55,7 @@ describe('BatchService', () => {
             BatchReminderOrmEntity,
             MeasurementOrmEntity,
             ObservationOrmEntity,
+            TastingOrmEntity,
           ],
           synchronize: true,
           logging: false,
@@ -62,6 +69,7 @@ describe('BatchService', () => {
           BatchReminderOrmEntity,
           MeasurementOrmEntity,
           ObservationOrmEntity,
+          TastingOrmEntity,
         ]),
       ],
       providers: [RecipeService, BatchService],
@@ -76,6 +84,7 @@ describe('BatchService', () => {
     recipeStepRepo = module.get(getRepositoryToken(RecipeStepOrmEntity));
     measurementRepo = module.get(getRepositoryToken(MeasurementOrmEntity));
     observationRepo = module.get(getRepositoryToken(ObservationOrmEntity));
+    tastingRepo = module.get(getRepositoryToken(TastingOrmEntity));
   });
 
   afterAll(async () => {
@@ -83,6 +92,7 @@ describe('BatchService', () => {
   });
 
   beforeEach(async () => {
+    await tastingRepo.clear();
     await observationRepo.clear();
     await measurementRepo.clear();
     await batchStepRepo.clear();
@@ -508,6 +518,246 @@ describe('BatchService', () => {
     ).rejects.toThrow(NotFoundException);
     await expect(
       batchService.listMineObservations(otherOwner, batch.id),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  // B3 — priming (happy path): uses the recipe volume (ADR-0020)
+  it('getMinePriming() returns the simple dose from the recipe volume', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, {
+      name: 'My Blonde',
+      batch_size_l: 20,
+    });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    const result = await batchService.getMinePriming(ownerId, batch.id);
+    expect(result.volumeL).toBe(20);
+    expect(result.sugarGrams).toBe(130); // 20 * 6.5
+    expect(result.targetCo2Vol).toBe(2.4);
+  });
+
+  // B3 — priming (sad path): missing recipe volume => 400
+  it('getMinePriming() rejects when the recipe has no batch volume', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'No volume' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.getMinePriming(ownerId, batch.id),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // B3 — priming (sad path): a zero batch volume => 400 (the <= 0 branch)
+  it('getMinePriming() rejects a recipe whose batch volume is 0', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, {
+      name: 'Zero volume',
+      batch_size_l: 0,
+    });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.getMinePriming(ownerId, batch.id),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // B3 — priming (edge): both advanced params => precise dose (differs from simple)
+  it('getMinePriming() returns the precise dose when both query params are supplied', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, {
+      name: 'My Blonde',
+      batch_size_l: 20,
+    });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    const simple = await batchService.getMinePriming(ownerId, batch.id);
+    const precise = await batchService.getMinePriming(ownerId, batch.id, {
+      targetCo2Vol: 2.4,
+      beerTempC: 20,
+    });
+
+    expect(precise.volumeL).toBe(20);
+    // The temperature-corrected dose differs from the flat simple default.
+    expect(precise.sugarGrams).not.toBe(simple.sugarGrams);
+  });
+
+  // B3 — priming (edge): ownership enforced
+  it('getMinePriming() rejects a batch the user does not own', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, {
+      name: 'My Blonde',
+      batch_size_l: 20,
+    });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.getMinePriming('user-2', batch.id),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  // B3 — bottling/close (happy path): sets bottled_at and completes the batch
+  it('closeMineBottling() sets bottled_at and auto-COMPLETES on the last step', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    // Advance to the final (PACKAGING) step, then close.
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+
+    const { batch, steps } = await batchService.closeMineBottling(
+      ownerId,
+      started.batch.id,
+    );
+
+    expect(batch.bottled_at).toBeTruthy();
+    expect(batch.status).toBe(BatchStatus.COMPLETED);
+    expect(batch.current_step_order).toBeNull();
+    expect(batch.completed_at).toBeTruthy();
+    expect(steps[steps.length - 1].status).toBe(BatchStepStatus.COMPLETED);
+  });
+
+  // B3 — bottling/close (sad path): closing off the PACKAGING step is rejected
+  it('closeMineBottling() rejects when the current step is not packaging', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    // Advance only as far as FERMENTATION (step 3), NOT packaging (step 4).
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+
+    await expect(
+      batchService.closeMineBottling(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+
+    // Closure must NOT have leaked: no bottled_at, still in progress.
+    const reloaded = await batchRepo.findOneOrFail({
+      where: { id: started.batch.id },
+    });
+    expect(reloaded.bottled_at).toBeNull();
+    expect(reloaded.status).toBe(BatchStatus.IN_PROGRESS);
+  });
+
+  // B3 — bottling/close (sad path): a packaging step that is not in progress
+  it('closeMineBottling() rejects a packaging step that is not in progress', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    // Advance to the PACKAGING step (step 4, in_progress).
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+
+    // Force the packaging step out of IN_PROGRESS while it stays the current
+    // step — exercises the new status guard independently of the type guard.
+    await batchStepRepo.update(
+      { batch_id: started.batch.id, step_order: 4 },
+      { status: BatchStepStatus.PENDING },
+    );
+
+    await expect(
+      batchService.closeMineBottling(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+
+    const reloaded = await batchRepo.findOneOrFail({
+      where: { id: started.batch.id },
+    });
+    expect(reloaded.bottled_at).toBeNull();
+    expect(reloaded.status).toBe(BatchStatus.IN_PROGRESS);
+  });
+
+  // B3 — bottling/close (sad path): an already-completed batch is rejected
+  it('closeMineBottling() rejects an already-completed batch', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.completeMineCurrentStep(ownerId, started.batch.id);
+    await batchService.closeMineBottling(ownerId, started.batch.id);
+
+    await expect(
+      batchService.closeMineBottling(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // B3 — bottling/close (edge): ownership enforced
+  it('closeMineBottling() rejects a batch the user does not own', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.closeMineBottling('user-2', started.batch.id),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  // B3 — tasting (happy path): create then read back
+  it('createMineTasting() persists a rating + note and getMineTasting() returns it', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    const saved = await batchService.createMineTasting(ownerId, batch.id, {
+      rating: 4,
+      note: 'Belle mousse',
+    });
+
+    expect(saved.id).toBeDefined();
+    expect(saved.batch_id).toBe(batch.id);
+    expect(saved.rating).toBe(4);
+    expect(saved.note).toBe('Belle mousse');
+
+    const fetched = await batchService.getMineTasting(ownerId, batch.id);
+    expect(fetched?.id).toBe(saved.id);
+  });
+
+  // B3 — tasting (sad path): one tasting per batch (409)
+  it('createMineTasting() rejects a second tasting on the same batch', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await batchService.createMineTasting(ownerId, batch.id, { rating: 5 });
+
+    await expect(
+      batchService.createMineTasting(ownerId, batch.id, { rating: 3 }),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  // B3 — tasting (sad path): an out-of-range rating surfaces as 400
+  it('createMineTasting() rejects an out-of-range rating with BadRequest', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.createMineTasting(ownerId, batch.id, { rating: 9 }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // B3 — tasting (edge): ownership enforced, and absent tasting reads as null
+  it('tasting routes enforce ownership and return null when none', async () => {
+    const ownerId = 'user-1';
+    const otherOwner = 'user-2';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    expect(await batchService.getMineTasting(ownerId, batch.id)).toBeNull();
+
+    await expect(
+      batchService.createMineTasting(otherOwner, batch.id, { rating: 3 }),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      batchService.getMineTasting(otherOwner, batch.id),
     ).rejects.toThrow(NotFoundException);
   });
 });

--- a/packages/api/src/batch/controllers/batch.controller.ts
+++ b/packages/api/src/batch/controllers/batch.controller.ts
@@ -5,10 +5,12 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  NotFoundException,
   Param,
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
@@ -33,7 +35,11 @@ import { CreateMeasurementDto } from '../dtos/create-measurement.dto';
 import { CreateObservationDto } from '../dtos/create-observation.dto';
 import { MeasurementDto } from '../dtos/measurement.dto';
 import { ObservationDto } from '../dtos/observation.dto';
+import { CreateTastingDto } from '../dtos/create-tasting.dto';
+import { GetPrimingQueryDto } from '../dtos/get-priming-query.dto';
+import { PrimingDto } from '../dtos/priming.dto';
 import { StartBatchDto } from '../dtos/start-batch.dto';
+import { TastingDto } from '../dtos/tasting.dto';
 import { UpdateBatchReminderDto } from '../dtos/update-batch-reminder.dto';
 import { BatchService } from '../services/batch.service';
 
@@ -246,5 +252,66 @@ export class BatchController {
       observedAt: dto.observedAt ? new Date(dto.observedAt) : undefined,
     });
     return ObservationDto.fromEntity(saved);
+  }
+
+  @Get(':id/priming')
+  @ApiOperation({
+    summary: 'Get the priming-sugar guidance for one of my batches',
+  })
+  @ApiOkResponse({ type: PrimingDto })
+  async getMinePriming(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Query(new ValidationPipe({ transform: true, whitelist: true }))
+    query: GetPrimingQueryDto,
+  ): Promise<PrimingDto> {
+    const result = await this.service.getMinePriming(user.id, id, {
+      targetCo2Vol: query.targetCo2Vol,
+      beerTempC: query.beerTempC,
+    });
+    return PrimingDto.fromResult(result);
+  }
+
+  @Post(':id/bottling/close')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Bottle and close one of my batches' })
+  @ApiOkResponse({ type: BatchDto })
+  async closeMineBottling(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<BatchDto> {
+    const { batch, steps } = await this.service.closeMineBottling(user.id, id);
+    return BatchDto.fromEntities(batch, steps);
+  }
+
+  @Get(':id/tasting')
+  @ApiOperation({ summary: 'Get the tasting of one of my batches' })
+  @ApiOkResponse({ type: TastingDto })
+  async getMineTasting(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<TastingDto> {
+    const tasting = await this.service.getMineTasting(user.id, id);
+    if (!tasting) {
+      throw new NotFoundException('Tasting not found');
+    }
+    return TastingDto.fromEntity(tasting);
+  }
+
+  @Post(':id/tasting')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Record the first tasting of one of my batches' })
+  @ApiCreatedResponse({ type: TastingDto })
+  async createMineTasting(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    dto: CreateTastingDto,
+  ): Promise<TastingDto> {
+    const saved = await this.service.createMineTasting(user.id, id, {
+      rating: dto.rating,
+      note: dto.note,
+    });
+    return TastingDto.fromEntity(saved);
   }
 }

--- a/packages/api/src/batch/domain/entities/batch.entity.ts
+++ b/packages/api/src/batch/domain/entities/batch.entity.ts
@@ -53,6 +53,9 @@ export interface Batch {
   /** Timestamp when fermentation was completed. */
   readonly fermentationCompletedAt?: Date;
 
+  /** Timestamp when the batch was bottled/closed (B3). */
+  readonly bottledAt?: Date;
+
   /** Completion timestamp when the batch finishes. */
   readonly completedAt?: Date;
 }

--- a/packages/api/src/batch/domain/services/priming-calculator.spec.ts
+++ b/packages/api/src/batch/domain/services/priming-calculator.spec.ts
@@ -1,0 +1,86 @@
+import {
+  computePrecisePriming,
+  computeSimplePriming,
+  DEFAULT_G_PER_L,
+  DEFAULT_TARGET_CO2_VOL,
+  SAFETY_WARNING,
+  SugarType,
+} from './priming-calculator';
+
+describe('computeSimplePriming', () => {
+  // Happy path
+  it('computes the default ~6.5 g/L table-sugar dose for a typical volume', () => {
+    const result = computeSimplePriming(4.3);
+
+    expect(result.sugarGrams).toBe(28); // 4.3 * 6.5 = 27.95 -> 28.0
+    expect(result.sugarType).toBe(SugarType.TABLE_SUGAR);
+    expect(result.targetCo2Vol).toBe(DEFAULT_TARGET_CO2_VOL);
+    expect(result.volumeL).toBe(4.3);
+  });
+
+  // Happy path: scales linearly with the volume
+  it('scales the dose linearly with the volume', () => {
+    expect(computeSimplePriming(20).sugarGrams).toBe(20 * DEFAULT_G_PER_L);
+  });
+
+  // Edge: zero volume yields a zero dose, never NaN
+  it('returns a zero dose for a zero volume', () => {
+    const result = computeSimplePriming(0);
+    expect(result.sugarGrams).toBe(0);
+    expect(result.volumeL).toBe(0);
+  });
+
+  // Edge: rounds to one decimal place
+  it('rounds the dose to one decimal place', () => {
+    // 3.33 * 6.5 = 21.645 -> 21.6
+    expect(computeSimplePriming(3.33).sugarGrams).toBe(21.6);
+  });
+
+  // Sad path: invalid volume is rejected
+  it('throws for a negative or non-finite volume', () => {
+    expect(() => computeSimplePriming(-1)).toThrow();
+    expect(() => computeSimplePriming(Number.NaN)).toThrow();
+  });
+});
+
+describe('computePrecisePriming', () => {
+  // Happy path + temperature conversion
+  it('applies the residual-CO2 formula at a given beer temperature', () => {
+    // 20 L, target 2.4 vol, beer at 20°C (68°F):
+    // residual ≈ 0.8615 vol -> remaining ≈ 1.5385 vol
+    // 20 * 4.13 * 1.5385 ≈ 127.08 -> 127.1 g
+    const result = computePrecisePriming(20, 2.4, 20);
+    expect(result.sugarGrams).toBe(127.1);
+    expect(result.targetCo2Vol).toBe(2.4);
+    expect(result.sugarType).toBe(SugarType.TABLE_SUGAR);
+    expect(result.volumeL).toBe(20);
+  });
+
+  // Edge: a colder beer holds more CO2, so it needs less sugar
+  it('requires less sugar for a colder beer (more residual CO2)', () => {
+    const cold = computePrecisePriming(20, 2.4, 4);
+    const warm = computePrecisePriming(20, 2.4, 25);
+    expect(cold.sugarGrams).toBeLessThan(warm.sugarGrams);
+  });
+
+  // Edge: residual clamp — target below the residual yields a zero dose
+  it('clamps at zero when the target is below the residual CO2', () => {
+    // At 0°C the beer already holds well over 1.0 vol, so target 1.0 -> 0 g.
+    const result = computePrecisePriming(20, 1.0, 0);
+    expect(result.sugarGrams).toBe(0);
+  });
+
+  // Sad path: invalid inputs are rejected
+  it('throws for invalid volume, target, or temperature', () => {
+    expect(() => computePrecisePriming(-1, 2.4, 20)).toThrow();
+    expect(() => computePrecisePriming(20, -0.1, 20)).toThrow();
+    expect(() => computePrecisePriming(20, 2.4, Number.NaN)).toThrow();
+  });
+});
+
+describe('SAFETY_WARNING', () => {
+  it('warns (in French) about over-pressure / exploding bottles', () => {
+    expect(SAFETY_WARNING).toContain('EXPLOSER');
+    expect(SAFETY_WARNING.length).toBeGreaterThan(20);
+  });
+});

--- a/packages/api/src/batch/domain/services/priming-calculator.ts
+++ b/packages/api/src/batch/domain/services/priming-calculator.ts
@@ -1,0 +1,126 @@
+/**
+ * PrimingCalculator (B3) — pure, stateless priming-sugar domain service.
+ *
+ * Bottle conditioning carbonates the beer by feeding the remaining yeast a
+ * measured dose of fermentable sugar. Too little = flat beer; **too much =
+ * over-pressure = a bottle can literally explode**. This service computes the
+ * beginner-safe dose for a given beer volume; it never sources the volume
+ * itself (the volume comes from the batch / recipe, per ADR-0020).
+ *
+ * Two modes (KISS, ADR-0001):
+ * - `computeSimplePriming` — the zero-input default: a flat ~6.5 g/L of table
+ *   sugar for a friendly ~2.4 CO2 volumes. This is what a novice gets.
+ * - `computePrecisePriming` — the advanced option: the standard residual-CO2
+ *   formula taking a target CO2 volume and the beer temperature into account.
+ *
+ * No entity, no state — trivially unit-testable.
+ */
+
+/** Default simple dose, in grams of table sugar per litre of beer. */
+export const DEFAULT_G_PER_L = 6.5;
+
+/** Default target carbonation, in volumes of CO2 (friendly for most styles). */
+export const DEFAULT_TARGET_CO2_VOL = 2.4;
+
+/**
+ * Grams of sucrose per litre needed to raise carbonation by one CO2 volume.
+ * Used by the precise formula once the residual CO2 is subtracted.
+ */
+export const SUCROSE_G_PER_L_PER_VOL = 4.13;
+
+/**
+ * Priming sugar type. Table sugar (sucrose) is the beginner default; dextrose
+ * is the advanced alternative. v1 computes doses against sucrose; the enum is
+ * carried on the result so the mobile app can label the dose correctly.
+ */
+export enum SugarType {
+  TABLE_SUGAR = 'table_sugar',
+  DEXTROSE = 'dextrose',
+}
+
+/**
+ * Safety warning surfaced with every priming result (French — shown to the
+ * brewer). Over-priming is the only real physical danger of the novice
+ * journey: exceeding the dose builds excess pressure and a bottle can burst,
+ * which is an eye-injury hazard. Weigh the sugar; do not improvise.
+ */
+export const SAFETY_WARNING =
+  'Sécurité : ne dépassez jamais la dose de sucre indiquée. Un sur-sucrage ' +
+  'crée une surpression dans la bouteille qui peut la faire EXPLOSER ' +
+  '(danger pour les yeux). Pesez le sucre à la balance, ne dosez jamais à ' +
+  "l'œil et n'improvisez pas.";
+
+/** Result of a priming computation (value object served by GET /priming). */
+export interface PrimingResult {
+  sugarGrams: number;
+  sugarType: SugarType;
+  targetCo2Vol: number;
+  volumeL: number;
+}
+
+/** Round to a fixed number of decimals without floating-point drift. */
+function round(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function assertVolume(volumeL: number): void {
+  if (!Number.isFinite(volumeL) || volumeL < 0) {
+    throw new Error('volumeL must be a non-negative finite number');
+  }
+}
+
+/**
+ * Simple priming — the zero-input default. A flat `DEFAULT_G_PER_L` of table
+ * sugar for `DEFAULT_TARGET_CO2_VOL` CO2 volumes.
+ *
+ * @param volumeL beer volume to bottle, in litres (from the recipe, ADR-0020)
+ * @returns the priming result (table sugar, ~2.4 CO2 vol)
+ */
+export function computeSimplePriming(volumeL: number): PrimingResult {
+  assertVolume(volumeL);
+  return {
+    sugarGrams: round(volumeL * DEFAULT_G_PER_L, 1),
+    sugarType: SugarType.TABLE_SUGAR,
+    targetCo2Vol: DEFAULT_TARGET_CO2_VOL,
+    volumeL,
+  };
+}
+
+/**
+ * Precise priming — the advanced option. Subtracts the CO2 the beer already
+ * holds (a function of its temperature) from the target, then sizes the sucrose
+ * dose for the remaining volumes.
+ *
+ * Residual CO2 (volumes) = 3.0378 − 0.050062·Tf + 0.00026555·Tf², Tf in °F.
+ * The remaining carbonation is clamped at 0 (never a negative dose).
+ *
+ * @param volumeL beer volume to bottle, in litres (from the recipe, ADR-0020)
+ * @param targetCo2Vol desired carbonation, in CO2 volumes
+ * @param beerTempC current beer temperature, in °C
+ * @returns the priming result (table sugar, at the requested CO2 vol)
+ */
+export function computePrecisePriming(
+  volumeL: number,
+  targetCo2Vol: number,
+  beerTempC: number,
+): PrimingResult {
+  assertVolume(volumeL);
+  if (!Number.isFinite(targetCo2Vol) || targetCo2Vol < 0) {
+    throw new Error('targetCo2Vol must be a non-negative finite number');
+  }
+  if (!Number.isFinite(beerTempC)) {
+    throw new Error('beerTempC must be a finite number');
+  }
+
+  const tempF = beerTempC * (9 / 5) + 32;
+  const residualVols = 3.0378 - 0.050062 * tempF + 0.00026555 * tempF * tempF;
+  const remainingVols = Math.max(0, targetCo2Vol - residualVols);
+
+  return {
+    sugarGrams: round(volumeL * SUCROSE_G_PER_L_PER_VOL * remainingVols, 1),
+    sugarType: SugarType.TABLE_SUGAR,
+    targetCo2Vol,
+    volumeL,
+  };
+}

--- a/packages/api/src/batch/domain/tasting.factory.spec.ts
+++ b/packages/api/src/batch/domain/tasting.factory.spec.ts
@@ -1,0 +1,47 @@
+import { createTasting, TastingValidationError } from './tasting.factory';
+
+describe('createTasting', () => {
+  // Happy path
+  it('builds a normalised tasting for a valid rating + note', () => {
+    const t = createTasting({ batchId: 'b-1', rating: 4, note: '  Fruité  ' });
+    expect(t).toEqual({ batchId: 'b-1', rating: 4, note: 'Fruité' });
+  });
+
+  // Happy path: empty/whitespace note becomes null
+  it('normalises an empty or whitespace note to null', () => {
+    expect(
+      createTasting({ batchId: 'b-1', rating: 3, note: '   ' }).note,
+    ).toBeNull();
+    expect(createTasting({ batchId: 'b-1', rating: 3 }).note).toBeNull();
+  });
+
+  // Edge: rating bounds are inclusive
+  it('accepts the inclusive 1 and 5 bounds', () => {
+    expect(createTasting({ batchId: 'b-1', rating: 1 }).rating).toBe(1);
+    expect(createTasting({ batchId: 'b-1', rating: 5 }).rating).toBe(5);
+  });
+
+  // Sad path: rating out of range
+  it('rejects a rating below 1 or above 5', () => {
+    expect(() => createTasting({ batchId: 'b-1', rating: 0 })).toThrow(
+      TastingValidationError,
+    );
+    expect(() => createTasting({ batchId: 'b-1', rating: 6 })).toThrow(
+      TastingValidationError,
+    );
+  });
+
+  // Sad path: non-integer rating
+  it('rejects a non-integer rating', () => {
+    expect(() => createTasting({ batchId: 'b-1', rating: 3.5 })).toThrow(
+      TastingValidationError,
+    );
+  });
+
+  // Sad path: missing batch id
+  it('rejects a missing batch id', () => {
+    expect(() => createTasting({ batchId: '  ', rating: 3 })).toThrow(
+      TastingValidationError,
+    );
+  });
+});

--- a/packages/api/src/batch/domain/tasting.factory.ts
+++ b/packages/api/src/batch/domain/tasting.factory.ts
@@ -1,0 +1,51 @@
+/** Raw input for a new tasting, before validation/normalisation. */
+export interface TastingInput {
+  batchId: string;
+  rating: number;
+  note?: string | null;
+}
+
+/** A validated, normalised tasting (the shape the service persists). */
+export interface Tasting {
+  batchId: string;
+  rating: number;
+  note: string | null;
+}
+
+/** Raised when a tasting violates a domain invariant (B3). */
+export class TastingValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TastingValidationError';
+  }
+}
+
+const RATING_MIN = 1;
+const RATING_MAX = 5;
+
+/**
+ * Validate + normalise a tasting against its domain invariants (B3): non-empty
+ * batch, integer rating within 1-5, optional trimmed note (empty -> null).
+ * Returns the normalised value object or throws `TastingValidationError`.
+ */
+export function createTasting(input: TastingInput): Tasting {
+  if (!input.batchId || input.batchId.trim().length === 0) {
+    throw new TastingValidationError('batchId is required');
+  }
+  if (
+    !Number.isInteger(input.rating) ||
+    input.rating < RATING_MIN ||
+    input.rating > RATING_MAX
+  ) {
+    throw new TastingValidationError(
+      `rating must be an integer in [${RATING_MIN}, ${RATING_MAX}]`,
+    );
+  }
+
+  const trimmedNote = input.note?.trim();
+  return {
+    batchId: input.batchId,
+    rating: input.rating,
+    note: trimmedNote && trimmedNote.length > 0 ? trimmedNote : null,
+  };
+}

--- a/packages/api/src/batch/dtos/batch-summary.dto.ts
+++ b/packages/api/src/batch/dtos/batch-summary.dto.ts
@@ -29,6 +29,9 @@ export class BatchSummaryDto {
   fermentation_completed_at?: Date | null;
 
   @ApiPropertyOptional({ nullable: true })
+  bottled_at?: Date | null;
+
+  @ApiPropertyOptional({ nullable: true })
   completed_at?: Date | null;
 
   @ApiProperty()
@@ -47,6 +50,7 @@ export class BatchSummaryDto {
       started_at: e.started_at,
       fermentation_started_at: e.fermentation_started_at ?? null,
       fermentation_completed_at: e.fermentation_completed_at ?? null,
+      bottled_at: e.bottled_at ?? null,
       completed_at: e.completed_at ?? null,
       created_at: e.created_at,
       updated_at: e.updated_at,

--- a/packages/api/src/batch/dtos/create-tasting.dto.ts
+++ b/packages/api/src/batch/dtos/create-tasting.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+
+/** Body for recording the first tasting of a finished batch (B3). */
+export class CreateTastingDto {
+  @ApiProperty({ minimum: 1, maximum: 5, example: 4 })
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  rating: number;
+
+  @ApiProperty({ required: false, example: 'Belle mousse, finale fruitée.' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  note?: string;
+}

--- a/packages/api/src/batch/dtos/get-priming-query.dto.ts
+++ b/packages/api/src/batch/dtos/get-priming-query.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsNumber, IsOptional } from 'class-validator';
+import { IsNumber, IsOptional, Max, Min } from 'class-validator';
 
 /**
  * Optional query params for `GET /batches/:id/priming` (B3).
@@ -18,6 +18,8 @@ export class GetPrimingQueryDto {
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
+  @Min(0)
+  @Max(8)
   targetCo2Vol?: number;
 
   @ApiPropertyOptional({
@@ -27,5 +29,7 @@ export class GetPrimingQueryDto {
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
+  @Min(-10)
+  @Max(120)
   beerTempC?: number;
 }

--- a/packages/api/src/batch/dtos/get-priming-query.dto.ts
+++ b/packages/api/src/batch/dtos/get-priming-query.dto.ts
@@ -1,0 +1,31 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional } from 'class-validator';
+
+/**
+ * Optional query params for `GET /batches/:id/priming` (B3).
+ *
+ * The founder decision is "simple par défaut, précise en option": with no
+ * params the endpoint returns the beginner-safe simple dose; when BOTH
+ * `targetCo2Vol` and `beerTempC` are supplied it returns the precise,
+ * temperature-corrected dose. Partial params fall back to the simple default.
+ */
+export class GetPrimingQueryDto {
+  @ApiPropertyOptional({
+    example: 2.4,
+    description: 'Target carbonation in CO2 volumes (advanced, optional)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  targetCo2Vol?: number;
+
+  @ApiPropertyOptional({
+    example: 20,
+    description: 'Current beer temperature in °C (advanced, optional)',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  beerTempC?: number;
+}

--- a/packages/api/src/batch/dtos/priming.dto.ts
+++ b/packages/api/src/batch/dtos/priming.dto.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import {
+  PrimingResult,
+  SAFETY_WARNING,
+  SugarType,
+} from '../domain/services/priming-calculator';
+
+/**
+ * Priming-sugar guidance returned by `GET /batches/:id/priming` (B3). Carries
+ * the computed dose plus the mandatory bottle-bomb safety warning. The volume
+ * comes from the recipe (ADR-0020) — never recomputed here.
+ *
+ * Serialised in snake_case to match every other batch DTO (and the mobile
+ * `mapPriming` reader); the camelCase domain {@link PrimingResult} is mapped in
+ * {@link PrimingDto.fromResult}.
+ */
+export class PrimingDto {
+  @ApiProperty({ example: 28, description: 'Priming sugar dose in grams' })
+  sugar_grams: number;
+
+  @ApiProperty({ enum: SugarType })
+  sugar_type: SugarType;
+
+  @ApiProperty({
+    example: 2.4,
+    description: 'Target carbonation in CO2 volumes',
+  })
+  target_co2_vol: number;
+
+  @ApiProperty({
+    example: 4.3,
+    description: 'Beer volume to bottle, in litres',
+  })
+  volume_l: number;
+
+  @ApiProperty({ description: 'Mandatory bottle-bomb safety warning (French)' })
+  safety_warning: string;
+
+  static fromResult(result: PrimingResult): PrimingDto {
+    return {
+      sugar_grams: result.sugarGrams,
+      sugar_type: result.sugarType,
+      target_co2_vol: result.targetCo2Vol,
+      volume_l: result.volumeL,
+      safety_warning: SAFETY_WARNING,
+    };
+  }
+}

--- a/packages/api/src/batch/dtos/tasting.dto.ts
+++ b/packages/api/src/batch/dtos/tasting.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { TastingOrmEntity } from '../entities/tasting.orm.entity';
+
+/** Serialised tasting returned by the API (B3). */
+export class TastingDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  batch_id: string;
+
+  @ApiProperty({ minimum: 1, maximum: 5 })
+  rating: number;
+
+  @ApiProperty({ nullable: true })
+  note: string | null;
+
+  @ApiProperty()
+  created_at: Date;
+
+  static fromEntity(e: TastingOrmEntity): TastingDto {
+    return {
+      id: e.id,
+      batch_id: e.batch_id,
+      rating: e.rating,
+      note: e.note ?? null,
+      created_at: e.created_at,
+    };
+  }
+}

--- a/packages/api/src/batch/entities/batch.orm.entity.ts
+++ b/packages/api/src/batch/entities/batch.orm.entity.ts
@@ -70,6 +70,13 @@ export class BatchOrmEntity {
   @Column({ type: 'datetime', nullable: true })
   fermentation_completed_at?: Date | null;
 
+  // B3 — timestamp set when the batch is bottled/closed. Mirrors
+  // `fermentation_completed_at`; the batch status stays COMPLETED (no new
+  // BOTTLED state — see 05-state-batch-closure.md). Nullable so legacy rows
+  // and not-yet-bottled batches don't need backfill.
+  @Column({ type: 'datetime', nullable: true })
+  bottled_at?: Date | null;
+
   @Column({ type: 'datetime', nullable: true })
   completed_at?: Date | null;
 

--- a/packages/api/src/batch/entities/tasting.orm.entity.ts
+++ b/packages/api/src/batch/entities/tasting.orm.entity.ts
@@ -1,0 +1,35 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryColumn,
+} from 'typeorm';
+
+/**
+ * A brewer's first tasting note on a finished batch (B3). The novice rates the
+ * beer 1-5 and optionally jots a free note after the batch is closed (bottled).
+ *
+ * One tasting per batch in v1 (no structured BJCP form yet — deferred). Belongs
+ * to a `Batch`; SQLite-friendly column types (`integer`, `text`, `datetime`).
+ */
+@Entity('batch_tastings')
+@Index(['batch_id'], { unique: true })
+export class TastingOrmEntity {
+  @PrimaryColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  batch_id: string;
+
+  /** 1-5 stars (enforced by the DTO + domain factory). */
+  @Column({ type: 'integer', nullable: false })
+  rating: number;
+
+  /** Optional free-text tasting note. */
+  @Column({ type: 'text', nullable: true })
+  note?: string | null;
+
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+}

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -630,7 +630,15 @@ export class BatchService {
     batchId: string,
     input: CreateTastingInput,
   ): Promise<TastingOrmEntity> {
-    await this.getMineBatch(ownerId, batchId);
+    const batch = await this.getMineBatch(ownerId, batchId);
+
+    // Conception places tasting AFTER closure (the UI only exposes it from the
+    // closure view): a batch can only be tasted once it is bottled (completed).
+    if (batch.status !== BatchStatus.COMPLETED) {
+      throw new BadRequestException(
+        'Tasting can only be recorded once the batch is bottled (completed)',
+      );
+    }
 
     const existing = await this.tastingRepo.findOne({
       where: { batch_id: batchId },

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -1,13 +1,15 @@
 import {
   BadRequestException,
+  ConflictException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomUUID } from 'crypto';
-import { EntityManager, Repository } from 'typeorm';
+import { EntityManager, QueryFailedError, Repository } from 'typeorm';
 
 import { RecipeStep } from '../../recipe/domain/entities/recipe-step.entity';
+import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
 import { RecipeService } from '../../recipe/services/recipe.service';
 
 import { BatchDomainService } from '../domain/services/batch-domain.service';
@@ -15,6 +17,7 @@ import { BatchStep } from '../domain/entities/batch-step.entity';
 import { Batch } from '../domain/entities/batch.entity';
 import { BatchReminderStatus } from '../domain/enums/batch-reminder-status.enum';
 import { BatchStatus } from '../domain/enums/batch-status.enum';
+import { BatchStepStatus } from '../domain/enums/batch-step-status.enum';
 import { BatchReminderOrmEntity } from '../entities/batch-reminder.orm.entity';
 import { BatchOrmEntity } from '../entities/batch.orm.entity';
 import { BatchStepOrmEntity } from '../entities/batch-step.orm.entity';
@@ -31,6 +34,17 @@ import {
   Observation,
   ObservationValidationError,
 } from '../domain/observation.factory';
+import { TastingOrmEntity } from '../entities/tasting.orm.entity';
+import {
+  createTasting,
+  Tasting,
+  TastingValidationError,
+} from '../domain/tasting.factory';
+import {
+  computePrecisePriming,
+  computeSimplePriming,
+  PrimingResult,
+} from '../domain/services/priming-calculator';
 
 export interface BatchWithSteps {
   batch: BatchOrmEntity;
@@ -58,6 +72,16 @@ export interface CreateBatchReminderInput {
   dueAt: Date;
 }
 
+export interface CreateTastingInput {
+  rating: number;
+  note?: string | null;
+}
+
+export interface PrimingOptions {
+  targetCo2Vol?: number;
+  beerTempC?: number;
+}
+
 export interface UpdateBatchReminderInput {
   label?: string;
   dueAt?: Date;
@@ -79,6 +103,8 @@ export class BatchService {
     private readonly measurementRepo: Repository<MeasurementOrmEntity>,
     @InjectRepository(ObservationOrmEntity)
     private readonly observationRepo: Repository<ObservationOrmEntity>,
+    @InjectRepository(TastingOrmEntity)
+    private readonly tastingRepo: Repository<TastingOrmEntity>,
     private readonly recipeService: RecipeService,
   ) {}
 
@@ -343,6 +369,7 @@ export class BatchService {
       startedAt: batch.started_at,
       fermentationStartedAt: batch.fermentation_started_at ?? undefined,
       fermentationCompletedAt: batch.fermentation_completed_at ?? undefined,
+      bottledAt: batch.bottled_at ?? undefined,
       completedAt: batch.completed_at ?? undefined,
     };
   }
@@ -455,6 +482,224 @@ export class BatchService {
       observed_at: normalised.observedAt,
     });
     return this.observationRepo.save(observation);
+  }
+
+  /**
+   * Compute the priming-sugar dose for a batch (B3). Owner-guarded. The beer
+   * volume comes from the linked recipe's `batch_size_l` (ADR-0020) — never
+   * recomputed here.
+   *
+   * Mode follows the founder decision "simple par défaut, précise en option":
+   * with no options it returns the beginner-safe simple ~6.5 g/L dose; when
+   * BOTH `targetCo2Vol` and `beerTempC` are supplied it returns the precise,
+   * temperature-corrected dose. Partial options fall back to the simple default.
+   */
+  async getMinePriming(
+    ownerId: string,
+    batchId: string,
+    options: PrimingOptions = {},
+  ): Promise<PrimingResult> {
+    const batch = await this.getMineBatch(ownerId, batchId);
+
+    const recipe = await this.recipeService.getReadableById(
+      ownerId,
+      batch.recipe_id,
+    );
+    const volumeL = recipe.batch_size_l;
+    if (volumeL == null || !Number.isFinite(volumeL) || volumeL <= 0) {
+      throw new BadRequestException(
+        'Cannot compute priming: the recipe has no batch volume (batch_size_l)',
+      );
+    }
+
+    const { targetCo2Vol, beerTempC } = options;
+    if (targetCo2Vol != null && beerTempC != null) {
+      return computePrecisePriming(volumeL, targetCo2Vol, beerTempC);
+    }
+
+    return computeSimplePriming(volumeL);
+  }
+
+  /**
+   * Close a batch at bottling (B3). Sets `bottled_at` AND drives the PACKAGING
+   * step to completion through the proven step engine
+   * (`BatchDomainService.completeCurrentStep`), which auto-COMPLETES the batch.
+   * Does not duplicate completion logic. Owner-guarded.
+   */
+  async closeMineBottling(
+    ownerId: string,
+    batchId: string,
+  ): Promise<BatchWithSteps> {
+    return this.batchRepo.manager.transaction(async (manager) => {
+      const batchRepo = manager.getRepository(BatchOrmEntity);
+      const stepRepo = manager.getRepository(BatchStepOrmEntity);
+
+      const batch = await batchRepo.findOne({
+        where: { id: batchId, owner_id: ownerId },
+      });
+      if (!batch) {
+        throw new NotFoundException('Batch not found');
+      }
+      if (batch.status === BatchStatus.COMPLETED) {
+        throw new BadRequestException('Batch already completed');
+      }
+
+      const steps = await stepRepo.find({
+        where: { batch_id: batch.id },
+        order: { step_order: 'ASC' },
+      });
+
+      // Closing = bottling: only valid when the brewer is actually ON the
+      // PACKAGING step AND that step is in progress, otherwise
+      // completeCurrentStep would complete an earlier step (e.g. FERMENTATION)
+      // and set bottled_at prematurely.
+      const currentStep = steps.find(
+        (step) => step.step_order === batch.current_step_order,
+      );
+      if (
+        !currentStep ||
+        currentStep.type !== RecipeStepType.PACKAGING ||
+        currentStep.status !== BatchStepStatus.IN_PROGRESS
+      ) {
+        throw new BadRequestException(
+          'Batch is not at the bottling (packaging) step',
+        );
+      }
+
+      const domainBatch = this.toDomain(batch, steps);
+      // The step engine enforces its own preconditions; translate a domain
+      // precondition failure into a 400 (client error) rather than a 500.
+      let updated: Batch;
+      try {
+        updated = this.domain.completeCurrentStep(domainBatch);
+      } catch (error) {
+        if (error instanceof Error) {
+          throw new BadRequestException(error.message);
+        }
+        throw error;
+      }
+
+      batch.bottled_at = new Date();
+      batch.status = updated.status;
+      batch.current_step_order = updated.currentStepOrder ?? null;
+      batch.completed_at = updated.completedAt ?? null;
+
+      const savedBatch = await batchRepo.save(batch);
+
+      const stepPayloads = updated.steps.map((step) =>
+        stepRepo.create({
+          batch_id: savedBatch.id,
+          step_order: step.order,
+          type: step.type,
+          label: step.label,
+          description: step.description ?? null,
+          status: step.status,
+          started_at: step.startedAt ?? null,
+          completed_at: step.completedAt ?? null,
+          planned_duration_min: step.plannedDurationMin ?? null,
+          pedagogical_tip: step.pedagogicalTip ?? null,
+        }),
+      );
+
+      const savedSteps = await stepRepo.save(stepPayloads);
+      savedSteps.sort((a, b) => a.step_order - b.step_order);
+
+      return { batch: savedBatch, steps: savedSteps };
+    });
+  }
+
+  /**
+   * Get the (single) tasting of a batch, or null if none yet (B3).
+   * Owner-guarded.
+   */
+  async getMineTasting(
+    ownerId: string,
+    batchId: string,
+  ): Promise<TastingOrmEntity | null> {
+    await this.getMineBatch(ownerId, batchId);
+    return this.tastingRepo.findOne({ where: { batch_id: batchId } });
+  }
+
+  /**
+   * Record the first tasting of a batch (B3). One tasting per batch in v1:
+   * rejects with 409 if one already exists. Owner-guarded; the domain factory
+   * enforces the 1-5 rating invariant (surfaced as 400).
+   */
+  async createMineTasting(
+    ownerId: string,
+    batchId: string,
+    input: CreateTastingInput,
+  ): Promise<TastingOrmEntity> {
+    await this.getMineBatch(ownerId, batchId);
+
+    const existing = await this.tastingRepo.findOne({
+      where: { batch_id: batchId },
+    });
+    if (existing) {
+      throw new ConflictException('Batch already has a tasting');
+    }
+
+    let normalised: Tasting;
+    try {
+      normalised = createTasting({
+        batchId,
+        rating: input.rating,
+        note: input.note,
+      });
+    } catch (error) {
+      if (error instanceof TastingValidationError) {
+        throw new BadRequestException(error.message);
+      }
+      throw error;
+    }
+
+    const tasting = this.tastingRepo.create({
+      id: randomUUID(),
+      batch_id: batchId,
+      rating: normalised.rating,
+      note: normalised.note,
+    });
+    try {
+      return await this.tastingRepo.save(tasting);
+    } catch (error) {
+      // The findOne above is best-effort; the unique index on `batch_id` is the
+      // real backstop. A concurrent duplicate insert must surface as the same
+      // 409 as the read path, not a 500.
+      if (
+        error instanceof QueryFailedError &&
+        this.isUniqueConstraintViolation(error)
+      ) {
+        throw new ConflictException('Batch already has a tasting');
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Detects a unique-constraint violation across the SQLite (tests) and
+   * Postgres (prod) drivers — mirrors the recipe service's detection so a
+   * concurrent duplicate maps to a 409 rather than a 500.
+   */
+  private isUniqueConstraintViolation(error: QueryFailedError): boolean {
+    const driverError = error.driverError as {
+      code?: string | number;
+      message?: string;
+    };
+    const code =
+      typeof driverError.code === 'string'
+        ? driverError.code
+        : typeof driverError.code === 'number'
+          ? String(driverError.code)
+          : '';
+    const message = (driverError.message ?? error.message).toLowerCase();
+
+    return (
+      code === '23505' ||
+      code === 'ER_DUP_ENTRY' ||
+      code === 'SQLITE_CONSTRAINT_PRIMARYKEY' ||
+      code === 'SQLITE_CONSTRAINT_UNIQUE' ||
+      message.includes('unique constraint failed')
+    );
   }
 
   private async getMineBatch(

--- a/packages/api/src/database/migrations/1801000000000-AddBatchBottledAt.ts
+++ b/packages/api/src/database/migrations/1801000000000-AddBatchBottledAt.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `bottled_at` to `batches` (B3 — bottling / closure).
+ *
+ * Set when the batch is bottled and closed; mirrors `fermentation_completed_at`.
+ * The batch status stays `COMPLETED` (no new `BOTTLED` state — see
+ * `05-state-batch-closure.md`). Nullable so legacy and not-yet-bottled batches
+ * don't need backfill.
+ */
+export class AddBatchBottledAt1801000000000 implements MigrationInterface {
+  name = 'AddBatchBottledAt1801000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "bottled_at" datetime`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "bottled_at"`);
+  }
+}

--- a/packages/api/src/database/migrations/1802000000000-AddBatchTastingsTable.ts
+++ b/packages/api/src/database/migrations/1802000000000-AddBatchTastingsTable.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the `batch_tastings` table (B3 — first tasting note).
+ *
+ * One row per batch (a `UNIQUE` index on `batch_id` enforces the one-tasting-
+ * per-batch rule of v1): a 1-5 `rating` and an optional free-text `note`.
+ * SQLite-friendly types (`integer`, `text`, `datetime`); FK cascades on batch
+ * delete. A CHECK keeps the rating in range as a defence-in-depth alongside the
+ * DTO + domain factory.
+ */
+export class AddBatchTastingsTable1802000000000 implements MigrationInterface {
+  name = 'AddBatchTastingsTable1802000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "batch_tastings" (
+        "id" varchar PRIMARY KEY NOT NULL,
+        "batch_id" varchar NOT NULL,
+        "rating" integer NOT NULL,
+        "note" text,
+        "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+        CONSTRAINT "CHK_batch_tastings_rating" CHECK ("rating" >= 1 AND "rating" <= 5),
+        CONSTRAINT "FK_batch_tastings_batch_id" FOREIGN KEY ("batch_id") REFERENCES "batches" ("id") ON DELETE CASCADE ON UPDATE NO ACTION
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_batch_tastings_batch_id" ON "batch_tastings" ("batch_id")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_batch_tastings_batch_id"`);
+    await queryRunner.query(`DROP TABLE "batch_tastings"`);
+  }
+}

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -34,6 +34,7 @@ import { ScanLabelImageOrmEntity } from '../scan/entities/scan-label-image.orm.e
 import { ScanRequestOrmEntity } from '../scan/entities/scan-request.orm.entity';
 import { ScanReviewQueueOrmEntity } from '../scan/entities/scan-review-queue.orm.entity';
 import { StyleOrmEntity } from '../catalog/style/entities/style.orm.entity';
+import { TastingOrmEntity } from '../batch/entities/tasting.orm.entity';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { User } from '../user/entities/user.entity';
 import { WaterOrmEntity } from '../catalog/water/entities/water.orm.entity';
@@ -52,6 +53,7 @@ export const ormEntities = [
   MeasurementOrmEntity,
   ObservationOrmEntity,
   AlertOrmEntity,
+  TastingOrmEntity,
   RecipeOrmEntity,
   RecipeStepOrmEntity,
   RecipeFermentableOrmEntity,

--- a/packages/api/test/batch-priming.e2e-spec.ts
+++ b/packages/api/test/batch-priming.e2e-spec.ts
@@ -1,0 +1,97 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import request from 'supertest';
+import { useContainer } from 'class-validator';
+
+/**
+ * B3 — priming endpoint, e2e guard on `GET /batches/:id/priming` query
+ * validation.
+ *
+ * A malformed advanced query (e.g. a negative `targetCo2Vol`) must be a 400
+ * (client error) from the ValidationPipe, never a 500 from the calculator
+ * throwing a plain `Error` deeper down. The `@Min/@Max` constraints on
+ * `GetPrimingQueryDto` are what enforce this.
+ */
+const TEST_PASSWORD = 'SecurePassword123!'; // NOSONAR
+
+interface RegisterResult {
+  token: string;
+}
+
+describe('Batch priming (e2e — B3)', () => {
+  let app: INestApplication<App>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      // Override the rate limiter so registration is not throttled — this suite
+      // tests query validation, not rate limiting (same pattern as the tasting
+      // e2e suite).
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    useContainer(app.select(AppModule), { fallbackOnErrors: true });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  async function register(): Promise<RegisterResult> {
+    const suffix = `${Date.now()}${Math.floor(Math.random() * 1000)}`.slice(-9);
+    const response = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: `priming-e2e-${suffix}@example.com`,
+        username: `priming_${suffix}`,
+        password: TEST_PASSWORD,
+        first_name: 'Priming',
+        last_name: 'E2E',
+      })
+      .expect(201);
+
+    const body = response.body as { access_token?: unknown };
+    if (typeof body.access_token !== 'string') {
+      throw new TypeError(
+        'Expected register response to carry an access_token',
+      );
+    }
+    return { token: body.access_token };
+  }
+
+  async function startBatch(token: string): Promise<string> {
+    const recipeRes = await request(app.getHttpServer())
+      .post('/recipes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Blonde e2e' })
+      .expect(201);
+    const recipeId = (recipeRes.body as { id: string }).id;
+
+    const batchRes = await request(app.getHttpServer())
+      .post('/batches')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ recipeId })
+      .expect(201);
+    return (batchRes.body as { id: string }).id;
+  }
+
+  // Sad path — a negative targetCo2Vol is rejected by the ValidationPipe (400),
+  // never reaching the calculator (which would otherwise 500 on a plain Error).
+  it('rejects a negative targetCo2Vol with 400', async () => {
+    const { token } = await register();
+    const batchId = await startBatch(token);
+
+    await request(app.getHttpServer())
+      .get(`/batches/${batchId}/priming?targetCo2Vol=-1&beerTempC=20`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(400);
+  });
+});

--- a/packages/api/test/batch-tasting.e2e-spec.ts
+++ b/packages/api/test/batch-tasting.e2e-spec.ts
@@ -11,13 +11,15 @@ import { useContainer } from 'class-validator';
  * B3 — tasting endpoints, e2e regression guards on `POST/GET
  * /batches/:id/tasting`.
  *
- * Pins three contracts against the real TypeORM DataSource (would fail with
- * `EntityMetadataNotFoundError` if `TastingOrmEntity` were not registered in
- * `ormEntities`):
- *   1. Wiring — a real batch (started from a recipe) accepts a 1-5 tasting and
- *      returns it on GET.
+ * Pins the tasting contracts against the real TypeORM DataSource (would fail
+ * with `EntityMetadataNotFoundError` if `TastingOrmEntity` were not registered
+ * in `ormEntities`). Tasting is only allowed once the batch is bottled/closed,
+ * so every write path first drives the batch to COMPLETED via the real
+ * bottling-close flow:
+ *   1. Wiring — a completed batch accepts a 1-5 tasting and returns it on GET.
  *   2. One tasting per batch — a second POST is rejected with 409.
  *   3. Validation — an out-of-range rating is rejected with 400.
+ *   4. Lifecycle — a tasting on an in-progress (non-completed) batch is 400.
  */
 const TEST_PASSWORD = 'SecurePassword123!'; // NOSONAR
 
@@ -87,10 +89,27 @@ describe('Batch tasting (e2e — B3)', () => {
     return (batchRes.body as { id: string }).id;
   }
 
+  // Drive a freshly started batch through its 5 steps to COMPLETED via the real
+  // HTTP flow: advance the 4 steps before PACKAGING, then bottle-and-close (the
+  // close auto-completes the batch). Tasting is only allowed once completed.
+  async function completeBatch(token: string, batchId: string): Promise<void> {
+    for (let i = 0; i < 4; i += 1) {
+      await request(app.getHttpServer())
+        .post(`/batches/${batchId}/steps/current/complete`)
+        .set('Authorization', `Bearer ${token}`)
+        .expect(200);
+    }
+    await request(app.getHttpServer())
+      .post(`/batches/${batchId}/bottling/close`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+  }
+
   // Happy path — POST then GET returns the tasting (exercises the real DataSource)
   it('records a tasting and returns it on GET', async () => {
     const { token } = await register();
     const batchId = await startBatch(token);
+    await completeBatch(token, batchId);
 
     const created = await request(app.getHttpServer())
       .post(`/batches/${batchId}/tasting`)
@@ -118,6 +137,7 @@ describe('Batch tasting (e2e — B3)', () => {
   it('rejects a second tasting on the same batch', async () => {
     const { token } = await register();
     const batchId = await startBatch(token);
+    await completeBatch(token, batchId);
 
     await request(app.getHttpServer())
       .post(`/batches/${batchId}/tasting`)
@@ -136,11 +156,25 @@ describe('Batch tasting (e2e — B3)', () => {
   it('rejects an out-of-range rating', async () => {
     const { token } = await register();
     const batchId = await startBatch(token);
+    await completeBatch(token, batchId);
 
     await request(app.getHttpServer())
       .post(`/batches/${batchId}/tasting`)
       .set('Authorization', `Bearer ${token}`)
       .send({ rating: 9 })
+      .expect(400);
+  });
+
+  // Sad path — a tasting on an in-progress (non-completed) batch is rejected
+  // (400): conception places tasting strictly after bottling/closure.
+  it('rejects a tasting on an in-progress (non-completed) batch', async () => {
+    const { token } = await register();
+    const batchId = await startBatch(token);
+
+    await request(app.getHttpServer())
+      .post(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ rating: 4 })
       .expect(400);
   });
 
@@ -159,6 +193,7 @@ describe('Batch tasting (e2e — B3)', () => {
   it('isolates tastings across users (B gets 404 on A’s batch, GET and POST)', async () => {
     const { token: tokenA } = await register();
     const batchId = await startBatch(tokenA);
+    await completeBatch(tokenA, batchId);
 
     // A records a tasting on its own batch.
     await request(app.getHttpServer())

--- a/packages/api/test/batch-tasting.e2e-spec.ts
+++ b/packages/api/test/batch-tasting.e2e-spec.ts
@@ -1,0 +1,185 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import request from 'supertest';
+import { useContainer } from 'class-validator';
+
+/**
+ * B3 — tasting endpoints, e2e regression guards on `POST/GET
+ * /batches/:id/tasting`.
+ *
+ * Pins three contracts against the real TypeORM DataSource (would fail with
+ * `EntityMetadataNotFoundError` if `TastingOrmEntity` were not registered in
+ * `ormEntities`):
+ *   1. Wiring — a real batch (started from a recipe) accepts a 1-5 tasting and
+ *      returns it on GET.
+ *   2. One tasting per batch — a second POST is rejected with 409.
+ *   3. Validation — an out-of-range rating is rejected with 400.
+ */
+const TEST_PASSWORD = 'SecurePassword123!'; // NOSONAR
+
+interface RegisterResult {
+  token: string;
+}
+
+describe('Batch tasting (e2e — B3)', () => {
+  let app: INestApplication<App>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      // Override the rate limiter so the cross-user isolation test can register
+      // both users without tripping the 5-registrations-per-minute throttle
+      // (same pattern as feedback.e2e-spec.ts) — this suite tests ownership, not
+      // rate limiting.
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    useContainer(app.select(AppModule), { fallbackOnErrors: true });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  async function register(): Promise<RegisterResult> {
+    const suffix = `${Date.now()}${Math.floor(Math.random() * 1000)}`.slice(-9);
+    const response = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: `tasting-e2e-${suffix}@example.com`,
+        username: `tasting_${suffix}`,
+        password: TEST_PASSWORD,
+        first_name: 'Tasting',
+        last_name: 'E2E',
+      })
+      .expect(201);
+
+    const body = response.body as { access_token?: unknown };
+    if (typeof body.access_token !== 'string') {
+      throw new TypeError(
+        'Expected register response to carry an access_token',
+      );
+    }
+    return { token: body.access_token };
+  }
+
+  async function startBatch(token: string): Promise<string> {
+    const recipeRes = await request(app.getHttpServer())
+      .post('/recipes')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'Blonde e2e' })
+      .expect(201);
+    const recipeId = (recipeRes.body as { id: string }).id;
+
+    const batchRes = await request(app.getHttpServer())
+      .post('/batches')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ recipeId })
+      .expect(201);
+    return (batchRes.body as { id: string }).id;
+  }
+
+  // Happy path — POST then GET returns the tasting (exercises the real DataSource)
+  it('records a tasting and returns it on GET', async () => {
+    const { token } = await register();
+    const batchId = await startBatch(token);
+
+    const created = await request(app.getHttpServer())
+      .post(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ rating: 4, note: 'Belle mousse, finale fruitée.' })
+      .expect(201);
+
+    const createdBody = created.body as {
+      id: string;
+      rating: number;
+      note: string;
+    };
+    expect(typeof createdBody.id).toBe('string');
+    expect(createdBody.rating).toBe(4);
+    expect(createdBody.note).toBe('Belle mousse, finale fruitée.');
+
+    const fetched = await request(app.getHttpServer())
+      .get(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect((fetched.body as { id: string }).id).toBe(createdBody.id);
+  });
+
+  // Sad path — a second tasting on the same batch is rejected (409)
+  it('rejects a second tasting on the same batch', async () => {
+    const { token } = await register();
+    const batchId = await startBatch(token);
+
+    await request(app.getHttpServer())
+      .post(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ rating: 5 })
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ rating: 3 })
+      .expect(409);
+  });
+
+  // Edge — an out-of-range rating is rejected by validation (400)
+  it('rejects an out-of-range rating', async () => {
+    const { token } = await register();
+    const batchId = await startBatch(token);
+
+    await request(app.getHttpServer())
+      .post(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ rating: 9 })
+      .expect(400);
+  });
+
+  // Edge — GET on a batch without a tasting returns 404
+  it('returns 404 when no tasting exists yet', async () => {
+    const { token } = await register();
+    const batchId = await startBatch(token);
+
+    await request(app.getHttpServer())
+      .get(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404);
+  });
+
+  // Edge — cross-user isolation: B cannot read or write A's batch tasting (404)
+  it('isolates tastings across users (B gets 404 on A’s batch, GET and POST)', async () => {
+    const { token: tokenA } = await register();
+    const batchId = await startBatch(tokenA);
+
+    // A records a tasting on its own batch.
+    await request(app.getHttpServer())
+      .post(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ rating: 4, note: 'Private note' })
+      .expect(201);
+
+    const { token: tokenB } = await register();
+
+    // B must not see A's batch at all — ownership guard returns 404, not 403,
+    // to avoid leaking the existence of another user's batch.
+    await request(app.getHttpServer())
+      .get(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${tokenB}`)
+      .expect(404);
+
+    await request(app.getHttpServer())
+      .post(`/batches/${batchId}/tasting`)
+      .set('Authorization', `Bearer ${tokenB}`)
+      .send({ rating: 5 })
+      .expect(404);
+  });
+});

--- a/packages/mobile-app/app/(app)/batches/[id]/bottling.tsx
+++ b/packages/mobile-app/app/(app)/batches/[id]/bottling.tsx
@@ -1,0 +1,14 @@
+import { useLocalSearchParams } from "expo-router";
+
+import { BottlingScreen } from "@/features/batches/presentation/BottlingScreen";
+
+/**
+ * Route delegating to {@link BottlingScreen}. No business logic lives here: it
+ * only resolves the batch id from the URL params (mirrors `measurement.tsx`).
+ */
+export default function BatchBottlingRoute() {
+  const { id } = useLocalSearchParams<{ id?: string | string[] }>();
+  const batchId = Array.isArray(id) ? (id[0] ?? "") : (id ?? "");
+
+  return <BottlingScreen batchId={batchId} />;
+}

--- a/packages/mobile-app/app/(app)/batches/[id]/tasting.tsx
+++ b/packages/mobile-app/app/(app)/batches/[id]/tasting.tsx
@@ -1,0 +1,14 @@
+import { useLocalSearchParams } from "expo-router";
+
+import { TastingScreen } from "@/features/batches/presentation/TastingScreen";
+
+/**
+ * Route delegating to {@link TastingScreen}. No business logic lives here: it
+ * only resolves the batch id from the URL params (mirrors `bottling.tsx`).
+ */
+export default function BatchTastingRoute() {
+  const { id } = useLocalSearchParams<{ id?: string | string[] }>();
+  const batchId = Array.isArray(id) ? (id[0] ?? "") : (id ?? "");
+
+  return <TastingScreen batchId={batchId} />;
+}

--- a/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
+++ b/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
@@ -228,5 +228,37 @@ describe("batches use-cases", () => {
       expect(result?.batch.id).toBe("b-demo-pdd-mash");
       expect(result?.recipeName).toBeNull();
     });
+
+    it("surfaces the recipe batch volume for the closure view (happy path)", async () => {
+      mockedGetRecipeDetails.mockResolvedValue({
+        id: "r-demo-pdd",
+        name: "La Première du dimanche",
+        stats: { volumeLiters: 4.3 },
+      } as never);
+
+      const result = await getBatchDetailsViewModel("b-demo-pdd-mash");
+
+      expect(result?.recipeVolumeL).toBe(4.3);
+    });
+
+    it("returns a null volume when the recipe omits the volume stat (edge path)", async () => {
+      mockedGetRecipeDetails.mockResolvedValue({
+        id: "r-demo-pdd",
+        name: "La Première du dimanche",
+        stats: {},
+      } as never);
+
+      const result = await getBatchDetailsViewModel("b-demo-pdd-mash");
+
+      expect(result?.recipeVolumeL).toBeNull();
+    });
+
+    it("returns a null volume when the recipe lookup throws (degraded path)", async () => {
+      mockedGetRecipeDetails.mockRejectedValue(new Error("recipe API 500"));
+
+      const result = await getBatchDetailsViewModel("b-demo-pdd-mash");
+
+      expect(result?.recipeVolumeL).toBeNull();
+    });
   });
 });

--- a/packages/mobile-app/src/features/batches/application/__tests__/bottling.use-cases.test.ts
+++ b/packages/mobile-app/src/features/batches/application/__tests__/bottling.use-cases.test.ts
@@ -1,0 +1,154 @@
+import { dataSource } from "@/core/data/data-source";
+import { HttpError } from "@/core/http/http-error";
+import {
+  clearDemoTastings,
+  closeBottling,
+  getBottlingInfo,
+  getTasting,
+  recordTasting,
+} from "@/features/batches/application/bottling.use-cases";
+import {
+  closeBottling as closeBottlingApi,
+  createTasting as createTastingApi,
+  getPriming as getPrimingApi,
+  getTasting as getTastingApi,
+} from "@/features/batches/data/batches.api";
+import { Tasting } from "@/features/batches/domain/bottling.types";
+
+jest.mock("@/core/data/data-source", () => ({
+  dataSource: {
+    useDemoData: true,
+  },
+}));
+
+jest.mock("@/features/batches/data/batches.api", () => ({
+  getPriming: jest.fn(),
+  closeBottling: jest.fn(),
+  createTasting: jest.fn(),
+  getTasting: jest.fn(),
+}));
+
+const mockedGetPriming = getPrimingApi as jest.MockedFunction<
+  typeof getPrimingApi
+>;
+const mockedClose = closeBottlingApi as jest.MockedFunction<
+  typeof closeBottlingApi
+>;
+const mockedCreateTasting = createTastingApi as jest.MockedFunction<
+  typeof createTastingApi
+>;
+const mockedGetTasting = getTastingApi as jest.MockedFunction<
+  typeof getTastingApi
+>;
+
+const liveTasting: Tasting = {
+  id: "t-live",
+  batchId: "b-live",
+  rating: 4,
+  note: "Live note",
+  createdAt: "2026-06-20T09:00:00.000Z",
+};
+
+describe("bottling use-cases", () => {
+  beforeEach(() => {
+    dataSource.useDemoData = true;
+    mockedGetPriming.mockReset();
+    mockedClose.mockReset();
+    mockedCreateTasting.mockReset();
+    mockedGetTasting.mockReset();
+    clearDemoTastings();
+  });
+
+  it("returns null priming and skips the API for a missing batch id (edge path)", async () => {
+    const result = await getBottlingInfo("");
+
+    expect(result).toBeNull();
+    expect(mockedGetPriming).not.toHaveBeenCalled();
+  });
+
+  it("computes a local priming dose in demo mode (happy path)", async () => {
+    const priming = await getBottlingInfo("b-demo");
+
+    expect(priming?.sugarType).toBe("table_sugar");
+    expect(priming?.sugarGrams).toBeGreaterThan(0);
+    expect(priming?.safetyWarning).toMatch(/EXPLOSER/);
+    expect(mockedGetPriming).not.toHaveBeenCalled();
+  });
+
+  it("records and reads back a tasting locally in demo mode (happy path)", async () => {
+    const recorded = await recordTasting("b-demo", {
+      rating: 5,
+      note: "  Très bon  ",
+    });
+
+    expect(recorded?.rating).toBe(5);
+    // Whitespace is trimmed; non-empty stays.
+    expect(recorded?.note).toBe("Très bon");
+    expect(mockedCreateTasting).not.toHaveBeenCalled();
+
+    const readBack = await getTasting("b-demo");
+    expect(readBack?.rating).toBe(5);
+  });
+
+  it("normalises a whitespace-only note to null in demo mode (edge path)", async () => {
+    const recorded = await recordTasting("b-demo", {
+      rating: 3,
+      note: "   ",
+    });
+
+    expect(recorded?.note).toBeNull();
+  });
+
+  it("returns null tasting for a batch with no recorded tasting (sad path)", async () => {
+    const result = await getTasting("b-demo-empty");
+
+    expect(result).toBeNull();
+    expect(mockedGetTasting).not.toHaveBeenCalled();
+  });
+
+  it("returns the demo batch on close in demo mode (happy path)", async () => {
+    const batch = await closeBottling("b-demo-pdd-done");
+
+    expect(batch?.id).toBe("b-demo-pdd-done");
+    expect(mockedClose).not.toHaveBeenCalled();
+  });
+
+  it("delegates to the data layer in live mode (happy path)", async () => {
+    dataSource.useDemoData = false;
+    mockedGetTasting.mockResolvedValue(liveTasting);
+    mockedCreateTasting.mockResolvedValue(liveTasting);
+
+    const recorded = await recordTasting("b-live", { rating: 4 });
+    const read = await getTasting("b-live");
+
+    expect(mockedCreateTasting).toHaveBeenCalledWith("b-live", { rating: 4 });
+    expect(mockedGetTasting).toHaveBeenCalledWith("b-live");
+    expect(recorded).toEqual(liveTasting);
+    expect(read).toEqual(liveTasting);
+  });
+
+  it("maps a live 404 HttpError from getTasting to null (sad path)", async () => {
+    dataSource.useDemoData = false;
+    mockedGetTasting.mockRejectedValue(new HttpError(404, "Tasting not found"));
+
+    const result = await getTasting("b-live");
+
+    expect(result).toBeNull();
+  });
+
+  it("propagates a non-404 HttpError from getTasting instead of masking it (sad path)", async () => {
+    dataSource.useDemoData = false;
+    mockedGetTasting.mockRejectedValue(new HttpError(500, "Server error"));
+
+    await expect(getTasting("b-live")).rejects.toBeInstanceOf(HttpError);
+  });
+
+  it("propagates a live close error (sad path)", async () => {
+    dataSource.useDemoData = false;
+    mockedClose.mockRejectedValue(new Error("Batch already completed"));
+
+    await expect(closeBottling("b-live")).rejects.toThrow(
+      "Batch already completed",
+    );
+  });
+});

--- a/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
+++ b/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
@@ -32,6 +32,9 @@ export async function getBatchDetails(batchId: string): Promise<Batch | null> {
 export interface BatchDetailsViewModel {
   batch: Batch;
   recipeName: string | null;
+  // Recipe batch volume in litres, surfaced for the B3 closure view. Best-effort
+  // like `recipeName`: null when the recipe lookup fails or omits the stat.
+  recipeVolumeL?: number | null;
 }
 
 export async function getBatchDetailsViewModel(
@@ -46,13 +49,16 @@ export async function getBatchDetailsViewModel(
   // error in backend mode) must not break the batch details screen — fall
   // back to the "Brassin <id>" title instead of rejecting the whole query.
   let recipeName: string | null = null;
+  let recipeVolumeL: number | null = null;
   try {
     const recipe = await getRecipeDetails(batch.recipeId);
     recipeName = recipe?.name ?? null;
+    recipeVolumeL = recipe?.stats?.volumeLiters ?? null;
   } catch {
     recipeName = null;
+    recipeVolumeL = null;
   }
-  return { batch, recipeName };
+  return { batch, recipeName, recipeVolumeL };
 }
 
 export async function completeCurrentBatchStep(

--- a/packages/mobile-app/src/features/batches/application/bottling.use-cases.ts
+++ b/packages/mobile-app/src/features/batches/application/bottling.use-cases.ts
@@ -1,0 +1,154 @@
+/**
+ * Application use-cases for the B3 bottling / priming / tasting flow.
+ *
+ * Branches on {@link dataSource.useDemoData} exactly like the measurement
+ * use-cases: demo mode uses local mocks (so the soutenance demo runs offline);
+ * live mode delegates to the data layer (`batches.api` over the shared
+ * http-client). No UI imports — this layer sits between presentation and data.
+ */
+
+import { dataSource } from "@/core/data/data-source";
+import { HttpError } from "@/core/http/http-error";
+import {
+  closeBottling as closeBottlingApi,
+  createTasting as createTastingApi,
+  getPriming as getPrimingApi,
+  getTasting as getTastingApi,
+} from "@/features/batches/data/batches.api";
+import { Batch } from "@/features/batches/domain/batch.types";
+import {
+  PrimingInfo,
+  SAFETY_WARNING,
+  Tasting,
+  TastingInput,
+} from "@/features/batches/domain/bottling.types";
+import { demoBatches } from "@/mocks/demo-data";
+
+// Simple-mode priming defaults used by the demo path. These must track the
+// backend DEFAULT_G_PER_L / DEFAULT_TARGET_CO2_VOL (priming-calculator.ts) so
+// the offline demo and the live simple dose agree — change them together.
+const DEMO_PRIMING_G_PER_L = 6.5; // backend DEFAULT_G_PER_L
+const DEMO_TARGET_CO2_VOL = 2.4; // backend DEFAULT_TARGET_CO2_VOL
+const DEMO_VOLUME_L = 4.3;
+
+/**
+ * In-memory demo tasting store keyed by batch id. Mirrors the demo measurement
+ * tracker: a tasting recorded during a demo session persists for the lifetime
+ * of the JS runtime so the UI reflects it without a backend.
+ */
+const demoTastings = new Map<string, Tasting>();
+
+/**
+ * Clears the in-memory demo tasting store. Test-support only: lets a suite
+ * isolate the demo path between runs, since the store is module-level state.
+ */
+export function clearDemoTastings(): void {
+  demoTastings.clear();
+}
+
+/** Rounds a number to one decimal place (matches the backend rounding). */
+function roundOneDp(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * Reads the priming sugar guidance for a batch.
+ *
+ * @param batchId - Identifier of the batch to compute priming for.
+ * @returns The priming guidance, or `null` when `batchId` is empty.
+ */
+export async function getBottlingInfo(
+  batchId: string,
+): Promise<PrimingInfo | null> {
+  if (!batchId) {
+    return null;
+  }
+  if (dataSource.useDemoData) {
+    return {
+      sugarGrams: roundOneDp(DEMO_VOLUME_L * DEMO_PRIMING_G_PER_L),
+      sugarType: "table_sugar",
+      targetCo2Vol: DEMO_TARGET_CO2_VOL,
+      volumeL: DEMO_VOLUME_L,
+      safetyWarning: SAFETY_WARNING,
+    };
+  }
+  return getPrimingApi(batchId);
+}
+
+/**
+ * Closes the batch (bottling): records `bottledAt` and completes the current
+ * step. In demo mode it returns the matching demo batch unchanged (the demo
+ * closure view is driven separately).
+ *
+ * @param batchId - Identifier of the batch to close.
+ * @returns The updated batch, or `null` when `batchId` is empty.
+ */
+export async function closeBottling(batchId: string): Promise<Batch | null> {
+  if (!batchId) {
+    return null;
+  }
+  if (dataSource.useDemoData) {
+    return demoBatches.find((item) => item.id === batchId) ?? null;
+  }
+  return closeBottlingApi(batchId);
+}
+
+/**
+ * Records a tasting against a batch.
+ *
+ * @param batchId - Identifier of the batch to attach the tasting to.
+ * @param input - Tasting creation payload (rating 1..5, optional note).
+ * @returns The persisted tasting, or `null` when `batchId` is empty.
+ */
+export async function recordTasting(
+  batchId: string,
+  input: TastingInput,
+): Promise<Tasting | null> {
+  if (!batchId) {
+    return null;
+  }
+  if (dataSource.useDemoData) {
+    const note = input.note?.trim() ? input.note.trim() : null;
+    const tasting: Tasting = {
+      id: `demo-tasting-${batchId}`,
+      batchId,
+      rating: input.rating,
+      note,
+      createdAt: new Date().toISOString(),
+    };
+    demoTastings.set(batchId, tasting);
+    return tasting;
+  }
+  return createTastingApi(batchId, input);
+}
+
+/**
+ * Reads the tasting recorded for a batch, or `null` when none exists yet.
+ *
+ * Unlike the live data layer (which 404s when there is no tasting), this
+ * use-case maps the not-found case to `null` so the closure view can render
+ * "pas encore noté" without an error branch. Any OTHER failure (e.g. a 500 or a
+ * network error) is re-thrown so the screen surfaces it instead of masking a
+ * broken read as "not noted yet".
+ *
+ * @param batchId - Identifier of the batch to read the tasting for.
+ * @returns The recorded tasting, or `null` when none exists / `batchId` empty.
+ */
+export async function getTasting(batchId: string): Promise<Tasting | null> {
+  if (!batchId) {
+    return null;
+  }
+  if (dataSource.useDemoData) {
+    return demoTastings.get(batchId) ?? null;
+  }
+  try {
+    return await getTastingApi(batchId);
+  } catch (error) {
+    // 404 ("Tasting not found") is the expected "not noted yet" state, not an
+    // error the closure view should surface. Anything else is a real failure.
+    if (error instanceof HttpError && error.status === 404) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/packages/mobile-app/src/features/batches/data/__tests__/bottling.api.test.ts
+++ b/packages/mobile-app/src/features/batches/data/__tests__/bottling.api.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Guards the B3 priming / bottling / tasting DTO -> domain mapping and the
+ * calls against the shared http-client.
+ */
+
+import * as httpClient from "@/core/http/http-client";
+
+import {
+  closeBottling,
+  createTasting,
+  getPriming,
+  getTasting,
+} from "@/features/batches/data/batches.api";
+
+jest.mock("@/core/http/http-client");
+
+const mockedRequest = httpClient.request as jest.MockedFunction<
+  typeof httpClient.request
+>;
+
+function primingDto(overrides: Record<string, unknown> = {}) {
+  return {
+    sugar_grams: 28,
+    sugar_type: "table_sugar",
+    target_co2_vol: 2.4,
+    volume_l: 4.3,
+    safety_warning: "Sécurité : ne dépassez jamais la dose…",
+    ...overrides,
+  };
+}
+
+function tastingDto(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "t1",
+    batch_id: "b1",
+    rating: 4,
+    note: "Belle mousse",
+    created_at: "2026-06-20T09:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function batchDto(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "b1",
+    owner_id: "u1",
+    recipe_id: "r1",
+    status: "completed",
+    current_step_order: null,
+    started_at: "2026-02-05T09:00:00.000Z",
+    bottled_at: "2026-06-20T09:00:00.000Z",
+    completed_at: "2026-06-20T09:00:00.000Z",
+    created_at: "2026-02-05T09:00:00.000Z",
+    updated_at: "2026-06-20T09:00:00.000Z",
+    steps: [],
+    ...overrides,
+  };
+}
+
+describe("bottling data layer", () => {
+  beforeEach(() => {
+    mockedRequest.mockReset();
+  });
+
+  it("maps a priming DTO to the domain shape (happy path)", async () => {
+    mockedRequest.mockResolvedValue(primingDto());
+
+    const priming = await getPriming("b1");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/batches/b1/priming");
+    expect(priming).toEqual({
+      sugarGrams: 28,
+      sugarType: "table_sugar",
+      targetCo2Vol: 2.4,
+      volumeL: 4.3,
+      safetyWarning: "Sécurité : ne dépassez jamais la dose…",
+    });
+    // Pins the snake_case backend contract: the fixture above is the real
+    // backend `PrimingDto` shape and `sugar_grams` must surface as `sugarGrams`.
+    expect(priming.sugarGrams).toBe(28);
+  });
+
+  it("maps a tasting DTO and nullish-coalesces a missing note (edge path)", async () => {
+    mockedRequest.mockResolvedValue(tastingDto({ note: undefined }));
+
+    const tasting = await getTasting("b1");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/batches/b1/tasting");
+    expect(tasting).toEqual({
+      id: "t1",
+      batchId: "b1",
+      rating: 4,
+      note: null,
+      createdAt: "2026-06-20T09:00:00.000Z",
+    });
+  });
+
+  it("POSTs a tasting creation payload and maps the response (happy path)", async () => {
+    mockedRequest.mockResolvedValue(tastingDto({ rating: 5, note: "Top" }));
+
+    const created = await createTasting("b1", { rating: 5, note: "Top" });
+
+    expect(mockedRequest).toHaveBeenCalledWith("/batches/b1/tasting", {
+      method: "POST",
+      body: { rating: 5, note: "Top" },
+    });
+    expect(created.rating).toBe(5);
+    expect(created.note).toBe("Top");
+  });
+
+  it("POSTs the close endpoint and maps the batch (happy path)", async () => {
+    mockedRequest.mockResolvedValue(batchDto());
+
+    const batch = await closeBottling("b1");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/batches/b1/bottling/close", {
+      method: "POST",
+    });
+    expect(batch.status).toBe("completed");
+    expect(batch.bottledAt).toBe("2026-06-20T09:00:00.000Z");
+  });
+
+  it("nulls bottled_at when the backend omits it (edge path)", async () => {
+    mockedRequest.mockResolvedValue(batchDto({ bottled_at: undefined }));
+
+    const batch = await closeBottling("b1");
+
+    expect(batch.bottledAt).toBeNull();
+  });
+
+  it("propagates http-client errors when reading a tasting (sad path)", async () => {
+    mockedRequest.mockRejectedValue(new Error("404 Tasting not found"));
+
+    await expect(getTasting("b1")).rejects.toThrow("404 Tasting not found");
+  });
+});

--- a/packages/mobile-app/src/features/batches/data/batches.api.ts
+++ b/packages/mobile-app/src/features/batches/data/batches.api.ts
@@ -2,6 +2,12 @@ import { request } from "@/core/http/http-client";
 
 import { Batch, BatchStep, BatchSummary } from "../domain/batch.types";
 import {
+  PrimingInfo,
+  PrimingSugarType,
+  Tasting,
+  TastingInput,
+} from "../domain/bottling.types";
+import {
   Measurement,
   MeasurementInput,
   MeasurementType,
@@ -16,6 +22,7 @@ type BatchSummaryDto = {
   started_at: string;
   fermentation_started_at?: string | null;
   fermentation_completed_at?: string | null;
+  bottled_at?: string | null;
   completed_at?: string | null;
   created_at: string;
   updated_at: string;
@@ -68,6 +75,7 @@ function mapBatchSummary(dto: BatchSummaryDto): BatchSummary {
     startedAt: dto.started_at,
     fermentationStartedAt: dto.fermentation_started_at ?? null,
     fermentationCompletedAt: dto.fermentation_completed_at ?? null,
+    bottledAt: dto.bottled_at ?? null,
     completedAt: dto.completed_at ?? null,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
@@ -121,6 +129,122 @@ export async function startBatch(recipeId: string): Promise<Batch> {
     body: { recipeId },
   });
   return mapBatch(row);
+}
+
+/**
+ * Raw priming payload as returned by the backend (snake_case), mirroring the
+ * backend `PrimingDto`. Mapped to {@link PrimingInfo} by {@link mapPriming}.
+ */
+type PrimingDto = {
+  sugar_grams: number;
+  sugar_type: PrimingSugarType;
+  target_co2_vol: number;
+  volume_l: number;
+  safety_warning: string;
+};
+
+/**
+ * Raw tasting payload as returned by the backend (snake_case), mirroring the
+ * backend `TastingDto`. Mapped to {@link Tasting} by {@link mapTasting}.
+ */
+type TastingDto = {
+  id: string;
+  batch_id: string;
+  rating: number;
+  note?: string | null;
+  created_at: string;
+};
+
+/**
+ * Maps a raw {@link PrimingDto} to the {@link PrimingInfo} domain shape.
+ *
+ * @param dto - Raw priming payload from the backend.
+ * @returns The priming guidance in camelCase domain form.
+ */
+function mapPriming(dto: PrimingDto): PrimingInfo {
+  return {
+    sugarGrams: dto.sugar_grams,
+    sugarType: dto.sugar_type,
+    targetCo2Vol: dto.target_co2_vol,
+    volumeL: dto.volume_l,
+    safetyWarning: dto.safety_warning,
+  };
+}
+
+/**
+ * Maps a raw {@link TastingDto} to the {@link Tasting} domain shape,
+ * nullish-coalescing the optional note to `null` (same convention as
+ * {@link mapMeasurement}).
+ *
+ * @param dto - Raw tasting payload from the backend.
+ * @returns The tasting in camelCase domain form.
+ */
+function mapTasting(dto: TastingDto): Tasting {
+  return {
+    id: dto.id,
+    batchId: dto.batch_id,
+    rating: dto.rating,
+    note: dto.note ?? null,
+    createdAt: dto.created_at,
+  };
+}
+
+/**
+ * Reads the priming sugar guidance for a batch via
+ * `GET /batches/:id/priming`. Volume comes from the recipe (ADR-0020).
+ *
+ * @param batchId - Identifier of the batch to compute priming for.
+ * @returns The priming guidance in domain form.
+ */
+export async function getPriming(batchId: string): Promise<PrimingInfo> {
+  const row = await request<PrimingDto>(`/batches/${batchId}/priming`);
+  return mapPriming(row);
+}
+
+/**
+ * Closes the batch (bottling) via `POST /batches/:id/bottling/close`. Sets
+ * `bottled_at` and completes the current step through the workflow engine; the
+ * batch reaches `completed` when it was on its final (packaging) step.
+ *
+ * @param batchId - Identifier of the batch to close.
+ * @returns The updated batch (including `bottledAt`) in domain form.
+ */
+export async function closeBottling(batchId: string): Promise<Batch> {
+  const row = await request<BatchDto>(`/batches/${batchId}/bottling/close`, {
+    method: "POST",
+  });
+  return mapBatch(row);
+}
+
+/**
+ * Records a tasting against a batch via `POST /batches/:id/tasting`
+ * (one tasting per batch in v1).
+ *
+ * @param batchId - Identifier of the batch to attach the tasting to.
+ * @param input - Tasting creation payload (rating 1..5, optional note).
+ * @returns The persisted tasting in domain form.
+ */
+export async function createTasting(
+  batchId: string,
+  input: TastingInput,
+): Promise<Tasting> {
+  const row = await request<TastingDto>(`/batches/${batchId}/tasting`, {
+    method: "POST",
+    body: input,
+  });
+  return mapTasting(row);
+}
+
+/**
+ * Reads the tasting recorded for a batch via `GET /batches/:id/tasting`.
+ * The backend returns 404 ("Tasting not found") when none exists yet.
+ *
+ * @param batchId - Identifier of the batch to read the tasting for.
+ * @returns The recorded tasting in domain form.
+ */
+export async function getTasting(batchId: string): Promise<Tasting> {
+  const row = await request<TastingDto>(`/batches/${batchId}/tasting`);
+  return mapTasting(row);
 }
 
 /**

--- a/packages/mobile-app/src/features/batches/domain/batch.types.ts
+++ b/packages/mobile-app/src/features/batches/domain/batch.types.ts
@@ -18,6 +18,10 @@ export type BatchSummary = {
   startedAt: string;
   fermentationStartedAt?: string | null;
   fermentationCompletedAt?: string | null;
+  // ISO-8601 instant the batch was bottled (B3 closure), or null before
+  // bottling. The status stays "completed" — there is no BOTTLED status
+  // (ADR/state-05); bottledAt is the dedicated timestamp.
+  bottledAt?: string | null;
   completedAt?: string | null;
   createdAt: string;
   updatedAt: string;

--- a/packages/mobile-app/src/features/batches/domain/bottling.types.ts
+++ b/packages/mobile-app/src/features/batches/domain/bottling.types.ts
@@ -1,10 +1,12 @@
 /**
  * Domain types for the B3 bottling / priming / tasting flow (US-04xx).
  *
- * Type-only module: it carries the camelCase mirrors of the backend B3 DTOs
- * ({@link PrimingInfo}, {@link Tasting}, {@link TastingInput}) with no runtime
- * logic, so the domain layer never imports the data or presentation layers
- * (Clean Architecture dependency rule).
+ * Mostly a type module: it carries the camelCase mirrors of the backend B3 DTOs
+ * ({@link PrimingInfo}, {@link Tasting}, {@link TastingInput}), so the domain
+ * layer never imports the data or presentation layers (Clean Architecture
+ * dependency rule). It ALSO exports one runtime value — the {@link SAFETY_WARNING}
+ * constant (the fallback bottle-bomb warning) — so a refactor must not treat
+ * this file as types-only (it cannot be erased by `import type`).
  *
  * Brewing vocabulary: **priming** (réamorçage) is the controlled addition of
  * fermentable sugar at bottling time so the residual yeast re-carbonates the

--- a/packages/mobile-app/src/features/batches/domain/bottling.types.ts
+++ b/packages/mobile-app/src/features/batches/domain/bottling.types.ts
@@ -1,0 +1,84 @@
+/**
+ * Domain types for the B3 bottling / priming / tasting flow (US-04xx).
+ *
+ * Type-only module: it carries the camelCase mirrors of the backend B3 DTOs
+ * ({@link PrimingInfo}, {@link Tasting}, {@link TastingInput}) with no runtime
+ * logic, so the domain layer never imports the data or presentation layers
+ * (Clean Architecture dependency rule).
+ *
+ * Brewing vocabulary: **priming** (réamorçage) is the controlled addition of
+ * fermentable sugar at bottling time so the residual yeast re-carbonates the
+ * beer in the bottle. Over-priming over-pressurises the bottle and can make it
+ * explode — hence the prominent safety warning the backend ships in
+ * {@link PrimingInfo.safetyWarning}.
+ */
+
+/**
+ * Plain-French bottle-bomb safety warning, kept WORD-FOR-WORD identical to the
+ * backend `SAFETY_WARNING` (priming-calculator.ts). The single mobile source of
+ * truth: the demo priming path and the {@link import("../presentation/BottlingScreen")}
+ * fallback both reference it so the wording never drifts. Rendered verbatim —
+ * never paraphrased client-side.
+ */
+export const SAFETY_WARNING =
+  "Sécurité : ne dépassez jamais la dose de sucre indiquée. Un sur-sucrage " +
+  "crée une surpression dans la bouteille qui peut la faire EXPLOSER " +
+  "(danger pour les yeux). Pesez le sucre à la balance, ne dosez jamais à " +
+  "l'œil et n'improvisez pas.";
+
+/**
+ * Kind of priming sugar, mirroring the backend `sugar_type` enum.
+ *
+ * - `table_sugar` — saccharose (sucre de table), the novice default.
+ * - `dextrose` — glucose monohydrate, common in homebrew kits.
+ */
+export type PrimingSugarType = "table_sugar" | "dextrose";
+
+/**
+ * Priming guidance computed by the backend for a batch (ADR-0020: the volume
+ * always comes from the recipe — the calculator never sources it). The app's
+ * camelCase mirror of the backend `PrimingDto`.
+ */
+export interface PrimingInfo {
+  /** Grams of priming sugar to add, rounded to 1 decimal place. */
+  sugarGrams: number;
+  /** Kind of sugar the dose is computed for (see {@link PrimingSugarType}). */
+  sugarType: PrimingSugarType;
+  /** Target carbonation in CO2 volumes. */
+  targetCo2Vol: number;
+  /** Batch volume in litres, sourced from the recipe (`batch_size_l`). */
+  volumeL: number;
+  /**
+   * Plain-French bottle-bomb safety warning shipped by the backend. Rendered
+   * verbatim in a prominent banner — never paraphrased client-side.
+   */
+  safetyWarning: string;
+}
+
+/**
+ * A persisted tasting note for a batch (one per batch in v1), in the app's
+ * camelCase domain shape. Mirrors the backend `TastingDto`.
+ */
+export interface Tasting {
+  /** Server-assigned unique identifier. */
+  id: string;
+  /** Identifier of the batch this tasting belongs to. */
+  batchId: string;
+  /** Star rating from 1 to 5 (integer). */
+  rating: number;
+  /** Free-text note, or `null` when none was recorded. */
+  note: string | null;
+  /** ISO-8601 timestamp of when the tasting was created server-side. */
+  createdAt: string;
+}
+
+/**
+ * Payload to record a tasting. `note` is optional; an empty/whitespace note is
+ * normalised to `null` by the backend.
+ */
+export interface TastingInput {
+  /** Star rating from 1 to 5 (integer, required). */
+  rating: number;
+  /** Optional free-text note (<= 2000 chars). */
+  note?: string;
+}

--- a/packages/mobile-app/src/features/batches/presentation/BatchClosureView.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchClosureView.tsx
@@ -1,0 +1,182 @@
+import { Ionicons } from "@expo/vector-icons";
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { colors, radius, shadows, spacing, typography } from "@/core/theme";
+import { Card } from "@/core/ui/Card";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { Batch } from "@/features/batches/domain/batch.types";
+import { Tasting } from "@/features/batches/domain/bottling.types";
+
+type Props = {
+  /** The completed batch driving the celebration (real dates, real volume). */
+  batch: Batch;
+  /** Resolved recipe name, or `null` to fall back to a "Brassin <id>" title. */
+  recipeName: string | null;
+  /** Recipe batch volume in litres, or `null` when unknown. */
+  volumeL: number | null;
+  /** The recorded tasting, or `null` when not noted yet. */
+  tasting: Tasting | null;
+  /** Fired by the "Noter ma dégustation" CTA. */
+  onRateTasting: () => void;
+};
+
+/** Formats an ISO instant as a short French date (e.g. "12 mai 2026"). */
+function formatFrDate(iso: string | null | undefined): string | null {
+  if (!iso) {
+    return null;
+  }
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}
+
+/**
+ * Live closure / celebration view for a COMPLETED batch (B3).
+ *
+ * Replaces the hardcoded {@link import("./BatchFinishedScreen")} demo mock on
+ * the live path: it is driven entirely by the actual batch (real recipe name,
+ * real volume, real bottling date) and the recorded tasting if any. KISS —
+ * rich stats (ABV/IBU/EBC grid, full timeline) are deferred; this shows the
+ * essentials plus a "Noter ma dégustation" CTA.
+ *
+ * @param props - The completed batch, recipe name, volume, tasting and CTA.
+ */
+export function BatchClosureView({
+  batch,
+  recipeName,
+  volumeL,
+  tasting,
+  onRateTasting,
+}: Props) {
+  const title = recipeName ?? `Brassin ${batch.id.slice(0, 8)}`;
+  const bottledOn =
+    formatFrDate(batch.bottledAt) ?? formatFrDate(batch.completedAt);
+
+  return (
+    <View testID="batch-closure-view">
+      <Card style={styles.heroCard}>
+        <View style={styles.heroHeader}>
+          <Ionicons name="beer" size={28} color={colors.neutral.white} />
+          <Text style={styles.heroOverline}>Brassin terminé</Text>
+        </View>
+        <Text style={styles.heroTitle}>{title}</Text>
+        {bottledOn ? (
+          <Text style={styles.heroMeta}>Mis en bouteille le {bottledOn}</Text>
+        ) : null}
+        {volumeL != null ? (
+          <Text style={styles.heroMeta}>Volume : {volumeL} L</Text>
+        ) : null}
+      </Card>
+
+      <Card style={styles.tastingCard}>
+        <Text style={styles.sectionTitle}>Ta dégustation</Text>
+        {tasting ? (
+          <>
+            <View style={styles.starRow}>
+              {[1, 2, 3, 4, 5].map((value) => (
+                <Ionicons
+                  key={value}
+                  name={value <= tasting.rating ? "star" : "star-outline"}
+                  size={20}
+                  color={colors.semantic.warning}
+                />
+              ))}
+            </View>
+            {tasting.note ? (
+              <Text testID="closure-tasting-note" style={styles.tastingNote}>
+                “{tasting.note}”
+              </Text>
+            ) : null}
+          </>
+        ) : (
+          <Text style={styles.tastingHint}>
+            Pas encore noté. Quand tu auras goûté, note ce brassin pour t'en
+            souvenir et progresser.
+          </Text>
+        )}
+        {tasting ? null : (
+          <PrimaryButton
+            label="Noter ma dégustation"
+            onPress={onRateTasting}
+            style={styles.tastingCta}
+          />
+        )}
+      </Card>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  heroCard: {
+    padding: spacing.lg,
+    marginBottom: spacing.sm,
+    backgroundColor: colors.brand.primary,
+    borderColor: colors.brand.primary,
+    borderRadius: radius.lg,
+    ...shadows.md,
+  },
+  heroHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  heroOverline: {
+    color: colors.neutral.white,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    letterSpacing: 2,
+    textTransform: "uppercase",
+    opacity: 0.85,
+  },
+  heroTitle: {
+    color: colors.neutral.white,
+    fontSize: typography.size.h1,
+    lineHeight: typography.lineHeight.h1,
+    fontWeight: typography.weight.bold,
+  },
+  heroMeta: {
+    color: colors.neutral.white,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    marginTop: spacing.xxs,
+    opacity: 0.92,
+  },
+  tastingCard: {
+    padding: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  sectionTitle: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+    marginBottom: spacing.xs,
+  },
+  starRow: {
+    flexDirection: "row",
+    gap: spacing.xxs,
+    marginBottom: spacing.xs,
+  },
+  tastingNote: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontStyle: "italic",
+  },
+  tastingHint: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  tastingCta: {
+    marginTop: spacing.md,
+  },
+});

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -14,12 +14,15 @@ import {
   completeCurrentBatchStep,
   getBatchDetailsViewModel,
 } from "@/features/batches/application/batches.use-cases";
+import { getTasting } from "@/features/batches/application/bottling.use-cases";
 import { computeAbv } from "@/features/batches/application/measurement.calculations";
 import { listBatchMeasurements } from "@/features/batches/application/measurement.use-cases";
+import { Tasting } from "@/features/batches/domain/bottling.types";
 import { Measurement } from "@/features/batches/domain/measurement.types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { Batch } from "@/features/batches/domain/batch.types";
+import { BatchClosureView } from "@/features/batches/presentation/BatchClosureView";
 import { BATCH_STATUS_LABELS } from "@/features/batches/presentation/batch-display.constants";
 import { BatchTimeline } from "@/features/batches/presentation/BatchTimeline";
 import { StepCard } from "@/features/batches/presentation/StepCard";
@@ -157,6 +160,19 @@ export function BatchDetailsScreen({ batchId }: Props) {
 
   const batch = viewModel?.batch ?? null;
   const recipeName = viewModel?.recipeName ?? null;
+  const recipeVolumeL = viewModel?.recipeVolumeL ?? null;
+  const isCompletedLive =
+    batch?.status === "completed" && !dataSource.useDemoData;
+
+  const {
+    data: tasting = null,
+    error: tastingError,
+    isError: isTastingError,
+  } = useQuery<Tasting | null>({
+    queryKey: ["batches", "tasting", batchId],
+    queryFn: () => getTasting(batchId),
+    enabled: !missingBatchId && isCompletedLive,
+  });
 
   const { data: measurements = [] } = useQuery<Measurement[]>({
     queryKey: ["batches", "measurements", batchId],
@@ -199,7 +215,12 @@ export function BatchDetailsScreen({ batchId }: Props) {
         ? isFetching
           ? null
           : getErrorMessage(queryError, "Impossible de charger le brassin")
-        : null));
+        : isTastingError
+          ? getErrorMessage(
+              tastingError,
+              "Impossible de charger la dégustation",
+            )
+          : null));
 
   const isRetryingWithError = isFetching && Boolean(queryError);
   const handleRetry = () => {
@@ -235,7 +256,37 @@ export function BatchDetailsScreen({ batchId }: Props) {
     });
   };
 
+  const handleGoToBottling = () => {
+    if (missingBatchId) {
+      return;
+    }
+    router.push({
+      pathname: "/batches/[id]/bottling",
+      params: { id: batchId },
+    });
+  };
+
+  const handleRateTasting = () => {
+    if (missingBatchId) {
+      return;
+    }
+    router.push({
+      pathname: "/batches/[id]/tasting",
+      params: { id: batchId },
+    });
+  };
+
   const isCompleted = batch?.status === "completed";
+  // In LIVE mode the current step being PACKAGING routes the brewer to the
+  // dedicated bottling/closure screen instead of the dead-end "Terminer
+  // l'étape" button. Demo mode keeps its original single-button behaviour.
+  const currentStep =
+    batch?.steps?.find((step) => step.stepOrder === batch.currentStepOrder) ??
+    null;
+  const showBottlingCta =
+    !dataSource.useDemoData &&
+    !isCompleted &&
+    currentStep?.type === "packaging";
   const fermentationInfo = useFermentationTrackerInfo(batch);
   const activeStep =
     batch?.steps?.find((step) => step.status === "in_progress") ?? null;
@@ -278,7 +329,17 @@ export function BatchDetailsScreen({ batchId }: Props) {
         </Card>
       ) : null}
 
-      {fermentationInfo ? (
+      {isCompletedLive && batch ? (
+        <BatchClosureView
+          batch={batch}
+          recipeName={recipeName}
+          volumeL={recipeVolumeL}
+          tasting={tasting}
+          onRateTasting={handleRateTasting}
+        />
+      ) : null}
+
+      {!isCompletedLive && fermentationInfo ? (
         <Card style={styles.fermentationCard}>
           <View style={styles.fermentationHeader}>
             <Ionicons name="flask" size={18} color={colors.brand.secondary} />
@@ -319,7 +380,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
         </Card>
       ) : null}
 
-      {batch ? (
+      {!isCompletedLive && batch ? (
         <Card style={styles.measurementCard}>
           <View style={styles.fermentationHeader}>
             <Ionicons
@@ -359,25 +420,40 @@ export function BatchDetailsScreen({ batchId }: Props) {
         </Card>
       ) : null}
 
-      {activeStep ? (
+      {!isCompletedLive && activeStep ? (
         <BrewStepTimer step={activeStep} useDemoData={dataSource.useDemoData} />
       ) : null}
 
-      <PrimaryButton
-        label={completeButtonLabel}
-        onPress={handleComplete}
-        disabled={isCompleting || isCompleted || isLoading}
-      />
+      {showBottlingCta ? (
+        <PrimaryButton
+          label="Mettre en bouteille"
+          onPress={handleGoToBottling}
+          disabled={isLoading}
+        />
+      ) : !isCompletedLive ? (
+        <PrimaryButton
+          label={completeButtonLabel}
+          onPress={handleComplete}
+          disabled={isCompleting || isCompleted || isLoading}
+        />
+      ) : null}
 
-      <Text style={styles.sectionTitle}>Étapes</Text>
-      <FlatList
-        data={batch?.steps ?? []}
-        keyExtractor={(item) => `${item.batchId}-${item.stepOrder}`}
-        contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
-        renderItem={({ item }) => (
-          <StepCard step={item} onOpenTip={setOpenTip} />
-        )}
-      />
+      {!isCompletedLive ? (
+        <>
+          <Text style={styles.sectionTitle}>Étapes</Text>
+          <FlatList
+            data={batch?.steps ?? []}
+            keyExtractor={(item) => `${item.batchId}-${item.stepOrder}`}
+            contentContainerStyle={[
+              styles.list,
+              { paddingBottom: bottomPadding },
+            ]}
+            renderItem={({ item }) => (
+              <StepCard step={item} onOpenTip={setOpenTip} />
+            )}
+          />
+        </>
+      ) : null}
 
       <Modal
         visible={openTip !== null}

--- a/packages/mobile-app/src/features/batches/presentation/BottlingScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BottlingScreen.tsx
@@ -95,8 +95,13 @@ export function BottlingScreen({ batchId }: Props) {
     },
   });
 
+  // SAFETY: the brewer must never close without having received the sugar dose.
+  // The close gate therefore also requires the priming query to have loaded a
+  // dose (non-null data, no error) — over-priming is the bottle-bomb hazard.
+  const primingLoaded = priming != null && !primingError;
+
   const handleClose = () => {
-    if (missingBatchId || !acknowledged) {
+    if (missingBatchId || !acknowledged || !primingLoaded) {
       return;
     }
     mutateClose();
@@ -206,7 +211,9 @@ export function BottlingScreen({ batchId }: Props) {
             isPending ? "Clôture en cours…" : "Mettre en bouteille / clôturer"
           }
           onPress={handleClose}
-          disabled={isPending || !acknowledged || missingBatchId}
+          disabled={
+            isPending || !acknowledged || missingBatchId || !primingLoaded
+          }
         />
         {!acknowledged ? (
           <Text style={styles.gateHint}>

--- a/packages/mobile-app/src/features/batches/presentation/BottlingScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BottlingScreen.tsx
@@ -1,0 +1,331 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import React from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+
+import { dataSource } from "@/core/data/data-source";
+import { getErrorMessage } from "@/core/http/http-error";
+import { colors, spacing, typography } from "@/core/theme";
+import { Card } from "@/core/ui/Card";
+import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
+import { ListHeader } from "@/core/ui/ListHeader";
+import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { Screen } from "@/core/ui/Screen";
+import {
+  closeBottling,
+  getBottlingInfo,
+} from "@/features/batches/application/bottling.use-cases";
+import { Batch } from "@/features/batches/domain/batch.types";
+import {
+  PrimingInfo,
+  PrimingSugarType,
+  SAFETY_WARNING,
+} from "@/features/batches/domain/bottling.types";
+
+type Props = {
+  /** Identifier of the batch being bottled and closed. */
+  batchId: string;
+};
+
+/** Plain-French label for each priming sugar kind. */
+const SUGAR_TYPE_LABELS: Record<PrimingSugarType, string> = {
+  table_sugar: "sucre de table (saccharose)",
+  dextrose: "dextrose (glucose)",
+};
+
+/** Beginner bottling gestures, taught step by step (maître-mot : éduquer). */
+const BOTTLING_STEPS: ReadonlyArray<string> = [
+  "Désinfecte les bouteilles et les capsules : c'est l'étape qui évite la contamination.",
+  "Ajoute le sucre de réamorçage pesé à la balance, puis transvase la bière au siphon, doucement, sans éclabousser (pour ne pas oxyder).",
+  "Remplis en laissant ~2 cm sous le goulot, capsule fermement chaque bouteille.",
+  "Laisse refermenter en bouteille ~2 à 3 semaines à température ambiante, puis place au frais avant de déguster.",
+];
+
+/**
+ * Bottling + closure screen (B3).
+ *
+ * Teaches the novice the priming dose (from `GET /priming`, volume sourced
+ * from the recipe per ADR-0020) and the beginner bottling gestures, then gates
+ * the irreversible closure behind:
+ * - a PROMINENT bottle-bomb safety warning (rendered verbatim from the
+ *   backend), and
+ * - a required "j'ai compris le risque" checkbox that disables the close
+ *   button until ticked.
+ *
+ * On confirm it fires `closeBottling`, invalidates the batch detail + list
+ * query keys, and navigates to the closure / celebration view.
+ *
+ * @param props - The identifier of the batch being bottled.
+ */
+export function BottlingScreen({ batchId }: Props) {
+  const bottomPadding = useNavigationFooterOffset();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const missingBatchId = !batchId;
+
+  const [acknowledged, setAcknowledged] = React.useState(false);
+
+  const {
+    data: priming = null,
+    isLoading: isLoadingPriming,
+    error: primingError,
+  } = useQuery<PrimingInfo | null>({
+    queryKey: ["batches", "priming", batchId],
+    queryFn: () => getBottlingInfo(batchId),
+    enabled: !missingBatchId,
+  });
+
+  const {
+    mutate: mutateClose,
+    isPending,
+    error: closeError,
+  } = useMutation<Batch | null, Error, void>({
+    mutationFn: () => closeBottling(batchId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["batches", "details", batchId],
+      });
+      void queryClient.invalidateQueries({ queryKey: ["batches", "list"] });
+      router.replace({
+        pathname: "/batches/[id]",
+        params: { id: batchId },
+      });
+    },
+  });
+
+  const handleClose = () => {
+    if (missingBatchId || !acknowledged) {
+      return;
+    }
+    mutateClose();
+  };
+
+  const primingErrorMessage = primingError
+    ? getErrorMessage(primingError, "Impossible de calculer le réamorçage")
+    : null;
+
+  return (
+    <Screen>
+      <ListHeader
+        title="Mettre en bouteille"
+        subtitle="Réamorçage, gestes clés et clôture du brassin"
+        action={
+          <HeaderBackButton
+            label="Retour"
+            accessibilityLabel="Retour au brassin"
+            onPress={() => router.back()}
+          />
+        }
+      />
+
+      <ScrollView
+        contentContainerStyle={{ paddingBottom: bottomPadding }}
+        showsVerticalScrollIndicator={false}
+      >
+        <Card style={styles.card}>
+          <Text style={styles.cardTitle}>Dose de sucre de réamorçage</Text>
+          {isLoadingPriming ? (
+            <Text style={styles.helpText}>Calcul en cours…</Text>
+          ) : priming ? (
+            <>
+              <Text testID="priming-dose" style={styles.doseValue}>
+                {priming.sugarGrams} g
+              </Text>
+              <Text style={styles.helpText}>
+                {SUGAR_TYPE_LABELS[priming.sugarType]} pour {priming.volumeL} L,
+                soit environ {priming.targetCo2Vol} volumes de CO₂. Ce sucre
+                relance une petite fermentation en bouteille : c'est elle qui
+                crée les bulles.
+              </Text>
+            </>
+          ) : (
+            <Text testID="priming-error" style={styles.helpText}>
+              {primingErrorMessage ??
+                "Réamorçage indisponible pour ce brassin."}
+            </Text>
+          )}
+        </Card>
+
+        <Card style={styles.card}>
+          <Text style={styles.cardTitle}>Les gestes de l'embouteillage</Text>
+          {BOTTLING_STEPS.map((step, index) => (
+            <View key={step} style={styles.stepRow}>
+              <Text style={styles.stepIndex}>{index + 1}</Text>
+              <Text style={styles.stepText}>{step}</Text>
+            </View>
+          ))}
+        </Card>
+
+        <Card style={[styles.card, styles.warningCard]}>
+          <View style={styles.warningHeader}>
+            <Ionicons name="warning" size={22} color={colors.semantic.error} />
+            <Text style={styles.warningTitle}>
+              Danger : bouteille qui explose
+            </Text>
+          </View>
+          <Text testID="bottling-safety-warning" style={styles.warningText}>
+            {priming?.safetyWarning ?? SAFETY_WARNING}
+          </Text>
+        </Card>
+
+        <Pressable
+          testID="bottling-ack-checkbox"
+          accessibilityRole="checkbox"
+          accessibilityState={{ checked: acknowledged }}
+          accessibilityLabel="J'ai compris le risque de surpression"
+          style={({ pressed }) => [
+            styles.ackRow,
+            pressed && styles.ackRowPressed,
+          ]}
+          onPress={() => setAcknowledged((prev) => !prev)}
+        >
+          <Ionicons
+            name={acknowledged ? "checkmark-circle" : "ellipse-outline"}
+            size={24}
+            color={
+              acknowledged ? colors.semantic.success : colors.neutral.muted
+            }
+          />
+          <Text style={styles.ackText}>
+            J'ai compris le risque et je respecte la dose de sucre indiquée.
+          </Text>
+        </Pressable>
+
+        {closeError ? (
+          <Card style={[styles.card, styles.errorCard]}>
+            <Text style={styles.errorText}>
+              {getErrorMessage(closeError, "Échec de la mise en bouteille")}
+            </Text>
+          </Card>
+        ) : null}
+
+        <PrimaryButton
+          label={
+            isPending ? "Clôture en cours…" : "Mettre en bouteille / clôturer"
+          }
+          onPress={handleClose}
+          disabled={isPending || !acknowledged || missingBatchId}
+        />
+        {!acknowledged ? (
+          <Text style={styles.gateHint}>
+            Coche la case de sécurité pour pouvoir clôturer le brassin.
+          </Text>
+        ) : null}
+
+        {dataSource.useDemoData ? (
+          <Text style={styles.demoHint}>
+            Mode démo : la clôture est simulée.
+          </Text>
+        ) : null}
+      </ScrollView>
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: spacing.sm,
+  },
+  cardTitle: {
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    marginBottom: spacing.xs,
+  },
+  helpText: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.neutral.textSecondary,
+  },
+  doseValue: {
+    fontSize: typography.size.h1,
+    lineHeight: typography.lineHeight.h1,
+    fontWeight: typography.weight.bold,
+    color: colors.brand.primary,
+    marginBottom: spacing.xs,
+  },
+  stepRow: {
+    flexDirection: "row",
+    gap: spacing.sm,
+    marginTop: spacing.sm,
+  },
+  stepIndex: {
+    width: spacing.lg,
+    textAlign: "center",
+    fontWeight: typography.weight.bold,
+    color: colors.brand.secondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  stepText: {
+    flex: 1,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.neutral.textPrimary,
+  },
+  warningCard: {
+    backgroundColor: colors.state.errorBackground,
+    borderColor: colors.semantic.error,
+  },
+  warningHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+    marginBottom: spacing.xs,
+  },
+  warningTitle: {
+    flex: 1,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+    color: colors.semantic.error,
+  },
+  warningText: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.semantic.error,
+  },
+  ackRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+    paddingVertical: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  ackRowPressed: {
+    opacity: 0.7,
+  },
+  ackText: {
+    flex: 1,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+    color: colors.neutral.textPrimary,
+  },
+  errorCard: {
+    backgroundColor: colors.state.errorBackground,
+    borderColor: colors.semantic.error,
+  },
+  errorText: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.semantic.error,
+  },
+  gateHint: {
+    marginTop: spacing.xs,
+    textAlign: "center",
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    color: colors.neutral.textSecondary,
+  },
+  demoHint: {
+    marginTop: spacing.sm,
+    textAlign: "center",
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    color: colors.neutral.muted,
+  },
+});

--- a/packages/mobile-app/src/features/batches/presentation/TastingScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/TastingScreen.tsx
@@ -1,0 +1,207 @@
+import { Ionicons } from "@expo/vector-icons";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import React from "react";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+
+import { getErrorMessage } from "@/core/http/http-error";
+import { colors, radius, spacing, typography } from "@/core/theme";
+import { Card } from "@/core/ui/Card";
+import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
+import { ListHeader } from "@/core/ui/ListHeader";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { Screen } from "@/core/ui/Screen";
+import { recordTasting } from "@/features/batches/application/bottling.use-cases";
+import { Tasting } from "@/features/batches/domain/bottling.types";
+
+type Props = {
+  /** Identifier of the batch the tasting is recorded against. */
+  batchId: string;
+};
+
+/** Maximum note length, mirroring the backend `CreateTastingDto` constraint. */
+const NOTE_MAX_LENGTH = 2000;
+
+/** The five selectable star values. */
+const STAR_VALUES: ReadonlyArray<number> = [1, 2, 3, 4, 5];
+
+/**
+ * Tasting note screen (B3).
+ *
+ * Captures a 1-to-5 star rating (custom Pressable row with Ionicons
+ * star/star-outline) plus an optional free-text note, records it via
+ * `recordTasting`, invalidates the tasting query key, then returns to the
+ * closure view. One tasting per batch in v1: a 409 from the backend surfaces
+ * as an inline error.
+ *
+ * @param props - The identifier of the batch being rated.
+ */
+export function TastingScreen({ batchId }: Props) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const missingBatchId = !batchId;
+
+  const [rating, setRating] = React.useState(0);
+  const [note, setNote] = React.useState("");
+
+  const {
+    mutate: mutateRecord,
+    isPending,
+    error: mutationError,
+  } = useMutation<Tasting | null, Error, { rating: number; note?: string }>({
+    mutationFn: (input: { rating: number; note?: string }) =>
+      recordTasting(batchId, input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["batches", "tasting", batchId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["batches", "details", batchId],
+      });
+      router.back();
+    },
+  });
+
+  const handleSubmit = () => {
+    if (missingBatchId || rating < 1) {
+      return;
+    }
+    const trimmed = note.trim();
+    mutateRecord({
+      rating,
+      ...(trimmed ? { note: trimmed } : {}),
+    });
+  };
+
+  return (
+    <Screen>
+      <ListHeader
+        title="Noter ma dégustation"
+        subtitle="Une note et un commentaire pour te souvenir de ce brassin"
+        action={
+          <HeaderBackButton
+            label="Retour"
+            accessibilityLabel="Retour au brassin"
+            onPress={() => router.back()}
+          />
+        }
+      />
+
+      <Card style={styles.card}>
+        <Text style={styles.cardTitle}>Ta note</Text>
+        <Text style={styles.helpText}>
+          De 1 (à oublier) à 5 (à refaire) : il n'y a pas de mauvaise réponse,
+          c'est ton ressenti qui compte.
+        </Text>
+        <View style={styles.starRow}>
+          {STAR_VALUES.map((value) => {
+            const filled = value <= rating;
+            return (
+              <Pressable
+                key={value}
+                testID={`tasting-star-${value}`}
+                accessibilityRole="button"
+                accessibilityLabel={`Noter ${value} sur 5`}
+                accessibilityState={{ selected: filled }}
+                style={styles.star}
+                onPress={() => setRating(value)}
+              >
+                <Ionicons
+                  name={filled ? "star" : "star-outline"}
+                  size={36}
+                  color={
+                    filled ? colors.semantic.warning : colors.neutral.muted
+                  }
+                />
+              </Pressable>
+            );
+          })}
+        </View>
+      </Card>
+
+      <Card style={styles.card}>
+        <Text style={styles.inputLabel}>Commentaire (facultatif)</Text>
+        <TextInput
+          testID="tasting-note-input"
+          style={styles.noteInput}
+          value={note}
+          onChangeText={setNote}
+          placeholder="Mousse, amertume, ce que tu changerais la prochaine fois…"
+          multiline
+          maxLength={NOTE_MAX_LENGTH}
+        />
+      </Card>
+
+      {mutationError ? (
+        <Card style={[styles.card, styles.errorCard]}>
+          <Text style={styles.errorText}>
+            {getErrorMessage(
+              mutationError,
+              "Échec de l'enregistrement de la dégustation",
+            )}
+          </Text>
+        </Card>
+      ) : null}
+
+      <PrimaryButton
+        label={isPending ? "Enregistrement…" : "Enregistrer ma dégustation"}
+        onPress={handleSubmit}
+        disabled={isPending || rating < 1 || missingBatchId}
+      />
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: spacing.sm,
+  },
+  cardTitle: {
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    marginBottom: spacing.xs,
+  },
+  helpText: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.neutral.textSecondary,
+    marginBottom: spacing.sm,
+  },
+  starRow: {
+    flexDirection: "row",
+    gap: spacing.xs,
+  },
+  star: {
+    padding: spacing.xxs,
+  },
+  inputLabel: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+    color: colors.neutral.textPrimary,
+    marginBottom: spacing.xs,
+  },
+  noteInput: {
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    borderRadius: radius.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+    minHeight: spacing.xxl * 2,
+    textAlignVertical: "top",
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    color: colors.neutral.textPrimary,
+  },
+  errorCard: {
+    backgroundColor: colors.state.errorBackground,
+    borderColor: colors.semantic.error,
+  },
+  errorText: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.semantic.error,
+  },
+});

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchClosureView.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchClosureView.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { BatchClosureView } from "@/features/batches/presentation/BatchClosureView";
+import { Batch } from "@/features/batches/domain/batch.types";
+import { Tasting } from "@/features/batches/domain/bottling.types";
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+const TS = "2026-06-20T09:00:00.000Z";
+
+const completedBatch: Batch = {
+  id: "b1deadbeef-cafe",
+  ownerId: "u1",
+  recipeId: "r1",
+  status: "completed",
+  currentStepOrder: null,
+  startedAt: "2026-02-05T09:00:00.000Z",
+  bottledAt: TS,
+  completedAt: TS,
+  createdAt: "2026-02-05T09:00:00.000Z",
+  updatedAt: TS,
+  steps: [],
+};
+
+const recordedTasting: Tasting = {
+  id: "t1",
+  batchId: "b1deadbeef-cafe",
+  rating: 4,
+  note: "Belle mousse, finale fruitée.",
+  createdAt: TS,
+};
+
+describe("BatchClosureView", () => {
+  const onRateTasting = jest.fn();
+
+  beforeEach(() => {
+    onRateTasting.mockReset();
+  });
+
+  // Happy path: no tasting yet → CTA is present and fires the handler.
+  it("shows the rate CTA when no tasting exists and fires it on press", () => {
+    render(
+      <BatchClosureView
+        batch={completedBatch}
+        recipeName="Ma blonde"
+        volumeL={4.3}
+        tasting={null}
+        onRateTasting={onRateTasting}
+      />,
+    );
+
+    fireEvent.press(screen.getByText("Noter ma dégustation"));
+    expect(onRateTasting).toHaveBeenCalledTimes(1);
+  });
+
+  // Edge: a recorded tasting shows the note and HIDES the CTA (v1 = one tasting).
+  it("shows the note and hides the CTA when a tasting is recorded", () => {
+    render(
+      <BatchClosureView
+        batch={completedBatch}
+        recipeName="Ma blonde"
+        volumeL={4.3}
+        tasting={recordedTasting}
+        onRateTasting={onRateTasting}
+      />,
+    );
+
+    expect(screen.getByTestId("closure-tasting-note")).toHaveTextContent(
+      /Belle mousse/,
+    );
+    expect(screen.queryByText("Noter ma dégustation")).toBeNull();
+  });
+
+  // Sad path: no recipe name → title falls back to "Brassin <id.slice(0,8)>".
+  it("falls back to a 'Brassin <id>' title when recipeName is null", () => {
+    render(
+      <BatchClosureView
+        batch={completedBatch}
+        recipeName={null}
+        volumeL={4.3}
+        tasting={null}
+        onRateTasting={onRateTasting}
+      />,
+    );
+
+    expect(
+      screen.getByText(`Brassin ${completedBatch.id.slice(0, 8)}`),
+    ).toBeTruthy();
+  });
+
+  // Edge: no bottledAt but a completedAt → the date line still renders.
+  it("renders the date line from completedAt when bottledAt is absent", () => {
+    render(
+      <BatchClosureView
+        batch={{ ...completedBatch, bottledAt: null }}
+        recipeName="Ma blonde"
+        volumeL={4.3}
+        tasting={null}
+        onRateTasting={onRateTasting}
+      />,
+    );
+
+    expect(screen.getByText(/Mis en bouteille le/)).toBeTruthy();
+  });
+
+  // Edge: an invalid ISO date → no date line is rendered (no crash).
+  it("renders no date line for an invalid ISO date", () => {
+    render(
+      <BatchClosureView
+        batch={{
+          ...completedBatch,
+          bottledAt: "not-a-date",
+          completedAt: null,
+        }}
+        recipeName="Ma blonde"
+        volumeL={4.3}
+        tasting={null}
+        onRateTasting={onRateTasting}
+      />,
+    );
+
+    expect(screen.queryByText(/Mis en bouteille le/)).toBeNull();
+  });
+});

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -7,6 +7,7 @@ import {
   type BatchDetailsViewModel,
 } from "@/features/batches/application/batches.use-cases";
 import { listBatchMeasurements } from "@/features/batches/application/measurement.use-cases";
+import { getTasting } from "@/features/batches/application/bottling.use-cases";
 import { Batch } from "@/features/batches/domain/batch.types";
 import { Measurement } from "@/features/batches/domain/measurement.types";
 import { dataSource } from "@/core/data/data-source";
@@ -86,6 +87,10 @@ jest.mock("@/features/batches/application/batches.use-cases", () => ({
 jest.mock("@/features/batches/application/measurement.use-cases", () => ({
   listBatchMeasurements: jest.fn(() => Promise.resolve([])),
   recordBatchMeasurement: jest.fn(() => Promise.resolve(null)),
+}));
+
+jest.mock("@/features/batches/application/bottling.use-cases", () => ({
+  getTasting: jest.fn(() => Promise.resolve(null)),
 }));
 
 function renderBatchDetailsScreen(batchId = "b1") {
@@ -462,5 +467,172 @@ describe("BatchDetailsScreen — measurement card (B2)", () => {
       pathname: "/batches/[id]/measurement",
       params: { id: "b1" },
     });
+  });
+});
+
+describe("BatchDetailsScreen — B3 bottling routing + closure view", () => {
+  const packagingBatch: Batch = {
+    id: "b1",
+    ownerId: "u1",
+    recipeId: "r1",
+    status: "in_progress",
+    currentStepOrder: 1,
+    startedAt: TS,
+    createdAt: TS,
+    updatedAt: TS,
+    steps: [
+      {
+        batchId: "b1",
+        stepOrder: 0,
+        type: "fermentation",
+        label: "Fermentation",
+        status: "completed",
+        createdAt: TS,
+        updatedAt: TS,
+      },
+      {
+        batchId: "b1",
+        stepOrder: 1,
+        type: "packaging",
+        label: "Conditionnement",
+        status: "in_progress",
+        createdAt: TS,
+        updatedAt: TS,
+      },
+    ],
+  };
+
+  const completedBatch: Batch = {
+    ...packagingBatch,
+    status: "completed",
+    currentStepOrder: null,
+    bottledAt: "2026-06-20T09:00:00.000Z",
+    completedAt: "2026-06-20T09:00:00.000Z",
+    steps: packagingBatch.steps.map((step) => ({
+      ...step,
+      status: "completed",
+    })),
+  };
+
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockReplace.mockReset();
+    dataSource.useDemoData = false;
+    (listBatchMeasurements as jest.Mock).mockResolvedValue([]);
+    (getTasting as jest.Mock).mockResolvedValue(null);
+  });
+
+  it("routes a live PACKAGING step to the bottling screen instead of the dead-end button (happy path)", async () => {
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue({
+      batch: packagingBatch,
+      recipeName: "Ma blonde",
+      recipeVolumeL: 4.3,
+    });
+
+    renderBatchDetailsScreen();
+
+    fireEvent.press(await screen.findByText("Mettre en bouteille"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/batches/[id]/bottling",
+      params: { id: "b1" },
+    });
+    // The dead-end complete button must not be shown on the packaging step.
+    expect(screen.queryByText("Terminer l'étape en cours")).toBeNull();
+  });
+
+  it("keeps the complete button for non-packaging live steps (sad path)", async () => {
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue({
+      batch: {
+        ...packagingBatch,
+        currentStepOrder: 0,
+        steps: packagingBatch.steps.map((step) =>
+          step.stepOrder === 0
+            ? { ...step, status: "in_progress" }
+            : { ...step, status: "pending" },
+        ),
+      },
+      recipeName: "Ma blonde",
+      recipeVolumeL: 4.3,
+    });
+
+    renderBatchDetailsScreen();
+
+    expect(await screen.findByText("Terminer l'étape en cours")).toBeTruthy();
+    expect(screen.queryByText("Mettre en bouteille")).toBeNull();
+  });
+
+  it("renders the live closure view fed by the real batch when completed (happy path)", async () => {
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue({
+      batch: completedBatch,
+      recipeName: "Ma blonde",
+      recipeVolumeL: 4.3,
+    });
+
+    renderBatchDetailsScreen();
+
+    expect(await screen.findByTestId("batch-closure-view")).toBeTruthy();
+    expect(screen.getByText("Volume : 4.3 L")).toBeTruthy();
+    expect(screen.getByText(/Mis en bouteille le/)).toBeTruthy();
+    // The completed live path replaces the steps list + measurement card.
+    expect(screen.queryByText("Étapes")).toBeNull();
+  });
+
+  it("navigates to the tasting route from the closure CTA (happy path)", async () => {
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue({
+      batch: completedBatch,
+      recipeName: "Ma blonde",
+      recipeVolumeL: 4.3,
+    });
+
+    renderBatchDetailsScreen();
+
+    fireEvent.press(await screen.findByText("Noter ma dégustation"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/batches/[id]/tasting",
+      params: { id: "b1" },
+    });
+  });
+
+  it("shows the recorded tasting in the closure view when present (edge path)", async () => {
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue({
+      batch: completedBatch,
+      recipeName: "Ma blonde",
+      recipeVolumeL: 4.3,
+    });
+    (getTasting as jest.Mock).mockResolvedValue({
+      id: "t1",
+      batchId: "b1",
+      rating: 5,
+      note: "À refaire",
+      createdAt: "2026-06-21T09:00:00.000Z",
+    });
+
+    renderBatchDetailsScreen();
+
+    expect(await screen.findByTestId("closure-tasting-note")).toHaveTextContent(
+      /À refaire/,
+    );
+    // v1 = one tasting per batch (no update path): once recorded, the CTA is
+    // hidden rather than offering a "Modifier" that would 409 on the backend.
+    expect(screen.queryByText("Modifier ma dégustation")).toBeNull();
+    expect(screen.queryByText("Noter ma dégustation")).toBeNull();
+  });
+
+  it("does not show the closure view in demo mode even when completed (sad path)", async () => {
+    dataSource.useDemoData = true;
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue({
+      batch: completedBatch,
+      recipeName: "Ma blonde",
+      recipeVolumeL: 4.3,
+    });
+
+    renderBatchDetailsScreen();
+
+    await screen.findByText("Ma blonde");
+    // Demo keeps the original behaviour (steps list + disabled button).
+    expect(screen.queryByTestId("batch-closure-view")).toBeNull();
+    expect(screen.getByText("Étapes")).toBeTruthy();
   });
 });

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BottlingScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BottlingScreen.test.tsx
@@ -184,4 +184,18 @@ describe("BottlingScreen", () => {
     // The safety warning still renders from its hardcoded fallback.
     expect(screen.getByTestId("bottling-safety-warning")).toBeTruthy();
   });
+
+  it("keeps the close gate disabled when the priming dose did not load, even if acknowledged (safety, sad path)", async () => {
+    // A brewer must never close without having received the sugar dose: when
+    // priming is null the close gate stays shut regardless of the checkbox.
+    mockedGetBottlingInfo.mockResolvedValue(null);
+    renderScreen();
+
+    await screen.findByTestId("priming-error");
+
+    fireEvent.press(screen.getByTestId("bottling-ack-checkbox"));
+    fireEvent.press(screen.getByText("Mettre en bouteille / clôturer"));
+
+    expect(mockedClose).not.toHaveBeenCalled();
+  });
 });

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BottlingScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BottlingScreen.test.tsx
@@ -1,0 +1,187 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+import React from "react";
+
+import { BottlingScreen } from "@/features/batches/presentation/BottlingScreen";
+import {
+  closeBottling,
+  getBottlingInfo,
+} from "@/features/batches/application/bottling.use-cases";
+import { PrimingInfo } from "@/features/batches/domain/bottling.types";
+
+const mockReplace = jest.fn();
+const mockBack = jest.fn();
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("expo-router", () => {
+  const actual = jest.requireActual("expo-router");
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: jest.fn(),
+      replace: mockReplace,
+      back: mockBack,
+    }),
+  };
+});
+
+jest.mock("@/features/batches/application/bottling.use-cases", () => ({
+  getBottlingInfo: jest.fn(),
+  closeBottling: jest.fn(),
+}));
+
+const mockedGetBottlingInfo = getBottlingInfo as jest.MockedFunction<
+  typeof getBottlingInfo
+>;
+const mockedClose = closeBottling as jest.MockedFunction<typeof closeBottling>;
+
+const priming: PrimingInfo = {
+  sugarGrams: 28,
+  sugarType: "table_sugar",
+  targetCo2Vol: 2.4,
+  volumeL: 4.3,
+  safetyWarning:
+    "Sécurité : un sur-sucrage peut faire EXPLOSER la bouteille. Pesez le sucre.",
+};
+
+function renderScreen(batchId = "b1") {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BottlingScreen batchId={batchId} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("BottlingScreen", () => {
+  beforeEach(() => {
+    mockReplace.mockReset();
+    mockBack.mockReset();
+    mockedGetBottlingInfo.mockReset();
+    mockedClose.mockReset();
+    mockedGetBottlingInfo.mockResolvedValue(priming);
+    mockedClose.mockResolvedValue({
+      id: "b1",
+      ownerId: "u1",
+      recipeId: "r1",
+      status: "completed",
+      currentStepOrder: null,
+      startedAt: "2026-02-05T09:00:00.000Z",
+      bottledAt: "2026-06-20T09:00:00.000Z",
+      completedAt: "2026-06-20T09:00:00.000Z",
+      createdAt: "2026-02-05T09:00:00.000Z",
+      updatedAt: "2026-06-20T09:00:00.000Z",
+      steps: [],
+    });
+  });
+
+  it("shows the priming dose, sugar type and the safety warning (happy path)", async () => {
+    renderScreen();
+
+    expect(await screen.findByTestId("priming-dose")).toHaveTextContent("28 g");
+    expect(screen.getByText(/sucre de table/)).toBeTruthy();
+    expect(screen.getByTestId("bottling-safety-warning")).toHaveTextContent(
+      /EXPLOSER/,
+    );
+  });
+
+  it("disables the close button until the safety checkbox is ticked (gating, happy path)", async () => {
+    renderScreen();
+
+    await screen.findByTestId("priming-dose");
+
+    // Pressing while the gate is closed must not fire the mutation.
+    fireEvent.press(screen.getByText("Mettre en bouteille / clôturer"));
+    expect(mockedClose).not.toHaveBeenCalled();
+    expect(screen.getByText(/Coche la case de sécurité/)).toBeTruthy();
+  });
+
+  it("closes the batch once acknowledged and navigates to the closure view (happy path)", async () => {
+    renderScreen();
+
+    await screen.findByTestId("priming-dose");
+
+    fireEvent.press(screen.getByTestId("bottling-ack-checkbox"));
+    fireEvent.press(screen.getByText("Mettre en bouteille / clôturer"));
+
+    await waitFor(() => expect(mockedClose).toHaveBeenCalledWith("b1"));
+    expect(mockReplace).toHaveBeenCalledWith({
+      pathname: "/batches/[id]",
+      params: { id: "b1" },
+    });
+  });
+
+  it("invalidates the batch detail + list caches on a successful close (regression)", async () => {
+    const invalidateSpy = jest.spyOn(
+      QueryClient.prototype,
+      "invalidateQueries",
+    );
+    renderScreen();
+
+    await screen.findByTestId("priming-dose");
+
+    fireEvent.press(screen.getByTestId("bottling-ack-checkbox"));
+    fireEvent.press(screen.getByText("Mettre en bouteille / clôturer"));
+
+    await waitFor(() => expect(mockReplace).toHaveBeenCalled());
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["batches", "details", "b1"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["batches", "list"],
+    });
+
+    invalidateSpy.mockRestore();
+  });
+
+  it("toggling the checkbox off again re-disables the close gate (edge path)", async () => {
+    renderScreen();
+
+    await screen.findByTestId("priming-dose");
+
+    const checkbox = screen.getByTestId("bottling-ack-checkbox");
+    fireEvent.press(checkbox); // on
+    fireEvent.press(checkbox); // off
+
+    fireEvent.press(screen.getByText("Mettre en bouteille / clôturer"));
+    expect(mockedClose).not.toHaveBeenCalled();
+  });
+
+  it("shows an error card and stays on the screen when the close fails (sad path)", async () => {
+    mockedClose.mockRejectedValue(new Error("Batch already completed"));
+    renderScreen();
+
+    await screen.findByTestId("priming-dose");
+
+    fireEvent.press(screen.getByTestId("bottling-ack-checkbox"));
+    fireEvent.press(screen.getByText("Mettre en bouteille / clôturer"));
+
+    expect(await screen.findByText(/Batch already completed/)).toBeTruthy();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("renders a fallback message when priming is unavailable (sad path)", async () => {
+    mockedGetBottlingInfo.mockRejectedValue(
+      new Error("Cannot compute priming"),
+    );
+    renderScreen();
+
+    expect(await screen.findByTestId("priming-error")).toBeTruthy();
+    // The safety warning still renders from its hardcoded fallback.
+    expect(screen.getByTestId("bottling-safety-warning")).toBeTruthy();
+  });
+});

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/TastingScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/TastingScreen.test.tsx
@@ -1,0 +1,149 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+import React from "react";
+
+import { TastingScreen } from "@/features/batches/presentation/TastingScreen";
+import { recordTasting } from "@/features/batches/application/bottling.use-cases";
+
+const mockBack = jest.fn();
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("expo-router", () => {
+  const actual = jest.requireActual("expo-router");
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: jest.fn(),
+      replace: jest.fn(),
+      back: mockBack,
+    }),
+  };
+});
+
+jest.mock("@/features/batches/application/bottling.use-cases", () => ({
+  recordTasting: jest.fn(),
+}));
+
+const mockedRecord = recordTasting as jest.MockedFunction<typeof recordTasting>;
+
+function renderScreen(batchId = "b1") {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TastingScreen batchId={batchId} />
+    </QueryClientProvider>,
+  );
+}
+
+describe("TastingScreen", () => {
+  beforeEach(() => {
+    mockBack.mockReset();
+    mockedRecord.mockReset();
+    mockedRecord.mockResolvedValue({
+      id: "t1",
+      batchId: "b1",
+      rating: 4,
+      note: null,
+      createdAt: "2026-06-20T09:00:00.000Z",
+    });
+  });
+
+  it("renders the five-star row and a disabled save until a rating is picked (happy path)", () => {
+    renderScreen();
+
+    expect(screen.getByText("Noter ma dégustation")).toBeTruthy();
+    for (let value = 1; value <= 5; value += 1) {
+      expect(screen.getByTestId(`tasting-star-${value}`)).toBeTruthy();
+    }
+
+    // No rating yet → submitting does nothing.
+    fireEvent.press(screen.getByText("Enregistrer ma dégustation"));
+    expect(mockedRecord).not.toHaveBeenCalled();
+  });
+
+  it("captures the star rating and records it with the note (happy path)", async () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByTestId("tasting-star-4"));
+    fireEvent.changeText(
+      screen.getByTestId("tasting-note-input"),
+      "Belle mousse",
+    );
+    fireEvent.press(screen.getByText("Enregistrer ma dégustation"));
+
+    await waitFor(() =>
+      expect(mockedRecord).toHaveBeenCalledWith("b1", {
+        rating: 4,
+        note: "Belle mousse",
+      }),
+    );
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it("omits the note when it is empty / whitespace only (edge path)", async () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByTestId("tasting-star-5"));
+    fireEvent.changeText(screen.getByTestId("tasting-note-input"), "   ");
+    fireEvent.press(screen.getByText("Enregistrer ma dégustation"));
+
+    await waitFor(() =>
+      expect(mockedRecord).toHaveBeenCalledWith("b1", { rating: 5 }),
+    );
+  });
+
+  it("lets the brewer change the rating before saving (edge path)", async () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByTestId("tasting-star-2"));
+    fireEvent.press(screen.getByTestId("tasting-star-3"));
+    fireEvent.press(screen.getByText("Enregistrer ma dégustation"));
+
+    await waitFor(() =>
+      expect(mockedRecord).toHaveBeenCalledWith("b1", { rating: 3 }),
+    );
+  });
+
+  it("shows an error card and stays on the screen when recording fails (sad path)", async () => {
+    mockedRecord.mockRejectedValue(new Error("Batch already has a tasting"));
+    renderScreen();
+
+    fireEvent.press(screen.getByTestId("tasting-star-3"));
+    fireEvent.press(screen.getByText("Enregistrer ma dégustation"));
+
+    expect(await screen.findByText(/Batch already has a tasting/)).toBeTruthy();
+    expect(mockBack).not.toHaveBeenCalled();
+  });
+
+  it("invalidates the tasting cache on a successful record (regression)", async () => {
+    const invalidateSpy = jest.spyOn(
+      QueryClient.prototype,
+      "invalidateQueries",
+    );
+    renderScreen();
+
+    fireEvent.press(screen.getByTestId("tasting-star-4"));
+    fireEvent.press(screen.getByText("Enregistrer ma dégustation"));
+
+    await waitFor(() => expect(mockBack).toHaveBeenCalled());
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["batches", "tasting", "b1"],
+    });
+
+    invalidateSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Slice **B3** of the first-real-brew journey: **bottling + live closure + first tasting** — the P0 slice that lifts the live dead-end so a novice reaches the bottle in-app.

**Backend (NestJS):**
- A pure **priming-sugar calculator** (simple ~6.5 g/L table-sugar default + an optional precise mode: target CO2 volumes + beer temperature) with a mandatory bottle-bomb safety warning.
- `GET /batches/:id/priming` (volume sourced from the recipe per ADR-0020; `?targetCo2Vol&beerTempC` enable the precise mode).
- `POST /batches/:id/bottling/close` — sets `bottled_at` and completes the in-progress **PACKAGING** step through the existing step engine (guarded; no new status — `bottled_at` mirrors `fermentation_completed_at`).
- A **Tasting** entity (rating 1-5 + optional note, one per batch) with `POST`/`GET /batches/:id/tasting`; migrations for `bottled_at` and the tasting table.

**Mobile (React Native):**
- **BottlingScreen** (priming dose + bottling gestures + a required acknowledgement checkbox that gates closing), **TastingScreen** (1-5 stars + note), and a live **BatchClosureView** replacing the demo-only celebration mock.
- **BatchDetailsScreen** routes the PACKAGING step to bottling instead of the dead-end, and shows the live closure on completion.

## Context

Locked with the founder: simple priming default + precise as an option; table sugar; tasting = stars + note; closure via a `bottled_at` timestamp; banner + acknowledgement checkbox for the bottle-bomb safety. Conception: `docs/architecture/diagrams/brew-day/03/04/05`.

## Quality

- `ci:check` green both packages; API build + **815** unit + **27** e2e; mobile **135** batch tests.
- Reviewed by the local pre-push reviewer **and** a dedicated 5-specialist audit (correctness, silent failures, test coverage, type design, anti-patterns) — all blocking + important findings fixed (incl. a priming wire-contract bug and a swallowed-error path).

## Checklist

- [x] Happy/Sad/Edge tests for every new unit
- [x] Conforms to the B3 conception + ADRs (0001 KISS, 0002 centralized backend, 0020 volume source)
- [x] No `any`, named exports, theme tokens, no raw fetch, French UI copy, owner-guarded endpoints

Refs the first real brew (B3).
