### PR TITLE
fix(batches): confirm before completing a step (F6) and keep the step list above the footer (F8)

### DIFF
--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  Alert,
   FlatList,
   Modal,
   Pressable,
@@ -235,8 +236,25 @@ export function BatchDetailsScreen({ batchId }: Props) {
     if (missingBatchId) {
       return;
     }
-    setMutationError(null);
-    mutateCompleteCurrentStep();
+    // F6 — confirm before completing a step. Completing advances the brew to
+    // the next step and is not undoable, so gate it behind an acknowledgment
+    // (the ✋ pattern already used on the bottling step) instead of firing on
+    // a single tap.
+    Alert.alert(
+      "Terminer cette étape ?",
+      "Tu confirmes avoir terminé l'étape en cours ? L'étape suivante démarrera.",
+      [
+        { text: "Annuler", style: "cancel" },
+        {
+          text: "Terminer",
+          style: "default",
+          onPress: () => {
+            setMutationError(null);
+            mutateCompleteCurrentStep();
+          },
+        },
+      ],
+    );
   };
 
   const handleGoBack = () => {
@@ -444,6 +462,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
           <FlatList
             data={batch?.steps ?? []}
             keyExtractor={(item) => `${item.batchId}-${item.stepOrder}`}
+            style={styles.stepsList}
             contentContainerStyle={[
               styles.list,
               { paddingBottom: bottomPadding },
@@ -510,6 +529,14 @@ const styles = StyleSheet.create({
     lineHeight: typography.lineHeight.body,
   },
   list: {},
+  stepsList: {
+    // F8 — give the steps list its own bounded, scrollable region so the last
+    // steps stay reachable above the floating nav footer. Without flex, the
+    // list grew with its content inside a non-scrolling container and the
+    // bottom steps were clipped behind the footer (the paddingBottom offset
+    // alone could not rescue content that overflowed the screen).
+    flex: 1,
+  },
   fermentationCard: {
     padding: spacing.md,
     marginBottom: spacing.sm,

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -1,8 +1,15 @@
+import { Alert, type AlertButton } from "react-native";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react-native";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
 
 import { BatchDetailsScreen } from "@/features/batches/presentation/BatchDetailsScreen";
 import {
+  completeCurrentBatchStep,
   getBatchDetailsViewModel,
   type BatchDetailsViewModel,
 } from "@/features/batches/application/batches.use-cases";
@@ -130,6 +137,52 @@ describe("BatchDetailsScreen", () => {
     expect(screen.getByText("Progression du brassin")).toBeTruthy();
     expect(screen.getByText("Étapes")).toBeTruthy();
     expect(screen.getByText("Terminer l'étape en cours")).toBeTruthy();
+  });
+
+  it("confirms before completing a step, then completes on confirm (F6)", async () => {
+    (completeCurrentBatchStep as jest.Mock).mockClear();
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderBatchDetailsScreen();
+
+    fireEvent.press(await screen.findByText("Terminer l'étape en cours"));
+
+    // The tap opens a confirmation dialog rather than completing immediately.
+    expect(alertSpy).toHaveBeenCalledWith(
+      "Terminer cette étape ?",
+      expect.any(String),
+      expect.any(Array),
+    );
+    expect(completeCurrentBatchStep).not.toHaveBeenCalled();
+
+    // Confirming the dialog runs the completion.
+    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
+    buttons.find((button) => button.text === "Terminer")?.onPress?.();
+
+    await waitFor(() =>
+      expect(completeCurrentBatchStep).toHaveBeenCalledTimes(1),
+    );
+
+    alertSpy.mockRestore();
+  });
+
+  it("does not complete the step when the confirmation is cancelled (F6, sad path)", async () => {
+    (completeCurrentBatchStep as jest.Mock).mockClear();
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderBatchDetailsScreen();
+
+    fireEvent.press(await screen.findByText("Terminer l'étape en cours"));
+
+    // Opening the confirmation dialog must not complete anything on its own.
+    expect(completeCurrentBatchStep).not.toHaveBeenCalled();
+
+    // "Annuler" is a pure native dismiss (no handler), so cancelling can never
+    // reach the completion mutation — assert it carries no onPress.
+    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
+    const cancelButton = buttons.find((button) => button.text === "Annuler");
+    expect(cancelButton).toBeDefined();
+    expect(cancelButton?.onPress).toBeUndefined();
+
+    alertSpy.mockRestore();
   });
 
   it("renders French status, step index, badges and phase labels", async () => {

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -129,6 +129,12 @@ describe("BatchDetailsScreen", () => {
     );
   });
 
+  // Always restore jest.spyOn spies (e.g. the Alert.alert spy in the F6 tests)
+  // even when an assertion throws, so a spy can never leak into later tests.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("renders batch details with the recipe name as title (happy path)", async () => {
     renderBatchDetailsScreen();
 
@@ -161,8 +167,6 @@ describe("BatchDetailsScreen", () => {
     await waitFor(() =>
       expect(completeCurrentBatchStep).toHaveBeenCalledTimes(1),
     );
-
-    alertSpy.mockRestore();
   });
 
   it("does not complete the step when the confirmation is cancelled (F6, sad path)", async () => {
@@ -181,8 +185,6 @@ describe("BatchDetailsScreen", () => {
     const cancelButton = buttons.find((button) => button.text === "Annuler");
     expect(cancelButton).toBeDefined();
     expect(cancelButton?.onPress).toBeUndefined();
-
-    alertSpy.mockRestore();
   });
 
   it("renders French status, step index, badges and phase labels", async () => {


### PR DESCRIPTION
## Summary

Two novice brew-day frictions surfaced during the live novice-journey audit, both in `BatchDetailsScreen` (mobile-only, no backend change):

- **F6 — confirm before completing a step.** Completing the current brew step advanced the batch on a single tap, with no confirmation or undo — inconsistent with the bottling step, which already gates on an acknowledgment checkbox. The completion is now wrapped in an `Alert.alert` confirm (Annuler / Terminer); the confirm button runs the existing mutation, so an accidental tap no longer skips a step.
- **F8 — step list clipped behind the nav footer.** The brew-day step list (a `FlatList`) grew with its content inside a non-scrolling container, so the last steps were hidden behind the floating navigation footer. The list now has `flex: 1` so it scrolls in its own bounded region; the existing `paddingBottom` keeps footer clearance.

## Context

First "baby step" slice of the novice-journey correction backlog (Phase 1 quick wins). Deliberately tiny so it can be validated live before the next slice (the content-management cluster: equipment/recipe/batch delete + carnet import).

## Tests

- `BatchDetailsScreen` suite: 26/26 green, including two new F6 tests (confirm advances; the cancel button carries no handler, so it cannot complete).
- Local pre-push review run; Should-Have items addressed.

## Checklist

- [x] Lint + Prettier pass on the changed files
- [x] Tests added (happy + sad) and green
- [x] No backend change; no new dependency
- [x] Conventional Commits