### PR TITLE
chore(review): sync codex-review.sh checklist with pr-pre-reviewer agent

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -85,14 +85,22 @@ Must Have (blocking) — flag any of:
 - Hardcoded secret, token, or credential.
 - Hardcoded color/spacing/font in packages/mobile-app (must use theme tokens).
 - Inline `style={{...}}` in React Native (must use StyleSheet.create()).
+- Inline `style="..."` in packages/website/ HTML.
 - Bypass of the NestJS response envelope in packages/api.
+- Skipped or `xit`/`xdescribe` tests introduced.
 - Missing TypeORM migration when an entity adds/removes/renames a column.
+- Direct commit to `main` detectable in the commit history.
 - ADR violations (read docs/architecture/decisions/0001..0005 and 0013): e.g.
-  mobile calling a third-party HTTP service directly instead of via the API.
+  mobile calling a third-party HTTP service directly instead of via the API
+  (ADR-0002), or consent-store writes outside the canonical append-only
+  feature-namespaced API (ADR-0003).
 
-Should Have — tests not following Happy/Sad/Edge, missing Swagger decorator on a
-new endpoint, naming/import-order deviations, Conventional Commits not respected,
-any AI attribution in commit messages or files.
+Should Have — tests not following Happy/Sad/Edge, a new mobile feature not
+persisting via the API from day one, missing Swagger decorator on a new
+endpoint, naming/import-order deviations, Conventional Commits not respected,
+a packages/website/ public page edited on one language side only (missing
+French/English mirror), no PROJECT_LOG.md entry drafted for a significant
+change, any AI attribution in commit messages or files.
 
 Nice to Have — readability, extraction, WHY-not-WHAT comments.
 
@@ -100,7 +108,8 @@ Disagree — anything that looks off but is justified by a tolerated ADR-0001
 exception or an established pattern; give a one-line rationale.
 
 End with a Summary: ADRs honoured (y/n), forbidden patterns present (y/n),
-H/S/E covered for new units (y/n), Ready for push (y/n).
+H/S/E covered for new units (y/n), branch from main + Conventional Commits
+(y/n), Ready for push (y/n).
 PROMPT
 
 echo "Running Codex review of '$CURRENT_BRANCH' against '$BASE'..." >&2

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -89,7 +89,7 @@ Must Have (blocking) — flag any of:
 - Bypass of the NestJS response envelope in packages/api.
 - Skipped or `xit`/`xdescribe` tests introduced.
 - Missing TypeORM migration when an entity adds/removes/renames a column.
-- Direct commit to `main` detectable in the commit history.
+- Direct commit to `__BASE__` detectable in the commit history.
 - ADR violations (read docs/architecture/decisions/0001..0005 and 0013): e.g.
   mobile calling a third-party HTTP service directly instead of via the API
   (ADR-0002), or consent-store writes outside the canonical append-only
@@ -108,9 +108,12 @@ Disagree — anything that looks off but is justified by a tolerated ADR-0001
 exception or an established pattern; give a one-line rationale.
 
 End with a Summary: ADRs honoured (y/n), forbidden patterns present (y/n),
-H/S/E covered for new units (y/n), branch from main + Conventional Commits
+H/S/E covered for new units (y/n), branch from __BASE__ + Conventional Commits
 (y/n), Ready for push (y/n).
 PROMPT
+
+# The heredoc is quoted so its backticks stay literal; inject the runtime base.
+INSTRUCTIONS="${INSTRUCTIONS//__BASE__/$BASE}"
 
 echo "Running Codex review of '$CURRENT_BRANCH' against '$BASE'..." >&2
 


### PR DESCRIPTION
## Summary

The `INSTRUCTIONS` heredoc in `scripts/codex-review.sh` is a condensed copy of the review checklist in `.claude/agents/pr-pre-reviewer.md`, and a comment in the script requires the two to stay in sync. An item-by-item diff found drift; this PR re-aligns the script with the agent checklist, keeping the script's terse condensed style.

- **Must Have** — added three missing blocking items:
  - inline `style="..."` in `packages/website/` HTML
  - skipped or `xit`/`xdescribe` tests introduced
  - direct commit to `main` detectable in the commit history
  - and extended the ADR bullet with the ADR-0003 consent-store example (the condensed line only carried the ADR-0002 one).
- **Should Have** — added three missing items: persistence-imperative violation (new mobile feature not persisting via the API from day one), missing French/English mirror in `packages/website/`, and no PROJECT_LOG.md entry drafted for a significant change.
- **Summary line** — added the agent's "branch from `main` + Conventional Commits" check.
- **Nice to Have / Disagree** — already in sync (condensed but equivalent), unchanged.

Known remaining item (deliberately out of scope): both checklists still flag AI attribution as a Should Have, which contradicts the policy reversed on 2026-07-02 (attribution allowed, CLAUDE.md aligned in #1296). That fix must touch both files together and is tracked as a separate follow-up so this PR stays a pure sync.

## Context

Without these entries, the Codex side of the pre-push defence-in-depth ritual (`pre-push-review` skill) graded against a weaker bar than the Claude side (`pr-pre-reviewer` agent) — e.g. a PR introducing skipped tests or inline website styles would pass Codex silently.

## Checklist

- [x] `bash -n scripts/codex-review.sh` passes
- [x] `shellcheck scripts/codex-review.sh` passes (no findings)
- [x] Item-by-item diff of both checklists done (Must Have / Should Have / Nice to Have / Disagree / Summary)
- [x] Script keeps its condensed style; no behavioural change outside the heredoc

🤖 Generated with [Claude Code](https://claude.com/claude-code)