### PR TITLE
docs(log): record PR #1293 (faq-bot) + CLAUDE.md conformance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Each package ships its own `CLAUDE.md` with detailed conventions:
 
 ## Project-specific rules
 
-Global rules (Conventional Commits, branch from `main`, no `any`, no default exports, AI attribution forbidden, security defaults) are inherited from `~/.claude/CLAUDE.md` — not duplicated here. The rules below are the ones that *only* apply to this repo.
+Global rules (Conventional Commits, branch from `main`, no `any`, no default exports, AI attribution allowed for transparency, security defaults) are inherited from `~/.claude/CLAUDE.md` — not duplicated here. The rules below are the ones that *only* apply to this repo.
 
 ### TypeScript
 
@@ -100,6 +100,7 @@ Currently accepted ADRs (see each file for the `Status` line and full rationale)
 - [ADR-0015 — Beer ingestion & enrichment strategy (staging → human-gated promotion)](docs/architecture/decisions/0015-beer-ingestion-enrichment-strategy.md)
 - [ADR-0018 — Admin/moderation surface: in-app CREATOR moderation, secured at the NestJS API](docs/architecture/decisions/0018-admin-moderation-surface.md)
 - [ADR-0020 — Equipment-driven batch sizing & volume planning (computed in the backend)](docs/architecture/decisions/0020-equipment-driven-volume-planning.md)
+- [ADR-0022 — Public FAQ chatbot: Mistral LLM + self-hosted ALTCHA, EU-sovereign](docs/architecture/decisions/0022-public-faq-chatbot-llm.md)
 
 When a new ADR is accepted, add its file link here (no dates, no per-ADR summaries — open the file for the live status and content). When reviewing a PR, flag any diff that violates these ADRs and cite the ADR number and clause in the review comment.
 

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -5,6 +5,13 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ---
 
+## 2026-07-02
+
+### PR #1293 merged (`28a1535`) — feat(faq-bot): public FAQ chatbot — API (Mistral + ALTCHA) + website widget
+
+- Branch `feat/faq-bot`, 11 commits (API + website). **Conception-first**: ADR-0022 (accepted; EU-sovereign decision matrices → Mistral + ALTCHA) + 4 UML diagrams under `docs/architecture/diagrams/faq-bot/`. Adds an isolated `faq-bot` NestJS module — `POST /faq-bot/ask` + `GET /faq-bot/challenge` (public, anonymous) — with two DIP seams: `LlmPort` → `MistralLlmAdapter` (`mistral-small-latest`, native `fetch`, key server-side only) and `BotCheckPort` → `AltchaBotCheckAdapter` (self-hosted `altcha-lib`, no third-party call). Anti-abuse: throttle 5/min/IP, **single-use ALTCHA proofs** (in-memory replay rejection), **fail-closed guard** when the HMAC secret is missing outside dev/test (503; derivation via the canonical `resolveBootstrapEnvironment`), kill-switch + monthly budget cap, Mistral adapter fails fast on a missing key. RGPD: no conversation content logged — anonymous aggregate counters only. Website: self-hosted `chat-widget.js`, staging/localhost-gated (never prod in v1), solves the ALTCHA proof-of-work with Web Crypto, XSS-safe (`textContent`), no network call on page load, bilingual FR/EN. Prompt guardrails: project-only FAQ (NOT a brewing assistant), abstain → `[CONTACT]`, founder first-name-only (no links/contact), no emojis. Prompt-as-spec eval harness (`evals/AGENT.md` judge protocol) re-judged pre-merge — **13/13 GREEN**; 865 API unit tests.
+- Reviews — Copilot (8 threads) + Codex (2 × P2) all addressed, then a **three-agent adversarial follow-up** (architecture / test-quality / security): env derivation moved to the canonical resolver (DRY, case-normalised), new `faq-bot.config.spec.ts` pins the bypass derivation, new concurrent-replay spec pins check-and-claim atomicity; one flagged TOCTOU race **rejected with rationale** (synchronous has/set after the await) and locked in by that spec. Conception docs re-aligned in the same pass (fail-closed + single-use reflected in ADR-0022 and the sequence/component/class diagrams). CORS restriction deferred to a cross-consumer review (documented in ADR-0022). **Deploy config pending**: Fly secrets (`MISTRAL_API_KEY`, `ALTCHA_HMAC_KEY`) + the widget's staging API origin — at deploy time.
+
 ## 2026-07-01
 
 ### PR #1292 merged (`3f99584`) — feat(batches): cancel + archive batch soft-lifecycle (F16/F25)


### PR DESCRIPTION
## Summary

- `PROJECT_LOG.md`: entry for merged PR #1293 (`28a1535`) — public FAQ chatbot (Mistral + ALTCHA API module + staging-gated website widget), including the three-agent adversarial follow-up and the pending deploy config.
- Root `CLAUDE.md` conformance (two one-liners):
  - Add **ADR-0022** to the accepted-ADRs list (per the repo's own rule).
  - Fix the stale "AI attribution forbidden" summary line — policy reversed 2026-07-02, attribution is now allowed for transparency.

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)