### PR TITLE
feat(equipment): equipment wizard — 3-question profile + server-side defaults (E1)

### DIFF
--- a/docs/architecture/decisions/0021-equipment-readiness-cleaning-and-adaptive-pedagogy.md
+++ b/docs/architecture/decisions/0021-equipment-readiness-cleaning-and-adaptive-pedagogy.md
@@ -2,6 +2,7 @@
 
 **Status**  Proposed
 **Date**    2026-06-24
+**Amended** 2026-06-29 — D1 build (E1): hidden constants seeded server-side per `system_type`; `equipment_templates`→profile mapping deferred to E2.
 **Owners**  @benoit-bremaud
 
 > Settles how "equipment readiness" works in the novice brew-preparation journey,
@@ -28,13 +29,18 @@
 
 **D1 — Equipment is a reusable profile, declared once via a guided wizard.** An
 `EquipmentProfile` (on the existing `equipment_profiles` API) is created in a
-**dedicated equipment space**, from a **preset** (`equipment_templates`),
-answering **3 essential questions** (system type, fermenter + size, kettle size).
-The create-DTO requires more than those 3 answers (`name`, `mash_tun_volume_l`,
-`evaporation_rate_l_per_hour`, `efficiency_estimated_percent`, plus the losses):
-these are **preset-seeded and hidden from the novice, but still sent** in the
-snake_case `POST /equipment-profiles` body so validation passes (editable later).
-Multi-fermenter is out of v1.
+**dedicated equipment space**, answering **3 essential questions** (system type,
+fermenter + size, kettle size). In E1, the create-DTO makes the hidden fields
+(`mash_tun_volume_l`, `evaporation_rate_l_per_hour`,
+`efficiency_estimated_percent`) **optional**: the wizard sends only the 3 answers
+plus `name`, and the backend **seeds the hidden constants server-side** from a
+per-`system_type` defaults table (`equipment/domain/equipment-system-defaults.ts`),
+with `mash_tun_volume_l` defaulting to the boil-kettle volume (single-vessel
+assumption). This keeps the brewing constants **backend-owned** (ADR-0020) and the
+novice client free of domain numbers (editable later). **Q1 maps to the 3-value
+`EquipmentSystemType` enum**; mapping the richer **`equipment_templates`** catalog
+onto a profile is **deferred to E2** (its BeerXML-shaped fields don't map 1:1 to
+the profile DTO). Multi-fermenter is out of v1.
 
 **D2 — Equipment readiness for a brew = a capacity fit-check + the cleaning
 ritual, NOT a possession checklist.** Per brew the app does **not** re-tick owned

--- a/docs/architecture/diagrams/equipment-cleaning/02-sequence-equipment-wizard.md
+++ b/docs/architecture/diagrams/equipment-cleaning/02-sequence-equipment-wizard.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-How a novice creates a **reusable** equipment profile **from a preset** with minimal questions. The API (`equipment_profiles`, CRUD per user) and the **`equipment_templates`** catalog already exist; this is the missing mobile capture. Only 3 essentials are asked; losses / evaporation / efficiency are inherited from the chosen preset (invisible until the ADR-0020 volume calc lands).
+How a novice creates a **reusable** equipment profile with minimal questions. The API (`equipment_profiles`, CRUD per user) already exists; this is the missing mobile capture. Only **3 essentials** are asked (system type, fermenter size, kettle size); the hidden constants (mash-tun volume, evaporation, efficiency) are **seeded server-side** from a per-`system_type` defaults table (E1 build, ADR-0021 D1). Mapping the richer **`equipment_templates`** catalog onto a profile is **deferred to E2** (its BeerXML fields don't map 1:1).
 
 ## Diagram
 
@@ -14,24 +14,23 @@ sequenceDiagram
   actor B as Brewer
   participant M as Mobile (Equipment space)
   participant API as Backend API
-  B->>M: Open "Mes équipements", then "Ajouter un profil"
-  M->>API: GET /catalog/equipment-templates
-  API-->>M: presets (kitchen starter, BIAB 20/30L, all-in-one, ...)
-  B->>M: Q1 - choose a preset (system type)
-  M->>M: seed name, mash tun, losses, evaporation, efficiency from the preset
-  B->>M: Q2 - fermentation vessel + size (caps the batch)
+  B->>M: Open "Mon matériel", then "Ajouter mon matériel"
+  B->>M: Q1 - choose a system type (extract / all-grain / all-in-one)
+  B->>M: Q2 - fermentation vessel size (caps the batch)
   B->>M: Q3 - largest kettle / pot size (selects the method)
   M->>M: suggest a name, show a recap
   B->>M: Confirm
-  M->>API: POST /equipment-profiles (3 answers + preset defaults)
+  M->>API: POST /equipment-profiles (name + 3 answers, snake_case)
+  API->>API: seed hidden constants from system_type defaults (mash-tun = kettle)
+  API->>API: validate invariants, persist
   API-->>M: 201 saved profile
   M-->>B: Profile ready - reusable for every brew
 ```
 
 ## Notes
 
-- **Guided / progressive (ADR-0021):** one question at a time; the preset prefills everything else, so a beginner answers only **3** essentials (type, fermenter, kettle). Advanced fields (losses, efficiency) stay editable later, hidden by default (adaptive pedagogy).
+- **Guided / progressive (ADR-0021):** one question at a time; a beginner answers only **3** essentials (type, fermenter, kettle). The backend fills everything else; advanced fields (losses, efficiency) stay editable later, hidden by default (adaptive pedagogy).
 - **Reuse, not per-recipe:** a profile is created **once** and reused; it is **not** tied to a recipe (no recipe↔equipment relation — the gear is the brewer's). Multi-fermenter is out of v1 (enter the vessel you ferment in).
 - The **fermenter size** captured here caps the batch and the recipe target-volume slider (ADR-0020 D1, ADR-0021 D3). The **kettle size** selects full-volume vs dunk-sparge (ADR-0020 D2) — consumed by the fit-check (03).
-- **API payload (beyond the 3 answers):** the `POST /equipment-profiles` body is **snake_case**, and the create-DTO **requires more than the 3 essentials** — `name`, `mash_tun_volume_l`, `evaporation_rate_l_per_hour`, `efficiency_estimated_percent` — which the wizard **seeds from the preset** (hidden from the novice) and **still sends** so `ValidationPipe({ whitelist: true })` passes. The `equipment_templates` BeerXML fields (`evap_rate_percent`, `hop_utilization_percent`, …) don't map 1:1, so the wizard applies an explicit template → create-DTO mapping/defaults.
+- **API payload (E1 build):** the `POST /equipment-profiles` body is **snake_case** and carries only the wizard's answers — `name`, `system_type`, `fermenter_volume_l`, `boil_kettle_volume_l`. The create-DTO makes `mash_tun_volume_l`, `evaporation_rate_l_per_hour`, `efficiency_estimated_percent` **optional**; the service **seeds them server-side** from `EQUIPMENT_SYSTEM_DEFAULTS[system_type]` (mash-tun = boil-kettle volume) before invariant validation, keeping the brewing constants backend-owned (ADR-0020). Mapping the `equipment_templates` BeerXML catalog onto the profile is **deferred to E2**.
 - Inline help + a glossary explain each term ("fermenteur", "empâtage", "dunk-sparge") in beginner language, with academy links (ADR-0021 D5).

--- a/packages/api/src/equipment/domain/equipment-system-defaults.ts
+++ b/packages/api/src/equipment/domain/equipment-system-defaults.ts
@@ -1,0 +1,43 @@
+import { EquipmentSystemType } from './enums/equipment-system-type.enum';
+
+/**
+ * Educational defaults for the brewing constants that the 3-question equipment
+ * wizard never asks a novice (mash/brewhouse efficiency and boil-off rate).
+ *
+ * The mobile wizard sends only the user's three answers (system type, fermenter
+ * volume, boil-kettle volume); the backend fills the remaining required
+ * constants from this table, keyed by system type. These are starting estimates,
+ * not measured values — a profile stays editable so the user can refine them
+ * once they brew.
+ *
+ * Aligns with ADR-0020 (volume-planning constants owned by the backend).
+ */
+export interface EquipmentSystemDefaults {
+  /** Estimated mash/brewhouse efficiency, percent in [0, 100]. */
+  efficiencyEstimatedPercent: number;
+  /** Boil-off rate, litres per hour. */
+  evaporationRateLPerHour: number;
+}
+
+/**
+ * Per-system-type defaults applied at creation when the wizard omits the hidden
+ * constants. Mash-tun volume is intentionally absent: it is derived from the
+ * boil-kettle volume (single-vessel assumption) in the service, not table-driven.
+ */
+export const EQUIPMENT_SYSTEM_DEFAULTS: Record<
+  EquipmentSystemType,
+  EquipmentSystemDefaults
+> = {
+  [EquipmentSystemType.EXTRACT]: {
+    efficiencyEstimatedPercent: 100,
+    evaporationRateLPerHour: 2.5,
+  },
+  [EquipmentSystemType.ALL_GRAIN]: {
+    efficiencyEstimatedPercent: 72,
+    evaporationRateLPerHour: 3,
+  },
+  [EquipmentSystemType.ALL_IN_ONE]: {
+    efficiencyEstimatedPercent: 68,
+    evaporationRateLPerHour: 2.5,
+  },
+};

--- a/packages/api/src/equipment/dtos/create-equipment-profile.dto.ts
+++ b/packages/api/src/equipment/dtos/create-equipment-profile.dto.ts
@@ -22,11 +22,16 @@ export class CreateEquipmentProfileDto {
   name: string;
 
   // Volumes (L)
-  @ApiProperty({ example: 25 })
+  /**
+   * Mash-tun volume. Optional from the wizard: when omitted, the service
+   * defaults it to the boil-kettle volume (single-vessel assumption).
+   */
+  @ApiPropertyOptional({ example: 25 })
   @Type(() => Number)
+  @IsOptional()
   @IsNumber()
   @Min(0)
-  mash_tun_volume_l: number;
+  mash_tun_volume_l?: number;
 
   @ApiProperty({ example: 25 })
   @Type(() => Number)
@@ -63,18 +68,28 @@ export class CreateEquipmentProfileDto {
   transfer_loss_l?: number;
 
   // Rates / efficiency
-  @ApiProperty({ example: 3 })
+  /**
+   * Boil-off rate. Optional from the wizard: when omitted, the service defaults
+   * it from EQUIPMENT_SYSTEM_DEFAULTS keyed by system_type.
+   */
+  @ApiPropertyOptional({ example: 3 })
   @Type(() => Number)
+  @IsOptional()
   @IsNumber()
   @Min(0)
-  evaporation_rate_l_per_hour: number;
+  evaporation_rate_l_per_hour?: number;
 
-  @ApiProperty({ example: 75, minimum: 0, maximum: 100 })
+  /**
+   * Estimated efficiency. Optional from the wizard: when omitted, the service
+   * defaults it from EQUIPMENT_SYSTEM_DEFAULTS keyed by system_type.
+   */
+  @ApiPropertyOptional({ example: 75, minimum: 0, maximum: 100 })
   @Type(() => Number)
+  @IsOptional()
   @IsNumber()
   @Min(0)
   @Max(100)
-  efficiency_estimated_percent: number;
+  efficiency_estimated_percent?: number;
 
   @ApiPropertyOptional({ example: 72, minimum: 0, maximum: 100 })
   @Type(() => Number)

--- a/packages/api/src/equipment/services/equipment-profile.service.spec.ts
+++ b/packages/api/src/equipment/services/equipment-profile.service.spec.ts
@@ -2,6 +2,7 @@ import { DeleteResult, Repository } from 'typeorm';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { CreateEquipmentProfileDto } from '../dtos/create-equipment-profile.dto';
+import { EQUIPMENT_SYSTEM_DEFAULTS } from '../domain/equipment-system-defaults';
 import { EquipmentProfileOrmEntity } from '../entities/equipment-profile.orm.entity';
 import { EquipmentProfileService } from './equipment-profile.service';
 import { EquipmentSystemType } from '../domain/enums/equipment-system-type.enum';
@@ -199,6 +200,74 @@ describe('EquipmentProfileService', () => {
       );
       expect(createSpy).toHaveBeenCalled();
       expect(saveSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('create() — wizard hidden-constant defaults', () => {
+    const minimalDto = (
+      systemType: EquipmentSystemType,
+    ): CreateEquipmentProfileDto => ({
+      name: 'Wizard setup',
+      fermenter_volume_l: 23,
+      boil_kettle_volume_l: 30,
+      system_type: systemType,
+    });
+
+    it.each([
+      EquipmentSystemType.EXTRACT,
+      EquipmentSystemType.ALL_GRAIN,
+      EquipmentSystemType.ALL_IN_ONE,
+    ])(
+      'seeds efficiency and evaporation from the system-type defaults when omitted (%s)',
+      async (systemType) => {
+        const dto = minimalDto(systemType);
+        const createdEntity = makeEntity({ system_type: systemType });
+
+        const createSpy = jest
+          .spyOn(repo, 'create')
+          .mockReturnValue(createdEntity);
+        jest.spyOn(repo, 'save').mockResolvedValue(createdEntity);
+
+        await service.create(ownerId, dto);
+
+        const defaults = EQUIPMENT_SYSTEM_DEFAULTS[systemType];
+        expect(createSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            evaporation_rate_l_per_hour: defaults.evaporationRateLPerHour,
+            efficiency_estimated_percent: defaults.efficiencyEstimatedPercent,
+            // Single-vessel assumption: mash tun mirrors the boil kettle.
+            mash_tun_volume_l: dto.boil_kettle_volume_l,
+          }),
+        );
+      },
+    );
+
+    it('does not overwrite hidden constants when the caller provides them', async () => {
+      const dto: CreateEquipmentProfileDto = {
+        name: 'Explicit setup',
+        fermenter_volume_l: 23,
+        boil_kettle_volume_l: 30,
+        mash_tun_volume_l: 27,
+        evaporation_rate_l_per_hour: 3.7,
+        efficiency_estimated_percent: 81,
+        system_type: EquipmentSystemType.ALL_GRAIN,
+      };
+      const createdEntity = makeEntity();
+
+      const createSpy = jest
+        .spyOn(repo, 'create')
+        .mockReturnValue(createdEntity);
+      jest.spyOn(repo, 'save').mockResolvedValue(createdEntity);
+
+      await service.create(ownerId, dto);
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mash_tun_volume_l: 27,
+          evaporation_rate_l_per_hour: 3.7,
+          efficiency_estimated_percent: 81,
+        }),
+      );
     });
   });
 

--- a/packages/api/src/equipment/services/equipment-profile.service.ts
+++ b/packages/api/src/equipment/services/equipment-profile.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { randomUUID } from 'crypto';
 import { Repository } from 'typeorm';
 
+import { EQUIPMENT_SYSTEM_DEFAULTS } from '../domain/equipment-system-defaults';
 import { EquipmentProfileDomainService } from '../domain/services/equipment-profile-domain.service';
 import { EquipmentProfileOrmEntity } from '../entities/equipment-profile.orm.entity';
 import { CreateEquipmentProfileDto } from '../dtos/create-equipment-profile.dto';
@@ -35,12 +36,18 @@ export class EquipmentProfileService {
   ): Promise<EquipmentProfileOrmEntity> {
     const id = randomUUID();
 
+    // The 3-question wizard omits the "hidden" brewing constants; seed them per
+    // system type so the novice never has to supply efficiency / boil-off rate.
+    const defaults = EQUIPMENT_SYSTEM_DEFAULTS[dto.system_type];
+
     const entity = this.repo.create({
       id,
       owner_id: ownerId,
       name: dto.name,
 
-      mash_tun_volume_l: dto.mash_tun_volume_l,
+      // Mash-tun volume defaults to the boil-kettle volume (single-vessel
+      // assumption) when the wizard does not ask for it separately.
+      mash_tun_volume_l: dto.mash_tun_volume_l ?? dto.boil_kettle_volume_l,
       boil_kettle_volume_l: dto.boil_kettle_volume_l,
       fermenter_volume_l: dto.fermenter_volume_l,
 
@@ -48,8 +55,10 @@ export class EquipmentProfileService {
       dead_space_loss_l: dto.dead_space_loss_l ?? 0,
       transfer_loss_l: dto.transfer_loss_l ?? 0,
 
-      evaporation_rate_l_per_hour: dto.evaporation_rate_l_per_hour,
-      efficiency_estimated_percent: dto.efficiency_estimated_percent,
+      evaporation_rate_l_per_hour:
+        dto.evaporation_rate_l_per_hour ?? defaults.evaporationRateLPerHour,
+      efficiency_estimated_percent:
+        dto.efficiency_estimated_percent ?? defaults.efficiencyEstimatedPercent,
       efficiency_measured_percent: dto.efficiency_measured_percent ?? null,
 
       cooling_time_minutes: dto.cooling_time_minutes ?? null,

--- a/packages/api/test/equipment-profile.e2e-spec.ts
+++ b/packages/api/test/equipment-profile.e2e-spec.ts
@@ -124,4 +124,17 @@ describe('Equipment profile create (e2e — E1)', () => {
       })
       .expect(400);
   });
+
+  // Sad — the endpoint is JWT-guarded; a request without a token is a 401.
+  it('rejects an unauthenticated create with 401', async () => {
+    await request(app.getHttpServer())
+      .post('/equipment-profiles')
+      .send({
+        name: 'No auth',
+        fermenter_volume_l: 23,
+        boil_kettle_volume_l: 30,
+        system_type: EquipmentSystemType.ALL_GRAIN,
+      })
+      .expect(401);
+  });
 });

--- a/packages/api/test/equipment-profile.e2e-spec.ts
+++ b/packages/api/test/equipment-profile.e2e-spec.ts
@@ -1,0 +1,127 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+import { App } from 'supertest/types';
+import { AppModule } from '../src/app.module';
+import request from 'supertest';
+import { useContainer } from 'class-validator';
+
+import { EQUIPMENT_SYSTEM_DEFAULTS } from '../src/equipment/domain/equipment-system-defaults';
+import { EquipmentSystemType } from '../src/equipment/domain/enums/equipment-system-type.enum';
+
+/**
+ * E1 — equipment wizard create endpoint, e2e.
+ *
+ * The 3-question wizard sends only name + system type + fermenter & boil-kettle
+ * volumes. The backend must accept that minimal body (201) and seed the hidden
+ * brewing constants (efficiency, boil-off rate, mash-tun volume) from the
+ * per-system-type defaults. An out-of-range efficiency must still be a 400.
+ */
+const TEST_PASSWORD = 'SecurePassword123!'; // NOSONAR
+
+interface RegisterResult {
+  token: string;
+}
+
+describe('Equipment profile create (e2e — E1)', () => {
+  let app: INestApplication<App>;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    })
+      // Override the rate limiter so registration is not throttled — this suite
+      // tests the create contract, not rate limiting.
+      .overrideGuard(ThrottlerGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    useContainer(app.select(AppModule), { fallbackOnErrors: true });
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  async function register(): Promise<RegisterResult> {
+    const suffix = `${Date.now()}${Math.floor(Math.random() * 1000)}`.slice(-9);
+    const response = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: `equipment-e2e-${suffix}@example.com`,
+        username: `equip_${suffix}`,
+        password: TEST_PASSWORD,
+        first_name: 'Equip',
+        last_name: 'E2E',
+      })
+      .expect(201);
+
+    const body = response.body as { access_token?: unknown };
+    if (typeof body.access_token !== 'string') {
+      throw new TypeError(
+        'Expected register response to carry an access_token',
+      );
+    }
+    return { token: body.access_token };
+  }
+
+  // Happy — a minimal wizard body is accepted and the hidden constants are
+  // seeded from the all-grain defaults; mash tun mirrors the boil kettle.
+  it('creates a profile from the minimal wizard body and seeds defaults', async () => {
+    const { token } = await register();
+
+    const response = await request(app.getHttpServer())
+      .post('/equipment-profiles')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Tout-grain 30 L',
+        fermenter_volume_l: 23,
+        boil_kettle_volume_l: 30,
+        system_type: EquipmentSystemType.ALL_GRAIN,
+      })
+      .expect(201);
+
+    const defaults = EQUIPMENT_SYSTEM_DEFAULTS[EquipmentSystemType.ALL_GRAIN];
+    const body = response.body as {
+      id: string;
+      mash_tun_volume_l: number;
+      boil_kettle_volume_l: number;
+      fermenter_volume_l: number;
+      evaporation_rate_l_per_hour: number;
+      efficiency_estimated_percent: number;
+      system_type: string;
+    };
+
+    expect(typeof body.id).toBe('string');
+    expect(body.boil_kettle_volume_l).toBe(30);
+    expect(body.fermenter_volume_l).toBe(23);
+    expect(body.mash_tun_volume_l).toBe(30);
+    expect(body.evaporation_rate_l_per_hour).toBe(
+      defaults.evaporationRateLPerHour,
+    );
+    expect(body.efficiency_estimated_percent).toBe(
+      defaults.efficiencyEstimatedPercent,
+    );
+    expect(body.system_type).toBe(EquipmentSystemType.ALL_GRAIN);
+  });
+
+  // Sad — an out-of-range efficiency is rejected by the ValidationPipe (400).
+  it('rejects an out-of-range efficiency with 400', async () => {
+    const { token } = await register();
+
+    await request(app.getHttpServer())
+      .post('/equipment-profiles')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        name: 'Invalid',
+        fermenter_volume_l: 23,
+        boil_kettle_volume_l: 30,
+        efficiency_estimated_percent: 101,
+        system_type: EquipmentSystemType.ALL_GRAIN,
+      })
+      .expect(400);
+  });
+});

--- a/packages/mobile-app/app/(app)/equipment/wizard.tsx
+++ b/packages/mobile-app/app/(app)/equipment/wizard.tsx
@@ -1,0 +1,9 @@
+import { EquipmentWizardScreen } from "@/features/equipment/presentation/EquipmentWizardScreen";
+
+/**
+ * Route delegating to {@link EquipmentWizardScreen}. No business logic lives
+ * here (mirrors `equipment/index.tsx`).
+ */
+export default function EquipmentWizardRoute() {
+  return <EquipmentWizardScreen />;
+}

--- a/packages/mobile-app/src/features/equipment/application/__tests__/equipment.use-cases.test.ts
+++ b/packages/mobile-app/src/features/equipment/application/__tests__/equipment.use-cases.test.ts
@@ -114,4 +114,23 @@ describe("equipment.use-cases", () => {
     expect(result).toHaveLength(demoEquipments.length);
     expect(result[0].id).toBe(demoEquipments[0].id);
   });
+
+  it("create: propagates an API error when demo is off (sad)", async () => {
+    mockedCreateApi.mockRejectedValue(new Error("network down"));
+
+    await expect(
+      createEquipmentProfile({
+        name: "S",
+        systemType: "all-grain",
+        fermenterVolumeL: 23,
+        boilKettleVolumeL: 30,
+      }),
+    ).rejects.toThrow("network down");
+  });
+
+  it("list: propagates an API error when demo is off (sad)", async () => {
+    mockedListApi.mockRejectedValue(new Error("timeout"));
+
+    await expect(listEquipmentProfiles()).rejects.toThrow("timeout");
+  });
 });

--- a/packages/mobile-app/src/features/equipment/application/__tests__/equipment.use-cases.test.ts
+++ b/packages/mobile-app/src/features/equipment/application/__tests__/equipment.use-cases.test.ts
@@ -1,0 +1,117 @@
+import {
+  createEquipmentProfile as createEquipmentProfileApi,
+  listMyEquipmentProfiles,
+} from "@/features/equipment/data/equipment.api";
+import {
+  createEquipmentProfile,
+  listEquipmentProfiles,
+} from "@/features/equipment/application/equipment.use-cases";
+
+import { EquipmentProfile } from "@/features/equipment/domain/equipment.types";
+import { dataSource } from "@/core/data/data-source";
+import { demoEquipments } from "@/mocks/demo-data";
+
+jest.mock("@/core/data/data-source", () => ({
+  dataSource: { useDemoData: false },
+}));
+
+jest.mock("@/features/equipment/data/equipment.api", () => ({
+  createEquipmentProfile: jest.fn(),
+  listMyEquipmentProfiles: jest.fn(),
+}));
+
+const mockedCreateApi = createEquipmentProfileApi as jest.MockedFunction<
+  typeof createEquipmentProfileApi
+>;
+const mockedListApi = listMyEquipmentProfiles as jest.MockedFunction<
+  typeof listMyEquipmentProfiles
+>;
+
+function setDemo(value: boolean) {
+  (dataSource as { useDemoData: boolean }).useDemoData = value;
+}
+
+function makeProfile(
+  overrides: Partial<EquipmentProfile> = {},
+): EquipmentProfile {
+  return {
+    id: "eq-1",
+    ownerId: "u-1",
+    name: "Setup",
+    mashTunVolumeL: 30,
+    boilKettleVolumeL: 30,
+    fermenterVolumeL: 23,
+    trubLossL: 0,
+    deadSpaceLossL: 0,
+    transferLossL: 0,
+    evaporationRateLPerHour: 3,
+    efficiencyEstimatedPercent: 72,
+    efficiencyMeasuredPercent: null,
+    coolingTimeMinutes: null,
+    coolingFlowRateLPerMinute: null,
+    systemType: "all-grain",
+    createdAt: "2026-02-01T10:00:00.000Z",
+    updatedAt: "2026-02-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("equipment.use-cases", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setDemo(false);
+  });
+
+  it("create: calls the API with the input when demo is off (happy)", async () => {
+    const profile = makeProfile();
+    mockedCreateApi.mockResolvedValue(profile);
+
+    const input = {
+      name: "Tout-grain 30 L",
+      systemType: "all-grain" as const,
+      fermenterVolumeL: 23,
+      boilKettleVolumeL: 30,
+    };
+    const result = await createEquipmentProfile(input);
+
+    expect(mockedCreateApi).toHaveBeenCalledWith(input);
+    expect(result).toBe(profile);
+  });
+
+  it("create: synthesizes a demo profile without calling the API (happy)", async () => {
+    setDemo(true);
+
+    const result = await createEquipmentProfile({
+      name: "Demo",
+      systemType: "all-in-one",
+      fermenterVolumeL: 20,
+      boilKettleVolumeL: 25,
+    });
+
+    expect(mockedCreateApi).not.toHaveBeenCalled();
+    expect(result.name).toBe("Demo");
+    expect(result.systemType).toBe("all-in-one");
+    // Single-vessel demo assumption: mash tun mirrors the boil kettle.
+    expect(result.mashTunVolumeL).toBe(25);
+  });
+
+  it("list: returns API rows when demo is off (happy)", async () => {
+    const rows = [makeProfile()];
+    mockedListApi.mockResolvedValue(rows);
+
+    const result = await listEquipmentProfiles();
+
+    expect(mockedListApi).toHaveBeenCalledTimes(1);
+    expect(result).toBe(rows);
+  });
+
+  it("list: maps demo equipment without calling the API (edge)", async () => {
+    setDemo(true);
+
+    const result = await listEquipmentProfiles();
+
+    expect(mockedListApi).not.toHaveBeenCalled();
+    expect(result).toHaveLength(demoEquipments.length);
+    expect(result[0].id).toBe(demoEquipments[0].id);
+  });
+});

--- a/packages/mobile-app/src/features/equipment/application/equipment.use-cases.ts
+++ b/packages/mobile-app/src/features/equipment/application/equipment.use-cases.ts
@@ -1,0 +1,87 @@
+import { dataSource } from "@/core/data/data-source";
+import { Equipment, demoEquipments } from "@/mocks/demo-data";
+
+import {
+  EquipmentProfile,
+  EquipmentProfileInput,
+  EquipmentSystemType,
+} from "../domain/equipment.types";
+import {
+  createEquipmentProfile as createEquipmentProfileApi,
+  listMyEquipmentProfiles,
+} from "../data/equipment.api";
+
+const DEMO_TIMESTAMP = "2026-02-01T10:00:00.000Z";
+
+/**
+ * Adapt a legacy demo `Equipment` record to the real {@link EquipmentProfile}
+ * shape so the screen consumes a single type in both data modes.
+ */
+function fromDemoEquipment(equipment: Equipment): EquipmentProfile {
+  const systemType: EquipmentSystemType =
+    equipment.type === "all-in-one" ? "all-in-one" : "all-grain";
+
+  return {
+    id: equipment.id,
+    ownerId: "demo-owner",
+    name: equipment.name,
+    mashTunVolumeL: equipment.volumeLiters,
+    boilKettleVolumeL: equipment.volumeLiters,
+    fermenterVolumeL: equipment.volumeLiters,
+    trubLossL: 0,
+    deadSpaceLossL: 0,
+    transferLossL: 0,
+    evaporationRateLPerHour: 0,
+    efficiencyEstimatedPercent: equipment.efficiencyPercent,
+    efficiencyMeasuredPercent: null,
+    coolingTimeMinutes: null,
+    coolingFlowRateLPerMinute: null,
+    systemType,
+    createdAt: DEMO_TIMESTAMP,
+    updatedAt: DEMO_TIMESTAMP,
+  };
+}
+
+/**
+ * Synthesize a profile from the wizard answers without a network call, so the
+ * demo flow still ends on a created-profile screen.
+ */
+function synthesizeDemoProfile(input: EquipmentProfileInput): EquipmentProfile {
+  const now = new Date().toISOString();
+
+  return {
+    id: `demo-${input.systemType}-${input.fermenterVolumeL}`,
+    ownerId: "demo-owner",
+    name: input.name,
+    mashTunVolumeL: input.boilKettleVolumeL,
+    boilKettleVolumeL: input.boilKettleVolumeL,
+    fermenterVolumeL: input.fermenterVolumeL,
+    trubLossL: 0,
+    deadSpaceLossL: 0,
+    transferLossL: 0,
+    evaporationRateLPerHour: 0,
+    efficiencyEstimatedPercent: 0,
+    efficiencyMeasuredPercent: null,
+    coolingTimeMinutes: null,
+    coolingFlowRateLPerMinute: null,
+    systemType: input.systemType,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export async function listEquipmentProfiles(): Promise<EquipmentProfile[]> {
+  if (dataSource.useDemoData) {
+    return demoEquipments.map(fromDemoEquipment);
+  }
+  return listMyEquipmentProfiles();
+}
+
+export async function createEquipmentProfile(
+  input: EquipmentProfileInput,
+): Promise<EquipmentProfile> {
+  if (dataSource.useDemoData) {
+    return synthesizeDemoProfile(input);
+  }
+  return createEquipmentProfileApi(input);
+}

--- a/packages/mobile-app/src/features/equipment/application/equipment.use-cases.ts
+++ b/packages/mobile-app/src/features/equipment/application/equipment.use-cases.ts
@@ -11,6 +11,7 @@ import {
   listMyEquipmentProfiles,
 } from "../data/equipment.api";
 
+// Fixed past date so demo profiles are deterministic across renders.
 const DEMO_TIMESTAMP = "2026-02-01T10:00:00.000Z";
 
 /**
@@ -18,6 +19,9 @@ const DEMO_TIMESTAMP = "2026-02-01T10:00:00.000Z";
  * shape so the screen consumes a single type in both data modes.
  */
 function fromDemoEquipment(equipment: Equipment): EquipmentProfile {
+  // Legacy demo records only carry "all-in-one" / "kettle" / "fermenter"; map
+  // the all-in-one rigs as such and treat the rest as all-grain (no demo
+  // "extract" rig exists today).
   const systemType: EquipmentSystemType =
     equipment.type === "all-in-one" ? "all-in-one" : "all-grain";
 

--- a/packages/mobile-app/src/features/equipment/data/__tests__/equipment.api.test.ts
+++ b/packages/mobile-app/src/features/equipment/data/__tests__/equipment.api.test.ts
@@ -1,0 +1,96 @@
+import {
+  createEquipmentProfile,
+  listMyEquipmentProfiles,
+  mapEquipmentProfile,
+} from "@/features/equipment/data/equipment.api";
+
+import { HttpError } from "@/core/http/http-error";
+
+const mockRequest = jest.fn();
+
+jest.mock("@/core/http/http-client", () => ({
+  request: (...args: unknown[]) => mockRequest(...args),
+}));
+
+const sampleDto = {
+  id: "eq-1",
+  owner_id: "u-1",
+  name: "Tout-grain 30 L",
+  mash_tun_volume_l: 30,
+  boil_kettle_volume_l: 30,
+  fermenter_volume_l: 23,
+  trub_loss_l: 0,
+  dead_space_loss_l: 0,
+  transfer_loss_l: 0,
+  evaporation_rate_l_per_hour: 3,
+  efficiency_estimated_percent: 72,
+  efficiency_measured_percent: null,
+  cooling_time_minutes: null,
+  cooling_flow_rate_l_per_minute: null,
+  system_type: "all-grain" as const,
+  created_at: "2026-02-01T10:00:00.000Z",
+  updated_at: "2026-02-01T10:00:00.000Z",
+};
+
+describe("equipment.api", () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it("POSTs only the four wizard fields and maps the response (happy)", async () => {
+    mockRequest.mockResolvedValue(sampleDto);
+
+    const result = await createEquipmentProfile({
+      name: "Tout-grain 30 L",
+      systemType: "all-grain",
+      fermenterVolumeL: 23,
+      boilKettleVolumeL: 30,
+    });
+
+    expect(mockRequest).toHaveBeenCalledWith("/equipment-profiles", {
+      method: "POST",
+      body: {
+        name: "Tout-grain 30 L",
+        system_type: "all-grain",
+        fermenter_volume_l: 23,
+        boil_kettle_volume_l: 30,
+      },
+    });
+    expect(result.fermenterVolumeL).toBe(23);
+    expect(result.efficiencyEstimatedPercent).toBe(72);
+    expect(result.systemType).toBe("all-grain");
+  });
+
+  it("lists profiles and maps each to the domain shape (happy)", async () => {
+    mockRequest.mockResolvedValue([sampleDto]);
+
+    const result = await listMyEquipmentProfiles();
+
+    expect(mockRequest).toHaveBeenCalledWith("/equipment-profiles");
+    expect(result).toHaveLength(1);
+    expect(result[0].ownerId).toBe("u-1");
+    expect(result[0].mashTunVolumeL).toBe(30);
+  });
+
+  it("maps an absent measured efficiency to null (edge)", () => {
+    const mapped = mapEquipmentProfile({
+      ...sampleDto,
+      efficiency_measured_percent: undefined,
+    });
+
+    expect(mapped.efficiencyMeasuredPercent).toBeNull();
+  });
+
+  it("propagates an HttpError from the client (sad)", async () => {
+    mockRequest.mockRejectedValue(new HttpError(500, "boom"));
+
+    await expect(
+      createEquipmentProfile({
+        name: "x",
+        systemType: "extract",
+        fermenterVolumeL: 10,
+        boilKettleVolumeL: 12,
+      }),
+    ).rejects.toBeInstanceOf(HttpError);
+  });
+});

--- a/packages/mobile-app/src/features/equipment/data/equipment.api.ts
+++ b/packages/mobile-app/src/features/equipment/data/equipment.api.ts
@@ -1,0 +1,87 @@
+import { request } from "@/core/http/http-client";
+
+import {
+  EquipmentProfile,
+  EquipmentProfileInput,
+  EquipmentSystemType,
+} from "../domain/equipment.types";
+
+/**
+ * Raw equipment profile as returned by the backend (snake_case). Mapped to the
+ * {@link EquipmentProfile} domain shape by {@link mapEquipmentProfile}.
+ */
+type EquipmentProfileDto = {
+  id: string;
+  owner_id: string;
+  name: string;
+  mash_tun_volume_l: number;
+  boil_kettle_volume_l: number;
+  fermenter_volume_l: number;
+  trub_loss_l: number;
+  dead_space_loss_l: number;
+  transfer_loss_l: number;
+  evaporation_rate_l_per_hour: number;
+  efficiency_estimated_percent: number;
+  efficiency_measured_percent?: number | null;
+  cooling_time_minutes?: number | null;
+  cooling_flow_rate_l_per_minute?: number | null;
+  system_type: EquipmentSystemType;
+  created_at: string;
+  updated_at: string;
+};
+
+/**
+ * Wizard create payload — only the three answers the novice gives. The backend
+ * seeds the remaining required constants from per-system-type defaults.
+ */
+type CreateEquipmentProfileBody = {
+  name: string;
+  system_type: EquipmentSystemType;
+  fermenter_volume_l: number;
+  boil_kettle_volume_l: number;
+};
+
+export function mapEquipmentProfile(
+  dto: EquipmentProfileDto,
+): EquipmentProfile {
+  return {
+    id: dto.id,
+    ownerId: dto.owner_id,
+    name: dto.name,
+    mashTunVolumeL: dto.mash_tun_volume_l,
+    boilKettleVolumeL: dto.boil_kettle_volume_l,
+    fermenterVolumeL: dto.fermenter_volume_l,
+    trubLossL: dto.trub_loss_l,
+    deadSpaceLossL: dto.dead_space_loss_l,
+    transferLossL: dto.transfer_loss_l,
+    evaporationRateLPerHour: dto.evaporation_rate_l_per_hour,
+    efficiencyEstimatedPercent: dto.efficiency_estimated_percent,
+    efficiencyMeasuredPercent: dto.efficiency_measured_percent ?? null,
+    coolingTimeMinutes: dto.cooling_time_minutes ?? null,
+    coolingFlowRateLPerMinute: dto.cooling_flow_rate_l_per_minute ?? null,
+    systemType: dto.system_type,
+    createdAt: dto.created_at,
+    updatedAt: dto.updated_at,
+  };
+}
+
+export async function listMyEquipmentProfiles(): Promise<EquipmentProfile[]> {
+  const rows = await request<EquipmentProfileDto[]>("/equipment-profiles");
+  return rows.map(mapEquipmentProfile);
+}
+
+export async function createEquipmentProfile(
+  input: EquipmentProfileInput,
+): Promise<EquipmentProfile> {
+  const body: CreateEquipmentProfileBody = {
+    name: input.name,
+    system_type: input.systemType,
+    fermenter_volume_l: input.fermenterVolumeL,
+    boil_kettle_volume_l: input.boilKettleVolumeL,
+  };
+  const row = await request<EquipmentProfileDto>("/equipment-profiles", {
+    method: "POST",
+    body,
+  });
+  return mapEquipmentProfile(row);
+}

--- a/packages/mobile-app/src/features/equipment/domain/equipment-system-options.ts
+++ b/packages/mobile-app/src/features/equipment/domain/equipment-system-options.ts
@@ -1,0 +1,36 @@
+import { EquipmentSystemType } from "./equipment.types";
+
+/**
+ * Novice-facing presentation metadata for the three system types. Pure
+ * reference data (labels only) — the hidden brewing constants live server-side.
+ */
+export interface EquipmentSystemOption {
+  value: EquipmentSystemType;
+  /** Short label reused in the auto-generated profile name. */
+  shortLabel: string;
+  /** Full label shown in the Q1 picker. */
+  label: string;
+  /** One-line beginner explanation. */
+  help: string;
+}
+
+export const EQUIPMENT_SYSTEM_OPTIONS: readonly EquipmentSystemOption[] = [
+  {
+    value: "extract",
+    shortLabel: "Extrait",
+    label: "Extrait de malt",
+    help: "Kit ou extrait : pas d'empâtage, on dilue puis on fait bouillir.",
+  },
+  {
+    value: "all-grain",
+    shortLabel: "Tout-grain",
+    label: "Tout grain",
+    help: "Empâtage en cuve séparée, puis ébullition.",
+  },
+  {
+    value: "all-in-one",
+    shortLabel: "Tout-en-un",
+    label: "Tout-en-un (BIAB)",
+    help: "Une seule cuve pour empâter et bouillir (Braumeister, Grainfather…).",
+  },
+];

--- a/packages/mobile-app/src/features/equipment/domain/equipment.types.ts
+++ b/packages/mobile-app/src/features/equipment/domain/equipment.types.ts
@@ -1,0 +1,41 @@
+/**
+ * High-level classification of a brewing system, mirroring the backend
+ * `EquipmentSystemType` enum.
+ */
+export type EquipmentSystemType = "extract" | "all-grain" | "all-in-one";
+
+/**
+ * A user's saved equipment profile, mirroring the backend `EquipmentProfileDto`
+ * in camelCase. The "hidden" constants (efficiency, boil-off rate, mash-tun
+ * volume) are seeded server-side and read back here.
+ */
+export interface EquipmentProfile {
+  id: string;
+  ownerId: string;
+  name: string;
+  mashTunVolumeL: number;
+  boilKettleVolumeL: number;
+  fermenterVolumeL: number;
+  trubLossL: number;
+  deadSpaceLossL: number;
+  transferLossL: number;
+  evaporationRateLPerHour: number;
+  efficiencyEstimatedPercent: number;
+  efficiencyMeasuredPercent: number | null;
+  coolingTimeMinutes: number | null;
+  coolingFlowRateLPerMinute: number | null;
+  systemType: EquipmentSystemType;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * The three answers collected by the equipment wizard. The remaining required
+ * fields are filled by the backend from per-system-type defaults.
+ */
+export interface EquipmentProfileInput {
+  name: string;
+  systemType: EquipmentSystemType;
+  fermenterVolumeL: number;
+  boilKettleVolumeL: number;
+}

--- a/packages/mobile-app/src/features/equipment/presentation/EquipmentScreen.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/EquipmentScreen.tsx
@@ -1,59 +1,140 @@
 import { FlatList, StyleSheet, Text, View } from "react-native";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
-import { colors, radius, spacing, typography } from "@/core/theme";
 
+import { colors, radius, spacing, typography } from "@/core/theme";
+import { getErrorMessage } from "@/core/http/http-error";
 import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
+import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { Ionicons } from "@expo/vector-icons";
 import { ListHeader } from "@/core/ui/ListHeader";
-import React from "react";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
-import { demoEquipments } from "@/mocks/demo-data";
+import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { listEquipmentProfiles } from "@/features/equipment/application/equipment.use-cases";
+import { EQUIPMENT_SYSTEM_OPTIONS } from "@/features/equipment/domain/equipment-system-options";
+import {
+  EquipmentProfile,
+  EquipmentSystemType,
+} from "@/features/equipment/domain/equipment.types";
+import { useQuery } from "@tanstack/react-query";
+import { Href, useRouter } from "expo-router";
+import React from "react";
+
+/**
+ * The wizard route is new, so Expo Router's generated typed-routes union may not
+ * include it yet; cast to {@link Href} (same approach as the labels feature).
+ */
+const EQUIPMENT_WIZARD_ROUTE = "/equipment/wizard" as Href;
+
+function systemTypeLabel(systemType: EquipmentSystemType): string {
+  return (
+    EQUIPMENT_SYSTEM_OPTIONS.find((option) => option.value === systemType)
+      ?.shortLabel ?? systemType
+  );
+}
 
 export function EquipmentScreen() {
+  const router = useRouter();
   const bottomPadding = useNavigationFooterOffset();
+
+  const {
+    data: profiles,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["equipment", "list"],
+    queryFn: listEquipmentProfiles,
+  });
+
+  const goToWizard = () => router.push(EQUIPMENT_WIZARD_ROUTE);
+
+  if (isLoading) {
+    return <Screen isLoading>{null}</Screen>;
+  }
+
+  const hasProfiles = profiles != null && profiles.length > 0;
+
   return (
     <Screen>
-      <ListHeader
-        title="L'Office 🍽️"
-        subtitle="Matériel brassicole disponible"
-      />
+      <ListHeader title="L'Office 🍽️" subtitle="Ton matériel brassicole" />
 
-      <FlatList
-        data={demoEquipments}
-        keyExtractor={(item) => item.id}
-        contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
-        renderItem={({ item }) => (
-          <Card style={styles.card}>
-            <View style={styles.cardContent}>
-              <View style={styles.itemIcon}>
-                <Ionicons
-                  name="construct-outline"
-                  size={24}
-                  color={colors.brand.secondary}
-                />
-              </View>
-              <View style={styles.cardInfo}>
-                <View style={styles.cardTopRow}>
-                  <Text style={styles.cardTitle}>{item.name}</Text>
-                  <Badge label={item.type} variant="info" />
-                </View>
-                <Text style={styles.meta}>
-                  {item.volumeLiters} L • {item.efficiencyPercent}% eff.
-                </Text>
-                {item.notes ? (
-                  <Text style={styles.notes}>{item.notes}</Text>
-                ) : null}
-              </View>
-            </View>
-          </Card>
-        )}
-      />
+      {isError ? (
+        <Card style={[styles.card, styles.blockCard]}>
+          <Text style={styles.blockText}>
+            {getErrorMessage(error, "Échec du chargement du matériel")}
+          </Text>
+        </Card>
+      ) : hasProfiles ? (
+        <>
+          <PrimaryButton
+            testID="equipment-add-cta"
+            label="+ Ajouter mon matériel"
+            onPress={goToWizard}
+            style={styles.cta}
+          />
+          <FlatList
+            data={profiles}
+            keyExtractor={(item) => item.id}
+            contentContainerStyle={[
+              styles.list,
+              { paddingBottom: bottomPadding },
+            ]}
+            renderItem={({ item }) => <EquipmentCard profile={item} />}
+          />
+        </>
+      ) : (
+        <EmptyStateCard
+          title="Aucun matériel enregistré"
+          description="Ajoute ton matériel pour adapter tes brassins à ta cuve."
+          action={
+            <PrimaryButton
+              testID="equipment-empty-cta"
+              label="Ajouter mon matériel"
+              onPress={goToWizard}
+            />
+          }
+        />
+      )}
     </Screen>
   );
 }
 
+type EquipmentCardProps = {
+  profile: EquipmentProfile;
+};
+
+function EquipmentCard({ profile }: EquipmentCardProps) {
+  return (
+    <Card style={styles.card}>
+      <View style={styles.cardContent}>
+        <View style={styles.itemIcon}>
+          <Ionicons
+            name="construct-outline"
+            size={24}
+            color={colors.brand.secondary}
+          />
+        </View>
+        <View style={styles.cardInfo}>
+          <View style={styles.cardTopRow}>
+            <Text style={styles.cardTitle}>{profile.name}</Text>
+            <Badge label={systemTypeLabel(profile.systemType)} variant="info" />
+          </View>
+          <Text style={styles.meta}>
+            Fermenteur {profile.fermenterVolumeL} L •{" "}
+            {profile.efficiencyEstimatedPercent}% eff.
+          </Text>
+        </View>
+      </View>
+    </Card>
+  );
+}
+
 const styles = StyleSheet.create({
+  cta: {
+    marginHorizontal: spacing.sm,
+    marginBottom: spacing.sm,
+  },
   list: {
     paddingHorizontal: spacing.sm,
   },
@@ -95,10 +176,14 @@ const styles = StyleSheet.create({
     fontSize: typography.size.label,
     lineHeight: typography.lineHeight.label,
   },
-  notes: {
-    marginTop: spacing.xxs,
-    color: colors.neutral.muted,
-    fontSize: typography.size.caption,
-    lineHeight: typography.lineHeight.caption,
+  blockCard: {
+    marginHorizontal: spacing.sm,
+    backgroundColor: colors.state.errorBackground,
+    borderColor: colors.semantic.error,
+  },
+  blockText: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.semantic.error,
   },
 });

--- a/packages/mobile-app/src/features/equipment/presentation/EquipmentWizardScreen.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/EquipmentWizardScreen.tsx
@@ -1,0 +1,384 @@
+import { colors, radius, spacing, typography } from "@/core/theme";
+import { Card } from "@/core/ui/Card";
+import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
+import { ListHeader } from "@/core/ui/ListHeader";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { Screen } from "@/core/ui/Screen";
+import { getErrorMessage } from "@/core/http/http-error";
+import { createEquipmentProfile } from "@/features/equipment/application/equipment.use-cases";
+import {
+  EQUIPMENT_SYSTEM_OPTIONS,
+  EquipmentSystemOption,
+} from "@/features/equipment/domain/equipment-system-options";
+import {
+  EquipmentProfile,
+  EquipmentProfileInput,
+  EquipmentSystemType,
+} from "@/features/equipment/domain/equipment.types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import React from "react";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+
+/** Wizard step: 3 questions then a recap/confirm. */
+type WizardStep = 1 | 2 | 3 | 4;
+
+const LAST_STEP: WizardStep = 4;
+
+/**
+ * Normalise a FR-style comma decimal ("12,5") to a dot before parsing,
+ * otherwise parseFloat stops at the comma and silently truncates.
+ */
+function parseVolume(text: string): number {
+  return parseFloat(text.replace(",", "."));
+}
+
+function isPositive(value: number): boolean {
+  return !Number.isNaN(value) && value > 0;
+}
+
+function findOption(
+  systemType: EquipmentSystemType | null,
+): EquipmentSystemOption | null {
+  return (
+    EQUIPMENT_SYSTEM_OPTIONS.find((option) => option.value === systemType) ??
+    null
+  );
+}
+
+/**
+ * Equipment wizard (E1 — US "créer mon matériel").
+ *
+ * Asks the novice three questions — system type, fermenter volume, largest
+ * kettle volume — then confirms. The technical constants (efficiency, boil-off
+ * rate, mash-tun volume) are seeded server-side, never asked here. On success
+ * the freshly-created profile appears in the equipment screen.
+ */
+export function EquipmentWizardScreen() {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [step, setStep] = React.useState<WizardStep>(1);
+  const [systemType, setSystemType] =
+    React.useState<EquipmentSystemType | null>(null);
+  const [fermenterText, setFermenterText] = React.useState("");
+  const [kettleText, setKettleText] = React.useState("");
+  const [nameText, setNameText] = React.useState("");
+
+  const fermenterVolumeL = parseVolume(fermenterText);
+  const kettleVolumeL = parseVolume(kettleText);
+  const selectedOption = findOption(systemType);
+
+  const {
+    mutate: mutateCreate,
+    isPending,
+    error: mutationError,
+  } = useMutation<EquipmentProfile, Error, EquipmentProfileInput>({
+    mutationFn: (input: EquipmentProfileInput) => createEquipmentProfile(input),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["equipment", "list"] });
+      router.replace("/equipment");
+    },
+  });
+
+  const isStepValid = ((): boolean => {
+    switch (step) {
+      case 1:
+        return systemType !== null;
+      case 2:
+        return isPositive(fermenterVolumeL);
+      case 3:
+        return isPositive(kettleVolumeL);
+      case 4:
+        return nameText.trim() !== "";
+      default:
+        return false;
+    }
+  })();
+
+  const handleBack = () => {
+    if (step > 1) {
+      setStep((current) => (current - 1) as WizardStep);
+      return;
+    }
+    router.back();
+  };
+
+  const handleNext = () => {
+    if (!isStepValid) {
+      return;
+    }
+    // Entering the recap: pre-fill an editable default name (minimal friction).
+    if (step === 3 && nameText.trim() === "" && selectedOption) {
+      setNameText(`${selectedOption.shortLabel} ${fermenterVolumeL} L`);
+    }
+    setStep((current) => (current + 1) as WizardStep);
+  };
+
+  const handleCreate = () => {
+    if (!isStepValid || systemType === null) {
+      return;
+    }
+    mutateCreate({
+      name: nameText.trim(),
+      systemType,
+      fermenterVolumeL,
+      boilKettleVolumeL: kettleVolumeL,
+    });
+  };
+
+  return (
+    <Screen>
+      <ListHeader
+        title="Mon matériel"
+        subtitle={step < LAST_STEP ? `Question ${step} / 3` : "Récapitulatif"}
+        action={
+          <HeaderBackButton
+            label="Retour"
+            accessibilityLabel="Étape précédente"
+            onPress={handleBack}
+          />
+        }
+      />
+
+      {step === 1 ? (
+        <Card style={styles.card}>
+          <Text style={styles.cardTitle}>Quel type de système ?</Text>
+          <Text style={styles.helpText}>
+            Choisis ce qui ressemble le plus à ton installation. Pas
+            d'inquiétude : tu pourras affiner plus tard.
+          </Text>
+
+          <View style={styles.optionList}>
+            {EQUIPMENT_SYSTEM_OPTIONS.map((option) => {
+              const selected = option.value === systemType;
+              return (
+                <Pressable
+                  key={option.value}
+                  testID={`equipment-system-option-${option.value}`}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected }}
+                  style={[styles.option, selected && styles.optionSelected]}
+                  onPress={() => setSystemType(option.value)}
+                >
+                  <Text
+                    style={[
+                      styles.optionLabel,
+                      selected && styles.optionLabelSelected,
+                    ]}
+                  >
+                    {option.label}
+                  </Text>
+                  <Text
+                    style={[
+                      styles.optionHelp,
+                      selected && styles.optionHelpSelected,
+                    ]}
+                  >
+                    {option.help}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </Card>
+      ) : null}
+
+      {step === 2 ? (
+        <Card style={styles.card}>
+          <Text style={styles.cardTitle}>Volume de ton fermenteur ?</Text>
+          <Text style={styles.helpText}>
+            En litres. C'est ce volume qui plafonne la taille de ton brassin.
+          </Text>
+          <TextInput
+            testID="equipment-fermenter-input"
+            style={styles.textInput}
+            value={fermenterText}
+            onChangeText={setFermenterText}
+            keyboardType="decimal-pad"
+            placeholder="23"
+          />
+        </Card>
+      ) : null}
+
+      {step === 3 ? (
+        <Card style={styles.card}>
+          <Text style={styles.cardTitle}>
+            Volume de ta plus grande marmite ?
+          </Text>
+          <Text style={styles.helpText}>
+            En litres. La marmite d'ébullition la plus grande dont tu disposes.
+          </Text>
+          <TextInput
+            testID="equipment-kettle-input"
+            style={styles.textInput}
+            value={kettleText}
+            onChangeText={setKettleText}
+            keyboardType="decimal-pad"
+            placeholder="30"
+          />
+        </Card>
+      ) : null}
+
+      {step === 4 ? (
+        <Card style={styles.card}>
+          <Text style={styles.cardTitle}>On y est presque</Text>
+          <Text style={styles.inputLabel}>Nom de ton matériel</Text>
+          <TextInput
+            testID="equipment-name-input"
+            style={styles.textInput}
+            value={nameText}
+            onChangeText={setNameText}
+            placeholder="Mon matériel"
+          />
+
+          <View style={styles.summary}>
+            <SummaryRow label="Type" value={selectedOption?.label ?? "—"} />
+            <SummaryRow label="Fermenteur" value={`${fermenterVolumeL} L`} />
+            <SummaryRow label="Marmite" value={`${kettleVolumeL} L`} />
+          </View>
+
+          <Text style={styles.helpText}>
+            Les réglages techniques (rendement, évaporation…) sont pré-remplis
+            automatiquement selon ton type de système. Tu pourras les ajuster
+            plus tard.
+          </Text>
+        </Card>
+      ) : null}
+
+      {mutationError ? (
+        <Card style={[styles.card, styles.blockCard]}>
+          <Text style={styles.blockText}>
+            {getErrorMessage(mutationError, "Échec de la création du matériel")}
+          </Text>
+        </Card>
+      ) : null}
+
+      {step < LAST_STEP ? (
+        <PrimaryButton
+          testID="equipment-wizard-next"
+          label="Suivant"
+          onPress={handleNext}
+          disabled={!isStepValid}
+        />
+      ) : (
+        <PrimaryButton
+          testID="equipment-wizard-create"
+          label={isPending ? "Création…" : "Créer mon matériel"}
+          onPress={handleCreate}
+          disabled={isPending || !isStepValid}
+        />
+      )}
+    </Screen>
+  );
+}
+
+type SummaryRowProps = {
+  label: string;
+  value: string;
+};
+
+function SummaryRow({ label, value }: SummaryRowProps) {
+  return (
+    <View style={styles.summaryRow}>
+      <Text style={styles.summaryLabel}>{label}</Text>
+      <Text style={styles.summaryValue}>{value}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginBottom: spacing.sm,
+  },
+  cardTitle: {
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    marginBottom: spacing.xs,
+  },
+  helpText: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.neutral.textSecondary,
+    marginBottom: spacing.sm,
+  },
+  optionList: {
+    gap: spacing.xs,
+  },
+  option: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    borderRadius: radius.sm,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+  },
+  optionSelected: {
+    backgroundColor: colors.brand.primary,
+    borderColor: colors.brand.primary,
+  },
+  optionLabel: {
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    marginBottom: spacing.xxs,
+  },
+  optionLabelSelected: {
+    color: colors.neutral.white,
+  },
+  optionHelp: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.neutral.textSecondary,
+  },
+  optionHelpSelected: {
+    color: colors.neutral.white,
+  },
+  inputLabel: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+    color: colors.neutral.textPrimary,
+    marginBottom: spacing.xs,
+  },
+  textInput: {
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    borderRadius: radius.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    color: colors.neutral.textPrimary,
+  },
+  summary: {
+    marginVertical: spacing.sm,
+    gap: spacing.xxs,
+  },
+  summaryRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  summaryLabel: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.neutral.textSecondary,
+  },
+  summaryValue: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+    color: colors.neutral.textPrimary,
+  },
+  blockCard: {
+    backgroundColor: colors.state.errorBackground,
+    borderColor: colors.semantic.error,
+  },
+  blockText: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.semantic.error,
+  },
+});

--- a/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentScreen.test.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentScreen.test.tsx
@@ -101,4 +101,14 @@ describe("EquipmentScreen", () => {
     fireEvent.press(screen.getByTestId("equipment-add-cta"));
     expect(mockPush).toHaveBeenCalledWith("/equipment/wizard");
   });
+
+  it("shows an error card when the query fails (sad)", async () => {
+    // getErrorMessage surfaces the error's own message (falling back to the
+    // generic copy only when the error has none).
+    mockedList.mockRejectedValue(new Error("timeout"));
+
+    renderScreen();
+
+    expect(await screen.findByText("timeout")).toBeTruthy();
+  });
 });

--- a/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentScreen.test.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentScreen.test.tsx
@@ -1,0 +1,104 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { EquipmentProfile } from "@/features/equipment/domain/equipment.types";
+import { EquipmentScreen } from "@/features/equipment/presentation/EquipmentScreen";
+import React from "react";
+import { listEquipmentProfiles } from "@/features/equipment/application/equipment.use-cases";
+
+const mockPush = jest.fn();
+
+jest.mock("@expo/vector-icons", () => ({
+  Ionicons: () => null,
+}));
+
+jest.mock("expo-router", () => {
+  const actual = jest.requireActual("expo-router");
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: mockPush,
+      replace: jest.fn(),
+      back: jest.fn(),
+    }),
+  };
+});
+
+jest.mock("@/features/equipment/application/equipment.use-cases", () => ({
+  listEquipmentProfiles: jest.fn(),
+}));
+
+const mockedList = listEquipmentProfiles as jest.MockedFunction<
+  typeof listEquipmentProfiles
+>;
+
+function makeProfile(
+  overrides: Partial<EquipmentProfile> = {},
+): EquipmentProfile {
+  return {
+    id: "eq-1",
+    ownerId: "u-1",
+    name: "Ma cuve",
+    mashTunVolumeL: 30,
+    boilKettleVolumeL: 30,
+    fermenterVolumeL: 23,
+    trubLossL: 0,
+    deadSpaceLossL: 0,
+    transferLossL: 0,
+    evaporationRateLPerHour: 3,
+    efficiencyEstimatedPercent: 72,
+    efficiencyMeasuredPercent: null,
+    coolingTimeMinutes: null,
+    coolingFlowRateLPerMinute: null,
+    systemType: "all-grain",
+    createdAt: "2026-02-01T10:00:00.000Z",
+    updatedAt: "2026-02-01T10:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderScreen() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EquipmentScreen />
+    </QueryClientProvider>,
+  );
+}
+
+describe("EquipmentScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the user's profiles (happy)", async () => {
+    mockedList.mockResolvedValue([makeProfile({ name: "Ma cuve" })]);
+
+    renderScreen();
+
+    expect(await screen.findByText("Ma cuve")).toBeTruthy();
+  });
+
+  it("shows the empty state with a CTA when there is no profile (edge)", async () => {
+    mockedList.mockResolvedValue([]);
+
+    renderScreen();
+
+    expect(await screen.findByText("Aucun matériel enregistré")).toBeTruthy();
+    fireEvent.press(screen.getByTestId("equipment-empty-cta"));
+    expect(mockPush).toHaveBeenCalledWith("/equipment/wizard");
+  });
+
+  it("navigates to the wizard from the add CTA (happy)", async () => {
+    mockedList.mockResolvedValue([makeProfile()]);
+
+    renderScreen();
+    await screen.findByTestId("equipment-add-cta");
+
+    fireEvent.press(screen.getByTestId("equipment-add-cta"));
+    expect(mockPush).toHaveBeenCalledWith("/equipment/wizard");
+  });
+});

--- a/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentWizardScreen.test.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentWizardScreen.test.tsx
@@ -1,0 +1,126 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+
+import { EquipmentProfile } from "@/features/equipment/domain/equipment.types";
+import { EquipmentWizardScreen } from "@/features/equipment/presentation/EquipmentWizardScreen";
+import React from "react";
+import { createEquipmentProfile } from "@/features/equipment/application/equipment.use-cases";
+
+const mockReplace = jest.fn();
+const mockBack = jest.fn();
+
+jest.mock("expo-router", () => {
+  const actual = jest.requireActual("expo-router");
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: jest.fn(),
+      replace: mockReplace,
+      back: mockBack,
+    }),
+  };
+});
+
+jest.mock("@/features/equipment/application/equipment.use-cases", () => ({
+  createEquipmentProfile: jest.fn(),
+}));
+
+const mockedCreate = createEquipmentProfile as jest.MockedFunction<
+  typeof createEquipmentProfile
+>;
+
+const CREATED_PROFILE: EquipmentProfile = {
+  id: "eq-1",
+  ownerId: "u-1",
+  name: "Tout-grain 23 L",
+  mashTunVolumeL: 30,
+  boilKettleVolumeL: 30,
+  fermenterVolumeL: 23,
+  trubLossL: 0,
+  deadSpaceLossL: 0,
+  transferLossL: 0,
+  evaporationRateLPerHour: 3,
+  efficiencyEstimatedPercent: 72,
+  efficiencyMeasuredPercent: null,
+  coolingTimeMinutes: null,
+  coolingFlowRateLPerMinute: null,
+  systemType: "all-grain",
+  createdAt: "2026-02-01T10:00:00.000Z",
+  updatedAt: "2026-02-01T10:00:00.000Z",
+};
+
+function renderScreen() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <EquipmentWizardScreen />
+    </QueryClientProvider>,
+  );
+}
+
+function completeAllSteps() {
+  fireEvent.press(screen.getByTestId("equipment-system-option-all-grain"));
+  fireEvent.press(screen.getByTestId("equipment-wizard-next"));
+  fireEvent.changeText(screen.getByTestId("equipment-fermenter-input"), "23");
+  fireEvent.press(screen.getByTestId("equipment-wizard-next"));
+  fireEvent.changeText(screen.getByTestId("equipment-kettle-input"), "30");
+  fireEvent.press(screen.getByTestId("equipment-wizard-next"));
+}
+
+describe("EquipmentWizardScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("walks the 3 questions then creates and navigates (happy)", async () => {
+    mockedCreate.mockResolvedValue(CREATED_PROFILE);
+
+    renderScreen();
+    completeAllSteps();
+    fireEvent.press(screen.getByTestId("equipment-wizard-create"));
+
+    await waitFor(() => {
+      expect(mockedCreate).toHaveBeenCalledWith({
+        name: "Tout-grain 23 L",
+        systemType: "all-grain",
+        fermenterVolumeL: 23,
+        boilKettleVolumeL: 30,
+      });
+    });
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/equipment");
+    });
+  });
+
+  it("does not advance past question 1 until a system type is chosen (edge)", () => {
+    renderScreen();
+
+    fireEvent.press(screen.getByTestId("equipment-wizard-next"));
+
+    expect(screen.getByText("Question 1 / 3")).toBeTruthy();
+    expect(screen.queryByTestId("equipment-fermenter-input")).toBeNull();
+  });
+
+  it("shows an error message when creation fails (sad)", async () => {
+    mockedCreate.mockRejectedValue(new Error("network down"));
+
+    renderScreen();
+    completeAllSteps();
+    fireEvent.press(screen.getByTestId("equipment-wizard-create"));
+
+    await waitFor(() => {
+      expect(screen.getByText("network down")).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements **E1 — the equipment wizard**: a novice can declare a reusable
equipment profile through a guided 3-question flow, persisted via the existing
`/equipment-profiles` API.

**API**

- `POST /equipment-profiles` now accepts a minimal body — the wizard sends only
  `name`, `system_type`, `fermenter_volume_l`, `boil_kettle_volume_l`.
- The hidden brewing constants (`mash_tun_volume_l`,
  `evaporation_rate_l_per_hour`, `efficiency_estimated_percent`) become optional
  and are **seeded server-side** from a per-`system_type` defaults table
  (`EQUIPMENT_SYSTEM_DEFAULTS`); `mash_tun_volume_l` defaults to the boil-kettle
  volume. Explicitly-provided values are never overwritten. Keeps these
  constants backend-owned (ADR-0020).

**Mobile**

- New `equipment/` Clean-Architecture layers (domain / data / application /
  presentation) on the existing http-client.
- `EquipmentWizardScreen`: 3 questions (system type, fermenter, kettle) then a
  recap with an auto-generated, editable name.
- `EquipmentScreen` now lists the user's real profiles (TanStack Query) with an
  "add" CTA and an empty state, replacing the demo-only list.

**Conception**

- ADR-0021 D1 and the equipment-wizard sequence diagram synced to the as-built:
  server-side seeding; the `equipment_templates` catalog → profile mapping is
  deferred to E2 (its BeerXML fields don't map 1:1 to the profile DTO).

## Context

Next slice of the "Premier brassage réel" epic, after B1–B3. The equipment
profile API already existed; this adds the missing mobile capture and makes the
create endpoint novice-friendly. Fit-check, launch-gate wiring and the cleaning
ritual stay out of scope (E2 / C1).

## Checklist

- [x] Tests added (happy / sad / edge) — API service spec + e2e; mobile data,
  use-cases, and both screens.
- [x] `lint` + `build` green — API (820 unit tests pass) and mobile (equipment
  suite, 17 tests).
- [x] Clean Architecture + SOLID review — conformant, 0 must-fix.
- [x] Conception synced (ADR-0021 D1 + sequence diagram).
- [x] e2e suite added; it runs in CI (the local e2e DB environment is broken,
  pre-existing — a stock `health` e2e fails identically here).
