### PR TITLE
feat(batches): gate density prompts to fermentation + novice estimate (F3)

### DIFF
--- a/docs/architecture/diagrams/brew-day/08-sequence-jit-density.md
+++ b/docs/architecture/diagrams/brew-day/08-sequence-jit-density.md
@@ -3,16 +3,19 @@
 > **Feature**: brewing assistant / brew-day guidance layer (novice-journey audit F3).
 > **Related**: reuses the B2 measurement flow `02-sequence-record-gravity-measurement.md`; the
 > phase context (fermentation ACTIF / end) comes from the step machine `06-state-brew-step.md`.
-> **Decisions captured**: debrief 2026-07-01 — density entry is gated to the moment it makes
-> sense (OG at pitch, FG at fermentation end), not offered out of context from the mash.
+> **Decisions captured**: debrief 2026-07-01 — (a) density entry is gated to the moment it makes
+> sense (OG at pitch, FG at fermentation end), not offered out of context from the mash; (b) a
+> novice who cannot measure yet gets an educated-default **display-only estimate** (from the
+> recipe targets), clearly marked, never persisted as a measurement.
 
 ## Context
 
 `sd` — WHEN the app surfaces the gravity-entry affordances, tied to the fermentation step's
-phase. Today the density card is offered out of context (from the mash), which confuses a
-novice (F3). This gates OG to the entry of fermentation ACTIF (pitch) and FG to the end of
-fermentation (before Packaging). It does NOT change the measurement endpoint or the ABV maths
-(those are B2, `02`).
+phase, AND how a novice who cannot measure still gets a believable ABV without being lied to.
+Today the density card is offered out of context (from the mash), which confuses a novice (F3).
+This gates OG to the entry of fermentation ACTIF (pitch) and FG to the end of fermentation (or
+before Packaging). It does NOT change the measurement endpoint or the ABV maths (those are B2,
+`02`); it moves *when* the prompt shows and adds an *estimated* (non-persisted) fallback.
 
 ## Diagram
 
@@ -23,33 +26,56 @@ sequenceDiagram
   participant API as Backend API
 
   Note over M: Gate — current step = Fermentation, phase = ACTIF (06), yeast just pitched
-  M->>B: Surface "Note the original gravity (OG)"
-  B->>M: Enter OG
-  M->>API: POST /batches/:id/measurements — og
-  API-->>M: 201
+  M->>B: Prompt "Note the original gravity (OG)" + "How do I measure?" guide
+  alt Brewer can measure
+    B->>M: Enter OG
+    M->>API: "POST /batches/:id/measurements (og)"
+    API-->>M: 201 — persisted (real reading)
+  else Cannot measure now (novice escape)
+    B->>M: "I can't measure right now"
+    M->>M: Estimate ABV from the recipe target OG/FG
+    M->>B: Show "≈ X % vol (estimated from the recipe, not measured)" — display-only, nothing persisted
+  end
 
-  Note over M: Gate — Fermentation nearing end (gravity stabilising) or before Packaging (06)
-  M->>B: Surface "Note the final gravity (FG)"
+  Note over M: Gate — Fermentation nearing end or before Packaging (06)
+  M->>B: Prompt "Note the final gravity (FG)"
   B->>M: Enter FG
-  M->>API: POST /batches/:id/measurements — fg
+  M->>API: "POST /batches/:id/measurements (fg)"
   API-->>M: 201
-  M->>M: Compute ABV from OG and FG
-  M->>B: Show ABV + "stable 2–3 days = done"
+  M->>M: Compute ABV from the measured OG and FG (supersedes any estimate)
+  M->>B: Show ABV (measured) + "stable 2–3 days = done"
 ```
 
 ## Notes
 
-- **JIT gating is the F3 fix.** The OG affordance appears only when the fermentation step enters
-  ACTIF (yeast pitched); the FG affordance appears only near fermentation end (or before the
-  Packaging step). The density card is **no longer offered from the mash**. The gating condition
-  is derived from the current step + phase (`06`), not a new endpoint.
+- **JIT gating is the F3 fix.** The OG affordance appears only when the fermentation step is
+  **ACTIF** (`current step type = fermentation`, `in_progress`, `startedAt` set — yeast pitched);
+  the FG affordance appears when the OG is recorded and fermentation is ACTIF, **or** at the
+  Packaging step. The density card is **no longer offered from the mash**. The gating condition is
+  derived from the current step + phase (`06`), not a new endpoint.
 - **Reuse, don't rebuild.** The recording flow, `POST /batches/:id/measurements`, and the ABV
   formula `(OG − FG) × 131.25` are the shipped B2 feature (`02`). This diagram only moves *when*
-  the prompt is shown.
-- **Escape hatch (already shipped).** "Je n'ai pas de densimètre" stays available at both
-  moments — advice, never a blocker (B2). A brewer without a hydrometer is not stuck.
-- **Pedagogy (ADR-0021 D5).** Each prompt carries the "why?" (OG = sugar available before
-  fermentation; FG = what's left → alcohol) tuned to the brewer level.
+  the prompt is shown and adds the estimate fallback below.
+- **Escape hatch — two levels.** (1) *Already shipped* (B2): "Je n'ai pas de densimètre" shows
+  buy-advice and never blocks the brew. (2) *New (this slice)*: **"Je ne peux pas mesurer
+  maintenant"** offers an **educated-default estimate** — a **display-only** ABV computed from the
+  **recipe target OG/FG** (`recipe.stats.og/fg`), labeled `≈ X % vol (estimé d'après la recette,
+  non mesuré)` with a one-line "why it's approximate" (depends on your mash efficiency). This
+  evolves the stance from "never invent" to **"never invent silently"**: the brewer opts in to a
+  clearly-marked estimate.
+- **Honesty — nothing fake is persisted.** The estimate is UI-only; **no** measurement row is
+  written for it, so persisted readings stay 100 % real. A real reading, once entered,
+  **supersedes** the estimate on screen. (No `estimated` DB flag in v1 — deferred.)
+- **Three visual states (founder, must be obvious).** *Measured* = normal styling; *estimated* =
+  **italic + an « estimé » label + a muted/secondary tone + « ≈ » prefix**; *not-entered* = an
+  empty prompt. Uses design-system tokens (no hardcoded style).
+- **Teach first (ADR-0021 D5 pedagogy).** The primary path is "measure it", with a **"Comment
+  mesurer ?"** guide (how to read a hydrometer) beside the prompt; the estimate is the fallback,
+  not the default. Each prompt keeps the "why?" (OG = sugar available before fermentation;
+  FG = what's left → alcohol) tuned to the brewer level.
+- **Deferred (later tiers, not v1).** Attenuation-based FG estimate (`calculateEstimatedFgFromAttenuation`
+  exists but introduces the advanced *attenuation* concept), refractometer support, temperature
+  correction, and a persisted `estimated`/`source` flag on measurements.
 - **Fermentation timeline (F11) is a sibling, deferred.** The forecast timeline + milestones
   (J0 pitch+OG, J1-3 krausen, J~7 slows, J10-14 stable→FG) is a richer P2 concern; this diagram
   only fixes the density-prompt timing.

--- a/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
+++ b/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
@@ -335,5 +335,31 @@ describe("batches use-cases", () => {
 
       expect(result?.recipeVolumeL).toBeNull();
     });
+
+    it("surfaces the recipe target gravities for the density estimate (happy path)", async () => {
+      mockedGetRecipeDetails.mockResolvedValue({
+        id: "r-demo-pdd",
+        name: "La Première du dimanche",
+        stats: { og: 1.06, fg: 1.012 },
+      } as never);
+
+      const result = await getBatchDetailsViewModel("b-demo-pdd-mash");
+
+      expect(result?.recipeOg).toBe(1.06);
+      expect(result?.recipeFg).toBe(1.012);
+    });
+
+    it("returns null target gravities when the recipe omits them (edge path)", async () => {
+      mockedGetRecipeDetails.mockResolvedValue({
+        id: "r-demo-pdd",
+        name: "La Première du dimanche",
+        stats: {},
+      } as never);
+
+      const result = await getBatchDetailsViewModel("b-demo-pdd-mash");
+
+      expect(result?.recipeOg).toBeNull();
+      expect(result?.recipeFg).toBeNull();
+    });
   });
 });

--- a/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
+++ b/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
@@ -361,5 +361,20 @@ describe("batches use-cases", () => {
       expect(result?.recipeOg).toBeNull();
       expect(result?.recipeFg).toBeNull();
     });
+
+    it("normalizes an implausible 0-sentinel target gravity to null (edge path)", async () => {
+      // The recipe-stats mapper fills a missing target with 0; that sentinel
+      // must NOT reach the estimate (it would yield a ~130% ABV).
+      mockedGetRecipeDetails.mockResolvedValue({
+        id: "r-demo-pdd",
+        name: "La Première du dimanche",
+        stats: { og: 1.06, fg: 0 },
+      } as never);
+
+      const result = await getBatchDetailsViewModel("b-demo-pdd-mash");
+
+      expect(result?.recipeOg).toBe(1.06);
+      expect(result?.recipeFg).toBeNull();
+    });
   });
 });

--- a/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
+++ b/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
@@ -48,6 +48,11 @@ export interface BatchDetailsViewModel {
   // Recipe batch volume in litres, surfaced for the B3 closure view. Best-effort
   // like `recipeName`: null when the recipe lookup fails or omits the stat.
   recipeVolumeL?: number | null;
+  // Recipe target gravities, surfaced for the JIT-density estimate fallback (F3):
+  // a novice who cannot measure sees a display-only ABV computed from these.
+  // Best-effort like the others — null when the recipe lookup fails or omits them.
+  recipeOg?: number | null;
+  recipeFg?: number | null;
 }
 
 export async function getBatchDetailsViewModel(
@@ -63,15 +68,21 @@ export async function getBatchDetailsViewModel(
   // back to the "Brassin <id>" title instead of rejecting the whole query.
   let recipeName: string | null = null;
   let recipeVolumeL: number | null = null;
+  let recipeOg: number | null = null;
+  let recipeFg: number | null = null;
   try {
     const recipe = await getRecipeDetails(batch.recipeId);
     recipeName = recipe?.name ?? null;
     recipeVolumeL = recipe?.stats?.volumeLiters ?? null;
+    recipeOg = recipe?.stats?.og ?? null;
+    recipeFg = recipe?.stats?.fg ?? null;
   } catch {
     recipeName = null;
     recipeVolumeL = null;
+    recipeOg = null;
+    recipeFg = null;
   }
-  return { batch, recipeName, recipeVolumeL };
+  return { batch, recipeName, recipeVolumeL, recipeOg, recipeFg };
 }
 
 export async function startCurrentBatchStep(

--- a/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
+++ b/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
@@ -55,6 +55,13 @@ export interface BatchDetailsViewModel {
   recipeFg?: number | null;
 }
 
+// A real beer gravity sits roughly in [0.98, 1.2]. The recipe-stats mapper fills
+// a missing target with 0 (sentinel); treat any out-of-range value as absent so
+// the density estimate never computes a nonsensical ABV from it (brew-day/08).
+function plausibleGravity(value: number | null | undefined): number | null {
+  return value != null && value > 0.9 && value < 1.25 ? value : null;
+}
+
 export async function getBatchDetailsViewModel(
   batchId: string,
 ): Promise<BatchDetailsViewModel | null> {
@@ -74,8 +81,8 @@ export async function getBatchDetailsViewModel(
     const recipe = await getRecipeDetails(batch.recipeId);
     recipeName = recipe?.name ?? null;
     recipeVolumeL = recipe?.stats?.volumeLiters ?? null;
-    recipeOg = recipe?.stats?.og ?? null;
-    recipeFg = recipe?.stats?.fg ?? null;
+    recipeOg = plausibleGravity(recipe?.stats?.og);
+    recipeFg = plausibleGravity(recipe?.stats?.fg);
   } catch {
     recipeName = null;
     recipeVolumeL = null;

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -49,6 +49,16 @@ const DEMO_FERMENTATION_TARGET_DAYS = 14;
 const DEMO_FERMENTATION_DAYS_ELAPSED = 5;
 const DEMO_FERMENTATION_TEMPERATURE_C = 19;
 
+// Plain-French guide shown from the "Comment mesurer ?" affordance on the
+// density card (F3 pedagogy): teaches a novice how to read a hydrometer.
+const HOW_TO_MEASURE_TIP =
+  "Prélève un peu de moût dans un tube (ou un verre haut), plonge le " +
+  "densimètre et laisse-le flotter sans toucher les bords. Lis la valeur à la " +
+  "surface du liquide, à hauteur des yeux — par exemple 1.050. Un densimètre " +
+  "coûte quelques euros en magasin de brassage ou en ligne. L'OG se lit au " +
+  "début de la fermentation, la FG à la fin (quand la densité ne bouge plus " +
+  "2-3 jours de suite).";
+
 // Dynamic widths cannot live in `StyleSheet.create()` because they
 // depend on the runtime progress percentage. Centralising the
 // computed object in a tiny helper keeps the JSX free of inline
@@ -164,6 +174,8 @@ export function BatchDetailsScreen({ batchId }: Props) {
   const batch = viewModel?.batch ?? null;
   const recipeName = viewModel?.recipeName ?? null;
   const recipeVolumeL = viewModel?.recipeVolumeL ?? null;
+  const recipeOg = viewModel?.recipeOg ?? null;
+  const recipeFg = viewModel?.recipeFg ?? null;
   const isCompletedLive =
     batch?.status === "completed" && !dataSource.useDemoData;
 
@@ -200,7 +212,9 @@ export function BatchDetailsScreen({ batchId }: Props) {
       setMutationError(null);
       queryClient.setQueryData<BatchDetailsViewModel | null>(
         ["batches", "details", batchId],
-        nextBatch ? { batch: nextBatch, recipeName, recipeVolumeL } : null,
+        nextBatch
+          ? { batch: nextBatch, recipeName, recipeVolumeL, recipeOg, recipeFg }
+          : null,
       );
       void queryClient.invalidateQueries({ queryKey: ["batches", "list"] });
     },
@@ -220,7 +234,9 @@ export function BatchDetailsScreen({ batchId }: Props) {
       setMutationError(null);
       queryClient.setQueryData<BatchDetailsViewModel | null>(
         ["batches", "details", batchId],
-        nextBatch ? { batch: nextBatch, recipeName, recipeVolumeL } : null,
+        nextBatch
+          ? { batch: nextBatch, recipeName, recipeVolumeL, recipeOg, recipeFg }
+          : null,
       );
       void queryClient.invalidateQueries({ queryKey: ["batches", "list"] });
     },
@@ -385,6 +401,34 @@ export function BatchDetailsScreen({ batchId }: Props) {
     tip: string;
   } | null>(null);
 
+  // JIT density gating (F3): the density card belongs to the fermentation
+  // phase, not the mash. Show it only when fermentation is ACTIF (yeast pitched
+  // → startedAt set) or at the Packaging step (FG before bottling). See
+  // brew-day/08. Demo mode keeps its always-on card for the screenshot.
+  const isFermentationActive =
+    currentStep?.type === "fermentation" &&
+    currentStep.status === "in_progress" &&
+    currentStep.startedAt != null;
+  const isPackagingStep = currentStep?.type === "packaging";
+  const showDensityCard =
+    !isCompletedLive &&
+    (dataSource.useDemoData || isFermentationActive || isPackagingStep);
+
+  // Novice escape (F3): a display-only ABV estimated from the recipe targets,
+  // revealed on demand when the brewer cannot measure. Never persisted; a real
+  // reading (recordedOg/Fg) always takes precedence.
+  const [showDensityEstimate, setShowDensityEstimate] = React.useState(false);
+  const estimatedAbv =
+    recipeOg != null && recipeFg != null && recipeFg < recipeOg
+      ? computeAbv(recipeOg, recipeFg)
+      : null;
+  const handleExplainMeasurement = () => {
+    setOpenTip({
+      label: "Comment mesurer une densité ?",
+      tip: HOW_TO_MEASURE_TIP,
+    });
+  };
+
   const completeButtonLabel = getCompleteButtonLabel(isCompleted, isCompleting);
 
   return (
@@ -488,7 +532,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
         </Card>
       ) : null}
 
-      {!isCompletedLive && batch ? (
+      {showDensityCard ? (
         <Card style={styles.measurementCard}>
           <View style={styles.fermentationHeader}>
             <Ionicons
@@ -520,11 +564,65 @@ export function BatchDetailsScreen({ batchId }: Props) {
             </Text>
           )}
 
+          {abv == null && showDensityEstimate ? (
+            estimatedAbv != null ? (
+              <View style={styles.estimateBox}>
+                <Text
+                  style={styles.estimateValue}
+                  testID="density-estimated-abv"
+                >
+                  ≈ {estimatedAbv.toFixed(1)} % vol
+                </Text>
+                <Text style={styles.estimateLabel}>
+                  {"estimé d'après la recette · non mesuré"}
+                </Text>
+                <Text style={styles.estimateHint}>
+                  {
+                    "Approximatif : l'alcool réel dépend de ton rendement d'empâtage. Mesure la densité pour la vraie valeur."
+                  }
+                </Text>
+              </View>
+            ) : (
+              <Text style={styles.metricHint}>
+                {
+                  "Estimation indisponible : la recette n'indique pas de densités cibles."
+                }
+              </Text>
+            )
+          ) : null}
+
+          {/* OG-then-FG assumption: OG is prompted during fermentation ACTIF,
+              so by the Packaging gate an OG normally already exists and the CTA
+              reads « … finale (FG) ». */}
           <PrimaryButton
-            label="Saisir une densité"
+            label={
+              recordedOg == null
+                ? "Noter la densité initiale (OG)"
+                : "Noter la densité finale (FG)"
+            }
             onPress={handleRecordMeasurement}
             style={styles.measurementCta}
           />
+
+          <Pressable
+            accessibilityRole="button"
+            onPress={handleExplainMeasurement}
+            style={styles.linkButton}
+          >
+            <Text style={styles.linkText}>Comment mesurer ?</Text>
+          </Pressable>
+
+          {abv == null && !showDensityEstimate ? (
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => setShowDensityEstimate(true)}
+              style={styles.linkButton}
+            >
+              <Text style={styles.linkText}>
+                Je ne peux pas mesurer maintenant
+              </Text>
+            </Pressable>
+          ) : null}
         </Card>
       ) : null}
 
@@ -708,6 +806,45 @@ const styles = StyleSheet.create({
     fontSize: typography.size.caption,
     lineHeight: typography.lineHeight.caption,
     marginTop: spacing.xxs,
+  },
+  // Estimated (not measured) value: visually distinct from the bold, primary
+  // measured ABV — italic + muted tone + « ≈ » prefix so it never reads as real.
+  estimateBox: {
+    marginTop: spacing.sm,
+  },
+  estimateValue: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.medium,
+    fontStyle: "italic",
+    marginTop: spacing.xxs,
+  },
+  estimateLabel: {
+    color: colors.neutral.muted,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontWeight: typography.weight.medium,
+    fontStyle: "italic",
+  },
+  estimateHint: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontStyle: "italic",
+    marginTop: spacing.xxs,
+  },
+  linkButton: {
+    marginTop: spacing.sm,
+    paddingVertical: spacing.xs,
+    alignSelf: "flex-start",
+  },
+  linkText: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+    textDecorationLine: "underline",
   },
   tipBackdrop: {
     flex: 1,

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -404,7 +404,8 @@ export function BatchDetailsScreen({ batchId }: Props) {
   // JIT density gating (F3): the density card belongs to the fermentation
   // phase, not the mash. Show it only when fermentation is ACTIF (yeast pitched
   // → startedAt set) or at the Packaging step (FG before bottling). See
-  // brew-day/08. Demo mode keeps its always-on card for the screenshot.
+  // brew-day/08. The gate applies in demo mode too, so the demo journey shows
+  // the same JIT behaviour (no out-of-context mash card).
   const isFermentationActive =
     currentStep?.type === "fermentation" &&
     currentStep.status === "in_progress" &&
@@ -412,7 +413,8 @@ export function BatchDetailsScreen({ batchId }: Props) {
   const isPackagingStep = currentStep?.type === "packaging";
   const showDensityCard =
     !isCompletedLive &&
-    (dataSource.useDemoData || isFermentationActive || isPackagingStep);
+    batch != null &&
+    (isFermentationActive || isPackagingStep);
 
   // Novice escape (F3): a display-only ABV estimated from the recipe targets,
   // revealed on demand when the brewer cannot measure. Never persisted; a real
@@ -605,7 +607,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
           />
 
           <Pressable
-            accessibilityRole="button"
+            accessibilityRole="link"
             onPress={handleExplainMeasurement}
             style={styles.linkButton}
           >
@@ -614,7 +616,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
 
           {abv == null && !showDensityEstimate ? (
             <Pressable
-              accessibilityRole="button"
+              accessibilityRole="link"
               onPress={() => setShowDensityEstimate(true)}
               style={styles.linkButton}
             >

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -539,11 +539,36 @@ describe("BatchDetailsScreen — measurement card (B2)", () => {
     createdAt: takenAt,
   });
 
+  // The density card is now gated to the fermentation ACTIF phase (F3), so the
+  // B2 card tests run on a fermentation-in-progress batch, not the mash.
+  const fermentationActiveBatch: Batch = {
+    id: "b1",
+    ownerId: "u-demo-1",
+    recipeId: "r1",
+    status: "in_progress",
+    currentStepOrder: 0,
+    startedAt: TS,
+    createdAt: TS,
+    updatedAt: TS,
+    steps: [
+      {
+        batchId: "b1",
+        stepOrder: 0,
+        type: "fermentation",
+        label: "Fermentation",
+        status: "in_progress",
+        startedAt: TS,
+        createdAt: TS,
+        updatedAt: TS,
+      },
+    ],
+  };
+
   beforeEach(() => {
     mockPush.mockReset();
     dataSource.useDemoData = false;
     (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
-      viewModel(mashBatch, "Ma recette test"),
+      viewModel(fermentationActiveBatch, "Ma recette test"),
     );
     (listBatchMeasurements as jest.Mock).mockResolvedValue([]);
   });
@@ -593,7 +618,8 @@ describe("BatchDetailsScreen — measurement card (B2)", () => {
 
     renderBatchDetailsScreen();
 
-    fireEvent.press(await screen.findByText("Saisir une densité"));
+    // OG already recorded → the CTA is the contextual FG prompt.
+    fireEvent.press(await screen.findByText("Noter la densité finale (FG)"));
 
     expect(mockPush).toHaveBeenCalledWith({
       pathname: "/batches/[id]/measurement",
@@ -605,12 +631,74 @@ describe("BatchDetailsScreen — measurement card (B2)", () => {
   it("navigates without an OG param when no measurement exists", async () => {
     renderBatchDetailsScreen();
 
-    fireEvent.press(await screen.findByText("Saisir une densité"));
+    // No OG yet → the CTA is the contextual OG prompt.
+    fireEvent.press(await screen.findByText("Noter la densité initiale (OG)"));
 
     expect(mockPush).toHaveBeenCalledWith({
       pathname: "/batches/[id]/measurement",
       params: { id: "b1" },
     });
+  });
+
+  // F3 gating: the density card must NOT appear during the mash (out of context).
+  it("hides the density card during the mash (F3)", async () => {
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(mashBatch, "Ma recette test"),
+    );
+
+    renderBatchDetailsScreen();
+
+    await screen.findByText("Ma recette test");
+    expect(screen.queryByText("Densités & alcool")).toBeNull();
+    expect(screen.queryByText("Noter la densité initiale (OG)")).toBeNull();
+  });
+
+  // Novice escape (F3): no measurement + recipe targets → a clearly-marked,
+  // display-only estimated ABV, revealed on demand.
+  it("reveals a labelled estimated ABV when the brewer cannot measure", async () => {
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue({
+      batch: fermentationActiveBatch,
+      recipeName: "Ma recette test",
+      recipeOg: 1.06,
+      recipeFg: 1.008,
+    });
+
+    renderBatchDetailsScreen();
+
+    fireEvent.press(
+      await screen.findByText("Je ne peux pas mesurer maintenant"),
+    );
+
+    expect(await screen.findByTestId("density-estimated-abv")).toBeTruthy();
+    expect(screen.getByText(/estimé d'après la recette/)).toBeTruthy();
+  });
+
+  // Edge: no recipe targets → the estimate is honestly unavailable, never faked.
+  it("shows 'estimation indisponible' when the recipe has no target gravities", async () => {
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue({
+      batch: fermentationActiveBatch,
+      recipeName: "Ma recette test",
+      recipeOg: null,
+      recipeFg: null,
+    });
+
+    renderBatchDetailsScreen();
+
+    fireEvent.press(
+      await screen.findByText("Je ne peux pas mesurer maintenant"),
+    );
+
+    expect(await screen.findByText(/Estimation indisponible/)).toBeTruthy();
+    expect(screen.queryByTestId("density-estimated-abv")).toBeNull();
+  });
+
+  // Pedagogy: the "Comment mesurer ?" affordance opens the how-to guide.
+  it("opens the how-to-measure guide", async () => {
+    renderBatchDetailsScreen();
+
+    fireEvent.press(await screen.findByText("Comment mesurer ?"));
+
+    expect(await screen.findByText(/plonge le densimètre/)).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## Summary

Slice 08 of the brew-day brewing assistant — fixes novice-journey friction **F3** (density prompts shown out of context) and adds a novice "can't measure yet" escape. Conforms to the conception [`brew-day/08-sequence-jit-density.md`](docs/architecture/diagrams/brew-day/08-sequence-jit-density.md) (updated in this branch). **Mobile-only — no backend, no migration; reuses the shipped B2 measurement flow.**

- **JIT gating (F3):** the density card now shows **only** when fermentation is ACTIF (`current step = fermentation`, `in_progress`, `startedAt` set — the phase model from F1) **or** at the Packaging step — no longer from the mash. The CTA is contextual (« Noter la densité initiale (OG) » / « … finale (FG) »).
- **Novice escape (educated default, display-only):** a « Je ne peux pas mesurer maintenant » link reveals a **display-only** estimated ABV computed from the recipe target OG/FG (surfaced via `getBatchDetailsViewModel` → `recipeOg`/`recipeFg`), labelled « ≈ X % vol · estimé d'après la recette · non mesuré ». **Nothing fake is persisted** — a real reading always supersedes it. Three visual states: measured (bold), **estimated (italic + « estimé » + muted + « ≈ »)**, not-entered (prompt). A « Comment mesurer ? » guide opens in the existing tip modal.

## Context

- Evolves the density escape from "never invent" (ABV stays unavailable) to **"never invent silently"** — the brewer opts into a clearly-marked estimate; nothing is written to the measurement store.
- The complete/start mutations preserve `recipeOg`/`recipeFg` in the cache (same pattern as the earlier `recipeVolumeL` fix), so a step transition never drops the estimate inputs.
- Deferred (noted in the conception): attenuation-based FG estimate, refractometer, temperature correction, a persisted `estimated` flag.

## Checklist

- [x] H/S/E tests — card hidden on the mash (F3), measured ABV, contextual OG/FG prompts, estimate reveal + label, estimate-unavailable edge, how-to-measure guide, view-model target-gravity surfacing
- [x] Full `batches` suite green (159); lint + format clean
- [x] No `any`, no default export, no direct fetch, design-system tokens only, response envelope respected (mobile-only)
- [x] Local pre-push review (pr-pre-reviewer): 0 Must Have
- [ ] Note: 4 mobile typecheck errors are the known stale `.expo` typed-route quirk (CI regenerates and passes)

Refs #868