### PR TITLE
docs(brew-day/architecture): add UML deliverables for the brewing-assistant step machine

### DIFF
--- a/docs/architecture/diagrams/batches/05-state-batch-lifecycle.md
+++ b/docs/architecture/diagrams/batches/05-state-batch-lifecycle.md
@@ -3,6 +3,8 @@
 > **Feature**: epic #595; status model (#605).
 > **Related**: the per-step state machine is the sibling brewing-session
 > conception (PR #1096 → `diagrams/brewing-session/05-state-batch-step.md`).
+> **Refined (brew-day scope)**: `../brew-day/07-state-batch-lifecycle.md` renames `planned`
+> to `draft` (« en préparation », now CARRYING the prep — F14/F15) and adds `cancelled` (F16).
 
 ## Context
 

--- a/docs/architecture/diagrams/brew-day/06-state-brew-step.md
+++ b/docs/architecture/diagrams/brew-day/06-state-brew-step.md
@@ -28,7 +28,7 @@ stateDiagram-v2
     paused --> active: Resume
   }
 
-  in_progress --> completed: Complete
+  active --> completed: Complete
   completed --> in_progress: Reopen
   pending --> skipped: Skip
   in_progress --> skipped: Skip
@@ -51,18 +51,22 @@ stateDiagram-v2
 - **Phase mapping to the existing enum (minimal reconciliation).** `prep` and `active` are the
   two inner phases of the existing `in_progress` status — modelled as an inner `phase`
   attribute, **not** new step statuses. TERMINÉ maps to the existing `completed`. So the step
-  keeps `pending / in_progress / completed`; only `paused` / `skipped` are new (inherited from
-  the brewing-session machine, implementation deferred). No breaking status change.
+  keeps its `pending / in_progress / completed` statuses; the two additions sit at **different
+  levels** — `paused` is a new **inner phase** of `in_progress` (like `prep` / `active`, not a
+  status), while `skipped` is a new **top-level status**. Both are inherited from the
+  brewing-session machine (implementation deferred). No breaking change to the existing statuses.
 - **PRÉP → ACTIF is the F1 fix.** `Start` is an actor-gated ✋ transition ("prep done, go") — it
   is what starts the countdown. In PRÉP no timer runs, so a novice heating strike water is not
   stressed by a ticking clock (the central audit friction).
-- **Complete is a ✋ confirm (F6, already shipped) and is reversible.** `Complete` exits the
-  `in_progress` composite **from the `active` phase** — the acknowledgment that generalises B3's
-  bottling checkbox pattern; `Reopen` re-enters the `in_progress` composite and **resumes at the
-  `active` phase** (history semantics — the concrete re-entry point is an implementation detail,
-  not depicted), undoing an accidental completion and moving the batch pointer back (see `07`). The
-  transitions are drawn on the **composite boundary** (`in_progress`), so `prep`/`active` stay
-  internal phases — never top-level states (the whole point of the composite).
+- **Complete is a ✋ confirm (F6, already shipped) and is reversible.** `Complete` is an
+  **explicit exit from the `active` phase** (`active --> completed`) — the acknowledgment that
+  generalises B3's bottling checkbox pattern. A step the brewer never performs is `Skip`ped, not
+  `Complete`d — so Complete originates in ACTIF, never PRÉP. `Reopen` re-enters the `in_progress`
+  composite (`completed --> in_progress`), undoing an accidental completion and moving the batch
+  pointer back (see `07`); the concrete re-entry phase (redo PRÉP vs resume ACTIF) is an
+  implementation detail, not depicted. `Reopen` and `Skip` are drawn on the **composite boundary**
+  so they apply to the whole `in_progress` state; either way `prep` / `active` stay internal
+  phases — never top-level states (the whole point of the composite).
 - **ACTIF end is unified (F5).** A step always ends on ✋ `Complete`; the timer is an optional
   aid when `plannedDurationMin` is known. Event-gated steps (e.g. "chill to 20°C", "gravity
   stable") simply have no timer and state the end condition in the guidance — no separate step

--- a/docs/architecture/diagrams/brew-day/06-state-brew-step.md
+++ b/docs/architecture/diagrams/brew-day/06-state-brew-step.md
@@ -1,0 +1,82 @@
+# State diagram — brew-day — brew step lifecycle (PRÉP → ACTIF → TERMINÉ)
+
+> **Feature**: brewing assistant / brew-day guidance layer (novice-journey audit F1–F12).
+> **Related**: supersedes `../brewing-session/05-state-batch-step.md` (#868/#608) for brew-day; see `07-state-batch-lifecycle.md` (batch level) and ADR-0021 D5 (adaptive pedagogy).
+> **Decisions captured**: debrief 2026-07-01 — PRÉP/ACTIF are internal phases of a step (composite `in_progress`); unified ✋ Complete + optional timer; reversible Complete; in-app T-minus cue.
+
+## Context
+
+The lifecycle of a single `BatchStep` during live brewing, refined so each step is a
+**three-phase sub-machine PRÉP → ACTIF → TERMINÉ** instead of the current atomic
+`pending → in_progress → completed`. Goal: make every step as guided as the bottling step
+(B3), and fix the root friction F1 (the countdown must not start before the brewer has done
+the physical prep). This diagram covers ONE step; the batch-level lifecycle is `07`. It does
+NOT cover the per-step-type guidance text (that is `01-sequence-step-enrichment.md`).
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending
+
+  pending --> in_progress: Open step
+
+  state in_progress {
+    [*] --> prep
+    prep --> active: Start
+    active --> paused: Pause
+    paused --> active: Resume
+  }
+
+  in_progress --> completed: Complete
+  completed --> in_progress: Reopen
+  pending --> skipped: Skip
+  in_progress --> skipped: Skip
+
+  completed --> [*]
+  skipped --> [*]
+
+  note right of prep
+    PRÉP — guided "do X", no timer yet (F1 fix).
+  end note
+
+  note right of active
+    ACTIF — timer starts here (optional aid);
+    actualStart persisted (survives app close).
+  end note
+```
+
+## Notes
+
+- **Phase mapping to the existing enum (minimal reconciliation).** `prep` and `active` are the
+  two inner phases of the existing `in_progress` status — modelled as an inner `phase`
+  attribute, **not** new step statuses. TERMINÉ maps to the existing `completed`. So the step
+  keeps `pending / in_progress / completed`; only `paused` / `skipped` are new (inherited from
+  the brewing-session machine, implementation deferred). No breaking status change.
+- **PRÉP → ACTIF is the F1 fix.** `Start` is an actor-gated ✋ transition ("prep done, go") — it
+  is what starts the countdown. In PRÉP no timer runs, so a novice heating strike water is not
+  stressed by a ticking clock (the central audit friction).
+- **Complete is a ✋ confirm (F6, already shipped) and is reversible.** `Complete` exits the
+  `in_progress` composite **from the `active` phase** — the acknowledgment that generalises B3's
+  bottling checkbox pattern; `Reopen` re-enters the `in_progress` composite and **resumes at the
+  `active` phase** (history semantics — the concrete re-entry point is an implementation detail,
+  not depicted), undoing an accidental completion and moving the batch pointer back (see `07`). The
+  transitions are drawn on the **composite boundary** (`in_progress`), so `prep`/`active` stay
+  internal phases — never top-level states (the whole point of the composite).
+- **ACTIF end is unified (F5).** A step always ends on ✋ `Complete`; the timer is an optional
+  aid when `plannedDurationMin` is known. Event-gated steps (e.g. "chill to 20°C", "gravity
+  stable") simply have no timer and state the end condition in the guidance — no separate step
+  *type* is introduced.
+- **Derived state, not transitions (from brewing-session/05).** The hop-addition cues, the
+  **T-minus pre-announce** of the *next* step's PRÉP (F9, in-app cue for v1 — real background
+  notifications are a later epic), and the *overdue* alert (`now > plannedEnd` while `active`)
+  are all **derived** from the step + timer state; they are not modelled as transitions.
+- **Pause / Skip** are inherited from `brewing-session/05-state-batch-step.md`: `Pause` freezes
+  the timer (stays inside `in_progress`); `Skip` (with a reason, confirm) is for optional phases
+  only (whirlpool, dry hop). This diagram subsumes that one for the brew-day scope.
+- **Pedagogy hook (ADR-0021 D5).** Each phase carries the adaptive "why?" (inline + foldable +
+  glossary), tuned to the declared brewer level — surfaced in PRÉP (what to do) and ACTIF (what
+  is happening). Not a state; an overlay on every phase.
+- **Open question.** Reopen semantics when the batch has already advanced several steps — bound
+  Reopen to the *current* step only, or allow reopening any completed step? Resolve at
+  implementation (baby-step slice).

--- a/docs/architecture/diagrams/brew-day/07-state-batch-lifecycle.md
+++ b/docs/architecture/diagrams/brew-day/07-state-batch-lifecycle.md
@@ -1,0 +1,83 @@
+# State diagram — brew-day — batch lifecycle (draft → archived)
+
+> **Feature**: brewing assistant / brew-day guidance layer (novice-journey audit).
+> **Related**: refines `../batches/05-state-batch-lifecycle.md` (#595/#605) for the brew-day
+> scope; the per-step machine that drives `in_progress` is `06-state-brew-step.md`.
+> **Decisions captured**: debrief 2026-07-01 — a batch created by "Préparer" is a reversible
+> `draft` (« en préparation ») that CARRIES the prep; add `cancelled` (abandon a launched brew).
+
+## Context
+
+The batch's overall lifecycle as the journal tracks it — coarser than the per-step machine
+(`06`), it is what the list status badge reflects. This refines `batches/05` by making the
+pre-launch state a first-class **`draft` (« en préparation »)** that holds the mise-en-place
+checklist (fixes F14/F15), and by adding **`cancelled`** for abandoning a launched brew (F16).
+It does NOT model the per-step phases (that is `06`).
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> draft: Prepare a recipe
+
+  draft --> in_progress: Launch
+  draft --> discarded: Discard
+
+  in_progress --> completed: Last step complete
+  in_progress --> cancelled: Cancel
+
+  completed --> archived: Archive
+  cancelled --> archived: Archive
+
+  completed --> [*]
+  archived --> [*]
+  cancelled --> [*]
+  discarded --> [*]
+
+  note right of draft
+    « En préparation » — the batch created by
+    "Préparer" CARRIES the mise-en-place checklist
+    (F14/F15): the prep lives on the batch, not the
+    recipe. Reversible / discardable before launch.
+  end note
+
+  note right of in_progress
+    Driven by the per-step machine (06). The batch
+    advances as each step reaches TERMINÉ; the last
+    step (Packaging) completing moves it to completed.
+  end note
+```
+
+## Notes
+
+- **Reconciliation with `batches/05`.** `draft` refines that diagram's `planned` state — same
+  slot (created-from-recipe, not started), but now explicitly **carrying the prep checklist**
+  so the mise-en-place is per-batch and resets each brew (fixes **F14**: the checklist no longer
+  persists on the recipe) and cleanly separates Recipe (template) from Batch (instance) (**F15**).
+- **`Launch`** is the existing pre-brew launch gate (#1266): the irreversible "Lancer le
+  brassage" after the ingredient checklist is complete. It is the `draft → in_progress`
+  transition.
+- **`Cancel` (F16).** `in_progress → cancelled` lets a brewer stop a launched brew (e.g. an
+  accidental launch, or a batch gone wrong) — distinct from `Discard` and `Archive`. Wires the
+  already-existing `DELETE /batches/:id` + a soft `cancelled` status, per the reversibility
+  cluster (F25 shipped the hard delete; this adds the lifecycle states).
+- **`Discard` vs `Archive` (delete mechanics).** `Discard` (`draft → discarded`) is a **hard
+  delete** of a never-launched draft — the same shipped `DELETE /batches/:id` (F25/F22), since a
+  draft has no journal worth keeping. `cancelled` and `archived` are **soft states** that
+  preserve the journal (a cancelled/finished brew stays in history, just hidden from the active
+  list).
+- **`Archive` (F25).** `completed → archived` (and `cancelled → archived`) soft-hides a batch
+  from the active « Mes brassins » list without deleting its journal — declutters the list.
+- **New statuses to persist (deferred — conception only).** `draft`, `cancelled`, `archived`,
+  `discarded` extend the current enum (`in_progress` / `completed`). A migration + the prep
+  moving onto the batch are the implementation work — NOT in this conception slice.
+- **`completed`** still opens the closure/celebration (B3 `BatchClosureView`) and is kept in
+  history; the transition is driven by the last step completing (see `06`). This is the **same
+  `completed` state** already amended by `05-state-batch-closure.md` with the `bottledAt`
+  timestamp + post-closure tasting — unchanged here (see `05` for that slice).
+- **Two levels kept separate** (as in `batches/05`): the fine-grained step phases
+  (`prep`/`active`/`paused`) live on `BatchStep` (`06`), never on the batch — a batch is
+  `in_progress` regardless of which phase its current step is in.
+- **Reopen-scope dependency (see `06`).** The open question in `06` — whether Reopen targets any
+  completed step or only the current one — affects the batch `currentStepOrder` pointer and the
+  "in_progress regardless of phase" claim above. Resolve before the implementation slice.

--- a/docs/architecture/diagrams/brew-day/07-state-batch-lifecycle.md
+++ b/docs/architecture/diagrams/brew-day/07-state-batch-lifecycle.md
@@ -58,19 +58,24 @@ stateDiagram-v2
   brassage" after the ingredient checklist is complete. It is the `draft → in_progress`
   transition.
 - **`Cancel` (F16).** `in_progress → cancelled` lets a brewer stop a launched brew (e.g. an
-  accidental launch, or a batch gone wrong) — distinct from `Discard` and `Archive`. Wires the
-  already-existing `DELETE /batches/:id` + a soft `cancelled` status, per the reversibility
-  cluster (F25 shipped the hard delete; this adds the lifecycle states).
+  accidental launch, or a batch gone wrong) — distinct from `Discard` and `Archive`. It is a
+  **status update to a soft `cancelled` state** (a new `PATCH` on the batch), **not** the
+  `DELETE /batches/:id` endpoint: cancelling **preserves the journal** (the brew stays in history,
+  hidden from the active list). The existing hard-deleting `DELETE` (F25/F22) is reserved for
+  `Discard` below.
 - **`Discard` vs `Archive` (delete mechanics).** `Discard` (`draft → discarded`) is a **hard
   delete** of a never-launched draft — the same shipped `DELETE /batches/:id` (F25/F22), since a
-  draft has no journal worth keeping. `cancelled` and `archived` are **soft states** that
-  preserve the journal (a cancelled/finished brew stays in history, just hidden from the active
-  list).
+  draft has no journal worth keeping; `discarded` is therefore **not a stored status** but the
+  terminal "row removed" outcome, drawn only to close the diagram. `cancelled` and `archived` are
+  **soft states** that preserve the journal (a cancelled/finished brew stays in history, just
+  hidden from the active list).
 - **`Archive` (F25).** `completed → archived` (and `cancelled → archived`) soft-hides a batch
   from the active « Mes brassins » list without deleting its journal — declutters the list.
-- **New statuses to persist (deferred — conception only).** `draft`, `cancelled`, `archived`,
-  `discarded` extend the current enum (`in_progress` / `completed`). A migration + the prep
-  moving onto the batch are the implementation work — NOT in this conception slice.
+- **New statuses to persist (deferred — conception only).** `draft`, `cancelled`, `archived`
+  extend the current enum (`in_progress` / `completed`). `discarded` is **not** a stored status —
+  it is the terminal outcome of the hard delete (the draft row is removed), shown as a state only
+  to close the diagram. A migration + the prep moving onto the batch are the implementation
+  work — NOT in this conception slice.
 - **`completed`** still opens the closure/celebration (B3 `BatchClosureView`) and is kept in
   history; the transition is driven by the last step completing (see `06`). This is the **same
   `completed` state** already amended by `05-state-batch-closure.md` with the `bottledAt`

--- a/docs/architecture/diagrams/brew-day/08-sequence-jit-density.md
+++ b/docs/architecture/diagrams/brew-day/08-sequence-jit-density.md
@@ -1,0 +1,55 @@
+# Sequence diagram — brew-day — just-in-time density prompts (OG / FG)
+
+> **Feature**: brewing assistant / brew-day guidance layer (novice-journey audit F3).
+> **Related**: reuses the B2 measurement flow `02-sequence-record-gravity-measurement.md`; the
+> phase context (fermentation ACTIF / end) comes from the step machine `06-state-brew-step.md`.
+> **Decisions captured**: debrief 2026-07-01 — density entry is gated to the moment it makes
+> sense (OG at pitch, FG at fermentation end), not offered out of context from the mash.
+
+## Context
+
+`sd` — WHEN the app surfaces the gravity-entry affordances, tied to the fermentation step's
+phase. Today the density card is offered out of context (from the mash), which confuses a
+novice (F3). This gates OG to the entry of fermentation ACTIF (pitch) and FG to the end of
+fermentation (before Packaging). It does NOT change the measurement endpoint or the ABV maths
+(those are B2, `02`).
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant M as Mobile — BatchDetailsScreen
+  participant API as Backend API
+
+  Note over M: Gate — current step = Fermentation, phase = ACTIF (06), yeast just pitched
+  M->>B: Surface "Note the original gravity (OG)"
+  B->>M: Enter OG
+  M->>API: POST /batches/:id/measurements — og
+  API-->>M: 201
+
+  Note over M: Gate — Fermentation nearing end (gravity stabilising) or before Packaging (06)
+  M->>B: Surface "Note the final gravity (FG)"
+  B->>M: Enter FG
+  M->>API: POST /batches/:id/measurements — fg
+  API-->>M: 201
+  M->>M: Compute ABV from OG and FG
+  M->>B: Show ABV + "stable 2–3 days = done"
+```
+
+## Notes
+
+- **JIT gating is the F3 fix.** The OG affordance appears only when the fermentation step enters
+  ACTIF (yeast pitched); the FG affordance appears only near fermentation end (or before the
+  Packaging step). The density card is **no longer offered from the mash**. The gating condition
+  is derived from the current step + phase (`06`), not a new endpoint.
+- **Reuse, don't rebuild.** The recording flow, `POST /batches/:id/measurements`, and the ABV
+  formula `(OG − FG) × 131.25` are the shipped B2 feature (`02`). This diagram only moves *when*
+  the prompt is shown.
+- **Escape hatch (already shipped).** "Je n'ai pas de densimètre" stays available at both
+  moments — advice, never a blocker (B2). A brewer without a hydrometer is not stuck.
+- **Pedagogy (ADR-0021 D5).** Each prompt carries the "why?" (OG = sugar available before
+  fermentation; FG = what's left → alcohol) tuned to the brewer level.
+- **Fermentation timeline (F11) is a sibling, deferred.** The forecast timeline + milestones
+  (J0 pitch+OG, J1-3 krausen, J~7 slows, J10-14 stable→FG) is a richer P2 concern; this diagram
+  only fixes the density-prompt timing.

--- a/docs/architecture/diagrams/brewing-session/05-state-batch-step.md
+++ b/docs/architecture/diagrams/brewing-session/05-state-batch-step.md
@@ -2,6 +2,9 @@
 
 > **Feature**: step state machine #608; epic #868.
 > **Source spec**: `docs/architecture/specs/brewing-session.md` § Step lifecycle.
+> **Superseded (brew-day scope)**: `../brew-day/06-state-brew-step.md` refines this step
+> machine with the internal PRÉP → ACTIF → TERMINÉ phases (novice-journey audit F1/F4/F5/F9);
+> it subsumes the pause/skip transitions below.
 
 ## Context
 


### PR DESCRIPTION
## Summary

UML conception (contract, **no code**) for the brewing-assistant structural block surfaced by the novice-journey audit. Debriefed with the founder 2026-07-01. Three new diagrams under `docs/architecture/diagrams/brew-day/`:

- **`06-state-brew-step.md`** — each brew step becomes a composite `in_progress` sub-machine **PRÉP → ACTIF → TERMINÉ**. The countdown starts only on PRÉP→ACTIF (fixes **F1**: the timer no longer runs before the physical prep); Complete is a ✋ acknowledgment (**F6**) and reversible; ACTIF ends uniformly on Complete with the timer as an optional aid (**F5**). `prep`/`active` are **inner phases of the existing `in_progress` status** — no new step enum value. Subsumes `brewing-session/05` (pause/skip).
- **`07-state-batch-lifecycle.md`** — `draft` (« en préparation », now **carrying the prep checklist** — fixes **F14/F15**) → `in_progress` → `completed` → `archived`, plus `cancelled` (abandon a launched brew, **F16**) and `discarded`. Refines `batches/05` (`planned` → `draft`).
- **`08-sequence-jit-density.md`** — OG prompt gated to fermentation ACTIF entry, FG to fermentation end (fixes **F3**: no more out-of-context density card). Reuses the shipped B2 endpoint.

Renvoi notes added on the two superseded diagrams (`brewing-session/05`, `batches/05`). All three render-validated with mermaid-cli; reviewed via the pre-push ritual (composite-state orthodoxy + cross-references fixed).

## Context

The UML-first contract for the biggest novice-journey lever (the « missing guidance layer »). **Implementation follows in baby-step slices**, one step-type / feature at a time, conforming to these diagrams. No migration / no code here (conception only).

## Checklist

- [x] UML 2.5 conformant (state machines + one sequence; no type-mixing)
- [x] Coherent with existing diagrams + ADRs (renvoi notes in place)
- [x] Mermaid render-validated (mermaid-cli)
- [x] Docs only — no code, no migration

Refs #868