### PR TITLE
feat(equipment): unique profile names per owner (F21) + equipment-axis labels (F17)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -5,6 +5,13 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ---
 
+## 2026-07-01
+
+### PR #1281 merged (`25578f5`) — feat(recipes): add-to-carnet import (F23) and delete-from-carnet (F24)
+
+- Branch `feat/recipe-carnet-management`. Second **baby-step slice** of the novice-journey backlog — the recipe « carnet » management layer (mobile-only; the backend endpoints already existed). **F23** — re-enabled « Ajouter à mon carnet »: `RecipeDetailsScreen`'s sticky CTA branches on ownership (the API only projects `ownerId` to the owner) — a public recipe the user does not own shows an import CTA wired to `importRecipeFromCommunity`; on success it invalidates the carnet + catalog queries and lands on the freshly-owned copy. Owned recipes keep the « Préparer mon brassin » CTA. The entry point had been dropped in the #740 detail-screen redesign. **F24** — delete from the carnet: an owned recipe shows a destructive trash button in the header (Alert confirm → new `deleteRecipeFromCarnet` use-case over `DELETE /recipes/:id`); both mutations surface an Alert on failure.
+- Reviews — local pre-push + Copilot: Copilot's stale-catalog-cache-on-delete gap fixed (`1ee5353` — delete now also invalidates `['recipes','catalog']`, symmetric with the import); Copilot's demo-mode no-op flagged but deferred (mirrors `importRecipeFromCommunity`'s demo branch; demo is a non-shipped showcase). Library usage verified up to date via Context7 (TanStack Query v5, Expo Router SDK 54). CI green; recipe suites 96+; live-validated on a preview APK.
+
 ## 2026-06-30
 
 ### PR #1280 merged (`6259a31`) — fix(batches): confirm before completing a step (F6) and keep the step list above the footer (F8)

--- a/packages/api/src/common/exceptions/equipment-profile-name-taken.exception.ts
+++ b/packages/api/src/common/exceptions/equipment-profile-name-taken.exception.ts
@@ -1,0 +1,16 @@
+import { ConflictException } from '@nestjs/common';
+
+/**
+ * Equipment Profile Name Taken Exception
+ *
+ * Thrown when a user tries to create an equipment profile with a name they
+ * already use for one of their own profiles. Names are unique per owner
+ * (composite unique index on `owner_id` + `name`).
+ *
+ * HTTP Status: 409 Conflict
+ */
+export class EquipmentProfileNameTakenException extends ConflictException {
+  constructor() {
+    super('An equipment profile with this name already exists');
+  }
+}

--- a/packages/api/src/common/exceptions/index.ts
+++ b/packages/api/src/common/exceptions/index.ts
@@ -1,3 +1,4 @@
 export { EmailAlreadyExistsException } from './email-already-exists.exception';
+export { EquipmentProfileNameTakenException } from './equipment-profile-name-taken.exception';
 export { UsernameAlreadyExistsException } from './username-already-exists.exception';
 export { UserNotFoundException } from './user-not-found.exception';

--- a/packages/api/src/database/migrations/1803000000000-AddEquipmentProfileNameOwnerUnique.ts
+++ b/packages/api/src/database/migrations/1803000000000-AddEquipmentProfileNameOwnerUnique.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Enforce per-owner uniqueness of equipment profile names (F21). A user cannot
+ * create two profiles with the same name; different users may reuse a name.
+ *
+ * The `up()` step defensively removes pre-existing duplicate (owner_id, name)
+ * rows — keeping the earliest — BEFORE creating the unique index, so the
+ * migration cannot fail (and brick the boot-time `migrationsRun`) on databases
+ * that already contain duplicates created before this constraint existed.
+ */
+export class AddEquipmentProfileNameOwnerUnique1803000000000 implements MigrationInterface {
+  name = 'AddEquipmentProfileNameOwnerUnique1803000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DELETE FROM "equipment_profiles"
+      WHERE rowid NOT IN (
+        SELECT MIN(rowid)
+        FROM "equipment_profiles"
+        GROUP BY "owner_id", "name"
+      )
+    `);
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_equipment_profiles_owner_id_name" ON "equipment_profiles" ("owner_id", "name")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "IDX_equipment_profiles_owner_id_name"`,
+    );
+  }
+}

--- a/packages/api/src/equipment/services/equipment-profile.service.spec.ts
+++ b/packages/api/src/equipment/services/equipment-profile.service.spec.ts
@@ -418,6 +418,26 @@ describe('EquipmentProfileService', () => {
       expect(result.system_type).toBe(EquipmentSystemType.ALL_IN_ONE);
     });
 
+    it('maps a rename that collides with another profile to a 409 (F21)', async () => {
+      const entity = makeEntity();
+      jest.spyOn(service, 'getMineById').mockResolvedValue(entity);
+      jest
+        .spyOn(repo, 'save')
+        .mockRejectedValue(
+          new QueryFailedError(
+            'UPDATE equipment_profiles',
+            [],
+            new Error(
+              'UNIQUE constraint failed: equipment_profiles.owner_id, equipment_profiles.name',
+            ),
+          ),
+        );
+
+      await expect(
+        service.updateMine(ownerId, entity.id, { name: 'Taken Name' }),
+      ).rejects.toBeInstanceOf(EquipmentProfileNameTakenException);
+    });
+
     it('should keep existing values when dto fields are undefined', async () => {
       const entity = makeEntity({
         name: 'Original Setup',

--- a/packages/api/src/equipment/services/equipment-profile.service.spec.ts
+++ b/packages/api/src/equipment/services/equipment-profile.service.spec.ts
@@ -1,8 +1,9 @@
-import { DeleteResult, Repository } from 'typeorm';
+import { DeleteResult, QueryFailedError, Repository } from 'typeorm';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { CreateEquipmentProfileDto } from '../dtos/create-equipment-profile.dto';
 import { EQUIPMENT_SYSTEM_DEFAULTS } from '../domain/equipment-system-defaults';
+import { EquipmentProfileNameTakenException } from '../../common/exceptions/equipment-profile-name-taken.exception';
 import { EquipmentProfileOrmEntity } from '../entities/equipment-profile.orm.entity';
 import { EquipmentProfileService } from './equipment-profile.service';
 import { EquipmentSystemType } from '../domain/enums/equipment-system-type.enum';
@@ -75,6 +76,62 @@ describe('EquipmentProfileService', () => {
   });
 
   describe('create()', () => {
+    beforeEach(() => {
+      // The happy-path create tests assume the name is available — state it
+      // explicitly rather than relying on the jest.fn() default.
+      jest.spyOn(repo, 'findOne').mockResolvedValue(null);
+    });
+
+    it('rejects a duplicate name for the same owner with a 409 and does not save (F21)', async () => {
+      const dto: CreateEquipmentProfileDto = {
+        name: 'My Brewing Setup',
+        boil_kettle_volume_l: 40,
+        fermenter_volume_l: 30,
+        system_type: EquipmentSystemType.ALL_GRAIN,
+      };
+      const findOneSpy = jest
+        .spyOn(repo, 'findOne')
+        .mockResolvedValue(makeEntity());
+      const saveSpy = jest.spyOn(repo, 'save');
+
+      await expect(service.create(ownerId, dto)).rejects.toBeInstanceOf(
+        EquipmentProfileNameTakenException,
+      );
+      expect(findOneSpy).toHaveBeenCalledWith({
+        where: { owner_id: ownerId, name: dto.name },
+      });
+      expect(saveSpy).not.toHaveBeenCalled();
+    });
+
+    it('maps a unique-constraint save failure to a 409 (F21 race backstop)', async () => {
+      const dto: CreateEquipmentProfileDto = {
+        name: 'Racy Setup',
+        boil_kettle_volume_l: 40,
+        fermenter_volume_l: 30,
+        system_type: EquipmentSystemType.ALL_GRAIN,
+      };
+      // Name looks available at check time, but the DB unique index rejects it
+      // at save time (concurrent insert) — must still surface a clean 409.
+      jest
+        .spyOn(repo, 'create')
+        .mockReturnValue(makeEntity({ name: dto.name }));
+      jest
+        .spyOn(repo, 'save')
+        .mockRejectedValue(
+          new QueryFailedError(
+            'INSERT INTO equipment_profiles',
+            [],
+            new Error(
+              'UNIQUE constraint failed: equipment_profiles.owner_id, equipment_profiles.name',
+            ),
+          ),
+        );
+
+      await expect(service.create(ownerId, dto)).rejects.toBeInstanceOf(
+        EquipmentProfileNameTakenException,
+      );
+    });
+
     it('should create profile with default optional values when omitted', async () => {
       const dto: CreateEquipmentProfileDto = {
         name: 'All Grain 30L',

--- a/packages/api/src/equipment/services/equipment-profile.service.ts
+++ b/packages/api/src/equipment/services/equipment-profile.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomUUID } from 'crypto';
-import { Repository } from 'typeorm';
+import { QueryFailedError, Repository } from 'typeorm';
 
+import { EquipmentProfileNameTakenException } from '../../common/exceptions';
 import { EQUIPMENT_SYSTEM_DEFAULTS } from '../domain/equipment-system-defaults';
 import { EquipmentProfileDomainService } from '../domain/services/equipment-profile-domain.service';
 import { EquipmentProfileOrmEntity } from '../entities/equipment-profile.orm.entity';
@@ -34,6 +35,10 @@ export class EquipmentProfileService {
     ownerId: string,
     dto: CreateEquipmentProfileDto,
   ): Promise<EquipmentProfileOrmEntity> {
+    // Names are unique per owner (F21). The composite unique index is the
+    // durable guarantee; this check produces a clean 409 for the common case.
+    await this.assertNameAvailable(ownerId, dto.name);
+
     const id = randomUUID();
 
     // The 3-question wizard omits the "hidden" brewing constants; seed them per
@@ -69,7 +74,45 @@ export class EquipmentProfileService {
     });
 
     this.assertValid(ownerId, entity);
-    return this.repo.save(entity);
+
+    try {
+      return await this.repo.save(entity);
+    } catch (error) {
+      // Backstop for the check-then-save race (and any path that bypasses
+      // assertNameAvailable): the composite unique index rejects a duplicate
+      // (owner_id, name) with a QueryFailedError — surface it as a clean 409
+      // rather than letting it fall through as a 500.
+      if (this.isDuplicateNameError(error)) {
+        throw new EquipmentProfileNameTakenException();
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Rejects a create when the owner already has a profile with the same name
+   * (F21). Throws a 409 EquipmentProfileNameTakenException.
+   *
+   * The comparison is exact — case- and whitespace-sensitive per the SQLite
+   * column collation (no normalisation), matching the unique index.
+   */
+  private async assertNameAvailable(
+    ownerId: string,
+    name: string,
+  ): Promise<void> {
+    const existing = await this.repo.findOne({
+      where: { owner_id: ownerId, name },
+    });
+    if (existing) {
+      throw new EquipmentProfileNameTakenException();
+    }
+  }
+
+  private isDuplicateNameError(error: unknown): boolean {
+    return (
+      error instanceof QueryFailedError &&
+      /UNIQUE constraint failed: equipment_profiles/i.test(error.message)
+    );
   }
 
   async listMine(ownerId: string): Promise<EquipmentProfileOrmEntity[]> {

--- a/packages/api/src/equipment/services/equipment-profile.service.ts
+++ b/packages/api/src/equipment/services/equipment-profile.service.ts
@@ -114,10 +114,25 @@ export class EquipmentProfileService {
     }
   }
 
+  /**
+   * True only for the `(owner_id, name)` composite unique-index violation.
+   * SQLite reports it column-qualified as "UNIQUE constraint failed:
+   * equipment_profiles.owner_id, equipment_profiles.name" (table.column, not
+   * the index name), so match both columns — a primary-key collision or any
+   * future unique index on the table is NOT mis-mapped to the name-taken 409.
+   */
   private isDuplicateNameError(error: unknown): boolean {
+    if (!(error instanceof QueryFailedError)) {
+      return false;
+    }
+    const driver = error.driverError as {
+      code?: string | number;
+      message?: string;
+    };
+    const message = (driver.message ?? error.message).toLowerCase();
     return (
-      error instanceof QueryFailedError &&
-      /UNIQUE constraint failed: equipment_profiles/i.test(error.message)
+      message.includes('equipment_profiles.owner_id') &&
+      message.includes('equipment_profiles.name')
     );
   }
 

--- a/packages/api/src/equipment/services/equipment-profile.service.ts
+++ b/packages/api/src/equipment/services/equipment-profile.service.ts
@@ -74,19 +74,7 @@ export class EquipmentProfileService {
     });
 
     this.assertValid(ownerId, entity);
-
-    try {
-      return await this.repo.save(entity);
-    } catch (error) {
-      // Backstop for the check-then-save race (and any path that bypasses
-      // assertNameAvailable): the composite unique index rejects a duplicate
-      // (owner_id, name) with a QueryFailedError — surface it as a clean 409
-      // rather than letting it fall through as a 500.
-      if (this.isDuplicateNameError(error)) {
-        throw new EquipmentProfileNameTakenException();
-      }
-      throw error;
-    }
+    return this.saveOrThrowOnDuplicateName(entity);
   }
 
   /**
@@ -105,6 +93,24 @@ export class EquipmentProfileService {
     });
     if (existing) {
       throw new EquipmentProfileNameTakenException();
+    }
+  }
+
+  /**
+   * Persists an entity, converting the composite unique-index violation on
+   * (owner_id, name) into a clean 409 for BOTH create and rename (updateMine)
+   * — otherwise the raw QueryFailedError surfaces as a 500.
+   */
+  private async saveOrThrowOnDuplicateName(
+    entity: EquipmentProfileOrmEntity,
+  ): Promise<EquipmentProfileOrmEntity> {
+    try {
+      return await this.repo.save(entity);
+    } catch (error) {
+      if (this.isDuplicateNameError(error)) {
+        throw new EquipmentProfileNameTakenException();
+      }
+      throw error;
     }
   }
 
@@ -176,7 +182,9 @@ export class EquipmentProfileService {
     if (dto.system_type !== undefined) entity.system_type = dto.system_type;
 
     this.assertValid(ownerId, entity);
-    return this.repo.save(entity);
+    // A rename that collides with another of the owner's profiles hits the same
+    // unique index — map it to a 409 too (F21), not a 500.
+    return this.saveOrThrowOnDuplicateName(entity);
   }
 
   async deleteMine(ownerId: string, id: string): Promise<{ deleted: true }> {

--- a/packages/api/test/equipment-profile.e2e-spec.ts
+++ b/packages/api/test/equipment-profile.e2e-spec.ts
@@ -137,4 +137,51 @@ describe('Equipment profile create (e2e — E1)', () => {
       })
       .expect(401);
   });
+
+  // F21 — a second profile with the same name for the same owner is a 409.
+  it('rejects a duplicate profile name for the same owner with 409', async () => {
+    const { token } = await register();
+    const body = {
+      name: 'Mon matériel',
+      fermenter_volume_l: 23,
+      boil_kettle_volume_l: 30,
+      system_type: EquipmentSystemType.ALL_GRAIN,
+    };
+
+    await request(app.getHttpServer())
+      .post('/equipment-profiles')
+      .set('Authorization', `Bearer ${token}`)
+      .send(body)
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post('/equipment-profiles')
+      .set('Authorization', `Bearer ${token}`)
+      .send(body)
+      .expect(409);
+  });
+
+  // F21 — uniqueness is per owner: two different users may reuse the same name.
+  it('allows the same profile name for two different owners', async () => {
+    const first = await register();
+    const second = await register();
+    const body = {
+      name: 'Setup partagé',
+      fermenter_volume_l: 23,
+      boil_kettle_volume_l: 30,
+      system_type: EquipmentSystemType.ALL_GRAIN,
+    };
+
+    await request(app.getHttpServer())
+      .post('/equipment-profiles')
+      .set('Authorization', `Bearer ${first.token}`)
+      .send(body)
+      .expect(201);
+
+    await request(app.getHttpServer())
+      .post('/equipment-profiles')
+      .set('Authorization', `Bearer ${second.token}`)
+      .send(body)
+      .expect(201);
+  });
 });

--- a/packages/mobile-app/src/features/equipment/domain/equipment-system-options.ts
+++ b/packages/mobile-app/src/features/equipment/domain/equipment-system-options.ts
@@ -14,23 +14,28 @@ export interface EquipmentSystemOption {
   help: string;
 }
 
+// Labels are framed on the *equipment* axis (number of vessels), not the
+// method — a novice can tell "separate vessels" from "single vessel" more
+// easily than "tout-grain" from "BIAB" (F17).
 export const EQUIPMENT_SYSTEM_OPTIONS: readonly EquipmentSystemOption[] = [
   {
+    // Extract has no vessel-count distinction, so label and shortLabel are
+    // intentionally identical (F17 wording).
     value: "extract",
     shortLabel: "Extrait",
-    label: "Extrait de malt",
+    label: "Extrait",
     help: "Kit ou extrait : pas d'empâtage, on dilue puis on fait bouillir.",
   },
   {
     value: "all-grain",
-    shortLabel: "Tout-grain",
-    label: "Tout grain",
-    help: "Empâtage en cuve séparée, puis ébullition.",
+    shortLabel: "Cuves séparées",
+    label: "Cuves séparées",
+    help: "Empâtage dans une cuve, puis ébullition dans une autre.",
   },
   {
     value: "all-in-one",
-    shortLabel: "Tout-en-un",
-    label: "Tout-en-un (BIAB)",
+    shortLabel: "Cuve unique",
+    label: "Cuve unique (BIAB)",
     help: "Une seule cuve pour empâter et bouillir (Braumeister, Grainfather…).",
   },
 ];

--- a/packages/mobile-app/src/features/equipment/presentation/EquipmentWizardScreen.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/EquipmentWizardScreen.tsx
@@ -4,7 +4,7 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
-import { getErrorMessage } from "@/core/http/http-error";
+import { HttpError, getErrorMessage } from "@/core/http/http-error";
 import { createEquipmentProfile } from "@/features/equipment/application/equipment.use-cases";
 import {
   EQUIPMENT_SYSTEM_OPTIONS,
@@ -80,6 +80,14 @@ export function EquipmentWizardScreen() {
       router.replace("/equipment");
     },
   });
+
+  // A 409 means the name is already used by another of the user's profiles
+  // (F21) — show a clear French hint instead of the raw server message.
+  const errorMessage = mutationError
+    ? mutationError instanceof HttpError && mutationError.status === 409
+      ? "Un matériel porte déjà ce nom. Choisis-en un autre."
+      : getErrorMessage(mutationError, "Échec de la création du matériel")
+    : null;
 
   const isStepValid = ((): boolean => {
     switch (step) {
@@ -246,11 +254,9 @@ export function EquipmentWizardScreen() {
         </Card>
       ) : null}
 
-      {mutationError ? (
+      {errorMessage ? (
         <Card style={[styles.card, styles.blockCard]}>
-          <Text style={styles.blockText}>
-            {getErrorMessage(mutationError, "Échec de la création du matériel")}
-          </Text>
+          <Text style={styles.blockText}>{errorMessage}</Text>
         </Card>
       ) : null}
 

--- a/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentWizardScreen.test.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentWizardScreen.test.tsx
@@ -9,6 +9,7 @@ import {
 import { EquipmentProfile } from "@/features/equipment/domain/equipment.types";
 import { EquipmentWizardScreen } from "@/features/equipment/presentation/EquipmentWizardScreen";
 import React from "react";
+import { HttpError } from "@/core/http/http-error";
 import { createEquipmentProfile } from "@/features/equipment/application/equipment.use-cases";
 
 const mockReplace = jest.fn();
@@ -37,7 +38,7 @@ const mockedCreate = createEquipmentProfile as jest.MockedFunction<
 const CREATED_PROFILE: EquipmentProfile = {
   id: "eq-1",
   ownerId: "u-1",
-  name: "Tout-grain 23 L",
+  name: "Cuves séparées 23 L",
   mashTunVolumeL: 30,
   boilKettleVolumeL: 30,
   fermenterVolumeL: 23,
@@ -92,7 +93,7 @@ describe("EquipmentWizardScreen", () => {
 
     await waitFor(() => {
       expect(mockedCreate).toHaveBeenCalledWith({
-        name: "Tout-grain 23 L",
+        name: "Cuves séparées 23 L",
         systemType: "all-grain",
         fermenterVolumeL: 23,
         boilKettleVolumeL: 30,
@@ -121,6 +122,30 @@ describe("EquipmentWizardScreen", () => {
 
     await waitFor(() => {
       expect(screen.getByText("network down")).toBeTruthy();
+    });
+  });
+
+  it("labels the system types on the equipment axis (F17)", () => {
+    renderScreen();
+
+    expect(screen.getByText("Extrait")).toBeTruthy();
+    expect(screen.getByText("Cuves séparées")).toBeTruthy();
+    expect(screen.getByText("Cuve unique (BIAB)")).toBeTruthy();
+  });
+
+  it("shows a French duplicate-name message on a 409 (F21)", async () => {
+    mockedCreate.mockRejectedValue(
+      new HttpError(409, "An equipment profile with this name already exists"),
+    );
+
+    renderScreen();
+    completeAllSteps();
+    fireEvent.press(screen.getByTestId("equipment-wizard-create"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Un matériel porte déjà ce nom. Choisis-en un autre."),
+      ).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Summary

Slice 3 of the novice-journey backlog — equipment wizard polish (API + mobile). Two frictions from the live audit:

- **F21 — block duplicate equipment profile names per owner.** A user could silently create two profiles with the same name. A composite unique index on `(owner_id, name)` is now the durable guarantee (the migration defensively de-dups any pre-existing rows first, so the boot-time `migrationsRun` cannot fail on prod data). The service rejects a duplicate up front with a 409 `EquipmentProfileNameTakenException`, and also converts a unique-constraint `QueryFailedError` from `save()` into the same 409 to close the check-then-save race. The mobile wizard maps the 409 to a clear French message (« Un matériel porte déjà ce nom. Choisis-en un autre. ») instead of the raw server text.
- **F17 — relabel the three system types on the equipment axis** (number of vessels): « Extrait » / « Cuves séparées » / « Cuve unique (BIAB) » — easier for a novice than « tout-grain » vs « BIAB ».

## Context

Baby-step iterative slice (after #1280, #1281). This one has a backend change, so it needs an API redeploy (the migration runs at boot) + a fresh APK to live-test.

## Tests

- API: `service.spec` — duplicate name → 409 (no save); unique-constraint `QueryFailedError` → 409 (race backstop); existing happy paths made explicit (`findOne → null`). e2e — same name/same owner → 409; same name/different owners → both 201.
- Mobile: wizard — the three equipment-axis labels render (F17); a 409 shows the French duplicate-name message (F21).
- Verified locally: API service spec 18/18 + `nest build` + lint; mobile prettier + equipment suites 19/19 + lint + 0 new typecheck errors.

## Checklist

- [x] Lint + build/prettier clean on changed files
- [x] Tests added (happy + sad + edge)
- [x] Migration is safe on existing data (de-dups before the unique index)
- [x] Conventional Commits

Also records PR #1281 in PROJECT_LOG.md.