### PR TITLE
feat(batches): cancel + archive batch soft-lifecycle (F16/F25)

### DIFF
--- a/docs/architecture/diagrams/brew-day/07-state-batch-lifecycle.md
+++ b/docs/architecture/diagrams/brew-day/07-state-batch-lifecycle.md
@@ -71,11 +71,16 @@ stateDiagram-v2
   hidden from the active list).
 - **`Archive` (F25).** `completed → archived` (and `cancelled → archived`) soft-hides a batch
   from the active « Mes brassins » list without deleting its journal — declutters the list.
-- **New statuses to persist (deferred — conception only).** `draft`, `cancelled`, `archived`
-  extend the current enum (`in_progress` / `completed`). `discarded` is **not** a stored status —
-  it is the terminal outcome of the hard delete (the draft row is removed), shown as a state only
-  to close the diagram. A migration + the prep moving onto the batch are the implementation
-  work — NOT in this conception slice.
+- **Persistence model — timestamps, not new status enum values (07a implementation refinement).**
+  `cancelled` and `archived` are persisted as nullable **`cancelled_at` / `archived_at` timestamp
+  columns** on the batch (a plain `ADD COLUMN` migration, no backfill), **NOT** as new `status`
+  enum values: SQLite cannot alter the `status` CHECK constraint in place, and `batches` is
+  referenced by many cascade-FK child tables, so a table rebuild would be risky. The **effective**
+  lifecycle state returned to clients is *derived* — `archived` > `cancelled` > the raw
+  `in_progress`/`completed` status. Endpoints: `cancelled` = `PATCH /batches/:id/cancel` (only a
+  launched brew), `archived` = `PATCH /batches/:id/archive` (only a finished or cancelled brew).
+  `discarded` stays the terminal hard-delete outcome (not stored). **`draft`** + moving the prep
+  onto the batch (F14/F15) is the deferred, bigger slice (07b) — not in 07a.
 - **`completed`** still opens the closure/celebration (B3 `BatchClosureView`) and is kept in
   history; the transition is driven by the last step completing (see `06`). This is the **same
   `completed` state** already amended by `05-state-batch-closure.md` with the `bottledAt`

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -520,94 +520,38 @@ describe('BatchService', () => {
     ).rejects.toThrow(NotFoundException);
   });
 
-  it('cancelMine() should soft-cancel a launched brew and keep the journal (F16)', async () => {
+  it('freezes a cancelled batch against every workflow endpoint (07a guard)', async () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
-    const started = await batchService.startMine(ownerId, recipe.id);
-
-    const cancelled = await batchService.cancelMine(ownerId, started.batch.id);
-
-    expect(cancelled.cancelled_at).toBeTruthy();
-    // Soft: the steps (journal) survive, unlike the hard deleteMine.
-    const steps = await batchStepRepo.find({
-      where: { batch_id: started.batch.id },
-    });
-    expect(steps.length).toBeGreaterThan(0);
-  });
-
-  it('cancelMine() should reject a re-cancel and a completed brew (sad)', async () => {
-    const ownerId = 'user-1';
-    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
-
     const started = await batchService.startMine(ownerId, recipe.id);
     await batchService.cancelMine(ownerId, started.batch.id);
-    await expect(
-      batchService.cancelMine(ownerId, started.batch.id),
-    ).rejects.toThrow(BadRequestException);
 
-    const other = await batchService.startMine(ownerId, recipe.id);
-    await completeBatch(ownerId, other.batch.id);
+    // A cancelled brew is frozen: no step transition, fermentation, or bottling
+    // may reactivate its journal (the timestamp-model cross-endpoint guard).
     await expect(
-      batchService.cancelMine(ownerId, other.batch.id),
+      batchService.startMineCurrentStep(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      batchService.completeMineCurrentStep(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      batchService.startFermentationMine(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      batchService.closeMineBottling(ownerId, started.batch.id),
     ).rejects.toThrow(BadRequestException);
   });
 
-  it('cancelMine() should enforce ownership', async () => {
+  it('freezes an archived batch against tasting (07a guard)', async () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
     const started = await batchService.startMine(ownerId, recipe.id);
-
-    await expect(
-      batchService.cancelMine('user-2', started.batch.id),
-    ).rejects.toThrow(NotFoundException);
-  });
-
-  it('archiveMine() should archive a completed OR a cancelled brew (F25)', async () => {
-    const ownerId = 'user-1';
-    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
-
-    const finished = await batchService.startMine(ownerId, recipe.id);
-    await completeBatch(ownerId, finished.batch.id);
-    const archivedDone = await batchService.archiveMine(
-      ownerId,
-      finished.batch.id,
-    );
-    expect(archivedDone.archived_at).toBeTruthy();
-
-    const toCancel = await batchService.startMine(ownerId, recipe.id);
-    await batchService.cancelMine(ownerId, toCancel.batch.id);
-    const archivedCancelled = await batchService.archiveMine(
-      ownerId,
-      toCancel.batch.id,
-    );
-    expect(archivedCancelled.archived_at).toBeTruthy();
-  });
-
-  it('archiveMine() should reject an in-progress brew and a re-archive (sad)', async () => {
-    const ownerId = 'user-1';
-    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
-    const started = await batchService.startMine(ownerId, recipe.id);
-
-    await expect(
-      batchService.archiveMine(ownerId, started.batch.id),
-    ).rejects.toThrow(BadRequestException);
-
     await completeBatch(ownerId, started.batch.id);
     await batchService.archiveMine(ownerId, started.batch.id);
+
     await expect(
-      batchService.archiveMine(ownerId, started.batch.id),
+      batchService.createMineTasting(ownerId, started.batch.id, { rating: 4 }),
     ).rejects.toThrow(BadRequestException);
-  });
-
-  it('archiveMine() should enforce ownership', async () => {
-    const ownerId = 'user-1';
-    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
-    const started = await batchService.startMine(ownerId, recipe.id);
-    await completeBatch(ownerId, started.batch.id);
-
-    await expect(
-      batchService.archiveMine('user-2', started.batch.id),
-    ).rejects.toThrow(NotFoundException);
   });
 
   it('completeFermentationMine() should require start and set completed_at', async () => {

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -554,6 +554,20 @@ describe('BatchService', () => {
     ).rejects.toThrow(BadRequestException);
   });
 
+  it('reports "archived" (not "cancelled") when a cancelled batch is later archived (07a precedence)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+    await batchService.cancelMine(ownerId, started.batch.id);
+    await batchService.archiveMine(ownerId, started.batch.id);
+
+    // Both stamps are set; the freeze guard mirrors deriveEffectiveStatus and
+    // surfaces "archived" (precedence over cancelled), not "Batch is cancelled".
+    await expect(
+      batchService.startFermentationMine(ownerId, started.batch.id),
+    ).rejects.toThrow('Batch is archived');
+  });
+
   it('completeFermentationMine() should require start and set completed_at', async () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My IPA' });

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -333,9 +333,143 @@ describe('BatchService', () => {
     expect(list.map((b) => b.id)).toEqual([batchA.batch.id, batchB.batch.id]);
   });
 
+  it('listMine() should preserve cancelled and archived soft lifecycle stamps', async () => {
+    const ownerId = 'user-1';
+    const recipeA = await recipeService.create(ownerId, {
+      name: 'Cancelled batch',
+    });
+    const recipeB = await recipeService.create(ownerId, {
+      name: 'Archived batch',
+    });
+
+    const cancelled = await batchService.startMine(ownerId, recipeA.id);
+    const archived = await batchService.startMine(ownerId, recipeB.id);
+    const cancelledAt = new Date('2026-06-01T10:00:00.000Z');
+    const archivedAt = new Date('2026-06-02T10:00:00.000Z');
+
+    await batchRepo.update(
+      { id: cancelled.batch.id },
+      { cancelled_at: cancelledAt },
+    );
+    await batchRepo.update(
+      { id: archived.batch.id },
+      { cancelled_at: cancelledAt, archived_at: archivedAt },
+    );
+
+    const list = await batchService.listMine(ownerId);
+
+    expect(list).toHaveLength(2);
+    const byId = new Map(list.map((batch) => [batch.id, batch]));
+    expect(byId.get(cancelled.batch.id)?.status).toBe(BatchStatus.IN_PROGRESS);
+    expect(byId.get(cancelled.batch.id)?.cancelled_at).toEqual(cancelledAt);
+    expect(byId.get(cancelled.batch.id)?.archived_at).toBeNull();
+    expect(byId.get(archived.batch.id)?.status).toBe(BatchStatus.IN_PROGRESS);
+    expect(byId.get(archived.batch.id)?.cancelled_at).toEqual(cancelledAt);
+    expect(byId.get(archived.batch.id)?.archived_at).toEqual(archivedAt);
+  });
+
   it('listMine() should return empty array when no batches', async () => {
     const list = await batchService.listMine('user-1');
     expect(list).toEqual([]);
+  });
+
+  it('cancelMine() should soft-cancel an in-progress batch and keep its journal', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    const cancelled = await batchService.cancelMine(ownerId, started.batch.id);
+
+    expect(cancelled.status).toBe(BatchStatus.IN_PROGRESS);
+    expect(cancelled.cancelled_at).toBeTruthy();
+    expect(cancelled.archived_at).toBeNull();
+    expect(
+      await batchStepRepo.count({ where: { batch_id: started.batch.id } }),
+    ).toBe(5);
+  });
+
+  it('cancelMine() should reject completed, archived, duplicate, and unowned batches', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.cancelMine('user-2', started.batch.id),
+    ).rejects.toThrow(NotFoundException);
+
+    await batchService.cancelMine(ownerId, started.batch.id);
+    await expect(
+      batchService.cancelMine(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+
+    const completedRecipe = await recipeService.create(ownerId, {
+      name: 'Completed IPA',
+    });
+    const completed = await batchService.startMine(ownerId, completedRecipe.id);
+    await completeBatch(ownerId, completed.batch.id);
+    await expect(
+      batchService.cancelMine(ownerId, completed.batch.id),
+    ).rejects.toThrow(BadRequestException);
+
+    const archivedRecipe = await recipeService.create(ownerId, {
+      name: 'Archived IPA',
+    });
+    const archived = await batchService.startMine(ownerId, archivedRecipe.id);
+    await batchRepo.update(
+      { id: archived.batch.id },
+      { archived_at: new Date('2026-06-01T10:00:00.000Z') },
+    );
+    await expect(
+      batchService.cancelMine(ownerId, archived.batch.id),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('archiveMine() should archive completed and cancelled batches', async () => {
+    const ownerId = 'user-1';
+    const completedRecipe = await recipeService.create(ownerId, {
+      name: 'Completed IPA',
+    });
+    const cancelledRecipe = await recipeService.create(ownerId, {
+      name: 'Cancelled IPA',
+    });
+
+    const completed = await batchService.startMine(ownerId, completedRecipe.id);
+    await completeBatch(ownerId, completed.batch.id);
+    const archivedCompleted = await batchService.archiveMine(
+      ownerId,
+      completed.batch.id,
+    );
+    expect(archivedCompleted.archived_at).toBeTruthy();
+
+    const cancelled = await batchService.startMine(ownerId, cancelledRecipe.id);
+    await batchService.cancelMine(ownerId, cancelled.batch.id);
+    const archivedCancelled = await batchService.archiveMine(
+      ownerId,
+      cancelled.batch.id,
+    );
+    expect(archivedCancelled.cancelled_at).toBeTruthy();
+    expect(archivedCancelled.archived_at).toBeTruthy();
+  });
+
+  it('archiveMine() should reject active, duplicate, and unowned batches', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.archiveMine('user-2', started.batch.id),
+    ).rejects.toThrow(NotFoundException);
+
+    await expect(
+      batchService.archiveMine(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+
+    await batchService.cancelMine(ownerId, started.batch.id);
+    await batchService.archiveMine(ownerId, started.batch.id);
+
+    await expect(
+      batchService.archiveMine(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
   });
 
   it('startMine() should backfill steps for legacy recipes', async () => {
@@ -383,6 +517,96 @@ describe('BatchService', () => {
 
     await expect(
       batchService.startFermentationMine('user-2', started.batch.id),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('cancelMine() should soft-cancel a launched brew and keep the journal (F16)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    const cancelled = await batchService.cancelMine(ownerId, started.batch.id);
+
+    expect(cancelled.cancelled_at).toBeTruthy();
+    // Soft: the steps (journal) survive, unlike the hard deleteMine.
+    const steps = await batchStepRepo.find({
+      where: { batch_id: started.batch.id },
+    });
+    expect(steps.length).toBeGreaterThan(0);
+  });
+
+  it('cancelMine() should reject a re-cancel and a completed brew (sad)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+
+    const started = await batchService.startMine(ownerId, recipe.id);
+    await batchService.cancelMine(ownerId, started.batch.id);
+    await expect(
+      batchService.cancelMine(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+
+    const other = await batchService.startMine(ownerId, recipe.id);
+    await completeBatch(ownerId, other.batch.id);
+    await expect(
+      batchService.cancelMine(ownerId, other.batch.id),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('cancelMine() should enforce ownership', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.cancelMine('user-2', started.batch.id),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('archiveMine() should archive a completed OR a cancelled brew (F25)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+
+    const finished = await batchService.startMine(ownerId, recipe.id);
+    await completeBatch(ownerId, finished.batch.id);
+    const archivedDone = await batchService.archiveMine(
+      ownerId,
+      finished.batch.id,
+    );
+    expect(archivedDone.archived_at).toBeTruthy();
+
+    const toCancel = await batchService.startMine(ownerId, recipe.id);
+    await batchService.cancelMine(ownerId, toCancel.batch.id);
+    const archivedCancelled = await batchService.archiveMine(
+      ownerId,
+      toCancel.batch.id,
+    );
+    expect(archivedCancelled.archived_at).toBeTruthy();
+  });
+
+  it('archiveMine() should reject an in-progress brew and a re-archive (sad)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.archiveMine(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+
+    await completeBatch(ownerId, started.batch.id);
+    await batchService.archiveMine(ownerId, started.batch.id);
+    await expect(
+      batchService.archiveMine(ownerId, started.batch.id),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('archiveMine() should enforce ownership', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My IPA' });
+    const started = await batchService.startMine(ownerId, recipe.id);
+    await completeBatch(ownerId, started.batch.id);
+
+    await expect(
+      batchService.archiveMine('user-2', started.batch.id),
     ).rejects.toThrow(NotFoundException);
   });
 

--- a/packages/api/src/batch/controllers/batch.controller.spec.ts
+++ b/packages/api/src/batch/controllers/batch.controller.spec.ts
@@ -109,6 +109,8 @@ describe('BatchController', () => {
             listMine: jest.fn(),
             getMineById: jest.fn(),
             deleteMine: jest.fn(),
+            cancelMine: jest.fn(),
+            archiveMine: jest.fn(),
             startFermentationMine: jest.fn(),
             completeFermentationMine: jest.fn(),
             listMineReminders: jest.fn(),
@@ -352,6 +354,33 @@ describe('BatchController', () => {
         mockUser.id,
         mockBatchOrm.id,
       );
+      expect(result).toBeDefined();
+    });
+  });
+
+  /**
+   * PATCH /batches/:id/cancel + /archive — soft lifecycle (F16 / F25)
+   */
+  describe('cancelMine() + archiveMine() - PATCH soft lifecycle', () => {
+    it('cancels the current batch', async () => {
+      const cancelSpy = jest
+        .spyOn(service, 'cancelMine')
+        .mockResolvedValue({ ...mockBatchOrm, cancelled_at: new Date() });
+
+      const result = await controller.cancelMine(mockUser, mockBatchOrm.id);
+
+      expect(cancelSpy).toHaveBeenCalledWith(mockUser.id, mockBatchOrm.id);
+      expect(result).toBeDefined();
+    });
+
+    it('archives the current batch', async () => {
+      const archiveSpy = jest
+        .spyOn(service, 'archiveMine')
+        .mockResolvedValue({ ...mockBatchOrm, archived_at: new Date() });
+
+      const result = await controller.archiveMine(mockUser, mockBatchOrm.id);
+
+      expect(archiveSpy).toHaveBeenCalledWith(mockUser.id, mockBatchOrm.id);
       expect(result).toBeDefined();
     });
   });

--- a/packages/api/src/batch/controllers/batch.controller.ts
+++ b/packages/api/src/batch/controllers/batch.controller.ts
@@ -132,6 +132,30 @@ export class BatchController {
     return BatchDto.fromEntities(batch, steps);
   }
 
+  @Patch(':id/cancel')
+  @ApiOperation({
+    summary: 'Cancel a launched brew (soft — keeps the journal)',
+  })
+  @ApiOkResponse({ type: BatchSummaryDto })
+  async cancelMine(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<BatchSummaryDto> {
+    const batch = await this.service.cancelMine(user.id, id);
+    return BatchSummaryDto.fromEntity(batch);
+  }
+
+  @Patch(':id/archive')
+  @ApiOperation({ summary: 'Archive a finished or cancelled brew (soft-hide)' })
+  @ApiOkResponse({ type: BatchSummaryDto })
+  async archiveMine(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<BatchSummaryDto> {
+    const batch = await this.service.archiveMine(user.id, id);
+    return BatchSummaryDto.fromEntity(batch);
+  }
+
   @Post(':id/fermentation/start')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Start fermentation for one of my batches' })

--- a/packages/api/src/batch/domain/enums/batch-status.enum.spec.ts
+++ b/packages/api/src/batch/domain/enums/batch-status.enum.spec.ts
@@ -1,0 +1,32 @@
+import { BatchStatus, deriveEffectiveStatus } from './batch-status.enum';
+
+describe('deriveEffectiveStatus', () => {
+  it('returns the raw brewing lifecycle status when no soft stamp exists', () => {
+    expect(deriveEffectiveStatus(BatchStatus.IN_PROGRESS, null, null)).toBe(
+      BatchStatus.IN_PROGRESS,
+    );
+    expect(deriveEffectiveStatus(BatchStatus.COMPLETED, null, null)).toBe(
+      BatchStatus.COMPLETED,
+    );
+  });
+
+  it('derives cancelled when cancelled_at is set', () => {
+    expect(
+      deriveEffectiveStatus(
+        BatchStatus.IN_PROGRESS,
+        new Date('2026-06-01T10:00:00.000Z'),
+        null,
+      ),
+    ).toBe('cancelled');
+  });
+
+  it('derives archived before cancelled when both soft stamps are set', () => {
+    expect(
+      deriveEffectiveStatus(
+        BatchStatus.IN_PROGRESS,
+        new Date('2026-06-01T10:00:00.000Z'),
+        new Date('2026-06-02T10:00:00.000Z'),
+      ),
+    ).toBe('archived');
+  });
+});

--- a/packages/api/src/batch/domain/enums/batch-status.enum.ts
+++ b/packages/api/src/batch/domain/enums/batch-status.enum.ts
@@ -16,6 +16,17 @@ export enum BatchStatus {
  */
 export type EffectiveBatchStatus = BatchStatus | 'cancelled' | 'archived';
 
+/**
+ * Every value {@link EffectiveBatchStatus} can take, in precedence order. Kept
+ * next to the type so the OpenAPI `enum` on BatchSummaryDto never drifts from it.
+ */
+export const EFFECTIVE_BATCH_STATUSES: EffectiveBatchStatus[] = [
+  BatchStatus.IN_PROGRESS,
+  BatchStatus.COMPLETED,
+  'cancelled',
+  'archived',
+];
+
 export function deriveEffectiveStatus(
   status: BatchStatus,
   cancelledAt: Date | null | undefined,

--- a/packages/api/src/batch/domain/enums/batch-status.enum.ts
+++ b/packages/api/src/batch/domain/enums/batch-status.enum.ts
@@ -7,3 +7,21 @@ export enum BatchStatus {
   IN_PROGRESS = 'in_progress',
   COMPLETED = 'completed',
 }
+
+/**
+ * Effective (derived) lifecycle state shown to clients. The DB keeps `status`
+ * as the brewing lifecycle (in_progress/completed) plus nullable `cancelled_at`
+ * / `archived_at` timestamps; the effective state is derived with archived
+ * taking precedence over cancelled over the raw status (brew-day/07).
+ */
+export type EffectiveBatchStatus = BatchStatus | 'cancelled' | 'archived';
+
+export function deriveEffectiveStatus(
+  status: BatchStatus,
+  cancelledAt: Date | null | undefined,
+  archivedAt: Date | null | undefined,
+): EffectiveBatchStatus {
+  if (archivedAt) return 'archived';
+  if (cancelledAt) return 'cancelled';
+  return status;
+}

--- a/packages/api/src/batch/dtos/batch-summary.dto.ts
+++ b/packages/api/src/batch/dtos/batch-summary.dto.ts
@@ -1,6 +1,9 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-import { deriveEffectiveStatus } from '../domain/enums/batch-status.enum';
+import {
+  deriveEffectiveStatus,
+  EFFECTIVE_BATCH_STATUSES,
+} from '../domain/enums/batch-status.enum';
 import type { EffectiveBatchStatus } from '../domain/enums/batch-status.enum';
 import { BatchOrmEntity } from '../entities/batch.orm.entity';
 
@@ -17,6 +20,7 @@ export class BatchSummaryDto {
   // Effective lifecycle status: the brewing status (in_progress | completed)
   // unless the batch was cancelled or archived (derived, archived > cancelled).
   @ApiProperty({
+    enum: EFFECTIVE_BATCH_STATUSES,
     description: 'in_progress | completed | cancelled | archived',
   })
   status: EffectiveBatchStatus;

--- a/packages/api/src/batch/dtos/batch-summary.dto.ts
+++ b/packages/api/src/batch/dtos/batch-summary.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-import { BatchStatus } from '../domain/enums/batch-status.enum';
+import { deriveEffectiveStatus } from '../domain/enums/batch-status.enum';
+import type { EffectiveBatchStatus } from '../domain/enums/batch-status.enum';
 import { BatchOrmEntity } from '../entities/batch.orm.entity';
 
 export class BatchSummaryDto {
@@ -13,8 +14,12 @@ export class BatchSummaryDto {
   @ApiProperty()
   recipe_id: string;
 
-  @ApiProperty({ enum: BatchStatus })
-  status: BatchStatus;
+  // Effective lifecycle status: the brewing status (in_progress | completed)
+  // unless the batch was cancelled or archived (derived, archived > cancelled).
+  @ApiProperty({
+    description: 'in_progress | completed | cancelled | archived',
+  })
+  status: EffectiveBatchStatus;
 
   @ApiPropertyOptional({ nullable: true })
   current_step_order?: number | null;
@@ -34,6 +39,12 @@ export class BatchSummaryDto {
   @ApiPropertyOptional({ nullable: true })
   completed_at?: Date | null;
 
+  @ApiPropertyOptional({ nullable: true })
+  cancelled_at?: Date | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  archived_at?: Date | null;
+
   @ApiProperty()
   created_at: Date;
 
@@ -45,13 +56,15 @@ export class BatchSummaryDto {
       id: e.id,
       owner_id: e.owner_id,
       recipe_id: e.recipe_id,
-      status: e.status,
+      status: deriveEffectiveStatus(e.status, e.cancelled_at, e.archived_at),
       current_step_order: e.current_step_order ?? null,
       started_at: e.started_at,
       fermentation_started_at: e.fermentation_started_at ?? null,
       fermentation_completed_at: e.fermentation_completed_at ?? null,
       bottled_at: e.bottled_at ?? null,
       completed_at: e.completed_at ?? null,
+      cancelled_at: e.cancelled_at ?? null,
+      archived_at: e.archived_at ?? null,
       created_at: e.created_at,
       updated_at: e.updated_at,
     };

--- a/packages/api/src/batch/entities/batch.orm.entity.ts
+++ b/packages/api/src/batch/entities/batch.orm.entity.ts
@@ -80,6 +80,18 @@ export class BatchOrmEntity {
   @Column({ type: 'datetime', nullable: true })
   completed_at?: Date | null;
 
+  // Soft lifecycle timestamps (brew-day/07). The `status` column stays the
+  // brewing lifecycle (in_progress/completed); these nullable stamps carry the
+  // reversibility states so no CHECK-constraint rebuild is needed. `cancelled_at`
+  // = a launched brew the brewer stopped (F16, keeps the journal); `archived_at`
+  // = a finished/cancelled brew hidden from the active list (F25). The effective
+  // status is derived (archived > cancelled > status) — see deriveEffectiveStatus.
+  @Column({ type: 'datetime', nullable: true })
+  cancelled_at?: Date | null;
+
+  @Column({ type: 'datetime', nullable: true })
+  archived_at?: Date | null;
+
   @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   created_at: Date;
 

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -184,6 +184,7 @@ export class BatchService {
     batchId: string,
   ): Promise<BatchOrmEntity> {
     const batch = await this.getMineBatch(ownerId, batchId);
+    this.assertMutable(batch);
     if (batch.status === BatchStatus.COMPLETED) {
       throw new BadRequestException('Batch already completed');
     }
@@ -200,6 +201,7 @@ export class BatchService {
     batchId: string,
   ): Promise<BatchOrmEntity> {
     const batch = await this.getMineBatch(ownerId, batchId);
+    this.assertMutable(batch);
     if (batch.status === BatchStatus.COMPLETED) {
       throw new BadRequestException('Batch already completed');
     }
@@ -374,6 +376,7 @@ export class BatchService {
       if (!batch) {
         throw new NotFoundException('Batch not found');
       }
+      this.assertMutable(batch);
       if (batch.status === BatchStatus.COMPLETED) {
         throw new BadRequestException('Batch already completed');
       }
@@ -638,6 +641,7 @@ export class BatchService {
       if (!batch) {
         throw new NotFoundException('Batch not found');
       }
+      this.assertMutable(batch);
       if (batch.status === BatchStatus.COMPLETED) {
         throw new BadRequestException('Batch already completed');
       }
@@ -732,6 +736,7 @@ export class BatchService {
 
     // Conception places tasting AFTER closure (the UI only exposes it from the
     // closure view): a batch can only be tasted once it is bottled (completed).
+    this.assertMutable(batch);
     if (batch.status !== BatchStatus.COMPLETED) {
       throw new BadRequestException(
         'Tasting can only be recorded once the batch is bottled (completed)',
@@ -819,5 +824,21 @@ export class BatchService {
       throw new NotFoundException('Batch not found');
     }
     return batch;
+  }
+
+  /**
+   * Guard against mutating a soft-closed batch. A cancelled or archived brew is
+   * frozen: its journal must not be reactivated by any workflow-advancing
+   * endpoint (fermentation, step transitions, bottling close, tasting). The raw
+   * `status` column stays in_progress/completed on a cancelled batch, so those
+   * endpoints check the soft-lifecycle stamps here (brew-day/07 timestamp model).
+   */
+  private assertMutable(batch: BatchOrmEntity): void {
+    if (batch.cancelled_at) {
+      throw new BadRequestException('Batch is cancelled');
+    }
+    if (batch.archived_at) {
+      throw new BadRequestException('Batch is archived');
+    }
   }
 }

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -214,6 +214,48 @@ export class BatchService {
     return this.batchRepo.save(batch);
   }
 
+  /**
+   * Cancel a launched brew (F16). Soft: sets `cancelled_at`, keeps the journal
+   * (steps/measurements) — distinct from the hard `deleteMine`. Only an
+   * in-progress brew can be cancelled.
+   */
+  async cancelMine(ownerId: string, batchId: string): Promise<BatchOrmEntity> {
+    const batch = await this.getMineBatch(ownerId, batchId);
+    if (batch.archived_at) {
+      throw new BadRequestException('Batch is archived');
+    }
+    if (batch.cancelled_at) {
+      throw new BadRequestException('Batch already cancelled');
+    }
+    if (batch.status !== BatchStatus.IN_PROGRESS) {
+      throw new BadRequestException('Only a launched brew can be cancelled');
+    }
+
+    batch.cancelled_at = new Date();
+    return this.batchRepo.save(batch);
+  }
+
+  /**
+   * Archive a finished or cancelled brew (F25). Soft-hides it from the active
+   * « Mes brassins » list without deleting its journal.
+   */
+  async archiveMine(ownerId: string, batchId: string): Promise<BatchOrmEntity> {
+    const batch = await this.getMineBatch(ownerId, batchId);
+    if (batch.archived_at) {
+      throw new BadRequestException('Batch already archived');
+    }
+    const isCompleted = batch.status === BatchStatus.COMPLETED;
+    const isCancelled = Boolean(batch.cancelled_at);
+    if (!isCompleted && !isCancelled) {
+      throw new BadRequestException(
+        'Only a finished or cancelled brew can be archived',
+      );
+    }
+
+    batch.archived_at = new Date();
+    return this.batchRepo.save(batch);
+  }
+
   async listMineReminders(
     ownerId: string,
     batchId: string,

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -834,11 +834,13 @@ export class BatchService {
    * endpoints check the soft-lifecycle stamps here (brew-day/07 timestamp model).
    */
   private assertMutable(batch: BatchOrmEntity): void {
-    if (batch.cancelled_at) {
-      throw new BadRequestException('Batch is cancelled');
-    }
+    // Archived takes precedence over cancelled (same order as
+    // deriveEffectiveStatus): an archive-after-cancel batch reports "archived".
     if (batch.archived_at) {
       throw new BadRequestException('Batch is archived');
+    }
+    if (batch.cancelled_at) {
+      throw new BadRequestException('Batch is cancelled');
     }
   }
 }

--- a/packages/api/src/database/migrations/1804000000000-AddBatchSoftLifecycleStamps.ts
+++ b/packages/api/src/database/migrations/1804000000000-AddBatchSoftLifecycleStamps.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `cancelled_at` and `archived_at` to `batches` (brew-day/07 lifecycle).
+ *
+ * These nullable timestamps carry the reversibility states (F16 cancel, F25
+ * archive) WITHOUT extending the `status` CHECK constraint — SQLite cannot
+ * alter a CHECK in place and `batches` is referenced by many cascade-FK child
+ * tables, so a table rebuild would be risky. A plain `ADD COLUMN` (like
+ * `bottled_at`) is safe and needs no backfill. The effective lifecycle state is
+ * derived (archived > cancelled > status) at the DTO boundary.
+ */
+export class AddBatchSoftLifecycleStamps1804000000000 implements MigrationInterface {
+  name = 'AddBatchSoftLifecycleStamps1804000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "cancelled_at" datetime`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "archived_at" datetime`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "archived_at"`);
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "cancelled_at"`);
+  }
+}

--- a/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
+++ b/packages/mobile-app/src/features/batches/application/__tests__/batches.use-cases.test.ts
@@ -1,4 +1,6 @@
 import {
+  archiveBatch,
+  cancelBatch,
   completeCurrentBatchStep,
   deleteBatch,
   getBatchDetails,
@@ -8,6 +10,8 @@ import {
   startCurrentBatchStep,
 } from "@/features/batches/application/batches.use-cases";
 import {
+  archiveBatch as archiveBatchApi,
+  cancelBatch as cancelBatchApi,
   completeCurrentStep,
   deleteBatch as deleteBatchApi,
   getMineById,
@@ -32,6 +36,8 @@ jest.mock("@/features/batches/data/batches.api", () => ({
   completeCurrentStep: jest.fn(),
   startBatch: jest.fn(),
   deleteBatch: jest.fn(),
+  cancelBatch: jest.fn(),
+  archiveBatch: jest.fn(),
 }));
 
 jest.mock("@/features/recipes/application/recipes.use-cases", () => ({
@@ -58,6 +64,12 @@ const mockedStartBatchApi = startBatchApi as jest.MockedFunction<
 const mockedDeleteBatchApi = deleteBatchApi as jest.MockedFunction<
   typeof deleteBatchApi
 >;
+const mockedCancelBatchApi = cancelBatchApi as jest.MockedFunction<
+  typeof cancelBatchApi
+>;
+const mockedArchiveBatchApi = archiveBatchApi as jest.MockedFunction<
+  typeof archiveBatchApi
+>;
 
 describe("batches use-cases", () => {
   beforeEach(() => {
@@ -68,6 +80,8 @@ describe("batches use-cases", () => {
     mockedStartBatchApi.mockReset();
     mockedGetRecipeDetails.mockReset();
     mockedDeleteBatchApi.mockReset();
+    mockedCancelBatchApi.mockReset();
+    mockedArchiveBatchApi.mockReset();
   });
 
   it("deleteBatch is a no-op in demo mode (F25, demo)", async () => {
@@ -91,6 +105,41 @@ describe("batches use-cases", () => {
     mockedDeleteBatchApi.mockRejectedValue(new Error("boom"));
 
     await expect(deleteBatch("b1")).rejects.toThrow("boom");
+  });
+
+  it("cancelBatch is a no-op in demo mode; calls the API when live (F16)", async () => {
+    dataSource.useDemoData = true;
+    await expect(cancelBatch("b1")).resolves.toBeUndefined();
+    expect(mockedCancelBatchApi).not.toHaveBeenCalled();
+
+    dataSource.useDemoData = false;
+    mockedCancelBatchApi.mockResolvedValue({ id: "b1" } as never);
+    await cancelBatch("b1");
+    expect(mockedCancelBatchApi).toHaveBeenCalledWith("b1");
+  });
+
+  it("cancelBatch returns early on a missing id (sad)", async () => {
+    dataSource.useDemoData = false;
+    await expect(cancelBatch("")).resolves.toBeUndefined();
+    expect(mockedCancelBatchApi).not.toHaveBeenCalled();
+  });
+
+  it("archiveBatch is a no-op in demo mode; calls the API when live (F25)", async () => {
+    dataSource.useDemoData = true;
+    await expect(archiveBatch("b1")).resolves.toBeUndefined();
+    expect(mockedArchiveBatchApi).not.toHaveBeenCalled();
+
+    dataSource.useDemoData = false;
+    mockedArchiveBatchApi.mockResolvedValue({ id: "b1" } as never);
+    await archiveBatch("b1");
+    expect(mockedArchiveBatchApi).toHaveBeenCalledWith("b1");
+  });
+
+  it("archiveBatch propagates the API error when live (sad)", async () => {
+    dataSource.useDemoData = false;
+    mockedArchiveBatchApi.mockRejectedValue(new Error("boom"));
+
+    await expect(archiveBatch("b1")).rejects.toThrow("boom");
   });
 
   it("returns demo batches list when demo data is enabled", async () => {

--- a/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
+++ b/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
@@ -1,4 +1,6 @@
 import {
+  archiveBatch as archiveBatchApi,
+  cancelBatch as cancelBatchApi,
   completeCurrentStep as completeCurrentStepApi,
   deleteBatch as deleteBatchApi,
   getMineById,
@@ -25,6 +27,28 @@ export async function deleteBatch(batchId: string): Promise<void> {
     return;
   }
   await deleteBatchApi(batchId);
+}
+
+/**
+ * Cancel a launched brew (F16) — soft, keeps the journal (distinct from
+ * deleteBatch). No-op in demo mode (demo batches are read-only).
+ */
+export async function cancelBatch(batchId: string): Promise<void> {
+  if (!batchId || dataSource.useDemoData) {
+    return;
+  }
+  await cancelBatchApi(batchId);
+}
+
+/**
+ * Archive a finished or cancelled brew (F25) — soft-hides it from the active
+ * list. No-op in demo mode.
+ */
+export async function archiveBatch(batchId: string): Promise<void> {
+  if (!batchId || dataSource.useDemoData) {
+    return;
+  }
+  await archiveBatchApi(batchId);
 }
 
 export async function getBatchDetails(batchId: string): Promise<Batch | null> {

--- a/packages/mobile-app/src/features/batches/data/__tests__/batches.api.test.ts
+++ b/packages/mobile-app/src/features/batches/data/__tests__/batches.api.test.ts
@@ -8,6 +8,8 @@
 import * as httpClient from "@/core/http/http-client";
 
 import {
+  archiveBatch,
+  cancelBatch,
   deleteBatch,
   getMineById,
   startCurrentStep,
@@ -93,6 +95,52 @@ describe("batches.api — deleteBatch (F25)", () => {
     mockedRequest.mockRejectedValue(new Error("boom"));
 
     await expect(deleteBatch("b1")).rejects.toThrow("boom");
+  });
+});
+
+describe("batches.api — cancelBatch + archiveBatch (F16 / F25)", () => {
+  beforeEach(() => {
+    mockedRequest.mockReset();
+  });
+
+  const summaryDto = (status: string) =>
+    ({
+      id: "b1",
+      owner_id: "u1",
+      recipe_id: "r1",
+      status,
+      started_at: "2026-01-01T00:00:00.000Z",
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-01T00:00:00.000Z",
+    }) as never;
+
+  it("PATCHes the cancel endpoint and maps the summary (happy)", async () => {
+    mockedRequest.mockResolvedValue(summaryDto("cancelled"));
+
+    const summary = await cancelBatch("b1");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/batches/b1/cancel", {
+      method: "PATCH",
+    });
+    expect(summary.status).toBe("cancelled");
+  });
+
+  it("PATCHes the archive endpoint and maps the summary (happy)", async () => {
+    mockedRequest.mockResolvedValue(summaryDto("archived"));
+
+    const summary = await archiveBatch("b1");
+
+    expect(mockedRequest).toHaveBeenCalledWith("/batches/b1/archive", {
+      method: "PATCH",
+    });
+    expect(summary.status).toBe("archived");
+  });
+
+  it("propagates the request error (sad)", async () => {
+    mockedRequest.mockRejectedValue(new Error("boom"));
+
+    await expect(cancelBatch("b1")).rejects.toThrow("boom");
+    await expect(archiveBatch("b1")).rejects.toThrow("boom");
   });
 });
 

--- a/packages/mobile-app/src/features/batches/data/batches.api.ts
+++ b/packages/mobile-app/src/features/batches/data/batches.api.ts
@@ -142,6 +142,20 @@ export async function deleteBatch(id: string): Promise<void> {
   await request<void>(`/batches/${id}`, { method: "DELETE" });
 }
 
+export async function cancelBatch(id: string): Promise<BatchSummary> {
+  const row = await request<BatchSummaryDto>(`/batches/${id}/cancel`, {
+    method: "PATCH",
+  });
+  return mapBatchSummary(row);
+}
+
+export async function archiveBatch(id: string): Promise<BatchSummary> {
+  const row = await request<BatchSummaryDto>(`/batches/${id}/archive`, {
+    method: "PATCH",
+  });
+  return mapBatchSummary(row);
+}
+
 /**
  * Raw priming payload as returned by the backend (snake_case), mirroring the
  * backend `PrimingDto`. Mapped to {@link PrimingInfo} by {@link mapPriming}.

--- a/packages/mobile-app/src/features/batches/domain/batch.types.ts
+++ b/packages/mobile-app/src/features/batches/domain/batch.types.ts
@@ -1,4 +1,11 @@
-export type BatchStatus = "in_progress" | "completed";
+// Effective lifecycle status returned by the API: the brewing status
+// (in_progress | completed) unless the batch was cancelled or archived
+// (soft states derived server-side, archived > cancelled — brew-day/07).
+export type BatchStatus =
+  | "in_progress"
+  | "completed"
+  | "cancelled"
+  | "archived";
 
 export type BatchStepStatus = "pending" | "in_progress" | "completed";
 

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -11,7 +11,9 @@ import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { BrewStepTimer } from "@/features/batches/presentation/BrewStepTimer";
 import { colors, radius, spacing, typography } from "@/core/theme";
 import {
+  archiveBatch,
   BatchDetailsViewModel,
+  cancelBatch,
   completeCurrentBatchStep,
   deleteBatch,
   getBatchDetailsViewModel,
@@ -243,6 +245,34 @@ export function BatchDetailsScreen({ batchId }: Props) {
     },
   });
 
+  const { mutate: mutateCancelBatch, isPending: isCancelling } = useMutation<
+    void,
+    Error
+  >({
+    mutationFn: () => cancelBatch(batchId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["batches", "list"] });
+      router.replace("/batches");
+    },
+    onError: (error) => {
+      setMutationError(getErrorMessage(error, "Échec de l'annulation"));
+    },
+  });
+
+  const { mutate: mutateArchiveBatch, isPending: isArchiving } = useMutation<
+    void,
+    Error
+  >({
+    mutationFn: () => archiveBatch(batchId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["batches", "list"] });
+      router.replace("/batches");
+    },
+    onError: (error) => {
+      setMutationError(getErrorMessage(error, "Échec de l'archivage"));
+    },
+  });
+
   const error = missingBatchId
     ? "Identifiant de brassin manquant."
     : (mutationError ??
@@ -311,7 +341,8 @@ export function BatchDetailsScreen({ batchId }: Props) {
       return;
     }
     // F25 — destructive + irreversible, so gate it behind a confirm (recovers
-    // an accidental/phantom batch). Archiving a completed brew is deferred.
+    // an accidental/phantom batch). Cancel (F16) and archive (F25) are the soft
+    // alternatives that keep the journal (see handleCancel / handleArchive).
     Alert.alert(
       "Supprimer ce brassin ?",
       "Il sera définitivement retiré de tes brassins. Cette action est irréversible.",
@@ -323,6 +354,51 @@ export function BatchDetailsScreen({ batchId }: Props) {
           onPress: () => {
             setMutationError(null);
             mutateDeleteBatch();
+          },
+        },
+      ],
+    );
+  };
+
+  const handleCancel = () => {
+    if (missingBatchId) {
+      return;
+    }
+    // F16 — stop a launched brew. Soft (keeps the journal), so a confirm is
+    // enough; it is not the irreversible delete.
+    Alert.alert(
+      "Annuler ce brassin ?",
+      "Le brassin sera arrêté et retiré de tes brassins actifs, mais son journal est conservé.",
+      [
+        { text: "Retour", style: "cancel" },
+        {
+          text: "Annuler le brassin",
+          style: "destructive",
+          onPress: () => {
+            setMutationError(null);
+            mutateCancelBatch();
+          },
+        },
+      ],
+    );
+  };
+
+  const handleArchive = () => {
+    if (missingBatchId) {
+      return;
+    }
+    // F25 — declutter: soft-hide a finished brew; its journal is kept.
+    Alert.alert(
+      "Archiver ce brassin ?",
+      "Il sera retiré de tes brassins actifs mais conservé dans ton historique.",
+      [
+        { text: "Retour", style: "cancel" },
+        {
+          text: "Archiver",
+          style: "default",
+          onPress: () => {
+            setMutationError(null);
+            mutateArchiveBatch();
           },
         },
       ],
@@ -570,6 +646,34 @@ export function BatchDetailsScreen({ batchId }: Props) {
         </>
       ) : null}
 
+      {batch?.status === "in_progress" ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Annuler ce brassin"
+          onPress={handleCancel}
+          disabled={isCancelling}
+          style={styles.softAction}
+        >
+          <Text style={styles.softActionDanger}>
+            {isCancelling ? "Annulation…" : "Annuler ce brassin"}
+          </Text>
+        </Pressable>
+      ) : null}
+
+      {isCompleted ? (
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Archiver ce brassin"
+          onPress={handleArchive}
+          disabled={isArchiving}
+          style={styles.softAction}
+        >
+          <Text style={styles.softActionText}>
+            {isArchiving ? "Archivage…" : "Archiver ce brassin"}
+          </Text>
+        </Pressable>
+      ) : null}
+
       <Modal
         visible={openTip !== null}
         transparent
@@ -640,6 +744,27 @@ const styles = StyleSheet.create({
     // bottom steps were clipped behind the footer (the paddingBottom offset
     // alone could not rescue content that overflowed the screen).
     flex: 1,
+  },
+  // Secondary soft-lifecycle actions (F16 cancel / F25 archive) — quiet text
+  // links, distinct from the primary CTA.
+  softAction: {
+    marginTop: spacing.sm,
+    alignItems: "center",
+    paddingVertical: spacing.sm,
+  },
+  softActionText: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+    color: colors.brand.secondary,
+    textDecorationLine: "underline",
+  },
+  softActionDanger: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+    color: colors.semantic.error,
+    textDecorationLine: "underline",
   },
   fermentationCard: {
     padding: spacing.md,

--- a/packages/mobile-app/src/features/batches/presentation/BatchesScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchesScreen.tsx
@@ -79,12 +79,18 @@ export function BatchesScreen() {
     queryFn: listBatches,
   });
 
+  // Active « Mes brassins »: soft states (cancelled/archived) are hidden from
+  // the list without deleting their journal (brew-day/07 — F16/F25).
+  const activeBatches = batches.filter(
+    (batch) => batch.status !== "cancelled" && batch.status !== "archived",
+  );
+
   const error = queryError
     ? isFetching
       ? null
       : getErrorMessage(queryError, "Failed to load batches")
     : null;
-  const showEmptyState = isFetched && !isLoading && batches.length === 0;
+  const showEmptyState = isFetched && !isLoading && activeBatches.length === 0;
   const isRetryingWithError = isFetching && Boolean(queryError);
 
   const handleRefetch = () => {
@@ -93,7 +99,9 @@ export function BatchesScreen() {
 
   return (
     <Screen
-      isLoading={(isLoading && batches.length === 0) || isRetryingWithError}
+      isLoading={
+        (isLoading && activeBatches.length === 0) || isRetryingWithError
+      }
       error={error}
       onRetry={handleRefetch}
     >
@@ -108,7 +116,7 @@ export function BatchesScreen() {
       ) : null}
 
       <FlatList
-        data={batches}
+        data={activeBatches}
         keyExtractor={(item) => item.id}
         contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
         refreshControl={

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -9,6 +9,8 @@ import {
 
 import { BatchDetailsScreen } from "@/features/batches/presentation/BatchDetailsScreen";
 import {
+  archiveBatch,
+  cancelBatch,
   completeCurrentBatchStep,
   deleteBatch,
   getBatchDetailsViewModel,
@@ -101,6 +103,8 @@ jest.mock("@/features/batches/application/batches.use-cases", () => ({
     steps: [],
   }),
   deleteBatch: jest.fn().mockResolvedValue(undefined),
+  cancelBatch: jest.fn().mockResolvedValue(undefined),
+  archiveBatch: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock("@/features/batches/application/measurement.use-cases", () => ({
@@ -274,6 +278,40 @@ describe("BatchDetailsScreen", () => {
     // error's own message ("boom") over the fallback copy.
     expect(await screen.findByText("boom")).toBeTruthy();
     expect(mockReplace).not.toHaveBeenCalledWith("/batches");
+  });
+
+  it("cancels an in-progress batch after confirmation and navigates back (F16)", async () => {
+    (cancelBatch as jest.Mock).mockClear();
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderBatchDetailsScreen();
+
+    // mashBatch is in_progress → the soft cancel action is offered.
+    fireEvent.press(await screen.findByLabelText("Annuler ce brassin"));
+    expect(cancelBatch).not.toHaveBeenCalled();
+
+    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
+    buttons.find((b) => b.text === "Annuler le brassin")?.onPress?.();
+
+    await waitFor(() => expect(cancelBatch).toHaveBeenCalledWith("b1"));
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/batches"));
+  });
+
+  it("archives a completed batch after confirmation and navigates back (F25)", async () => {
+    (archiveBatch as jest.Mock).mockClear();
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel({ ...mashBatch, status: "completed" }, "Ma recette test"),
+    );
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderBatchDetailsScreen();
+
+    fireEvent.press(await screen.findByLabelText("Archiver ce brassin"));
+    expect(archiveBatch).not.toHaveBeenCalled();
+
+    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
+    buttons.find((b) => b.text === "Archiver")?.onPress?.();
+
+    await waitFor(() => expect(archiveBatch).toHaveBeenCalledWith("b1"));
+    await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/batches"));
   });
 
   it("renders French status, step index, badges and phase labels", async () => {

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchesScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchesScreen.test.tsx
@@ -106,6 +106,30 @@ describe("BatchesScreen", () => {
     expect(screen.getByText("TERMINÉ")).toBeTruthy();
   });
 
+  it("hides archived and cancelled batches from the active list (07a)", async () => {
+    dataSource.useDemoData = true;
+    const base = {
+      ownerId: "u-demo-1",
+      recipeId: "r-demo-pdd",
+      startedAt: "2026-05-19T09:00:00.000Z",
+      createdAt: "2026-05-19T09:00:00.000Z",
+      updatedAt: "2026-05-19T09:30:00.000Z",
+    };
+    (listBatches as jest.Mock).mockResolvedValue([
+      { id: "b-active", status: "in_progress", ...base },
+      { id: "b-archived", status: "archived", ...base },
+      { id: "b-cancelled", status: "cancelled", ...base },
+    ]);
+
+    renderBatchesScreen();
+
+    // Only the active brew renders; the soft states are filtered out.
+    expect(await screen.findByText("EN COURS")).toBeTruthy();
+    expect(screen.queryByText("ARCHIVÉ")).toBeNull();
+    expect(screen.queryByText("ANNULÉ")).toBeNull();
+    expect(screen.getAllByText("La Première du dimanche").length).toBe(1);
+  });
+
   it("falls back to a French Brassin <id> label when no recipe is found (sad path)", async () => {
     dataSource.useDemoData = true;
     (listBatches as jest.Mock).mockResolvedValue([

--- a/packages/mobile-app/src/features/batches/presentation/batch-display.constants.ts
+++ b/packages/mobile-app/src/features/batches/presentation/batch-display.constants.ts
@@ -13,6 +13,8 @@ import type {
 export const BATCH_STATUS_LABELS: Record<BatchStatus, string> = {
   in_progress: "En cours",
   completed: "Terminé",
+  cancelled: "Annulé",
+  archived: "Archivé",
 };
 
 export const BATCH_STEP_STATUS_LABELS: Record<BatchStepStatus, string> = {

--- a/packages/mobile-app/src/features/labels/application/__tests__/labels.use-cases.test.ts
+++ b/packages/mobile-app/src/features/labels/application/__tests__/labels.use-cases.test.ts
@@ -129,6 +129,44 @@ describe("labels use-cases", () => {
     expect(candidates[1].style).toBe("Maltée");
   });
 
+  it("excludes cancelled and archived batches from label candidates", async () => {
+    mockedListBatches.mockResolvedValue([
+      {
+        id: "batch-live",
+        ownerId: "u1",
+        recipeId: "recipe-live",
+        status: "in_progress",
+        startedAt: "2026-03-01T00:00:00.000Z",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      },
+      {
+        id: "batch-cancelled",
+        ownerId: "u1",
+        recipeId: "recipe-cancelled",
+        status: "cancelled",
+        startedAt: "2026-03-02T00:00:00.000Z",
+        createdAt: "2026-03-02T00:00:00.000Z",
+        updatedAt: "2026-03-02T00:00:00.000Z",
+      },
+      {
+        id: "batch-archived",
+        ownerId: "u1",
+        recipeId: "recipe-archived",
+        status: "archived",
+        startedAt: "2026-03-03T00:00:00.000Z",
+        createdAt: "2026-03-03T00:00:00.000Z",
+        updatedAt: "2026-03-03T00:00:00.000Z",
+      },
+    ]);
+    mockedListRecipes.mockResolvedValue([]);
+
+    const candidates = await listLabelBatchCandidates();
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].batchId).toBe("batch-live");
+  });
+
   it("sorts drafts by updated date descending", async () => {
     mockedLabelsStorage.listDrafts.mockResolvedValue([
       buildLabelDraft({ id: "draft-1", updatedAt: "2026-01-01T00:00:00.000Z" }),

--- a/packages/mobile-app/src/features/labels/application/labels.use-cases.ts
+++ b/packages/mobile-app/src/features/labels/application/labels.use-cases.ts
@@ -1,4 +1,5 @@
 import { listBatches } from "@/features/batches/application/batches.use-cases";
+import { BatchSummary } from "@/features/batches/domain/batch.types";
 import { labelsStorage } from "@/features/labels/data/labels.repository";
 import { DEFAULT_LABEL_LEGAL_HINT } from "@/features/labels/domain/label.constants";
 import {
@@ -153,7 +154,16 @@ export async function listLabelBatchCandidates(): Promise<
   const [batches, recipes] = await Promise.all([listBatches(), listRecipes()]);
   const recipesById = new Map(recipes.map((recipe) => [recipe.id, recipe]));
 
+  // A cancelled or archived brew has nothing to bottle, so it is never a label
+  // candidate. The type predicate also narrows `status` to the two brewable
+  // states LabelBatchCandidate exposes (keeps getBatchStatusLabel exhaustive).
   return [...batches]
+    .filter(
+      (
+        batch,
+      ): batch is BatchSummary & { status: LabelBatchCandidate["status"] } =>
+        batch.status === "in_progress" || batch.status === "completed",
+    )
     .map((batch) => {
       const recipe = recipesById.get(batch.recipeId);
       const recipeName =


### PR DESCRIPTION
## Summary

Slice 07a of the brew-day batch lifecycle — soft **cancel** (F16) and **archive** (F25) of a batch. Conforms to [`brew-day/07-state-batch-lifecycle.md`](docs/architecture/diagrams/brew-day/07-state-batch-lifecycle.md) (updated here to the timestamp model).

- **Data model** — nullable `cancelled_at` / `archived_at` timestamp columns (plain `ADD COLUMN` migration, no backfill), **not** new `status` enum values: SQLite can't alter a CHECK in place and `batches` has many cascade-FK children, so a table rebuild would be risky. The **effective** status is derived at the DTO boundary (`archived` > `cancelled` > raw status).
- **Cancel (F16)** — `PATCH /batches/:id/cancel`: only a launched brew; soft, **keeps the journal** (distinct from the hard `DELETE`).
- **Archive (F25)** — `PATCH /batches/:id/archive`: only a finished/cancelled brew; soft-hides it.
- **Freeze guard** — a shared `assertMutable` rejects any workflow-advancing mutation (step transitions, fermentation, bottling, tasting) on a cancelled/archived batch, so a soft-closed journal can't be reactivated.
- **Mobile** — status type + labels gain cancelled/archived; `BatchesScreen` filters them out of the active list; `BatchDetailsScreen` gets confirm-gated « Annuler ce brassin » (in_progress) / « Archiver ce brassin » (completed).

## Context

- UI kept intentionally minimal — the brew-day UI/UX gets a **dedicated quality overhaul later** (business-logic-first priority). This PR is functional logic + data model.
- `draft` (« en préparation », F14/F15) is the deferred bigger slice (07b), not here.

## Checklist

- [x] H/S/E tests — service (cancel/archive happy/sad/edge + ownership + the freeze guard across every endpoint), DTO derivation, mobile data/use-cases/list-filter/confirm-flows
- [x] API 843 unit tests green; batches mobile suite green; lint + format clean
- [x] Safe migration (`ADD COLUMN`, no rebuild); no `any`, no default export, envelope respected
- [x] Local pre-push review reconciled (Must-Have freeze guard added)
- [ ] Note: 4 mobile typecheck errors are the known stale `.expo` typed-route quirk (CI regenerates)

Refs #868