### PR TITLE
feat(recipes): add-to-carnet import (F23) and delete-from-carnet (F24)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -5,6 +5,13 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ---
 
+## 2026-06-30
+
+### PR #1280 merged (`6259a31`) — fix(batches): confirm before completing a step (F6) and keep the step list above the footer (F8)
+
+- Branch `fix/batch-step-ux`. First **baby-step slice** of the novice-journey correction backlog (live-test audit, 25 frictions F1–F25). Mobile-only, no backend. **F6** — completing a brew step happened on a single tap with no confirmation/undo, inconsistent with the bottling step's acknowledgment gate; now wrapped in an `Alert.alert` confirm (Annuler / Terminer) in `BatchDetailsScreen.handleComplete`. **F8** — the brew-day step `FlatList` grew inside a non-scrolling container, clipping the last steps behind the floating nav footer; gave the list `flex: 1` so it scrolls in a bounded region (the existing `paddingBottom` keeps footer clearance).
+- Reviews — local pre-push (pr-pre-reviewer) + Codex + Copilot reconciled: Copilot test-hygiene fix applied (`afterEach(jest.restoreAllMocks)` so the `Alert` spy can't leak on a thrown assertion); Codex P2 (`Alert.alert` is a no-op on `react-native-web`) **deferred** with rationale — it is the app-wide pattern (BrewPrep / scan / login) and web is not a shipped target; a shared cross-platform `confirmAsync()` helper is the right fix if web ever ships. Codex CLI unavailable locally (noted, not skipped). CI green (mobile-app incl. typecheck — local typecheck false-fails on stale `.expo` route types); `BatchDetailsScreen` 26/26.
+
 ## 2026-06-29
 
 ### PR #1277 merged (`a3dc240`) — feat(equipment): equipment wizard — 3-question profile + server-side defaults (E1)

--- a/packages/mobile-app/src/features/recipes/application/__tests__/delete-recipe.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/delete-recipe.test.ts
@@ -1,0 +1,48 @@
+import { deleteRecipeFromCarnet } from "@/features/recipes/application/recipes.use-cases";
+import { deleteRecipe } from "@/features/recipes/data/recipes.api";
+
+const dataSourceMock = { useDemoData: true };
+
+jest.mock("@/core/data/data-source", () => ({
+  get dataSource() {
+    return dataSourceMock;
+  },
+}));
+
+jest.mock("@/features/recipes/data/recipes.api", () => ({
+  deleteRecipe: jest.fn(),
+}));
+
+const mockedDelete = deleteRecipe as jest.MockedFunction<typeof deleteRecipe>;
+
+describe("deleteRecipeFromCarnet", () => {
+  beforeEach(() => {
+    mockedDelete.mockReset();
+    dataSourceMock.useDemoData = true;
+  });
+
+  describe("demo mode", () => {
+    it("is a no-op and never calls the API (the demo catalog is read-only)", async () => {
+      await expect(deleteRecipeFromCarnet("r-demo-1")).resolves.toBeUndefined();
+      expect(mockedDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("backend mode", () => {
+    it("delegates to the recipes API delete with the recipe id (happy path)", async () => {
+      dataSourceMock.useDemoData = false;
+      mockedDelete.mockResolvedValueOnce(undefined);
+
+      await deleteRecipeFromCarnet("r-42");
+
+      expect(mockedDelete).toHaveBeenCalledWith("r-42");
+    });
+
+    it("propagates the API error (sad path)", async () => {
+      dataSourceMock.useDemoData = false;
+      mockedDelete.mockRejectedValueOnce(new Error("forbidden"));
+
+      await expect(deleteRecipeFromCarnet("r-42")).rejects.toThrow("forbidden");
+    });
+  });
+});

--- a/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
@@ -1,4 +1,5 @@
 import {
+  deleteRecipe,
   getMineById,
   importFromCommunity,
   listMine,
@@ -140,6 +141,17 @@ export async function importRecipeFromCommunity(
   }
   const imported = await importFromCommunity(sourceId);
   return { recipeId: imported.id, name: imported.name };
+}
+
+/**
+ * Delete one of the current user's recipes from « Mon Carnet ». In demo mode
+ * this is a no-op — the bundled demo catalog is read-only.
+ */
+export async function deleteRecipeFromCarnet(recipeId: string): Promise<void> {
+  if (dataSource.useDemoData) {
+    return;
+  }
+  await deleteRecipe(recipeId);
 }
 
 export async function getRecipeDetailsViewModel(

--- a/packages/mobile-app/src/features/recipes/data/__tests__/recipes.api.test.ts
+++ b/packages/mobile-app/src/features/recipes/data/__tests__/recipes.api.test.ts
@@ -1,4 +1,11 @@
-import { mapRecipe } from "@/features/recipes/data/recipes.api";
+import { deleteRecipe, mapRecipe } from "@/features/recipes/data/recipes.api";
+import { request } from "@/core/http/http-client";
+
+jest.mock("@/core/http/http-client", () => ({
+  request: jest.fn(),
+}));
+
+const mockedRequest = request as jest.MockedFunction<typeof request>;
 
 /**
  * Issue #779 — coverage guard on the API mapper for the catalog
@@ -123,5 +130,27 @@ describe("mapRecipe (Issue #779 — catalog API mapper coverage)", () => {
     expect(recipe.ownerId).toBeUndefined();
     expect(recipe.id).toBe("r-1");
     expect(recipe.name).toBe("Recipe");
+  });
+});
+
+describe("deleteRecipe (F24 — delete from carnet)", () => {
+  beforeEach(() => {
+    mockedRequest.mockReset();
+  });
+
+  it("happy: issues a DELETE to /recipes/:id", async () => {
+    mockedRequest.mockResolvedValueOnce(undefined as never);
+
+    await deleteRecipe("r-42");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/recipes/r-42", {
+      method: "DELETE",
+    });
+  });
+
+  it("sad: propagates the request error", async () => {
+    mockedRequest.mockRejectedValueOnce(new Error("boom"));
+
+    await expect(deleteRecipe("r-42")).rejects.toThrow("boom");
   });
 });

--- a/packages/mobile-app/src/features/recipes/data/recipes.api.ts
+++ b/packages/mobile-app/src/features/recipes/data/recipes.api.ts
@@ -132,3 +132,7 @@ export async function importFromCommunity(sourceId: string): Promise<Recipe> {
   );
   return mapRecipe(row);
 }
+
+export async function deleteRecipe(id: string): Promise<void> {
+  await request<void>(`/recipes/${id}`, { method: "DELETE" });
+}

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -361,6 +361,9 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
     mutationFn: () => deleteRecipeFromCarnet(recipeId),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["recipes", "list"] });
+      // An owned recipe can be public, so it may also sit in the catalog —
+      // invalidate both surfaces (symmetric with the import mutation).
+      void queryClient.invalidateQueries({ queryKey: ["recipes", "catalog"] });
       router.replace("/recipes");
     },
     onError: () => {

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { ScrollView, StyleSheet, View } from "react-native";
+import { Alert, Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
 
 import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
@@ -9,12 +12,12 @@ import { Screen } from "@/core/ui/Screen";
 import { colors, spacing } from "@/core/theme";
 import { getErrorMessage } from "@/core/http/http-error";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
-import { useQuery } from "@tanstack/react-query";
-import { useRouter } from "expo-router";
 
 import {
   RecipeDetailsViewModel,
+  deleteRecipeFromCarnet,
   getRecipeDetailsViewModel,
+  importRecipeFromCommunity,
 } from "@/features/recipes/application/recipes.use-cases";
 import {
   RECIPE_DETAIL_TABS,
@@ -90,6 +93,7 @@ const DEFAULT_TARGET_VOLUME_LITRES = 20;
 export function RecipeDetailsScreen({ recipeId }: Props) {
   const router = useRouter();
   const bottomPadding = useNavigationFooterOffset();
+  const queryClient = useQueryClient();
 
   const hasRecipeId = recipeId.trim().length > 0;
 
@@ -328,6 +332,60 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
     return null;
   }, [recipe]);
 
+  // Ownership signal (verified against GET /recipes/:id): the API only
+  // projects `ownerId` when the caller owns the recipe; a PUBLIC recipe read
+  // by a non-owner comes back without it. So `ownerId` present ⟺ owned.
+  const isOwned = recipe != null && recipe.ownerId != null;
+  const canImportToCarnet = recipe != null && recipe.ownerId == null;
+
+  const importMutation = useMutation({
+    mutationFn: () => importRecipeFromCommunity(recipeId),
+    onSuccess: (result) => {
+      void queryClient.invalidateQueries({ queryKey: ["recipes", "list"] });
+      void queryClient.invalidateQueries({ queryKey: ["recipes", "catalog"] });
+      // Land on the freshly owned copy, ready to prepare.
+      router.replace({
+        pathname: "/(app)/recipes/[id]",
+        params: { id: result.recipeId },
+      });
+    },
+    onError: () => {
+      Alert.alert(
+        "Ajout impossible",
+        "La recette n'a pas pu être ajoutée à ton carnet. Vérifie ta connexion et réessaie.",
+      );
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => deleteRecipeFromCarnet(recipeId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["recipes", "list"] });
+      router.replace("/recipes");
+    },
+    onError: () => {
+      Alert.alert(
+        "Suppression impossible",
+        "La recette n'a pas pu être supprimée. Vérifie ta connexion et réessaie.",
+      );
+    },
+  });
+
+  const handleDelete = () => {
+    Alert.alert(
+      "Supprimer cette recette ?",
+      "Elle sera retirée de ton carnet. Cette action est irréversible.",
+      [
+        { text: "Annuler", style: "cancel" },
+        {
+          text: "Supprimer",
+          style: "destructive",
+          onPress: () => deleteMutation.mutate(),
+        },
+      ],
+    );
+  };
+
   const ctaLabel = "Préparer mon brassin";
   const ctaDisabled = isLoading || !recipe;
   const showStickyCta = activeTab !== "reviews";
@@ -365,11 +423,29 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
           title="Détail recette"
           subtitle="Carnet de brassage"
           action={
-            <HeaderBackButton
-              label="Mes recettes"
-              accessibilityLabel="Retour à mes recettes"
-              onPress={handleGoBack}
-            />
+            <View style={styles.headerActions}>
+              <HeaderBackButton
+                label="Mes recettes"
+                accessibilityLabel="Retour à mes recettes"
+                onPress={handleGoBack}
+              />
+              {isOwned ? (
+                <Pressable
+                  onPress={handleDelete}
+                  disabled={deleteMutation.isPending}
+                  accessibilityRole="button"
+                  accessibilityLabel="Supprimer cette recette"
+                  hitSlop={8}
+                  style={styles.deleteButton}
+                >
+                  <Ionicons
+                    name="trash-outline"
+                    size={22}
+                    color={colors.semantic.error}
+                  />
+                </Pressable>
+              ) : null}
+            </View>
           }
         />
       </View>
@@ -454,12 +530,23 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
       </View>
 
       {showStickyCta ? (
-        <RecipeStickyCta
-          label={ctaLabel}
-          onPress={handlePrepare}
-          disabled={ctaDisabled}
-          bottomOffset={bottomPadding}
-        />
+        canImportToCarnet ? (
+          // A public recipe the user does not own yet: the primary action is
+          // to import it into « Mon Carnet » before preparing a brew from it.
+          <RecipeStickyCta
+            label="Ajouter à mon carnet"
+            onPress={() => importMutation.mutate()}
+            disabled={importMutation.isPending || !recipe}
+            bottomOffset={bottomPadding}
+          />
+        ) : (
+          <RecipeStickyCta
+            label={ctaLabel}
+            onPress={handlePrepare}
+            disabled={ctaDisabled}
+            bottomOffset={bottomPadding}
+          />
+        )
       ) : null}
     </Screen>
   );
@@ -472,6 +559,14 @@ const styles = StyleSheet.create({
   headerWrapper: {
     paddingHorizontal: spacing.md,
     paddingTop: spacing.md,
+  },
+  headerActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  deleteButton: {
+    padding: spacing.xs,
   },
   body: {
     flex: 1,

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -1,9 +1,19 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react-native";
-
 import React from "react";
+import { Alert, type AlertButton } from "react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+
 import { RecipeDetailsScreen } from "@/features/recipes/presentation/RecipeDetailsScreen";
-import { getRecipeDetailsViewModel } from "@/features/recipes/application/recipes.use-cases";
+import {
+  deleteRecipeFromCarnet,
+  getRecipeDetailsViewModel,
+  importRecipeFromCommunity,
+} from "@/features/recipes/application/recipes.use-cases";
 
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
@@ -58,6 +68,8 @@ jest.mock("expo-router", () => {
 const baseViewModel = {
   recipe: {
     id: "r1",
+    // Private recipe → owned by the current user, so the API projects ownerId.
+    ownerId: "u1",
     name: "Test Recipe",
     description: "Test description",
     visibility: "private",
@@ -116,7 +128,21 @@ const baseViewModel = {
 
 jest.mock("@/features/recipes/application/recipes.use-cases", () => ({
   getRecipeDetailsViewModel: jest.fn(),
+  importRecipeFromCommunity: jest.fn(),
+  deleteRecipeFromCarnet: jest.fn(),
 }));
+
+// A PUBLIC recipe the current user does NOT own: the API strips ownerId, so the
+// detail screen should offer « Ajouter à mon carnet » (import) instead of the
+// prepare / delete actions.
+const publicViewModel = {
+  ...baseViewModel,
+  recipe: {
+    ...baseViewModel.recipe,
+    ownerId: undefined,
+    visibility: "public",
+  },
+};
 
 function renderRecipeDetails(recipeId = "r1") {
   const queryClient = new QueryClient({
@@ -148,6 +174,19 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     mockReplace.mockReset();
     (getRecipeDetailsViewModel as jest.Mock).mockReset();
     (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue(baseViewModel);
+    (importRecipeFromCommunity as jest.Mock).mockReset();
+    (importRecipeFromCommunity as jest.Mock).mockResolvedValue({
+      recipeId: "r-owned-9",
+      name: "Imported recipe",
+    });
+    (deleteRecipeFromCarnet as jest.Mock).mockReset();
+    (deleteRecipeFromCarnet as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  // Restore jest.spyOn spies (the Alert.alert spy in the delete test) even when
+  // an assertion throws, so the spy never leaks into later tests.
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("renders the side rail and lands on Overview by default", async () => {
@@ -184,6 +223,80 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
       pathname: "/(app)/recipes/[id]/prepare",
       params: { id: "r1" },
     });
+  });
+
+  it("F23: a public recipe shows « Ajouter à mon carnet » and imports on press, then lands on the owned copy", async () => {
+    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue(publicViewModel);
+    renderRecipeDetails("pub-1");
+
+    fireEvent.press(await screen.findByText("Ajouter à mon carnet"));
+
+    await waitFor(() =>
+      expect(importRecipeFromCommunity).toHaveBeenCalledWith("pub-1"),
+    );
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: "/(app)/recipes/[id]",
+        params: { id: "r-owned-9" },
+      }),
+    );
+    // The prepare action is not offered for a recipe the user does not own yet.
+    expect(screen.queryByText("Préparer mon brassin")).toBeNull();
+  });
+
+  it("F23: an owned recipe does not show the import CTA (it shows prepare)", async () => {
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    expect(screen.getByText("Préparer mon brassin")).toBeTruthy();
+    expect(screen.queryByText("Ajouter à mon carnet")).toBeNull();
+  });
+
+  it("F24: an owned recipe offers delete and removes it on confirm", async () => {
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    fireEvent.press(screen.getByLabelText("Supprimer cette recette"));
+
+    // The tap opens a confirmation dialog rather than deleting immediately.
+    expect(alertSpy).toHaveBeenCalled();
+    expect(deleteRecipeFromCarnet).not.toHaveBeenCalled();
+
+    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
+    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+
+    await waitFor(() =>
+      expect(deleteRecipeFromCarnet).toHaveBeenCalledWith("r1"),
+    );
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/recipes"));
+  });
+
+  it("F24: a public recipe the user does not own offers no delete action", async () => {
+    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue(publicViewModel);
+    renderRecipeDetails("pub-1");
+
+    await screen.findByText("Ajouter à mon carnet");
+    expect(screen.queryByLabelText("Supprimer cette recette")).toBeNull();
+  });
+
+  it("F24: surfaces an alert and does not navigate when the delete fails (sad path)", async () => {
+    (deleteRecipeFromCarnet as jest.Mock).mockRejectedValueOnce(
+      new Error("boom"),
+    );
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    fireEvent.press(screen.getByLabelText("Supprimer cette recette"));
+
+    // Confirm the deletion in the first dialog.
+    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
+    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+
+    // The failure surfaces a second alert and never navigates away.
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(2));
+    expect(mockReplace).not.toHaveBeenCalledWith("/recipes");
   });
 
   it("switches to the Ingredients tab and shows the ingredient list", async () => {


### PR DESCRIPTION
## Summary

Slice 2 of the novice-journey correction backlog — the recipe "carnet" management layer (mobile-only; all backend endpoints already exist). Two frictions from the live audit:

- **F23 — « Ajouter à mon carnet » (re-enabled).** Importing a discovered/community recipe into the user's carnet had no UI entry point (dropped in the #740 detail-screen refactor, though the `importRecipeFromCommunity` use-case + `POST /recipes/import-from-community/:id` both exist). RecipeDetailsScreen's sticky CTA now branches on ownership — a PUBLIC recipe the user does not own (signal: the API only projects `ownerId` to the owner) shows an « Ajouter à mon carnet » CTA; on success it invalidates the carnet + catalog queries and lands on the freshly-owned copy. Owned recipes keep the unchanged « Préparer mon brassin » CTA.
- **F24 — delete from the carnet.** An owned recipe now shows a destructive trash button in the header, gated behind an `Alert` confirm, wired to a new `deleteRecipeFromCarnet` use-case (demo no-op) over the existing `DELETE /recipes/:id`; on success it invalidates the carnet and returns to the list.

Both mutations surface an `Alert` on failure (no silent failure).

## Context

Baby-step iterative slice (after #1280). Catalogue→carnet ownership model: a public recipe is imported into the carnet; an owned recipe is preparable/deletable.

## Tests

- New `delete-recipe.test.ts` (use-case demo/happy/sad) + `deleteRecipe` in `recipes.api.test.ts` (happy/sad) + RecipeDetailsScreen F23/F24 (import navigates; owned shows delete & deletes on confirm; mutual exclusivity; delete-failure shows an alert and does not navigate). Recipe suites green (96+ tests).
- Library usage verified against current docs (Context7): TanStack Query v5 mutation/invalidation and Expo Router SDK 54 typed navigation are up to date.

## Checklist

- [x] Lint + Prettier clean on changed files
- [x] Tests added (happy + sad + edge) and green
- [x] No backend change; no new dependency
- [x] Conventional Commits

Also records PR #1280 in PROJECT_LOG.md.