### PR TITLE
chore(scripts): fix codex-review.sh for codex CLI >= 0.142

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -64,6 +64,12 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   exit 1
 fi
 
+# Reject option-lookalike or malformed refs before handing $BASE to git.
+if [[ "$BASE" == -* ]] || ! git check-ref-format --branch "$BASE" >/dev/null 2>&1; then
+  echo "error: invalid base branch name: '$BASE'" >&2
+  exit 2
+fi
+
 CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 if [[ "$CURRENT_BRANCH" == "$BASE" ]]; then
   echo "error: current branch is '$BASE'; nothing to review against itself." >&2

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -12,6 +12,12 @@
 # without mutating the working tree. It replays the same checklist as the
 # `pr-pre-reviewer` agent so both reviewers judge against the same rules.
 #
+# Since codex CLI 0.142, `--base <BRANCH>` and a custom [PROMPT] are mutually
+# exclusive: the positional prompt is now its own "custom" review target,
+# alongside --uncommitted / --base / --commit. To keep the shared checklist
+# AND the base-branch scope, the script passes everything as the custom
+# prompt, pinning the diff scope to the merge-base SHA computed locally.
+#
 # Cost note: each run consumes the OpenAI/ChatGPT quota tied to your Codex
 # CLI auth — a quota SEPARATE from GitHub Copilot premium requests.
 #
@@ -65,14 +71,30 @@ if [[ "$CURRENT_BRANCH" == "$BASE" ]]; then
 fi
 
 # Keep the comparison honest against the latest remote base (read-only fetch).
-git fetch origin "$BASE" --quiet 2>/dev/null || true
+git fetch origin "$BASE" --quiet 2>/dev/null \
+  || echo "warning: could not fetch 'origin/$BASE' (offline or no remote?); comparing against local refs." >&2
+
+# Pin the review scope to an exact merge-base SHA so the reviewer cannot
+# drift onto the wrong diff (prefer the freshly fetched remote base).
+MERGE_BASE="$(git merge-base "origin/$BASE" HEAD 2>/dev/null || git merge-base "$BASE" HEAD 2>/dev/null || true)"
+if [[ -z "$MERGE_BASE" ]]; then
+  echo "error: cannot find a merge base between '$CURRENT_BRANCH' and '$BASE' (nor 'origin/$BASE')." >&2
+  exit 1
+fi
 
 # The review instructions mirror the pr-pre-reviewer checklist so Claude and
 # Codex grade against the same bar. Keep this in sync with
 # .claude/agents/pr-pre-reviewer.md.
+read -r -d '' SCOPE <<SCOPE_BLOCK || true
+Review scope (mandatory): the changes of branch '$CURRENT_BRANCH' relative to
+base branch '$BASE'. The merge base is commit $MERGE_BASE. Inspect exactly:
+  git diff $MERGE_BASE HEAD
+Review ONLY that diff — nothing outside it. Do not modify any file.
+SCOPE_BLOCK
+
 read -r -d '' INSTRUCTIONS <<'PROMPT' || true
 You are a strict, read-only reviewer for the brasse-bouillon monorepo.
-Review ONLY the diff against the base branch. Output English, no AI attribution.
+Output English, no AI attribution.
 
 Group findings as Must Have / Should Have / Nice to Have / Disagree, each with
 a `path/to/file.ts:line` anchor and a one-line suggested fix.
@@ -103,12 +125,18 @@ End with a Summary: ADRs honoured (y/n), forbidden patterns present (y/n),
 H/S/E covered for new units (y/n), Ready for push (y/n).
 PROMPT
 
-echo "Running Codex review of '$CURRENT_BRANCH' against '$BASE'..." >&2
+echo "Running Codex review of '$CURRENT_BRANCH' against '$BASE' (merge base $MERGE_BASE)..." >&2
+
+# The full prompt is the "custom" review target (codex >= 0.142 forbids
+# combining --base with a prompt); sandbox_mode pins the run read-only.
+FULL_PROMPT="$SCOPE
+
+$INSTRUCTIONS"
 
 if [[ -n "$OUT" ]]; then
-  codex exec review --base "$BASE" --output-last-message "$OUT" "$INSTRUCTIONS"
+  codex exec review -c 'sandbox_mode="read-only"' --output-last-message "$OUT" "$FULL_PROMPT"
   echo "Report written to: $OUT" >&2
   cat "$OUT"
 else
-  codex exec review --base "$BASE" "$INSTRUCTIONS"
+  codex exec review -c 'sandbox_mode="read-only"' "$FULL_PROMPT"
 fi


### PR DESCRIPTION
## Summary

`scripts/codex-review.sh` — the Codex side of the local pre-push review ritual — broke with codex CLI 0.142.5: `codex exec review` now declares the positional `[PROMPT]` as its own "custom" review target, mutually exclusive with `--base` / `--commit` / `--uncommitted` (clap `conflicts_with_all` in the CLI source), so passing our shared checklist prompt together with `--base main` fails to parse. The stdin `-` form is the same positional argument and is rejected too.

Fix — keep **both** the shared `pr-pre-reviewer` checklist and the base-branch scope by passing everything as the custom prompt:

- Compute the merge-base SHA locally (prefer freshly fetched `origin/<base>`, fall back to the local ref with a warning) and fail fast with a clear error when none exists.
- Prepend a scope block to the checklist pinning the review to `git diff <merge-base> HEAD` — the reviewer cannot drift onto the wrong diff.
- Drop the now-conflicting `--base` CLI flag; the script's own `--base` option keeps its meaning (it feeds the scope block).
- Pin the run read-only explicitly via `-c 'sandbox_mode="read-only"'` (previously the script relied on the review preset's default).
- `--out` behavior (`--output-last-message`) unchanged.

## Context

- Verified end-to-end against codex-cli 0.142.5 on this very branch's diff: prompt accepted, banner shows `sandbox: read-only`, review completed and the `--out` report was written ("No blocking or actionable issues").
- Companion machine-local fix (not in this repo): `~/.codex/config.toml` pinned `review_model = "gpt-5.2-codex"`, which ChatGPT-account auth now rejects with a 400; realigned to the main model so the ritual runs.
- Known pre-existing drift, deliberately out of scope: the script's condensed checklist omits two items from `.claude/agents/pr-pre-reviewer.md` (website inline `style="..."`, skipped `xit`/`xdescribe` tests) — to be synced in a follow-up.

## Checklist

- [x] `bash -n` + `shellcheck` pass
- [x] Local pre-push ritual run (Claude `pr-pre-reviewer`: 0 Must Have; Codex live run: clean)
- [x] Read-only behavior verified (`git status --porcelain` clean before/after a full run)
- [x] Conventional Commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)