### PR TITLE
feat(batches): derive PRÉP/ACTIF step phase from startedAt (F1)

### DIFF
--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -281,6 +281,20 @@ describe('BatchService', () => {
     ).rejects.toThrow(NotFoundException);
   });
 
+  it('startMineCurrentStep() should 409 (not 500) when the step is already active', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    // First activation succeeds (PRÉP -> ACTIF)...
+    await batchService.startMineCurrentStep(ownerId, started.batch.id);
+
+    // ...a second one is a normal conflict, surfaced as a client 409, not a 500.
+    await expect(
+      batchService.startMineCurrentStep(ownerId, started.batch.id),
+    ).rejects.toThrow(ConflictException);
+  });
+
   it('listMine() should filter by owner and order by updated_at desc', async () => {
     const ownerId = 'user-1';
     const otherOwner = 'user-2';

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -252,6 +252,35 @@ describe('BatchService', () => {
     ).rejects.toThrow(NotFoundException);
   });
 
+  it('startMineCurrentStep() should activate the current step (set started_at)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+
+    const started = await batchService.startMine(ownerId, recipe.id);
+    // PRÉP: the current step is in progress but not yet timed (F1)
+    expect(started.steps[0].status).toBe(BatchStepStatus.IN_PROGRESS);
+    expect(started.steps[0].started_at).toBeNull();
+
+    const activated = await batchService.startMineCurrentStep(
+      ownerId,
+      started.batch.id,
+    );
+
+    expect(activated.steps[0].status).toBe(BatchStepStatus.IN_PROGRESS);
+    expect(activated.steps[0].started_at).toBeTruthy();
+    expect(activated.batch.current_step_order).toBe(0);
+  });
+
+  it('startMineCurrentStep() should enforce ownership', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.startMineCurrentStep('user-2', started.batch.id),
+    ).rejects.toThrow(NotFoundException);
+  });
+
   it('listMine() should filter by owner and order by updated_at desc', async () => {
     const ownerId = 'user-1';
     const otherOwner = 'user-2';

--- a/packages/api/src/batch/controllers/batch.controller.spec.ts
+++ b/packages/api/src/batch/controllers/batch.controller.spec.ts
@@ -114,6 +114,7 @@ describe('BatchController', () => {
             listMineReminders: jest.fn(),
             createMineReminder: jest.fn(),
             updateMineReminder: jest.fn(),
+            startMineCurrentStep: jest.fn(),
             completeMineCurrentStep: jest.fn(),
             listMineMeasurements: jest.fn(),
             createMineMeasurement: jest.fn(),
@@ -291,6 +292,34 @@ describe('BatchController', () => {
 
       // Verify
       expect(completeMineCurrentStepSpy).toHaveBeenCalledWith(
+        mockUser.id,
+        mockBatchOrm.id,
+      );
+      expect(result).toBeDefined();
+    });
+  });
+
+  /**
+   * POST /batches/:id/steps/current/start - Activate current step (PRÉP -> ACTIF)
+   */
+  describe('startMineCurrentStep() - POST /batches/:id/steps/current/start', () => {
+    it('should activate the current step', async () => {
+      // Setup
+      const startMineCurrentStepSpy = jest
+        .spyOn(service, 'startMineCurrentStep')
+        .mockResolvedValue({
+          batch: mockBatchOrm,
+          steps: mockSteps,
+        });
+
+      // Execute
+      const result = await controller.startMineCurrentStep(
+        mockUser,
+        mockBatchOrm.id,
+      );
+
+      // Verify
+      expect(startMineCurrentStepSpy).toHaveBeenCalledWith(
         mockUser.id,
         mockBatchOrm.id,
       );

--- a/packages/api/src/batch/controllers/batch.controller.ts
+++ b/packages/api/src/batch/controllers/batch.controller.ts
@@ -102,6 +102,21 @@ export class BatchController {
     await this.service.deleteMine(user.id, id);
   }
 
+  @Post(':id/steps/current/start')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Activate the current batch step (PRÉP → ACTIF)' })
+  @ApiOkResponse({ type: BatchDto })
+  async startMineCurrentStep(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<BatchDto> {
+    const { batch, steps } = await this.service.startMineCurrentStep(
+      user.id,
+      id,
+    );
+    return BatchDto.fromEntities(batch, steps);
+  }
+
   @Post(':id/steps/current/complete')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Complete the current batch step' })

--- a/packages/api/src/batch/domain/batch.domain.spec.ts
+++ b/packages/api/src/batch/domain/batch.domain.spec.ts
@@ -6,7 +6,7 @@ import { BatchStatus } from './enums/batch-status.enum';
 import { BatchDomainService } from './services/batch-domain.service';
 
 describe('BatchDomainService', () => {
-  it('should start a batch and auto-start step 0', () => {
+  it('should start a batch and open step 0 in PRÉP (no startedAt yet)', () => {
     const t0 = new Date('2026-02-05T09:00:00.000Z');
     const service = new BatchDomainService(() => t0);
 
@@ -41,7 +41,9 @@ describe('BatchDomainService', () => {
       BatchStepStatus.PENDING,
       BatchStepStatus.PENDING,
     ]);
-    expect(batch.steps[0].startedAt).toEqual(t0);
+    // PRÉP: the current step is in progress but not yet activated — the
+    // countdown only starts once the brewer runs startCurrentStep (F1).
+    expect(batch.steps[0].startedAt).toBeUndefined();
   });
 
   it('enriches each step with type-level pedagogical guidance', () => {
@@ -101,7 +103,8 @@ describe('BatchDomainService', () => {
     expect(batch.steps[0].status).toBe(BatchStepStatus.COMPLETED);
     expect(batch.steps[0].completedAt).toEqual(t1);
     expect(batch.steps[1].status).toBe(BatchStepStatus.IN_PROGRESS);
-    expect(batch.steps[1].startedAt).toEqual(t1);
+    // the advanced step opens in PRÉP too — activated on demand, not on advance
+    expect(batch.steps[1].startedAt).toBeUndefined();
 
     batch = service.completeCurrentStep(batch); // t2
     batch = service.completeCurrentStep(batch); // t3
@@ -113,6 +116,108 @@ describe('BatchDomainService', () => {
     expect(batch.completedAt).toEqual(t5);
     expect(batch.steps[4].status).toBe(BatchStepStatus.COMPLETED);
     expect(batch.steps[4].completedAt).toEqual(t5);
+  });
+
+  it('should activate the current step (PRÉP -> ACTIF) and set startedAt', () => {
+    const t0 = new Date('2026-02-05T09:00:00.000Z');
+    const t1 = new Date('2026-02-05T09:05:00.000Z');
+    const timestamps = [t0, t1];
+    const service = new BatchDomainService(() => {
+      const next = timestamps.shift();
+      if (!next) throw new Error('Missing timestamp');
+      return next;
+    });
+
+    const started = service.startBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+      steps: new RecipeWorkflowService().getDefaultWorkflow(),
+    });
+    expect(started.steps[0].startedAt).toBeUndefined();
+
+    const active = service.startCurrentStep(started);
+
+    expect(active.steps[0].status).toBe(BatchStepStatus.IN_PROGRESS);
+    expect(active.steps[0].startedAt).toEqual(t1);
+    expect(active.currentStepOrder).toBe(0);
+    expect(active.updatedAt).toEqual(t1);
+  });
+
+  it('should activate the step advanced to after a completion', () => {
+    const t0 = new Date('2026-02-05T09:00:00.000Z');
+    const t1 = new Date('2026-02-05T09:10:00.000Z');
+    const t2 = new Date('2026-02-05T09:12:00.000Z');
+    const timestamps = [t0, t1, t2];
+    const service = new BatchDomainService(() => {
+      const next = timestamps.shift();
+      if (!next) throw new Error('Missing timestamp');
+      return next;
+    });
+
+    let batch = service.startBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+      steps: new RecipeWorkflowService().getDefaultWorkflow(),
+    });
+
+    batch = service.completeCurrentStep(batch); // completes step 0, advances to 1 (PRÉP)
+    expect(batch.steps[1].startedAt).toBeUndefined();
+
+    batch = service.startCurrentStep(batch);
+    expect(batch.steps[1].startedAt).toEqual(t2);
+  });
+
+  it('should throw when activating an already active step', () => {
+    const service = new BatchDomainService(
+      () => new Date('2026-02-05T09:00:00.000Z'),
+    );
+
+    const started = service.startBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+      steps: new RecipeWorkflowService().getDefaultWorkflow(),
+    });
+
+    const active = service.startCurrentStep(started);
+
+    expect(() => service.startCurrentStep(active)).toThrow(
+      'Current step is already active',
+    );
+  });
+
+  it('should throw when activating a step of a completed batch', () => {
+    const t0 = new Date('2026-02-05T09:00:00.000Z');
+    const t1 = new Date('2026-02-05T09:10:00.000Z');
+    const timestamps = [t0, t1];
+    const service = new BatchDomainService(() => {
+      const next = timestamps.shift();
+      if (!next) throw new Error('Missing timestamp');
+      return next;
+    });
+
+    const started = service.startBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+      steps: [
+        {
+          order: 0,
+          type: RecipeStepType.MASH,
+          label: 'Mash',
+          description: 'Single-step test.',
+        },
+      ],
+    });
+
+    const completed = service.completeCurrentStep(started);
+    expect(completed.status).toBe(BatchStatus.COMPLETED);
+
+    expect(() => service.startCurrentStep(completed)).toThrow(
+      'Batch is not in progress',
+    );
   });
 
   it('should throw when completing an already completed batch', () => {

--- a/packages/api/src/batch/domain/services/batch-domain.service.ts
+++ b/packages/api/src/batch/domain/services/batch-domain.service.ts
@@ -21,8 +21,10 @@ export interface StartBatchInput {
  * - Tracking strict workflow progress through steps
  *
  * Current MVP behavior:
- * - Step 0 is auto-started when the batch starts
- * - Completing the current step auto-advances to the next one
+ * - Step 0 becomes the current step when the batch starts, but opens in the
+ *   PRÉP phase (in_progress with no `startedAt`) — the timer only starts once
+ *   the brewer activates it via `startCurrentStep` (ACTIF). See brew-day/06.
+ * - Completing the current step auto-advances to the next one (also in PRÉP)
  */
 export class BatchDomainService {
   constructor(private readonly now: () => Date = () => new Date()) {}
@@ -42,7 +44,10 @@ export class BatchDomainService {
         label: step.label,
         description: step.description,
         status: isFirst ? BatchStepStatus.IN_PROGRESS : BatchStepStatus.PENDING,
-        startedAt: isFirst ? createdAt : undefined,
+        // PRÉP phase: the current step has no `startedAt` until the brewer
+        // activates it (ACTIF). This keeps the countdown from running before
+        // the physical prep is done (novice-journey friction F1).
+        startedAt: undefined,
         completedAt: undefined,
         pedagogicalTip: guidance?.pedagogicalTip,
         plannedDurationMin: guidance?.plannedDurationMin ?? undefined,
@@ -91,7 +96,8 @@ export class BatchDomainService {
         return { ...step, status: BatchStepStatus.COMPLETED, completedAt: now };
       }
       if (step.order === nextOrder) {
-        return { ...step, status: BatchStepStatus.IN_PROGRESS, startedAt: now };
+        // Next step opens in PRÉP (no `startedAt`) — activated later (F1).
+        return { ...step, status: BatchStepStatus.IN_PROGRESS };
       }
       return step;
     });
@@ -113,6 +119,43 @@ export class BatchDomainService {
       updatedAt: now,
       completedAt: now,
     };
+  }
+
+  /**
+   * Activate the current step: PRÉP → ACTIF (brew-day/06).
+   *
+   * Sets `startedAt` on the current in-progress step, which is the anchor the
+   * countdown keys off. Idempotency is the caller's concern: activating an
+   * already-active step (one that already has `startedAt`) is rejected.
+   */
+  startCurrentStep(batch: Batch): Batch {
+    if (batch.status !== BatchStatus.IN_PROGRESS) {
+      throw new Error('Batch is not in progress');
+    }
+
+    const currentOrder = this.getCurrentStepOrder(batch);
+    if (currentOrder === undefined) {
+      throw new Error('Batch has no current step');
+    }
+
+    const current = batch.steps.find((step) => step.order === currentOrder);
+    if (!current) {
+      throw new Error(`Current step ${String(currentOrder)} not found`);
+    }
+    if (current.status !== BatchStepStatus.IN_PROGRESS) {
+      throw new Error('Current step is not in progress');
+    }
+    if (current.startedAt !== undefined) {
+      throw new Error('Current step is already active');
+    }
+
+    const now = this.now();
+
+    const steps: BatchStep[] = batch.steps.map((step) =>
+      step.order === currentOrder ? { ...step, startedAt: now } : step,
+    );
+
+    return { ...batch, steps, updatedAt: now };
   }
 
   private getCurrentStepOrder(batch: Batch): number | undefined {

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -281,6 +281,37 @@ export class BatchService {
   }
 
   /**
+   * Run a pure domain step-transition and translate its state-guard rejections
+   * into HTTP-meaningful errors. The domain throws plain `Error`s for invalid
+   * transitions; without this they would surface as HTTP 500 for what are in
+   * fact normal client-side conflicts (e.g. a double-tap on « Démarrer »).
+   * Unknown errors are re-thrown untouched so genuine bugs still fail loud.
+   */
+  private runStepTransition(
+    transition: (batch: Batch) => Batch,
+    batch: Batch,
+  ): Batch {
+    try {
+      return transition(batch);
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'Current step is already active') {
+          throw new ConflictException(error.message);
+        }
+        const clientErrors = new Set([
+          'Batch is not in progress',
+          'Batch has no current step',
+          'Current step is not in progress',
+        ]);
+        if (clientErrors.has(error.message)) {
+          throw new BadRequestException(error.message);
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Load the owner's batch, run a pure domain transition on it, and persist the
    * result in a single transaction. Shared by the current-step transitions
    * (activate PRÉP → ACTIF, complete). The domain function is the only variable
@@ -311,7 +342,7 @@ export class BatchService {
       });
 
       const domainBatch = this.toDomain(batch, steps);
-      const updated = transition(domainBatch);
+      const updated = this.runStepTransition(transition, domainBatch);
 
       batch.status = updated.status;
       batch.current_step_order = updated.currentStepOrder ?? null;

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -266,6 +266,31 @@ export class BatchService {
     ownerId: string,
     batchId: string,
   ): Promise<BatchWithSteps> {
+    return this.applyCurrentStepTransition(ownerId, batchId, (batch) =>
+      this.domain.completeCurrentStep(batch),
+    );
+  }
+
+  async startMineCurrentStep(
+    ownerId: string,
+    batchId: string,
+  ): Promise<BatchWithSteps> {
+    return this.applyCurrentStepTransition(ownerId, batchId, (batch) =>
+      this.domain.startCurrentStep(batch),
+    );
+  }
+
+  /**
+   * Load the owner's batch, run a pure domain transition on it, and persist the
+   * result in a single transaction. Shared by the current-step transitions
+   * (activate PRÉP → ACTIF, complete). The domain function is the only variable
+   * part; loading, ownership/completed guards, and persistence are common.
+   */
+  private async applyCurrentStepTransition(
+    ownerId: string,
+    batchId: string,
+    transition: (batch: Batch) => Batch,
+  ): Promise<BatchWithSteps> {
     return this.batchRepo.manager.transaction(async (manager) => {
       const batchRepo = manager.getRepository(BatchOrmEntity);
       const stepRepo = manager.getRepository(BatchStepOrmEntity);
@@ -286,7 +311,7 @@ export class BatchService {
       });
 
       const domainBatch = this.toDomain(batch, steps);
-      const updated = this.domain.completeCurrentStep(domainBatch);
+      const updated = transition(domainBatch);
 
       batch.status = updated.status;
       batch.current_step_order = updated.currentStepOrder ?? null;

--- a/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
+++ b/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
@@ -5,6 +5,7 @@ import {
   getBatchDetailsViewModel,
   listBatches,
   startBatch,
+  startCurrentBatchStep,
 } from "@/features/batches/application/batches.use-cases";
 import {
   completeCurrentStep,
@@ -12,6 +13,7 @@ import {
   getMineById,
   listMine,
   startBatch as startBatchApi,
+  startCurrentStep,
 } from "@/features/batches/data/batches.api";
 
 import { dataSource } from "@/core/data/data-source";
@@ -26,6 +28,7 @@ jest.mock("@/core/data/data-source", () => ({
 jest.mock("@/features/batches/data/batches.api", () => ({
   listMine: jest.fn(),
   getMineById: jest.fn(),
+  startCurrentStep: jest.fn(),
   completeCurrentStep: jest.fn(),
   startBatch: jest.fn(),
   deleteBatch: jest.fn(),
@@ -45,6 +48,9 @@ const mockedGetMineById = getMineById as jest.MockedFunction<
 >;
 const mockedCompleteCurrentStep = completeCurrentStep as jest.MockedFunction<
   typeof completeCurrentStep
+>;
+const mockedStartCurrentStep = startCurrentStep as jest.MockedFunction<
+  typeof startCurrentStep
 >;
 const mockedStartBatchApi = startBatchApi as jest.MockedFunction<
   typeof startBatchApi
@@ -186,6 +192,45 @@ describe("batches use-cases", () => {
 
     expect(mockedCompleteCurrentStep).toHaveBeenCalledWith("b-live-1");
     expect(updatedBatch?.status).toBe("completed");
+  });
+
+  it("returns null for missing batch id in start step", async () => {
+    const batch = await startCurrentBatchStep("");
+
+    expect(batch).toBeNull();
+    expect(mockedStartCurrentStep).not.toHaveBeenCalled();
+  });
+
+  it("returns demo batch on start step when demo data is enabled", async () => {
+    dataSource.useDemoData = true;
+
+    const batch = await startCurrentBatchStep("b-demo-pdd-mash");
+
+    expect(batch?.id).toBe("b-demo-pdd-mash");
+    expect(mockedStartCurrentStep).not.toHaveBeenCalled();
+  });
+
+  it("uses live API for start current step when demo mode is disabled", async () => {
+    dataSource.useDemoData = false;
+    mockedStartCurrentStep.mockResolvedValue({
+      id: "b-live-1",
+      ownerId: "u1",
+      recipeId: "r1",
+      status: "in_progress",
+      currentStepOrder: 0,
+      startedAt: "2026-01-01T00:00:00.000Z",
+      fermentationStartedAt: null,
+      fermentationCompletedAt: null,
+      completedAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      steps: [],
+    });
+
+    const activated = await startCurrentBatchStep("b-live-1");
+
+    expect(mockedStartCurrentStep).toHaveBeenCalledWith("b-live-1");
+    expect(activated?.status).toBe("in_progress");
   });
 
   it("returns the fil-rouge mash batch when starting a batch in demo mode", async () => {

--- a/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
+++ b/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
@@ -4,6 +4,7 @@ import {
   getMineById,
   listMine,
   startBatch as startBatchApi,
+  startCurrentStep as startCurrentStepApi,
 } from "@/features/batches/data/batches.api";
 import { Batch, BatchSummary } from "@/features/batches/domain/batch.types";
 import { demoBatchSummaries, demoBatches } from "@/mocks/demo-data";
@@ -71,6 +72,18 @@ export async function getBatchDetailsViewModel(
     recipeVolumeL = null;
   }
   return { batch, recipeName, recipeVolumeL };
+}
+
+export async function startCurrentBatchStep(
+  batchId: string,
+): Promise<Batch | null> {
+  if (!batchId) {
+    return null;
+  }
+  if (dataSource.useDemoData) {
+    return demoBatches.find((item) => item.id === batchId) ?? null;
+  }
+  return startCurrentStepApi(batchId);
 }
 
 export async function completeCurrentBatchStep(

--- a/packages/mobile-app/src/features/batches/data/__tests__/batches.api.test.ts
+++ b/packages/mobile-app/src/features/batches/data/__tests__/batches.api.test.ts
@@ -7,7 +7,11 @@
 
 import * as httpClient from "@/core/http/http-client";
 
-import { deleteBatch, getMineById } from "@/features/batches/data/batches.api";
+import {
+  deleteBatch,
+  getMineById,
+  startCurrentStep,
+} from "@/features/batches/data/batches.api";
 
 jest.mock("@/core/http/http-client");
 
@@ -89,5 +93,33 @@ describe("batches.api — deleteBatch (F25)", () => {
     mockedRequest.mockRejectedValue(new Error("boom"));
 
     await expect(deleteBatch("b1")).rejects.toThrow("boom");
+  });
+});
+
+describe("batches.api — startCurrentStep (F1 PRÉP → ACTIF)", () => {
+  beforeEach(() => {
+    mockedRequest.mockReset();
+  });
+
+  it("POSTs to the step-start endpoint and maps the batch (happy)", async () => {
+    mockedRequest.mockResolvedValue(
+      batchDtoWithStep({ started_at: "2026-02-05T09:05:00.000Z" }),
+    );
+
+    const batch = await startCurrentStep("b1");
+
+    expect(mockedRequest).toHaveBeenCalledWith(
+      "/batches/b1/steps/current/start",
+      {
+        method: "POST",
+      },
+    );
+    expect(batch.steps[0].startedAt).toBe("2026-02-05T09:05:00.000Z");
+  });
+
+  it("propagates the request error (sad)", async () => {
+    mockedRequest.mockRejectedValue(new Error("boom"));
+
+    await expect(startCurrentStep("b1")).rejects.toThrow("boom");
   });
 });

--- a/packages/mobile-app/src/features/batches/data/batches.api.ts
+++ b/packages/mobile-app/src/features/batches/data/batches.api.ts
@@ -116,6 +116,13 @@ export async function getMineById(id: string): Promise<Batch> {
   return mapBatch(row);
 }
 
+export async function startCurrentStep(id: string): Promise<Batch> {
+  const row = await request<BatchDto>(`/batches/${id}/steps/current/start`, {
+    method: "POST",
+  });
+  return mapBatch(row);
+}
+
 export async function completeCurrentStep(id: string): Promise<Batch> {
   const row = await request<BatchDto>(`/batches/${id}/steps/current/complete`, {
     method: "POST",

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -15,6 +15,7 @@ import {
   completeCurrentBatchStep,
   deleteBatch,
   getBatchDetailsViewModel,
+  startCurrentBatchStep,
 } from "@/features/batches/application/batches.use-cases";
 import { getTasting } from "@/features/batches/application/bottling.use-cases";
 import { computeAbv } from "@/features/batches/application/measurement.calculations";
@@ -210,6 +211,24 @@ export function BatchDetailsScreen({ batchId }: Props) {
     },
   });
 
+  const { mutate: mutateStartCurrentStep, isPending: isStarting } = useMutation<
+    Batch | null,
+    Error
+  >({
+    mutationFn: () => startCurrentBatchStep(batchId),
+    onSuccess: (nextBatch) => {
+      setMutationError(null);
+      queryClient.setQueryData<BatchDetailsViewModel | null>(
+        ["batches", "details", batchId],
+        nextBatch ? { batch: nextBatch, recipeName } : null,
+      );
+      void queryClient.invalidateQueries({ queryKey: ["batches", "list"] });
+    },
+    onError: (error) => {
+      setMutationError(getErrorMessage(error, "Échec du démarrage de l'étape"));
+    },
+  });
+
   const { mutate: mutateDeleteBatch, isPending: isDeleting } = useMutation<
     void,
     Error
@@ -270,6 +289,17 @@ export function BatchDetailsScreen({ batchId }: Props) {
         },
       ],
     );
+  };
+
+  const handleStart = () => {
+    if (missingBatchId) {
+      return;
+    }
+    // F1 — the current step opens in PRÉP (no timer). Tapping « Démarrer »
+    // activates it (ACTIF): the countdown only starts here, once the brewer has
+    // done the physical prep. No confirm — starting is low-stakes.
+    setMutationError(null);
+    mutateStartCurrentStep();
   };
 
   const handleGoBack = () => {
@@ -346,6 +376,10 @@ export function BatchDetailsScreen({ batchId }: Props) {
   const fermentationInfo = useFermentationTrackerInfo(batch);
   const activeStep =
     batch?.steps?.find((step) => step.status === "in_progress") ?? null;
+  // PRÉP: the current step is in progress but not yet activated (no startedAt),
+  // so the timer is idle and the CTA is « Démarrer » rather than « Terminer »
+  // (F1; see brew-day/06). Demo steps carry a startedAt, so they read as ACTIF.
+  const isPrepPhase = activeStep != null && activeStep.startedAt == null;
   const [openTip, setOpenTip] = React.useState<{
     label: string;
     tip: string;
@@ -503,6 +537,12 @@ export function BatchDetailsScreen({ batchId }: Props) {
           label="Mettre en bouteille"
           onPress={handleGoToBottling}
           disabled={isLoading}
+        />
+      ) : isPrepPhase ? (
+        <PrimaryButton
+          label={isStarting ? "Démarrage…" : "Démarrer l'étape"}
+          onPress={handleStart}
+          disabled={isStarting || isLoading}
         />
       ) : !isCompletedLive ? (
         <PrimaryButton

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -200,7 +200,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
       setMutationError(null);
       queryClient.setQueryData<BatchDetailsViewModel | null>(
         ["batches", "details", batchId],
-        nextBatch ? { batch: nextBatch, recipeName } : null,
+        nextBatch ? { batch: nextBatch, recipeName, recipeVolumeL } : null,
       );
       void queryClient.invalidateQueries({ queryKey: ["batches", "list"] });
     },
@@ -220,7 +220,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
       setMutationError(null);
       queryClient.setQueryData<BatchDetailsViewModel | null>(
         ["batches", "details", batchId],
-        nextBatch ? { batch: nextBatch, recipeName } : null,
+        nextBatch ? { batch: nextBatch, recipeName, recipeVolumeL } : null,
       );
       void queryClient.invalidateQueries({ queryKey: ["batches", "list"] });
     },

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -12,6 +12,7 @@ import {
   completeCurrentBatchStep,
   deleteBatch,
   getBatchDetailsViewModel,
+  startCurrentBatchStep,
   type BatchDetailsViewModel,
 } from "@/features/batches/application/batches.use-cases";
 import { listBatchMeasurements } from "@/features/batches/application/measurement.use-cases";
@@ -58,6 +59,9 @@ const mashBatch: Batch = {
       type: "mash",
       label: "Empâtage 67°C",
       status: "in_progress",
+      // ACTIF: the step has been activated (startedAt set), so the CTA is
+      // « Terminer ». A step with no startedAt is PRÉP (« Démarrer »).
+      startedAt: TS,
       createdAt: TS,
       updatedAt: TS,
     },
@@ -84,6 +88,12 @@ const viewModel = (
 
 jest.mock("@/features/batches/application/batches.use-cases", () => ({
   getBatchDetailsViewModel: jest.fn(),
+  startCurrentBatchStep: jest.fn().mockResolvedValue({
+    id: "b1",
+    status: "in_progress",
+    currentStepOrder: 0,
+    steps: [],
+  }),
   completeCurrentBatchStep: jest.fn().mockResolvedValue({
     id: "b1",
     status: "completed",
@@ -145,6 +155,50 @@ describe("BatchDetailsScreen", () => {
     expect(screen.getByText("Progression du brassin")).toBeTruthy();
     expect(screen.getByText("Étapes")).toBeTruthy();
     expect(screen.getByText("Terminer l'étape en cours")).toBeTruthy();
+  });
+
+  it("shows « Démarrer » for a step still in PRÉP and activates it on tap (F1)", async () => {
+    const prepBatch: Batch = {
+      ...mashBatch,
+      steps: mashBatch.steps.map((step) =>
+        step.stepOrder === 0 ? { ...step, startedAt: null } : step,
+      ),
+    };
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(prepBatch, "Ma recette test"),
+    );
+    (startCurrentBatchStep as jest.Mock).mockClear();
+
+    renderBatchDetailsScreen();
+
+    // PRÉP: the CTA activates the step (no timer yet), it does not complete it.
+    fireEvent.press(await screen.findByText("Démarrer l'étape"));
+    expect(screen.queryByText("Terminer l'étape en cours")).toBeNull();
+
+    await waitFor(() => expect(startCurrentBatchStep).toHaveBeenCalledTimes(1));
+  });
+
+  it("surfaces an error when activating a PRÉP step fails (F1, sad)", async () => {
+    const prepBatch: Batch = {
+      ...mashBatch,
+      steps: mashBatch.steps.map((step) =>
+        step.stepOrder === 0 ? { ...step, startedAt: null } : step,
+      ),
+    };
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(prepBatch, "Ma recette test"),
+    );
+    (startCurrentBatchStep as jest.Mock).mockRejectedValueOnce(
+      new Error("boom"),
+    );
+
+    renderBatchDetailsScreen();
+
+    fireEvent.press(await screen.findByText("Démarrer l'étape"));
+
+    // onError sets the shared banner; getErrorMessage surfaces the error's own
+    // message ("boom") over the fallback copy.
+    expect(await screen.findByText("boom")).toBeTruthy();
   });
 
   it("confirms before completing a step, then completes on confirm (F6)", async () => {
@@ -638,7 +692,7 @@ describe("BatchDetailsScreen — B3 bottling routing + closure view", () => {
         currentStepOrder: 0,
         steps: packagingBatch.steps.map((step) =>
           step.stepOrder === 0
-            ? { ...step, status: "in_progress" }
+            ? { ...step, status: "in_progress", startedAt: TS }
             : { ...step, status: "pending" },
         ),
       },

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/use-step-countdown.test.ts
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/use-step-countdown.test.ts
@@ -53,6 +53,29 @@ describe("useStepCountdown", () => {
     expect(result.current).toBeNull();
   });
 
+  // F1 PRÉP: a timed step in progress but not yet activated (no startedAt) runs
+  // no countdown in live mode — the timer only starts on « Démarrer ».
+  it("returns null in PRÉP (live, timed step with no startedAt)", () => {
+    const { result } = renderHook(() =>
+      useStepCountdown(
+        makeStep({ plannedDurationMin: 30, startedAt: undefined }),
+        false,
+      ),
+    );
+    expect(result.current).toBeNull();
+  });
+
+  // F1 ACTIF: once activated (startedAt set) the countdown runs from that anchor.
+  it("runs once the step is activated (live, startedAt set)", () => {
+    const startedAt = new Date(Date.now() - 5 * 60_000).toISOString(); // 5 min ago
+    const { result } = renderHook(() =>
+      useStepCountdown(makeStep({ plannedDurationMin: 30, startedAt }), false),
+    );
+    expect(result.current).not.toBeNull();
+    expect(result.current?.remainingSec).toBeGreaterThanOrEqual(1480);
+    expect(result.current?.remainingSec).toBeLessThanOrEqual(1500);
+  });
+
   // Happy path: demo anchors mid-brew (~40% remaining of a 30 min step)
   it("computes a mid-brew countdown in demo mode", () => {
     const { result } = renderHook(() =>

--- a/packages/mobile-app/src/features/batches/presentation/use-step-countdown.ts
+++ b/packages/mobile-app/src/features/batches/presentation/use-step-countdown.ts
@@ -17,7 +17,9 @@ export type StepCountdown = {
  * Countdown for an in-progress brewing step that declares a planned duration
  * (brewing assistant, #781). Ticks once per second. Returns `null` when the
  * step has no `plannedDurationMin` (e.g. fermentation, which uses the day-based
- * tracker instead, or legacy steps).
+ * tracker instead, or legacy steps), or when the step is still in PRÉP — in
+ * progress but not yet activated (no `startedAt`), so no timer runs until the
+ * brewer taps « Démarrer » (novice-journey friction F1; see brew-day/06).
  *
  * Hooks run unconditionally; the `null` result is what callers gate on.
  */
@@ -25,8 +27,13 @@ export function useStepCountdown(
   step: BatchStep | null,
   useDemoData: boolean,
 ): StepCountdown | null {
+  // ACTIF vs PRÉP: a timed step only counts down once activated (`startedAt`
+  // set). Demo mode always shows a running timer for the screenshot.
+  const isActive = useDemoData || step?.startedAt != null;
   const totalSec =
-    step?.plannedDurationMin != null ? step.plannedDurationMin * 60 : 0;
+    isActive && step?.plannedDurationMin != null
+      ? step.plannedDurationMin * 60
+      : 0;
 
   // Identity of the step the anchor was fixed for. When it changes — the active
   // step moves on, or `startedAt` arrives late from persisted state — the anchor
@@ -50,7 +57,9 @@ export function useStepCountdown(
     } else if (step?.startedAt) {
       anchorRef.current = new Date(step.startedAt).getTime();
     } else {
-      anchorRef.current = Date.now();
+      // Unreachable while `stepKey` is non-null (that requires `totalSec > 0`,
+      // hence `isActive`). Defensive null so a stray render never anchors to now.
+      anchorRef.current = null;
     }
   }
 


### PR DESCRIPTION
## Summary

First implementation slice of the brew-day brewing-assistant structural block, conforming to the merged conception [`brew-day/06-state-brew-step.md`](docs/architecture/diagrams/brew-day/06-state-brew-step.md).

A brew step now has two phases:
- **PRÉP** — in progress, no timer. The step guides "do X" and shows a **« Démarrer l'étape »** CTA.
- **ACTIF** — the brewer tapped « Démarrer »; the countdown starts here.

This fixes novice-journey friction **F1**: the timer no longer runs before the brewer has done the physical prep.

The phase is **derived** from the existing nullable `started_at` column — **no new column, no migration, no new enum value**:
- PRÉP = current step `in_progress` with `started_at` null.
- ACTIF = current step `in_progress` with `started_at` set.

## Context

- **Backend** — steps open in PRÉP (no `startedAt` on entering `in_progress`, on start and on advance); new `startCurrentStep` domain transition + `POST /batches/:id/steps/current/start`; a shared `applyCurrentStepTransition` helper (DRY) backs both complete and start.
- **Mobile** — `use-step-countdown` gates the timer on activation (in PRÉP the hook returns null, no timer); conditional CTA (« Démarrer » / « Terminer »); packaging keeps « Mettre en bouteille » (B3 preserved).
- **Backward-compatible** — existing `in_progress` steps in prod already carry `started_at`, so they read as ACTIF.
- **Deliberate** — completing stays permissive at the API (order enforced by the UI); an API guard is a deferred follow-up.

## Checklist

- [x] H/S/E tests across domain, service, controller, hook, use-case, API + PRÉP/ACTIF screen cases
- [x] API: lint + build + 830 unit tests green
- [x] Mobile: lint + format green; `batches` suites green
- [x] No migration, no `any`, no default export, response envelope respected
- [x] Local pre-push review (pr-pre-reviewer): 0 Must Have
- [ ] Note: 4 mobile typecheck errors are the known stale `.expo` typed-route quirk (CI regenerates and passes)

Refs #868