### PR TITLE
feat(batches): draft/prep batch tier with persisted checklist (F14/F15)

### DIFF
--- a/docs/architecture/diagrams/brew-day/07-state-batch-lifecycle.md
+++ b/docs/architecture/diagrams/brew-day/07-state-batch-lifecycle.md
@@ -80,7 +80,20 @@ stateDiagram-v2
   `in_progress`/`completed` status. Endpoints: `cancelled` = `PATCH /batches/:id/cancel` (only a
   launched brew), `archived` = `PATCH /batches/:id/archive` (only a finished or cancelled brew).
   `discarded` stays the terminal hard-delete outcome (not stored). **`draft`** + moving the prep
-  onto the batch (F14/F15) is the deferred, bigger slice (07b) — not in 07a.
+  onto the batch (F14/F15) is the second slice (07b) — see below.
+- **`draft` persistence — same timestamp model (07b implementation refinement).** `draft` is
+  realised as a nullable **`launched_at`** stamp (plain `ADD COLUMN`, legacy rows backfilled
+  `launched_at = started_at` since they were all launched at creation), **not** a new `status`
+  enum value — same CHECK-constraint rationale as 07a. The effective-state derivation becomes
+  `archived` > `cancelled` > `draft` (`launched_at` null) > raw status; while a batch is a draft
+  its DTO `started_at` reads **null** (the brew has not started). The draft **carries the prep**
+  as a `prep_checked_ids` JSON column (only the coches — the checklist items stay derived from
+  the recipe, see brew-prep/04). Endpoints: `POST /batches/prepare` (idempotent per
+  owner+recipe: re-preparing resumes the existing draft), `PATCH /batches/:id/prep-checklist`
+  (draft-only), `PATCH /batches/:id/launch` (= `Launch`; the recipe steps are snapshotted at
+  launch, not at prepare, so the brew runs the recipe as it stands). Brewing-journal endpoints
+  (steps, fermentation, measurements, observations, reminders, cancel) reject a draft — it has
+  brewed nothing; its only exits are `Launch` and `Discard` (the shipped hard `DELETE`).
 - **`completed`** still opens the closure/celebration (B3 `BatchClosureView`) and is kept in
   history; the transition is driven by the last step completing (see `06`). This is the **same
   `completed` state** already amended by `05-state-batch-closure.md` with the `bottledAt`

--- a/docs/architecture/diagrams/brew-prep/02-sequence-plan-and-confirm.md
+++ b/docs/architecture/diagrams/brew-prep/02-sequence-plan-and-confirm.md
@@ -44,7 +44,14 @@ sequenceDiagram
 - **Egress explicit:** the mobile reaches the API only via `core/http/http-client`;
   the brewing math runs in the API domain service (ADR-0020 D3), never in the
   screen.
-- The checklists are **client state pre-batch** (reversible); they gate the launch
-  (UC6). The launch handoff persists the plan (single source of truth).
+- ~~The checklists are **client state pre-batch** (reversible)~~ — **superseded
+  (F14/F15, brew-day/07b):** opening the prep screen now `POST /batches/prepare`s
+  an idempotent « en préparation » **draft batch** that carries the ticks
+  (`PATCH /batches/:id/prep-checklist` on each toggle, full replacement), and
+  "Start the batch" becomes `PATCH /batches/:id/launch` (draft → in_progress;
+  the recipe steps are snapshotted at launch). The checklist *items* stay
+  derived from the recipe (see `04`); only the coches persist, per-batch. The
+  checklists still gate the launch (UC6) and the launch handoff still persists
+  the plan (single source of truth).
 - The round-trip cost is accepted (ADR-0020): the inputs change rarely (pick a
   pot, set boil-off), not per-keystroke; a mobile mirror is deferred.

--- a/docs/architecture/diagrams/brew-prep/04-class.md
+++ b/docs/architecture/diagrams/brew-prep/04-class.md
@@ -57,6 +57,7 @@ classDiagram
   class Batch {
     <<brewing-session epic>>
     +UUID id
+    +string[] prepCheckedIds
   }
   Recipe "1" ..> "1" VolumePlan : targets feed
   EquipmentProfile "1" ..> "1" VolumePlan : caps & method (D1/D2)
@@ -64,6 +65,7 @@ classDiagram
   BrewReadiness "1" o-- "2" ReadinessChecklist
   ReadinessChecklist "1" *-- "1..*" ChecklistItem
   Batch "1" *-- "1" VolumePlan : snapshot at launch (Memento)
+  Batch "1" ..> "1" ReadinessChecklist : carries the coches (draft, F14)
 ```
 
 ## Notes
@@ -82,6 +84,15 @@ classDiagram
   out of this conception's scope — it appears here solely to anchor the snapshot
   (Memento) target and make the persistence contract explicit.
 - `BrewReadiness.readyToLaunch = ingredientChecklist.isComplete() && equipmentChecklist.isComplete()` (UC6).
+- **Checklist state lives on the draft `Batch` (F14/F15 amendment, brew-day/07b).**
+  "Préparer" creates (or resumes) an « en préparation » draft batch that carries
+  the ticks as `prepCheckedIds` — only the CHECKED item ids are persisted; the
+  `ChecklistItem`s themselves (name, qty, required) stay **derived from the
+  Recipe** by the pure `buildIngredientChecklist` (single source of truth, no
+  snapshot of ingredient data). The coches are therefore per-batch and reset
+  naturally on each new brew — the original "client state pre-batch" note in
+  `02` is superseded. Ids from a recipe edited mid-prep simply stop matching
+  (benign; drafts are short-lived).
 - Enums: `Method` = {FULL_VOLUME, DUNK_SPARGE}; `Kind` = {INGREDIENT, EQUIPMENT}.
 - **Design patterns (named, see ADR-0020 § Design patterns):** `VolumePlan` is a
   **Value Object** (immutable, identity-less — the `«value object»` stereotype);

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -1013,4 +1013,190 @@ describe('BatchService', () => {
       batchService.getMineTasting(otherOwner, batch.id),
     ).rejects.toThrow(NotFoundException);
   });
+
+  // Draft « en préparation » lifecycle (brew-day/07, F14/F15)
+
+  it('prepareMine() creates a draft: no steps, no launched_at, empty prep state (happy)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+
+    const { batch, steps } = await batchService.prepareMine(ownerId, recipe.id);
+
+    expect(batch.owner_id).toBe(ownerId);
+    expect(batch.recipe_id).toBe(recipe.id);
+    expect(batch.launched_at).toBeNull();
+    expect(batch.prep_checked_ids).toBeNull();
+    expect(batch.current_step_order).toBeNull();
+    expect(steps).toHaveLength(0);
+  });
+
+  it('prepareMine() is idempotent: a second prepare resumes the same draft (happy)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+
+    const first = await batchService.prepareMine(ownerId, recipe.id);
+    await batchService.updateMinePrepChecklist(ownerId, first.batch.id, [
+      'malt-0',
+    ]);
+
+    const second = await batchService.prepareMine(ownerId, recipe.id);
+
+    expect(second.batch.id).toBe(first.batch.id);
+    expect(second.batch.prep_checked_ids).toEqual(['malt-0']);
+  });
+
+  it('prepareMine() resumes the winner draft when a concurrent prepare wins the race (edge)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+
+    const existing = await batchService.prepareMine(ownerId, recipe.id);
+
+    // Simulate the race: the pre-insert existence check misses the draft a
+    // concurrent request already committed, so the insert hits the partial
+    // unique index and the service must resume the winner's row instead.
+    const findOneSpy = jest
+      .spyOn(batchRepo, 'findOne')
+      .mockResolvedValueOnce(null);
+
+    const second = await batchService.prepareMine(ownerId, recipe.id);
+
+    expect(second.batch.id).toBe(existing.batch.id);
+    findOneSpy.mockRestore();
+  });
+
+  it('prepareMine() creates a fresh draft once the previous one is launched (edge)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+
+    const first = await batchService.prepareMine(ownerId, recipe.id);
+    await batchService.launchMine(ownerId, first.batch.id);
+
+    const second = await batchService.prepareMine(ownerId, recipe.id);
+    expect(second.batch.id).not.toBe(first.batch.id);
+  });
+
+  it('prepareMine() rejects a foreign or unknown recipe with NotFound (sad)', async () => {
+    const ownerId = 'user-1';
+    const otherOwner = 'user-2';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+
+    await expect(
+      batchService.prepareMine(otherOwner, recipe.id),
+    ).rejects.toThrow(NotFoundException);
+    await expect(
+      batchService.prepareMine(ownerId, randomUUID()),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('updateMinePrepChecklist() persists deduplicated coches on the draft (happy)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const { batch } = await batchService.prepareMine(ownerId, recipe.id);
+
+    const updated = await batchService.updateMinePrepChecklist(
+      ownerId,
+      batch.id,
+      ['malt-0', 'hop-1', 'malt-0'],
+    );
+
+    expect(updated.prep_checked_ids).toEqual(['malt-0', 'hop-1']);
+  });
+
+  it('updateMinePrepChecklist() rejects a launched batch and enforces ownership (sad)', async () => {
+    const ownerId = 'user-1';
+    const otherOwner = 'user-2';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const { batch } = await batchService.prepareMine(ownerId, recipe.id);
+
+    await expect(
+      batchService.updateMinePrepChecklist(otherOwner, batch.id, ['x']),
+    ).rejects.toThrow(NotFoundException);
+
+    await batchService.launchMine(ownerId, batch.id);
+    await expect(
+      batchService.updateMinePrepChecklist(ownerId, batch.id, ['x']),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('launchMine() snapshots steps, stamps launched_at/started_at and opens step 0 in PRÉP (happy)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const draft = await batchService.prepareMine(ownerId, recipe.id);
+
+    const { batch, steps } = await batchService.launchMine(
+      ownerId,
+      draft.batch.id,
+    );
+
+    expect(batch.id).toBe(draft.batch.id);
+    expect(batch.launched_at).toBeTruthy();
+    expect(batch.started_at).toEqual(batch.launched_at);
+    expect(batch.status).toBe(BatchStatus.IN_PROGRESS);
+    expect(batch.current_step_order).toBe(0);
+    expect(steps).toHaveLength(5);
+    expect(steps[0].status).toBe(BatchStepStatus.IN_PROGRESS);
+    expect(steps[0].started_at).toBeNull();
+  });
+
+  it('launchMine() rejects a double launch with Conflict-free 400 and keeps the journal intact (sad)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const draft = await batchService.prepareMine(ownerId, recipe.id);
+    await batchService.launchMine(ownerId, draft.batch.id);
+
+    await expect(
+      batchService.launchMine(ownerId, draft.batch.id),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('brewing-journal endpoints reject a draft (edge: guards on every surface)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const { batch } = await batchService.prepareMine(ownerId, recipe.id);
+
+    // A draft has brewed nothing: no step transitions, no fermentation, no
+    // journal entries, and no soft-cancel (a draft is discarded via DELETE).
+    await expect(
+      batchService.completeMineCurrentStep(ownerId, batch.id),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      batchService.startMineCurrentStep(ownerId, batch.id),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      batchService.startFermentationMine(ownerId, batch.id),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      batchService.createMineMeasurement(ownerId, batch.id, {
+        type: MeasurementType.OG,
+        value: 1.05,
+      }),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      batchService.createMineObservation(ownerId, batch.id, {
+        freeText: 'note',
+      }),
+    ).rejects.toThrow(BadRequestException);
+    await expect(
+      batchService.createMineReminder(ownerId, batch.id, {
+        label: 'buy yeast',
+        dueAt: new Date(),
+      }),
+    ).rejects.toThrow(BadRequestException);
+    await expect(batchService.cancelMine(ownerId, batch.id)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('a draft is discardable via deleteMine and shows as draft in listMine (edge)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const { batch } = await batchService.prepareMine(ownerId, recipe.id);
+
+    const rows = await batchService.listMine(ownerId);
+    expect(rows.map((row) => row.id)).toContain(batch.id);
+
+    await batchService.deleteMine(ownerId, batch.id);
+    const after = await batchService.listMine(ownerId);
+    expect(after.map((row) => row.id)).not.toContain(batch.id);
+  });
 });

--- a/packages/api/src/batch/controllers/batch.controller.spec.ts
+++ b/packages/api/src/batch/controllers/batch.controller.spec.ts
@@ -11,7 +11,7 @@ import { BatchStepStatus } from '../domain/enums/batch-step-status.enum';
 import { CreateBatchReminderDto } from '../dtos/create-batch-reminder.dto';
 import { MeasurementOrmEntity } from '../entities/measurement.orm.entity';
 import { MeasurementType } from '../domain/enums/measurement-type.enum';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ObservationOrmEntity } from '../entities/observation.orm.entity';
 import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
 import { StartBatchDto } from '../dtos/start-batch.dto';
@@ -41,11 +41,25 @@ describe('BatchController', () => {
     status: BatchStatus.IN_PROGRESS,
     current_step_order: 1,
     started_at: new Date(),
+    // launched: without this stamp the DTO would derive a draft (brew-day/07)
+    launched_at: new Date(),
+    prep_checked_ids: null,
     fermentation_started_at: null,
     fermentation_completed_at: null,
     completed_at: null,
     created_at: new Date(),
     updated_at: new Date(),
+  };
+
+  /**
+   * Mock draft batch (« en préparation » — never launched)
+   */
+  const mockDraftOrm: BatchOrmEntity = {
+    ...mockBatchOrm,
+    id: '550e8400-e29b-41d4-a716-446655440009',
+    current_step_order: null,
+    launched_at: null,
+    prep_checked_ids: ['malt-0'],
   };
 
   /**
@@ -106,6 +120,9 @@ describe('BatchController', () => {
           provide: BatchService,
           useValue: {
             startMine: jest.fn(),
+            prepareMine: jest.fn(),
+            updateMinePrepChecklist: jest.fn(),
+            launchMine: jest.fn(),
             listMine: jest.fn(),
             getMineById: jest.fn(),
             deleteMine: jest.fn(),
@@ -172,6 +189,102 @@ describe('BatchController', () => {
         NotFoundException,
       );
       expect(startMineSpy).toHaveBeenCalledWith(mockUser.id, dto.recipeId);
+    });
+  });
+
+  /**
+   * Draft « en préparation » routes (brew-day/07, F14/F15)
+   */
+  describe('prepareMine() - POST /batches/prepare', () => {
+    it('should create or resume the draft and expose the draft status + coches', async () => {
+      const prepareSpy = jest.spyOn(service, 'prepareMine').mockResolvedValue({
+        batch: mockDraftOrm,
+        steps: [],
+      });
+
+      const result = await controller.prepareMine(mockUser, {
+        recipeId: mockDraftOrm.recipe_id,
+      });
+
+      expect(prepareSpy).toHaveBeenCalledWith(
+        mockUser.id,
+        mockDraftOrm.recipe_id,
+      );
+      expect(result.status).toBe('draft');
+      expect(result.started_at).toBeNull();
+      expect(result.prep_checked_ids).toEqual(['malt-0']);
+      expect(result.steps).toHaveLength(0);
+    });
+
+    it('should propagate NotFound for a foreign or unknown recipe', async () => {
+      jest
+        .spyOn(service, 'prepareMine')
+        .mockRejectedValue(new NotFoundException('Recipe not found'));
+
+      await expect(
+        controller.prepareMine(mockUser, { recipeId: 'unknown' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('updateMinePrepChecklist() - PATCH /batches/:id/prep-checklist', () => {
+    it('should persist the coches and return the summary', async () => {
+      const updateSpy = jest
+        .spyOn(service, 'updateMinePrepChecklist')
+        .mockResolvedValue({
+          ...mockDraftOrm,
+          prep_checked_ids: ['malt-0', 'hop-1'],
+        });
+
+      const result = await controller.updateMinePrepChecklist(
+        mockUser,
+        mockDraftOrm.id,
+        { checkedIds: ['malt-0', 'hop-1'] },
+      );
+
+      expect(updateSpy).toHaveBeenCalledWith(mockUser.id, mockDraftOrm.id, [
+        'malt-0',
+        'hop-1',
+      ]);
+      expect(result.status).toBe('draft');
+    });
+
+    it('should propagate BadRequest when the batch is already launched', async () => {
+      jest
+        .spyOn(service, 'updateMinePrepChecklist')
+        .mockRejectedValue(new BadRequestException('Batch already launched'));
+
+      await expect(
+        controller.updateMinePrepChecklist(mockUser, mockBatchOrm.id, {
+          checkedIds: [],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('launchMine() - PATCH /batches/:id/launch', () => {
+    it('should launch the draft and return the batch with its snapshot', async () => {
+      const launchSpy = jest.spyOn(service, 'launchMine').mockResolvedValue({
+        batch: mockBatchOrm,
+        steps: mockSteps,
+      });
+
+      const result = await controller.launchMine(mockUser, mockDraftOrm.id);
+
+      expect(launchSpy).toHaveBeenCalledWith(mockUser.id, mockDraftOrm.id);
+      expect(result.status).toBe(BatchStatus.IN_PROGRESS);
+      expect(result.started_at).not.toBeNull();
+      expect(result.steps).toHaveLength(1);
+    });
+
+    it('should propagate BadRequest on a double launch', async () => {
+      jest
+        .spyOn(service, 'launchMine')
+        .mockRejectedValue(new BadRequestException('Batch already launched'));
+
+      await expect(
+        controller.launchMine(mockUser, mockBatchOrm.id),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 

--- a/packages/api/src/batch/controllers/batch.controller.ts
+++ b/packages/api/src/batch/controllers/batch.controller.ts
@@ -37,10 +37,12 @@ import { MeasurementDto } from '../dtos/measurement.dto';
 import { ObservationDto } from '../dtos/observation.dto';
 import { CreateTastingDto } from '../dtos/create-tasting.dto';
 import { GetPrimingQueryDto } from '../dtos/get-priming-query.dto';
+import { PrepareBatchDto } from '../dtos/prepare-batch.dto';
 import { PrimingDto } from '../dtos/priming.dto';
 import { StartBatchDto } from '../dtos/start-batch.dto';
 import { TastingDto } from '../dtos/tasting.dto';
 import { UpdateBatchReminderDto } from '../dtos/update-batch-reminder.dto';
+import { UpdatePrepChecklistDto } from '../dtos/update-prep-checklist.dto';
 import { BatchService } from '../services/batch.service';
 
 /**
@@ -69,6 +71,57 @@ export class BatchController {
       user.id,
       dto.recipeId,
     );
+    return BatchDto.fromEntities(batch, steps);
+  }
+
+  @Post('prepare')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({
+    summary:
+      'Create (or resume) the « en préparation » draft batch for a recipe',
+  })
+  @ApiCreatedResponse({ type: BatchDto })
+  async prepareMine(
+    @CurrentUser() user: User,
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    dto: PrepareBatchDto,
+  ): Promise<BatchDto> {
+    const { batch, steps } = await this.service.prepareMine(
+      user.id,
+      dto.recipeId,
+    );
+    return BatchDto.fromEntities(batch, steps);
+  }
+
+  @Patch(':id/prep-checklist')
+  @ApiOperation({
+    summary: "Replace the draft's checked prep-item ids (F14)",
+  })
+  @ApiOkResponse({ type: BatchSummaryDto })
+  async updateMinePrepChecklist(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body(new ValidationPipe({ transform: true, whitelist: true }))
+    dto: UpdatePrepChecklistDto,
+  ): Promise<BatchSummaryDto> {
+    const batch = await this.service.updateMinePrepChecklist(
+      user.id,
+      id,
+      dto.checkedIds,
+    );
+    return BatchSummaryDto.fromEntity(batch);
+  }
+
+  @Patch(':id/launch')
+  @ApiOperation({
+    summary: 'Launch a draft (snapshot the recipe steps, start the brew)',
+  })
+  @ApiOkResponse({ type: BatchDto })
+  async launchMine(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) id: string,
+  ): Promise<BatchDto> {
+    const { batch, steps } = await this.service.launchMine(user.id, id);
     return BatchDto.fromEntities(batch, steps);
   }
 

--- a/packages/api/src/batch/domain/batch.domain.spec.ts
+++ b/packages/api/src/batch/domain/batch.domain.spec.ts
@@ -81,7 +81,9 @@ describe('BatchDomainService', () => {
     const t4 = new Date('2026-02-05T09:40:00.000Z');
     const t5 = new Date('2026-02-05T09:50:00.000Z');
 
-    const timestamps = [t0, t1, t2, t3, t4, t5];
+    // startBatch = prepare + launch, so it consumes TWO clock ticks (both t0
+    // here); every queue below front-loads that duplicate.
+    const timestamps = [t0, t0, t1, t2, t3, t4, t5];
     const service = new BatchDomainService(() => {
       const next = timestamps.shift();
       if (!next) throw new Error('Missing timestamp');
@@ -121,7 +123,7 @@ describe('BatchDomainService', () => {
   it('should activate the current step (PRÉP -> ACTIF) and set startedAt', () => {
     const t0 = new Date('2026-02-05T09:00:00.000Z');
     const t1 = new Date('2026-02-05T09:05:00.000Z');
-    const timestamps = [t0, t1];
+    const timestamps = [t0, t0, t1];
     const service = new BatchDomainService(() => {
       const next = timestamps.shift();
       if (!next) throw new Error('Missing timestamp');
@@ -148,7 +150,7 @@ describe('BatchDomainService', () => {
     const t0 = new Date('2026-02-05T09:00:00.000Z');
     const t1 = new Date('2026-02-05T09:10:00.000Z');
     const t2 = new Date('2026-02-05T09:12:00.000Z');
-    const timestamps = [t0, t1, t2];
+    const timestamps = [t0, t0, t1, t2];
     const service = new BatchDomainService(() => {
       const next = timestamps.shift();
       if (!next) throw new Error('Missing timestamp');
@@ -191,7 +193,7 @@ describe('BatchDomainService', () => {
   it('should throw when activating a step of a completed batch', () => {
     const t0 = new Date('2026-02-05T09:00:00.000Z');
     const t1 = new Date('2026-02-05T09:10:00.000Z');
-    const timestamps = [t0, t1];
+    const timestamps = [t0, t0, t1];
     const service = new BatchDomainService(() => {
       const next = timestamps.shift();
       if (!next) throw new Error('Missing timestamp');
@@ -223,7 +225,7 @@ describe('BatchDomainService', () => {
   it('should throw when completing an already completed batch', () => {
     const t0 = new Date('2026-02-05T09:00:00.000Z');
     const t1 = new Date('2026-02-05T09:10:00.000Z');
-    const timestamps = [t0, t1];
+    const timestamps = [t0, t0, t1];
     const service = new BatchDomainService(() => {
       const next = timestamps.shift();
       if (!next) throw new Error('Missing timestamp');
@@ -249,6 +251,77 @@ describe('BatchDomainService', () => {
 
     expect(() => service.completeCurrentStep(completed)).toThrow(
       'Batch is not in progress',
+    );
+  });
+
+  // Draft « en préparation » lifecycle (brew-day/07, F14/F15)
+
+  it('prepareBatch() creates a stepless draft with no launchedAt', () => {
+    const t0 = new Date('2026-02-05T09:00:00.000Z');
+    const service = new BatchDomainService(() => t0);
+
+    const draft = service.prepareBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+    });
+
+    expect(draft.launchedAt).toBeUndefined();
+    expect(draft.steps).toHaveLength(0);
+    expect(draft.currentStepOrder).toBeUndefined();
+    expect(draft.status).toBe(BatchStatus.IN_PROGRESS);
+    expect(draft.createdAt).toEqual(t0);
+    expect(draft.startedAt).toEqual(t0);
+  });
+
+  it('launchBatch() stamps launchedAt/startedAt and snapshots steps in PRÉP', () => {
+    const t0 = new Date('2026-02-05T09:00:00.000Z');
+    const t1 = new Date('2026-02-05T10:00:00.000Z');
+    const timestamps = [t0, t1];
+    const service = new BatchDomainService(() => {
+      const next = timestamps.shift();
+      if (!next) throw new Error('Missing timestamp');
+      return next;
+    });
+
+    const draft = service.prepareBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+    });
+    const launched = service.launchBatch(
+      draft,
+      new RecipeWorkflowService().getDefaultWorkflow(),
+    );
+
+    expect(launched.launchedAt).toEqual(t1);
+    expect(launched.startedAt).toEqual(t1);
+    expect(launched.currentStepOrder).toBe(0);
+    expect(launched.steps).toHaveLength(5);
+    expect(launched.steps[0].status).toBe(BatchStepStatus.IN_PROGRESS);
+    expect(launched.steps[0].startedAt).toBeUndefined();
+    // the prep coches survive the launch untouched (journal history)
+    expect(launched.prepCheckedIds).toEqual(draft.prepCheckedIds);
+  });
+
+  it('launchBatch() rejects an already-launched batch and an empty snapshot', () => {
+    const service = new BatchDomainService(
+      () => new Date('2026-02-05T09:00:00.000Z'),
+    );
+
+    const draft = service.prepareBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+    });
+    const workflow = new RecipeWorkflowService().getDefaultWorkflow();
+    const launched = service.launchBatch(draft, workflow);
+
+    expect(() => service.launchBatch(launched, workflow)).toThrow(
+      'Batch already launched',
+    );
+    expect(() => service.launchBatch(draft, [])).toThrow(
+      'Batch must include at least one step',
     );
   });
 

--- a/packages/api/src/batch/domain/entities/batch.entity.ts
+++ b/packages/api/src/batch/domain/entities/batch.entity.ts
@@ -44,8 +44,24 @@ export interface Batch {
   readonly createdAt: Date;
   readonly updatedAt: Date;
 
-  /** Start timestamp for the batch. */
+  /**
+   * Start timestamp for the batch. For a prep draft (`launchedAt` undefined)
+   * this is the row-creation instant (the column is NOT NULL); Launch
+   * refreshes it to the launch instant, after which both agree.
+   */
   readonly startedAt: Date;
+
+  /**
+   * Launch timestamp (brew-day/07). Undefined = the batch is a « en
+   * préparation » draft: it carries the prep checklist and has no steps yet.
+   */
+  readonly launchedAt?: Date;
+
+  /**
+   * Checked prep-item ids the draft carries (F14 — per-batch checklist state;
+   * the items themselves stay derived from the recipe).
+   */
+  readonly prepCheckedIds?: ReadonlyArray<string>;
 
   /** Timestamp when fermentation was started. */
   readonly fermentationStartedAt?: Date;

--- a/packages/api/src/batch/domain/enums/batch-status.enum.spec.ts
+++ b/packages/api/src/batch/domain/enums/batch-status.enum.spec.ts
@@ -1,13 +1,24 @@
 import { BatchStatus, deriveEffectiveStatus } from './batch-status.enum';
 
 describe('deriveEffectiveStatus', () => {
-  it('returns the raw brewing lifecycle status when no soft stamp exists', () => {
-    expect(deriveEffectiveStatus(BatchStatus.IN_PROGRESS, null, null)).toBe(
-      BatchStatus.IN_PROGRESS,
-    );
-    expect(deriveEffectiveStatus(BatchStatus.COMPLETED, null, null)).toBe(
-      BatchStatus.COMPLETED,
-    );
+  const launchedAt = new Date('2026-05-01T10:00:00.000Z');
+
+  it('returns the raw brewing lifecycle status when launched and no soft stamp exists', () => {
+    expect(
+      deriveEffectiveStatus(BatchStatus.IN_PROGRESS, null, null, launchedAt),
+    ).toBe(BatchStatus.IN_PROGRESS);
+    expect(
+      deriveEffectiveStatus(BatchStatus.COMPLETED, null, null, launchedAt),
+    ).toBe(BatchStatus.COMPLETED);
+  });
+
+  it('derives draft when launched_at is missing (never-launched prep, brew-day/07)', () => {
+    expect(
+      deriveEffectiveStatus(BatchStatus.IN_PROGRESS, null, null, null),
+    ).toBe('draft');
+    expect(
+      deriveEffectiveStatus(BatchStatus.IN_PROGRESS, null, null, undefined),
+    ).toBe('draft');
   });
 
   it('derives cancelled when cancelled_at is set', () => {
@@ -16,6 +27,7 @@ describe('deriveEffectiveStatus', () => {
         BatchStatus.IN_PROGRESS,
         new Date('2026-06-01T10:00:00.000Z'),
         null,
+        launchedAt,
       ),
     ).toBe('cancelled');
   });
@@ -26,7 +38,22 @@ describe('deriveEffectiveStatus', () => {
         BatchStatus.IN_PROGRESS,
         new Date('2026-06-01T10:00:00.000Z'),
         new Date('2026-06-02T10:00:00.000Z'),
+        launchedAt,
       ),
     ).toBe('archived');
+  });
+
+  it('never reports a soft-closed batch as draft (stamps win over a missing launched_at)', () => {
+    // Unreachable through the API guards (a draft cannot be cancelled or
+    // archived) — locked here so the precedence stays archived > cancelled >
+    // draft even if data drifts.
+    expect(
+      deriveEffectiveStatus(
+        BatchStatus.IN_PROGRESS,
+        new Date('2026-06-01T10:00:00.000Z'),
+        null,
+        null,
+      ),
+    ).toBe('cancelled');
   });
 });

--- a/packages/api/src/batch/domain/enums/batch-status.enum.ts
+++ b/packages/api/src/batch/domain/enums/batch-status.enum.ts
@@ -10,17 +10,23 @@ export enum BatchStatus {
 
 /**
  * Effective (derived) lifecycle state shown to clients. The DB keeps `status`
- * as the brewing lifecycle (in_progress/completed) plus nullable `cancelled_at`
- * / `archived_at` timestamps; the effective state is derived with archived
- * taking precedence over cancelled over the raw status (brew-day/07).
+ * as the brewing lifecycle (in_progress/completed) plus nullable timestamps;
+ * the effective state is derived with archived taking precedence over
+ * cancelled, then draft (`launched_at` still null — prepared but never
+ * launched, brew-day/07 F14/F15), then the raw status.
  */
-export type EffectiveBatchStatus = BatchStatus | 'cancelled' | 'archived';
+export type EffectiveBatchStatus =
+  | BatchStatus
+  | 'draft'
+  | 'cancelled'
+  | 'archived';
 
 /**
- * Every value {@link EffectiveBatchStatus} can take, in precedence order. Kept
+ * Every value {@link EffectiveBatchStatus} can take, in lifecycle order. Kept
  * next to the type so the OpenAPI `enum` on BatchSummaryDto never drifts from it.
  */
 export const EFFECTIVE_BATCH_STATUSES: EffectiveBatchStatus[] = [
+  'draft',
   BatchStatus.IN_PROGRESS,
   BatchStatus.COMPLETED,
   'cancelled',
@@ -31,8 +37,10 @@ export function deriveEffectiveStatus(
   status: BatchStatus,
   cancelledAt: Date | null | undefined,
   archivedAt: Date | null | undefined,
+  launchedAt: Date | null | undefined,
 ): EffectiveBatchStatus {
   if (archivedAt) return 'archived';
   if (cancelledAt) return 'cancelled';
+  if (!launchedAt) return 'draft';
   return status;
 }

--- a/packages/api/src/batch/domain/services/batch-domain.service.ts
+++ b/packages/api/src/batch/domain/services/batch-domain.service.ts
@@ -13,15 +13,22 @@ export interface StartBatchInput {
   steps: ReadonlyArray<RecipeStep>;
 }
 
+export interface PrepareBatchInput {
+  id: BatchId;
+  ownerId: UserId;
+  recipeId: RecipeId;
+}
+
 /**
  * BatchDomainService
  *
  * Pure domain service responsible for:
- * - Starting a new brewing batch from a recipe step snapshot
+ * - Preparing a draft batch that carries the mise-en-place (brew-day/07)
+ * - Launching it (or starting one directly) from a recipe step snapshot
  * - Tracking strict workflow progress through steps
  *
  * Current MVP behavior:
- * - Step 0 becomes the current step when the batch starts, but opens in the
+ * - Step 0 becomes the current step when the batch launches, but opens in the
  *   PRÉP phase (in_progress with no `startedAt`) — the timer only starts once
  *   the brewer activates it via `startCurrentStep` (ACTIF). See brew-day/06.
  * - Completing the current step auto-advances to the next one (also in PRÉP)
@@ -29,13 +36,70 @@ export interface StartBatchInput {
 export class BatchDomainService {
   constructor(private readonly now: () => Date = () => new Date()) {}
 
-  startBatch(input: StartBatchInput): Batch {
-    this.validateRecipeSteps(input.steps);
-
+  /**
+   * Create a draft « en préparation » batch (brew-day/07, F14/F15): no steps,
+   * no `launchedAt` — it exists to carry the per-batch prep checklist until
+   * the brewer launches (or discards) it.
+   */
+  prepareBatch(input: PrepareBatchInput): Batch {
     const createdAt = this.now();
 
-    const sortedSteps = [...input.steps].sort((a, b) => a.order - b.order);
-    const steps: BatchStep[] = sortedSteps.map((step) => {
+    return {
+      id: input.id,
+      ownerId: input.ownerId,
+      recipeId: input.recipeId,
+      status: BatchStatus.IN_PROGRESS,
+      currentStepOrder: undefined,
+      steps: [],
+      createdAt,
+      updatedAt: createdAt,
+      // The schema keeps started_at NOT NULL: a draft stores its creation
+      // instant; launchBatch refreshes it. Clients never see it while draft
+      // (the DTO derives startedAt from launchedAt).
+      startedAt: createdAt,
+      launchedAt: undefined,
+      prepCheckedIds: undefined,
+      completedAt: undefined,
+    };
+  }
+
+  /**
+   * Launch a draft: snapshot the recipe steps onto the batch and stamp
+   * `launchedAt` (the draft → in_progress transition of brew-day/07). The
+   * first step opens in PRÉP (no step `startedAt`) per brew-day/06.
+   */
+  launchBatch(batch: Batch, recipeSteps: ReadonlyArray<RecipeStep>): Batch {
+    if (batch.launchedAt !== undefined) {
+      throw new Error('Batch already launched');
+    }
+    this.validateRecipeSteps(recipeSteps);
+
+    const now = this.now();
+
+    return {
+      ...batch,
+      status: BatchStatus.IN_PROGRESS,
+      currentStepOrder: 0,
+      steps: this.snapshotSteps(recipeSteps),
+      updatedAt: now,
+      startedAt: now,
+      launchedAt: now,
+    };
+  }
+
+  /** Prepare + launch in one shot — the direct POST /batches path. */
+  startBatch(input: StartBatchInput): Batch {
+    return this.launchBatch(this.prepareBatch(input), input.steps);
+  }
+
+  /**
+   * Freeze the recipe steps onto the batch (the launch-time snapshot). Every
+   * step starts pending except step 0, which opens as the current step in the
+   * PRÉP phase (no `startedAt` until the brewer activates it — F1).
+   */
+  private snapshotSteps(recipeSteps: ReadonlyArray<RecipeStep>): BatchStep[] {
+    const sortedSteps = [...recipeSteps].sort((a, b) => a.order - b.order);
+    return sortedSteps.map((step) => {
       const isFirst = step.order === 0;
       const guidance = getStepGuidance(step.type);
       return {
@@ -44,28 +108,12 @@ export class BatchDomainService {
         label: step.label,
         description: step.description,
         status: isFirst ? BatchStepStatus.IN_PROGRESS : BatchStepStatus.PENDING,
-        // PRÉP phase: the current step has no `startedAt` until the brewer
-        // activates it (ACTIF). This keeps the countdown from running before
-        // the physical prep is done (novice-journey friction F1).
         startedAt: undefined,
         completedAt: undefined,
         pedagogicalTip: guidance?.pedagogicalTip,
         plannedDurationMin: guidance?.plannedDurationMin ?? undefined,
       };
     });
-
-    return {
-      id: input.id,
-      ownerId: input.ownerId,
-      recipeId: input.recipeId,
-      status: BatchStatus.IN_PROGRESS,
-      currentStepOrder: 0,
-      steps,
-      createdAt,
-      updatedAt: createdAt,
-      startedAt: createdAt,
-      completedAt: undefined,
-    };
   }
 
   completeCurrentStep(batch: Batch): Batch {

--- a/packages/api/src/batch/dtos/batch-summary.dto.ts
+++ b/packages/api/src/batch/dtos/batch-summary.dto.ts
@@ -18,18 +18,22 @@ export class BatchSummaryDto {
   recipe_id: string;
 
   // Effective lifecycle status: the brewing status (in_progress | completed)
-  // unless the batch was cancelled or archived (derived, archived > cancelled).
+  // unless the batch is a never-launched draft, or was cancelled or archived
+  // (derived, archived > cancelled > draft — brew-day/07).
   @ApiProperty({
     enum: EFFECTIVE_BATCH_STATUSES,
-    description: 'in_progress | completed | cancelled | archived',
+    description: 'draft | in_progress | completed | cancelled | archived',
   })
   status: EffectiveBatchStatus;
 
   @ApiPropertyOptional({ nullable: true })
   current_step_order?: number | null;
 
-  @ApiProperty()
-  started_at: Date;
+  // Null while the batch is an « en préparation » draft (the brew has not
+  // started); stamped at launch. The raw column stays NOT NULL for schema
+  // stability — the DTO hides the placeholder a draft row carries.
+  @ApiPropertyOptional({ nullable: true })
+  started_at: Date | null;
 
   @ApiPropertyOptional({ nullable: true })
   fermentation_started_at?: Date | null;
@@ -60,9 +64,14 @@ export class BatchSummaryDto {
       id: e.id,
       owner_id: e.owner_id,
       recipe_id: e.recipe_id,
-      status: deriveEffectiveStatus(e.status, e.cancelled_at, e.archived_at),
+      status: deriveEffectiveStatus(
+        e.status,
+        e.cancelled_at,
+        e.archived_at,
+        e.launched_at,
+      ),
       current_step_order: e.current_step_order ?? null,
-      started_at: e.started_at,
+      started_at: e.launched_at ? e.started_at : null,
       fermentation_started_at: e.fermentation_started_at ?? null,
       fermentation_completed_at: e.fermentation_completed_at ?? null,
       bottled_at: e.bottled_at ?? null,

--- a/packages/api/src/batch/dtos/batch.dto.ts
+++ b/packages/api/src/batch/dtos/batch.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import { BatchStepOrmEntity } from '../entities/batch-step.orm.entity';
 import { BatchOrmEntity } from '../entities/batch.orm.entity';
@@ -10,6 +10,12 @@ export class BatchDto extends BatchSummaryDto {
   @ApiProperty({ type: BatchStepDto, isArray: true })
   steps: BatchStepDto[];
 
+  // Checked prep-item ids carried by an « en préparation » draft (F14). Null
+  // when nothing was ever checked; the checklist items themselves are derived
+  // from the recipe on the client — only the coches live on the batch.
+  @ApiPropertyOptional({ type: String, isArray: true, nullable: true })
+  prep_checked_ids?: string[] | null;
+
   static fromEntities(
     batch: BatchOrmEntity,
     steps: BatchStepOrmEntity[],
@@ -17,6 +23,7 @@ export class BatchDto extends BatchSummaryDto {
     return {
       ...BatchSummaryDto.fromEntity(batch),
       steps: steps.map((step) => BatchStepDto.fromEntity(step)),
+      prep_checked_ids: batch.prep_checked_ids ?? null,
     };
   }
 }

--- a/packages/api/src/batch/dtos/prepare-batch.dto.ts
+++ b/packages/api/src/batch/dtos/prepare-batch.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class PrepareBatchDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  @IsString()
+  @IsNotEmpty()
+  recipeId: string;
+}

--- a/packages/api/src/batch/dtos/update-prep-checklist.dto.ts
+++ b/packages/api/src/batch/dtos/update-prep-checklist.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ArrayMaxSize, IsArray, IsString, MaxLength } from 'class-validator';
+
+/**
+ * Full replacement of the draft's checked prep-item ids (F14). Bounded so no
+ * unbounded client payload is ever persisted: a checklist has one id per
+ * recipe-ingredient row, far below the caps.
+ */
+export class UpdatePrepChecklistDto {
+  @ApiProperty({
+    type: String,
+    isArray: true,
+    example: ['a1b2-hop-cascade-60min-0'],
+  })
+  @IsArray()
+  @ArrayMaxSize(200)
+  @IsString({ each: true })
+  @MaxLength(160, { each: true })
+  checkedIds: string[];
+}

--- a/packages/api/src/batch/entities/batch.orm.entity.ts
+++ b/packages/api/src/batch/entities/batch.orm.entity.ts
@@ -11,6 +11,13 @@ import {
 @Entity('batches')
 @Index(['owner_id'])
 @Index(['recipe_id'])
+// DB backstop for prepareMine's idempotency: at most ONE unlaunched draft per
+// owner+recipe, even under concurrent prepare calls (the read-then-insert in
+// the service cannot see a row another request has not committed yet).
+@Index('idx_batches_one_draft_per_owner_recipe', ['owner_id', 'recipe_id'], {
+  unique: true,
+  where: '"launched_at" IS NULL',
+})
 export class BatchOrmEntity {
   @PrimaryColumn('uuid')
   id: string;
@@ -91,6 +98,23 @@ export class BatchOrmEntity {
 
   @Column({ type: 'datetime', nullable: true })
   archived_at?: Date | null;
+
+  // Draft lifecycle (brew-day/07 F14/F15). `launched_at` null = an « en
+  // préparation » draft created by "Préparer": it carries the prep and has no
+  // steps yet; Launch stamps it (and refreshes `started_at`, which the CHECK-
+  // constrained schema keeps NOT NULL as the row-creation instant until then).
+  // Same additive-timestamp model as cancelled_at/archived_at — the effective
+  // status is derived, no `status` CHECK rebuild. Legacy rows are backfilled
+  // launched_at = started_at (they were all launched at creation).
+  @Column({ type: 'datetime', nullable: true })
+  launched_at?: Date | null;
+
+  // Prep-checklist state carried by the draft (F14: per-batch, resets each
+  // brew). Only the CHECKED item ids are stored — the items themselves stay
+  // derived from the recipe (single source of truth); ids from a recipe edited
+  // mid-prep simply stop matching (benign, drafts are short-lived).
+  @Column({ type: 'simple-json', nullable: true })
+  prep_checked_ids?: string[] | null;
 
   @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   created_at: Date;

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomUUID } from 'crypto';
-import { EntityManager, QueryFailedError, Repository } from 'typeorm';
+import { EntityManager, IsNull, QueryFailedError, Repository } from 'typeorm';
 
 import { RecipeStep } from '../../recipe/domain/entities/recipe-step.entity';
 import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
@@ -137,6 +137,113 @@ export class BatchService {
     });
   }
 
+  /**
+   * Create (or resume) the draft « en préparation » batch for a recipe
+   * (brew-day/07, F14/F15). Idempotent: if the owner already has an unlaunched
+   * draft for this recipe it is returned as-is — « Préparer » twice resumes
+   * the same prep instead of piling up phantom drafts. To start over, discard
+   * the draft (DELETE) and prepare again.
+   */
+  async prepareMine(
+    ownerId: string,
+    recipeId: string,
+  ): Promise<BatchWithSteps> {
+    const existingDraft = await this.batchRepo.findOne({
+      where: { owner_id: ownerId, recipe_id: recipeId, launched_at: IsNull() },
+    });
+    if (existingDraft) {
+      return { batch: existingDraft, steps: [] };
+    }
+
+    // Validates ownership/existence (404 on a foreign or unknown recipe) and
+    // fails fast on an un-brewable recipe: a stepless draft could never launch.
+    const recipeSteps = await this.recipeService.listMineSteps(
+      ownerId,
+      recipeId,
+    );
+    if (recipeSteps.length === 0) {
+      throw new BadRequestException('Recipe has no steps');
+    }
+
+    const draft = this.domain.prepareBatch({
+      id: randomUUID(),
+      ownerId,
+      recipeId,
+    });
+
+    try {
+      return await this.batchRepo.manager.transaction(async (manager) => {
+        return this.persistBatch(manager, draft);
+      });
+    } catch (error) {
+      // A concurrent prepare won the race on the one-draft-per-owner+recipe
+      // unique index between our findOne above and this insert — honour the
+      // idempotency contract by resuming the winner's draft.
+      if (error instanceof QueryFailedError) {
+        const winner = await this.batchRepo.findOne({
+          where: {
+            owner_id: ownerId,
+            recipe_id: recipeId,
+            launched_at: IsNull(),
+          },
+        });
+        if (winner) {
+          return { batch: winner, steps: [] };
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * Persist the draft's prep-checklist state (F14 — the coches live on the
+   * batch, not the recipe). Only the checked ids are stored; the checklist
+   * items themselves stay derived from the recipe on the client.
+   */
+  async updateMinePrepChecklist(
+    ownerId: string,
+    batchId: string,
+    checkedIds: string[],
+  ): Promise<BatchOrmEntity> {
+    const batch = await this.getMineBatch(ownerId, batchId);
+    this.assertMutable(batch);
+    this.assertDraft(batch);
+
+    batch.prep_checked_ids = [...new Set(checkedIds)];
+    return this.batchRepo.save(batch);
+  }
+
+  /**
+   * Launch a draft: the draft → in_progress transition of brew-day/07. The
+   * recipe steps are snapshotted onto the batch NOW (not at prepare time) so
+   * the brew always runs the recipe as it stands at launch.
+   */
+  async launchMine(ownerId: string, batchId: string): Promise<BatchWithSteps> {
+    const batch = await this.getMineBatch(ownerId, batchId);
+    this.assertMutable(batch);
+    this.assertDraft(batch);
+
+    const recipeSteps = await this.recipeService.listMineSteps(
+      ownerId,
+      batch.recipe_id,
+    );
+    const snapshotSteps: RecipeStep[] = recipeSteps.map((step) => ({
+      order: step.step_order,
+      type: step.type,
+      label: step.label,
+      description: step.description ?? undefined,
+    }));
+
+    const launched = this.runStepTransition(
+      (draft) => this.domain.launchBatch(draft, snapshotSteps),
+      this.toDomain(batch, []),
+    );
+
+    return this.batchRepo.manager.transaction(async (manager) => {
+      return this.persistBatch(manager, launched);
+    });
+  }
+
   async listMine(ownerId: string): Promise<BatchOrmEntity[]> {
     return this.batchRepo.find({
       where: { owner_id: ownerId },
@@ -185,6 +292,7 @@ export class BatchService {
   ): Promise<BatchOrmEntity> {
     const batch = await this.getMineBatch(ownerId, batchId);
     this.assertMutable(batch);
+    this.assertLaunched(batch);
     if (batch.status === BatchStatus.COMPLETED) {
       throw new BadRequestException('Batch already completed');
     }
@@ -202,6 +310,7 @@ export class BatchService {
   ): Promise<BatchOrmEntity> {
     const batch = await this.getMineBatch(ownerId, batchId);
     this.assertMutable(batch);
+    this.assertLaunched(batch);
     if (batch.status === BatchStatus.COMPLETED) {
       throw new BadRequestException('Batch already completed');
     }
@@ -229,6 +338,10 @@ export class BatchService {
     if (batch.cancelled_at) {
       throw new BadRequestException('Batch already cancelled');
     }
+    // A draft's raw status is already in_progress, so the status check alone
+    // would let a draft be cancelled — a draft is discarded (DELETE), not
+    // cancelled (brew-day/07).
+    this.assertLaunched(batch);
     if (batch.status !== BatchStatus.IN_PROGRESS) {
       throw new BadRequestException('Only a launched brew can be cancelled');
     }
@@ -274,7 +387,8 @@ export class BatchService {
     batchId: string,
     input: CreateBatchReminderInput,
   ): Promise<BatchReminderOrmEntity> {
-    await this.getMineBatch(ownerId, batchId);
+    const batch = await this.getMineBatch(ownerId, batchId);
+    this.assertLaunched(batch);
     const reminder = this.reminderRepo.create({
       id: randomUUID(),
       batch_id: batchId,
@@ -342,10 +456,20 @@ export class BatchService {
         if (error.message === 'Current step is already active') {
           throw new ConflictException(error.message);
         }
+        // NB: the domain's own 'Batch already launched' guard is unreachable
+        // here — launchMine pre-guards with assertDraft (400) — so it is
+        // deliberately unmapped: if a future path reaches it, it fails loud.
         const clientErrors = new Set([
           'Batch is not in progress',
           'Batch has no current step',
           'Current step is not in progress',
+          // Launch-time snapshot validation (the recipe was edited into an
+          // un-brewable state between prepare and launch).
+          'Batch must include at least one step',
+          'Step order must be a non-negative integer',
+          'Step orders must be unique',
+          'Step orders must start at 0 and be continuous',
+          'Step label must not be empty',
         ]);
         if (clientErrors.has(error.message)) {
           throw new BadRequestException(error.message);
@@ -377,6 +501,9 @@ export class BatchService {
         throw new NotFoundException('Batch not found');
       }
       this.assertMutable(batch);
+      // A draft has no steps to transition — reject it explicitly rather than
+      // via the opaque "no current step" domain error.
+      this.assertLaunched(batch);
       if (batch.status === BatchStatus.COMPLETED) {
         throw new BadRequestException('Batch already completed');
       }
@@ -431,6 +558,8 @@ export class BatchService {
       status: batch.status,
       current_step_order: batch.currentStepOrder ?? null,
       started_at: batch.startedAt,
+      launched_at: batch.launchedAt ?? null,
+      prep_checked_ids: batch.prepCheckedIds ? [...batch.prepCheckedIds] : null,
       completed_at: batch.completedAt ?? null,
     });
 
@@ -468,6 +597,8 @@ export class BatchService {
       createdAt: batch.created_at,
       updatedAt: batch.updated_at,
       startedAt: batch.started_at,
+      launchedAt: batch.launched_at ?? undefined,
+      prepCheckedIds: batch.prep_checked_ids ?? undefined,
       fermentationStartedAt: batch.fermentation_started_at ?? undefined,
       fermentationCompletedAt: batch.fermentation_completed_at ?? undefined,
       bottledAt: batch.bottled_at ?? undefined,
@@ -505,7 +636,8 @@ export class BatchService {
     batchId: string,
     input: CreateMeasurementInput,
   ): Promise<MeasurementOrmEntity> {
-    await this.getMineBatch(ownerId, batchId);
+    const batch = await this.getMineBatch(ownerId, batchId);
+    this.assertLaunched(batch);
 
     // The domain factory enforces per-type range invariants the DTO can't
     // express; surface a violation as a 400 rather than a 500.
@@ -554,7 +686,8 @@ export class BatchService {
     batchId: string,
     input: CreateObservationInput,
   ): Promise<ObservationOrmEntity> {
-    await this.getMineBatch(ownerId, batchId);
+    const batch = await this.getMineBatch(ownerId, batchId);
+    this.assertLaunched(batch);
 
     let normalised: Observation;
     try {
@@ -841,6 +974,29 @@ export class BatchService {
     }
     if (batch.cancelled_at) {
       throw new BadRequestException('Batch is cancelled');
+    }
+  }
+
+  /**
+   * Guard for draft-only operations (prep checklist, launch): the raw
+   * `status` column of a draft is already in_progress (CHECK constraint), so
+   * draftness is the absence of the `launched_at` stamp (brew-day/07).
+   */
+  private assertDraft(batch: BatchOrmEntity): void {
+    if (batch.launched_at) {
+      throw new BadRequestException('Batch already launched');
+    }
+  }
+
+  /**
+   * Guard for brewing-journal operations (fermentation, measurements,
+   * observations, reminders, cancel): a draft has not brewed anything yet, so
+   * these endpoints must reject it — its raw `status` alone cannot tell
+   * (in_progress covers both draft and launched, brew-day/07).
+   */
+  private assertLaunched(batch: BatchOrmEntity): void {
+    if (!batch.launched_at) {
+      throw new BadRequestException('Batch not launched');
     }
   }
 }

--- a/packages/api/src/database/migrations/1805000000000-AddBatchPrepDraftColumns.ts
+++ b/packages/api/src/database/migrations/1805000000000-AddBatchPrepDraftColumns.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds the draft « en préparation » lifecycle columns to `batches`
+ * (brew-day/07, F14/F15).
+ *
+ * - `launched_at` — nullable stamp; null = the batch is a prep draft that was
+ *   never launched. Same additive-timestamp model as `cancelled_at` /
+ *   `archived_at`: the `status` CHECK constraint is NOT extended (SQLite
+ *   cannot alter a CHECK in place and `batches` is referenced by cascade-FK
+ *   child tables, so a table rebuild is deliberately avoided — see the
+ *   1804 soft-lifecycle migration). The effective `draft` status is derived
+ *   at the DTO boundary.
+ * - `prep_checked_ids` — nullable JSON text holding the checked prep-item ids
+ *   the draft carries (F14: per-batch checklist state).
+ *
+ * Backfill: every pre-existing batch was launched at creation (the old
+ * POST /batches created it in_progress with steps), so `launched_at` is
+ * seeded from `started_at` — no legacy row may read as a draft.
+ */
+export class AddBatchPrepDraftColumns1805000000000 implements MigrationInterface {
+  name = 'AddBatchPrepDraftColumns1805000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "launched_at" datetime`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batches" ADD COLUMN "prep_checked_ids" text`,
+    );
+    await queryRunner.query(
+      `UPDATE "batches" SET "launched_at" = "started_at"`,
+    );
+    // One unlaunched draft per owner+recipe — the DB-level backstop that makes
+    // prepareMine's documented idempotency hold under concurrent requests.
+    // Safe on legacy data: the backfill above leaves no unlaunched row.
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "idx_batches_one_draft_per_owner_recipe" ` +
+        `ON "batches" ("owner_id", "recipe_id") WHERE "launched_at" IS NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // The partial index references launched_at — drop it before the column.
+    await queryRunner.query(
+      `DROP INDEX "idx_batches_one_draft_per_owner_recipe"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "batches" DROP COLUMN "prep_checked_ids"`,
+    );
+    await queryRunner.query(`ALTER TABLE "batches" DROP COLUMN "launched_at"`);
+  }
+}

--- a/packages/api/src/database/seeds/demo-batch.seed.spec.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.spec.ts
@@ -86,6 +86,8 @@ describe('seedDemoBatch (Issue #782)', () => {
       expect(created.recipe_id).toBe(DEMO_PUNK_IPA_RECIPE_ID);
       expect(created.name).toBe('Mon premier Punk IPA');
       expect(created.status).toBe(BatchStatus.COMPLETED);
+      // launched_at must be stamped or the derived status reads as draft.
+      expect(created.launched_at).toEqual(created.started_at);
       expect(created.target_volume_l).toBe(20);
       expect(created.final_volume_l).toBe(18);
       expect(created.og_actual).toBe(1.057);

--- a/packages/api/src/database/seeds/demo-batch.seed.ts
+++ b/packages/api/src/database/seeds/demo-batch.seed.ts
@@ -235,6 +235,9 @@ export async function seedDemoBatch(
     status: BatchStatus.COMPLETED,
     current_step_order: null,
     started_at: startedAt,
+    // A completed demo brew was launched — without this stamp the derived
+    // status (launched_at null => draft) would misclassify it as a draft.
+    launched_at: startedAt,
     fermentation_started_at: startedAt,
     fermentation_completed_at: completedAt,
     completed_at: completedAt,

--- a/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
+++ b/packages/mobile-app/src/features/batches/application/batches.use-cases.ts
@@ -4,9 +4,12 @@ import {
   completeCurrentStep as completeCurrentStepApi,
   deleteBatch as deleteBatchApi,
   getMineById,
+  launchBatch as launchBatchApi,
   listMine,
+  prepareBatch as prepareBatchApi,
   startBatch as startBatchApi,
   startCurrentStep as startCurrentStepApi,
+  updatePrepChecklist as updatePrepChecklistApi,
 } from "@/features/batches/data/batches.api";
 import { Batch, BatchSummary } from "@/features/batches/domain/batch.types";
 import { demoBatchSummaries, demoBatches } from "@/mocks/demo-data";
@@ -140,16 +143,75 @@ export async function completeCurrentBatchStep(
   return completeCurrentStepApi(batchId);
 }
 
+// Demo mode maps every batch start/launch onto the bundled fil-rouge batch —
+// the demo store is read-only, so no real batch is ever created.
+function getDemoFilRougeBatch(): Batch {
+  const filRouge = demoBatches.find((item) => item.id === "b-demo-pdd-mash");
+  if (!filRouge) {
+    throw new Error(
+      "Demo data is missing the fil-rouge batch b-demo-pdd-mash.",
+    );
+  }
+  return filRouge;
+}
+
 export async function startBatch(recipeId: string): Promise<Batch> {
   if (dataSource.useDemoData) {
-    const filRouge = demoBatches.find((item) => item.id === "b-demo-pdd-mash");
-    if (!filRouge) {
-      throw new Error(
-        "Demo data is missing the fil-rouge batch b-demo-pdd-mash.",
-      );
-    }
-    return filRouge;
+    return getDemoFilRougeBatch();
   }
 
   return startBatchApi(recipeId);
+}
+
+/**
+ * Create (or resume) the « en préparation » draft batch carrying the prep
+ * checklist for a recipe (brew-day/07, F14/F15). In demo mode the draft is a
+ * synthetic, non-persisted object — the demo store stays read-only, ticks
+ * live in screen state only.
+ */
+export async function prepareBatch(recipeId: string): Promise<Batch> {
+  if (dataSource.useDemoData) {
+    const now = new Date().toISOString();
+    return {
+      id: `demo-draft-${recipeId}`,
+      ownerId: "demo-user",
+      recipeId,
+      status: "draft",
+      currentStepOrder: null,
+      startedAt: null,
+      steps: [],
+      prepCheckedIds: [],
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  return prepareBatchApi(recipeId);
+}
+
+/**
+ * Persist the draft's checked prep-item ids (F14 — coches live on the batch,
+ * per-brew). No-op in demo mode (the synthetic draft is not persisted).
+ */
+export async function updateBatchPrepChecklist(
+  batchId: string,
+  checkedIds: string[],
+): Promise<void> {
+  if (!batchId || dataSource.useDemoData) {
+    return;
+  }
+  await updatePrepChecklistApi(batchId, checkedIds);
+}
+
+/**
+ * Launch a draft — the draft → in_progress transition of brew-day/07 (the
+ * recipe steps are snapshotted server-side at launch). Demo mode returns the
+ * fil-rouge batch, mirroring `startBatch`.
+ */
+export async function launchBatch(batchId: string): Promise<Batch> {
+  if (dataSource.useDemoData) {
+    return getDemoFilRougeBatch();
+  }
+
+  return launchBatchApi(batchId);
 }

--- a/packages/mobile-app/src/features/batches/data/batches.api.ts
+++ b/packages/mobile-app/src/features/batches/data/batches.api.ts
@@ -19,7 +19,8 @@ type BatchSummaryDto = {
   recipe_id: string;
   status: BatchSummary["status"];
   current_step_order?: number | null;
-  started_at: string;
+  // Null while the batch is an « en préparation » draft (brew-day/07).
+  started_at: string | null;
   fermentation_started_at?: string | null;
   fermentation_completed_at?: string | null;
   bottled_at?: string | null;
@@ -45,6 +46,7 @@ type BatchStepDto = {
 
 type BatchDto = BatchSummaryDto & {
   steps: BatchStepDto[];
+  prep_checked_ids?: string[] | null;
 };
 
 type StartBatchResponse = BatchDto;
@@ -103,6 +105,7 @@ function mapBatch(dto: BatchDto): Batch {
   return {
     ...mapBatchSummary(dto),
     steps: dto.steps.map(mapBatchStep),
+    prepCheckedIds: dto.prep_checked_ids ?? null,
   };
 }
 
@@ -134,6 +137,45 @@ export async function startBatch(recipeId: string): Promise<Batch> {
   const row = await request<StartBatchResponse>("/batches", {
     method: "POST",
     body: { recipeId },
+  });
+  return mapBatch(row);
+}
+
+/**
+ * Creates (or resumes) the « en préparation » draft batch for a recipe via
+ * `POST /batches/prepare` (brew-day/07, F14/F15). Idempotent server-side: a
+ * second call returns the existing unlaunched draft with its coches.
+ */
+export async function prepareBatch(recipeId: string): Promise<Batch> {
+  const row = await request<BatchDto>("/batches/prepare", {
+    method: "POST",
+    body: { recipeId },
+  });
+  return mapBatch(row);
+}
+
+/**
+ * Replaces the draft's checked prep-item ids via
+ * `PATCH /batches/:id/prep-checklist` (F14 — coches persisted on the batch).
+ */
+export async function updatePrepChecklist(
+  id: string,
+  checkedIds: string[],
+): Promise<BatchSummary> {
+  const row = await request<BatchSummaryDto>(`/batches/${id}/prep-checklist`, {
+    method: "PATCH",
+    body: { checkedIds },
+  });
+  return mapBatchSummary(row);
+}
+
+/**
+ * Launches a draft via `PATCH /batches/:id/launch` — the draft → in_progress
+ * transition of brew-day/07 (steps snapshotted server-side at launch).
+ */
+export async function launchBatch(id: string): Promise<Batch> {
+  const row = await request<BatchDto>(`/batches/${id}/launch`, {
+    method: "PATCH",
   });
   return mapBatch(row);
 }

--- a/packages/mobile-app/src/features/batches/domain/batch.types.ts
+++ b/packages/mobile-app/src/features/batches/domain/batch.types.ts
@@ -1,7 +1,9 @@
 // Effective lifecycle status returned by the API: the brewing status
-// (in_progress | completed) unless the batch was cancelled or archived
-// (soft states derived server-side, archived > cancelled — brew-day/07).
+// (in_progress | completed) unless the batch is a never-launched draft
+// (« en préparation », F14/F15) or was cancelled or archived (soft states
+// derived server-side, archived > cancelled > draft — brew-day/07).
 export type BatchStatus =
+  | "draft"
   | "in_progress"
   | "completed"
   | "cancelled"
@@ -22,7 +24,9 @@ export type BatchSummary = {
   recipeId: string;
   status: BatchStatus;
   currentStepOrder?: number | null;
-  startedAt: string;
+  // ISO-8601 launch instant, or null while the batch is an « en préparation »
+  // draft (the brew has not started — brew-day/07).
+  startedAt: string | null;
   fermentationStartedAt?: string | null;
   fermentationCompletedAt?: string | null;
   // ISO-8601 instant the batch was bottled (B3 closure), or null before
@@ -55,4 +59,8 @@ export type BatchStep = {
 
 export type Batch = BatchSummary & {
   steps: BatchStep[];
+  // Checked prep-item ids carried by an « en préparation » draft (F14 — the
+  // coches live on the batch, per-brew). Null when nothing was ever checked;
+  // the checklist items themselves stay derived from the recipe.
+  prepCheckedIds?: string[] | null;
 };

--- a/packages/mobile-app/src/features/batches/presentation/BatchesScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchesScreen.tsx
@@ -130,6 +130,12 @@ export function BatchesScreen() {
           return (
             <Pressable
               onPress={() => {
+                // An « en préparation » draft resumes its prep screen — it
+                // has no brewing journal to open yet (brew-day/07, F15).
+                if (item.status === "draft") {
+                  router.push(`/(app)/recipes/${item.recipeId}/prepare`);
+                  return;
+                }
                 // Demo mode: a finished brassin opens the celebration
                 // mockup ("La Première du dimanche est prête à
                 // déguster") instead of the technical details view.

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchesScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchesScreen.test.tsx
@@ -178,6 +178,31 @@ describe("BatchesScreen", () => {
     expect(mockPush).toHaveBeenCalledWith("/(app)/batches/b-demo-pdd-mash");
   });
 
+  it("routes an « en préparation » draft back to its prepare screen (F15)", async () => {
+    dataSource.useDemoData = true;
+    (listBatches as jest.Mock).mockResolvedValue([
+      {
+        id: "b-demo-pdd-draft",
+        ownerId: "u-demo-1",
+        recipeId: "r-demo-pdd",
+        status: "draft",
+        currentStepOrder: null,
+        startedAt: null,
+        fermentationStartedAt: null,
+        fermentationCompletedAt: null,
+        completedAt: null,
+        createdAt: "2026-05-19T09:00:00.000Z",
+        updatedAt: "2026-05-19T09:30:00.000Z",
+      },
+    ]);
+
+    renderBatchesScreen();
+
+    fireEvent.press(await screen.findByText("La Première du dimanche"));
+
+    expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/r-demo-pdd/prepare");
+  });
+
   it("routes a completed brassin to the celebration mockup in demo mode", async () => {
     dataSource.useDemoData = true;
     (listBatches as jest.Mock).mockResolvedValue([

--- a/packages/mobile-app/src/features/batches/presentation/batch-display.constants.ts
+++ b/packages/mobile-app/src/features/batches/presentation/batch-display.constants.ts
@@ -11,6 +11,7 @@ import type {
 // (BatchesScreen) and the batch detail (BatchDetailsScreen).
 
 export const BATCH_STATUS_LABELS: Record<BatchStatus, string> = {
+  draft: "En préparation",
   in_progress: "En cours",
   completed: "Terminé",
   cancelled: "Annulé",

--- a/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
+++ b/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
@@ -182,8 +182,11 @@ const ALERT_STATUS_PRIORITY: Record<AlertStatus, number> = {
   Bientôt: 2,
 };
 
-function parseDateOrNow(value: string, fallback: Date): Date {
-  const parsed = Date.parse(value);
+// `value` is nullable since batch.startedAt is null while a batch is an « en
+// préparation » draft (brew-day/07); drafts are filtered out upstream, so the
+// fallback path is a type-level safety net rather than a live branch.
+function parseDateOrNow(value: string | null, fallback: Date): Date {
+  const parsed = value === null ? Number.NaN : Date.parse(value);
   if (!Number.isNaN(parsed)) {
     return new Date(parsed);
   }
@@ -239,11 +242,11 @@ function formatRelativeDue(dueAt: Date, now: Date): string {
 }
 
 function isWithinSelectedPeriod(
-  isoDate: string,
+  isoDate: string | null,
   period: PeriodKey,
   now: Date,
 ): boolean {
-  const parsed = Date.parse(isoDate);
+  const parsed = isoDate === null ? Number.NaN : Date.parse(isoDate);
   if (Number.isNaN(parsed)) {
     return false;
   }

--- a/packages/mobile-app/src/features/labels/application/labels.use-cases.ts
+++ b/packages/mobile-app/src/features/labels/application/labels.use-cases.ts
@@ -176,7 +176,10 @@ export async function listLabelBatchCandidates(): Promise<
         style: resolveCandidateStyle(recipeName, recipe?.description),
         abv: recipe?.stats?.abv ?? null,
         breweryName: resolveCandidateBreweryName(),
-        brewedAtIso: batch.startedAt,
+        // Candidates are launched (in_progress/completed per the predicate
+        // above), so startedAt is always set in practice; the createdAt
+        // fallback only satisfies the nullable type (drafts never reach here).
+        brewedAtIso: batch.startedAt ?? batch.createdAt,
         status: batch.status,
       } satisfies LabelBatchCandidate;
     })

--- a/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { Alert, ScrollView, StyleSheet, Text, View } from "react-native";
 
 import { useRouter } from "expo-router";
@@ -25,7 +25,12 @@ import {
 } from "@/features/recipes/application/brew-readiness.use-cases";
 import type { ReadinessChecklist } from "@/features/recipes/domain/brew-readiness.types";
 import { RecipeStickyCta } from "@/features/recipes/presentation/components/RecipeStickyCta";
-import { startBatch } from "@/features/batches/application/batches.use-cases";
+import {
+  launchBatch,
+  prepareBatch,
+  updateBatchPrepChecklist,
+} from "@/features/batches/application/batches.use-cases";
+import type { Batch } from "@/features/batches/domain/batch.types";
 
 type Props = Readonly<{ recipeId: string }>;
 
@@ -39,10 +44,12 @@ type Props = Readonly<{ recipeId: string }>;
  * (A3) will be added to this same screen and extend the gate to
  * `ingredient.isComplete() && equipment.isComplete()` (BrewReadiness).
  *
- * The tick state is reversible client state (a sparse `have` overlay kept in
- * `useState`, reset when the screen unmounts) — matching the conception's
- * "client state pre-batch, mirror deferred". Confirming the launch starts the
- * batch and navigates to its tracking screen (phase B = point of no return).
+ * The prep is carried by an « en préparation » draft batch (brew-day/07,
+ * F14/F15): opening the screen prepares (or resumes) the recipe's draft, each
+ * tick is persisted on it, and « Lancer le brassage » is the draft →
+ * in_progress transition. The checklist items stay derived from the recipe —
+ * only the coches live on the batch, so they reset naturally on each new brew
+ * (F14) while surviving app restarts mid-prep.
  */
 export function BrewPrepScreen({ recipeId }: Props) {
   const router = useRouter();
@@ -62,13 +69,69 @@ export function BrewPrepScreen({ recipeId }: Props) {
     enabled: hasRecipeId,
   });
 
-  const startBatchMutation = useMutation({
-    mutationFn: () => startBatch(recipeId),
+  // The draft batch carrying this prep. A POST used as a query is deliberate:
+  // prepareBatch is idempotent server-side (it resumes the existing draft), so
+  // re-mounting the screen re-opens the same prep with its persisted coches.
+  const {
+    data: draft = null,
+    isLoading: isDraftLoading,
+    error: draftError,
+    refetch: refetchDraft,
+  } = useQuery<Batch | null>({
+    queryKey: ["batches", "prep", recipeId],
+    queryFn: () => prepareBatch(recipeId),
+    enabled: hasRecipeId,
+  });
+
+  const launchMutation = useMutation({
+    mutationFn: (draftId: string) => launchBatch(draftId),
     onSuccess: (batch) => {
       void queryClient.invalidateQueries({ queryKey: ["batches"] });
       router.push(`/(app)/batches/${batch.id}`);
     },
   });
+
+  // Persists the full checked-ids list on the draft. The payload being a full
+  // replacement, PATCHes must never overlap: two in-flight requests can reach
+  // the server out of order and the OLDER list would win (lost tick). So one
+  // request flies at a time; while it runs only the LATEST desired list is
+  // kept queued (intermediate lists are obsolete by construction).
+  const persistMutation = useMutation({
+    mutationFn: (input: { draftId: string; checkedIds: string[] }) =>
+      updateBatchPrepChecklist(input.draftId, input.checkedIds),
+  });
+  const patchInFlightRef = useRef(false);
+  const queuedCheckedIdsRef = useRef<string[] | null>(null);
+
+  const sendCheckedIds = (draftId: string, checkedIds: string[]) => {
+    patchInFlightRef.current = true;
+    persistMutation.mutate(
+      { draftId, checkedIds },
+      {
+        onError: (error) => {
+          // The failed PATCH may carry several coalesced ticks, so per-tick
+          // rollback is meaningless: drop the optimistic overlay, re-sync the
+          // draft from the server, and tell the brewer — a silently lost
+          // coche would resurface as a phantom missing ingredient later.
+          queuedCheckedIdsRef.current = null;
+          setHaveById({});
+          void refetchDraft();
+          Alert.alert(
+            "Coche non enregistrée",
+            getErrorMessage(error, "Réessaie dans un instant."),
+          );
+        },
+        onSettled: () => {
+          patchInFlightRef.current = false;
+          const queued = queuedCheckedIdsRef.current;
+          queuedCheckedIdsRef.current = null;
+          if (queued) {
+            sendCheckedIds(draftId, queued);
+          }
+        },
+      },
+    );
+  };
 
   // Base checklist derived from the recipe; never mutated by ticks (a refetch
   // re-derives it, but the user's `have` overlay below is kept separately so
@@ -78,6 +141,12 @@ export function BrewPrepScreen({ recipeId }: Props) {
     [viewModel],
   );
 
+  // Coches persisted on the draft (source of truth) + the session's optimistic
+  // overrides (snappy toggles while the PATCH is in flight).
+  const persistedChecked = useMemo(
+    () => new Set(draft?.prepCheckedIds ?? []),
+    [draft],
+  );
   const [haveById, setHaveById] = useState<Record<string, boolean>>({});
 
   const mergedChecklist = useMemo<ReadinessChecklist>(
@@ -85,10 +154,10 @@ export function BrewPrepScreen({ recipeId }: Props) {
       ...checklist,
       items: checklist.items.map((item) => ({
         ...item,
-        have: haveById[item.id] ?? false,
+        have: haveById[item.id] ?? persistedChecked.has(item.id),
       })),
     }),
-    [checklist, haveById],
+    [checklist, haveById, persistedChecked],
   );
 
   const missing = getMissingItems(mergedChecklist);
@@ -96,16 +165,30 @@ export function BrewPrepScreen({ recipeId }: Props) {
   const hasItems = mergedChecklist.items.length > 0;
 
   const toggle = (id: string) => {
-    setHaveById((current) => ({ ...current, [id]: !(current[id] ?? false) }));
+    const next = !(haveById[id] ?? persistedChecked.has(id));
+    setHaveById((current) => ({ ...current, [id]: next }));
+
+    if (!draft) {
+      return;
+    }
+    const checkedIds = mergedChecklist.items
+      .map((item) => (item.id === id ? { ...item, have: next } : item))
+      .filter((item) => item.have)
+      .map((item) => item.id);
+    if (patchInFlightRef.current) {
+      queuedCheckedIdsRef.current = checkedIds;
+      return;
+    }
+    sendCheckedIds(draft.id, checkedIds);
   };
 
-  const isStarting = startBatchMutation.isPending;
+  const isStarting = launchMutation.isPending;
 
   // The launch is irreversible (phase B = point of no return), so it is
   // gated twice: the CTA is disabled until the checklist is complete, and a
   // final confirmation dialog guards the actual batch creation.
   const handleLaunch = () => {
-    if (!complete || isStarting) {
+    if (!complete || isStarting || !draft) {
       return;
     }
     Alert.alert(
@@ -116,27 +199,30 @@ export function BrewPrepScreen({ recipeId }: Props) {
         {
           text: "Lancer",
           style: "default",
-          onPress: () => startBatchMutation.mutate(),
+          onPress: () => launchMutation.mutate(draft.id),
         },
       ],
     );
   };
 
   const handleRetry = () => {
-    if (startBatchMutation.error) {
-      startBatchMutation.reset();
+    if (launchMutation.error) {
+      launchMutation.reset();
     }
     void refetch();
+    void refetchDraft();
   };
 
   const errorMessage = queryError
     ? getErrorMessage(queryError, "Impossible de charger la recette")
-    : startBatchMutation.error
-      ? getErrorMessage(
-          startBatchMutation.error,
-          "Le démarrage du brassin a échoué",
-        )
-      : null;
+    : draftError
+      ? getErrorMessage(draftError, "Impossible de préparer le brassin")
+      : launchMutation.error
+        ? getErrorMessage(
+            launchMutation.error,
+            "Le démarrage du brassin a échoué",
+          )
+        : null;
 
   // A missing id, or a fetch that resolved to no recipe (stale / deleted id),
   // is a not-found state — not an empty checklist (see PR #1255 for context).
@@ -164,7 +250,11 @@ export function BrewPrepScreen({ recipeId }: Props) {
     : "Coche tous les ingrédients pour lancer le brassage.";
 
   return (
-    <Screen isLoading={isLoading} error={errorMessage} onRetry={handleRetry}>
+    <Screen
+      isLoading={isLoading || isDraftLoading}
+      error={errorMessage}
+      onRetry={handleRetry}
+    >
       <HeaderBackButton
         label="Recette"
         accessibilityLabel="Revenir à la recette"
@@ -237,7 +327,7 @@ export function BrewPrepScreen({ recipeId }: Props) {
         label={ctaLabel}
         helperText={ctaHelper}
         onPress={handleLaunch}
-        disabled={!complete || isStarting || !viewModel}
+        disabled={!complete || isStarting || !viewModel || !draft}
         bottomOffset={footerOffset}
       />
     </Screen>

--- a/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
@@ -183,12 +183,18 @@ export function BrewPrepScreen({ recipeId }: Props) {
   };
 
   const isStarting = launchMutation.isPending;
+  // Launching while a checklist PATCH is in flight (or queued) would race
+  // the backend: launch stamps launched_at, then the late PATCH is rejected
+  // ("already launched") — last tick lost + error alert after navigation.
+  // The queue only fills while a send is in flight and is flushed on settle,
+  // so isPending alone covers both.
+  const isSavingChecklist = persistMutation.isPending;
 
   // The launch is irreversible (phase B = point of no return), so it is
-  // gated twice: the CTA is disabled until the checklist is complete, and a
-  // final confirmation dialog guards the actual batch creation.
+  // gated twice: the CTA is disabled until the checklist is complete AND
+  // persisted, and a final confirmation dialog guards the batch creation.
   const handleLaunch = () => {
-    if (!complete || isStarting || !draft) {
+    if (!complete || isStarting || isSavingChecklist || !draft) {
       return;
     }
     Alert.alert(
@@ -327,7 +333,9 @@ export function BrewPrepScreen({ recipeId }: Props) {
         label={ctaLabel}
         helperText={ctaHelper}
         onPress={handleLaunch}
-        disabled={!complete || isStarting || !viewModel || !draft}
+        disabled={
+          !complete || isStarting || isSavingChecklist || !viewModel || !draft
+        }
         bottomOffset={footerOffset}
       />
     </Screen>

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
@@ -297,6 +297,15 @@ describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
     await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalled());
 
     tickAll();
+    // The launch stays gated while the coche saves are in flight — let them
+    // settle before pressing the CTA.
+    await waitFor(() =>
+      expect(mockUpdateChecklist).toHaveBeenLastCalledWith("draft-1", [
+        PILSNER_ID,
+        CASCADE_ID,
+      ]),
+    );
+    await act(async () => {});
     fireEvent.press(screen.getByText("Lancer le brassage"));
     expect(Alert.alert).toHaveBeenCalledTimes(1);
 
@@ -319,6 +328,13 @@ describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
     await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalled());
 
     tickAll();
+    await waitFor(() =>
+      expect(mockUpdateChecklist).toHaveBeenLastCalledWith("draft-1", [
+        PILSNER_ID,
+        CASCADE_ID,
+      ]),
+    );
+    await act(async () => {});
     fireEvent.press(screen.getByText("Lancer le brassage"));
     await act(async () => {
       confirmLaunchAlert();
@@ -356,6 +372,41 @@ describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
     await waitFor(() => {
       expect(mockLaunchBatch).toHaveBeenCalledWith("draft-1");
       expect(mockPush).toHaveBeenCalledWith("/(app)/batches/b1");
+    });
+  });
+
+  it("edge: the launch stays gated while a coche save is still in flight", async () => {
+    // One ingredient only: a single tick completes the checklist while its
+    // PATCH hangs — the optimistic gate is open but persistence is not done.
+    mockGetViewModel.mockResolvedValue(buildViewModel([TWO_INGREDIENTS[0]]));
+    let resolveSave: () => void = () => {};
+    mockUpdateChecklist.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = () => resolve(undefined);
+        }),
+    );
+
+    renderScreen();
+    await screen.findByText("Pilsner Malt");
+    await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalled());
+
+    fireEvent.press(screen.getAllByRole("checkbox")[0]);
+    // Wait for the hanging PATCH to actually be in flight (the mutationFn
+    // runs on a microtask, and captures resolveSave only then).
+    await waitFor(() => expect(mockUpdateChecklist).toHaveBeenCalled());
+    expect(screen.getByText("PRÊT")).toBeTruthy();
+
+    // Launching now would race the backend: launch stamps launched_at and
+    // the in-flight PATCH gets rejected ("already launched") — so the CTA
+    // must stay inert until the save settles.
+    fireEvent.press(screen.getByText("Lancer le brassage"));
+    expect(Alert.alert).not.toHaveBeenCalled();
+
+    resolveSave();
+    await waitFor(() => {
+      fireEvent.press(screen.getByText("Lancer le brassage"));
+      expect(Alert.alert).toHaveBeenCalled();
     });
   });
 

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
@@ -15,7 +15,12 @@ import {
   getRecipeDetailsViewModel,
   type RecipeDetailsIngredientItem,
 } from "@/features/recipes/application/recipes.use-cases";
-import { startBatch } from "@/features/batches/application/batches.use-cases";
+import {
+  launchBatch,
+  prepareBatch,
+  updateBatchPrepChecklist,
+} from "@/features/batches/application/batches.use-cases";
+import type { Batch } from "@/features/batches/domain/batch.types";
 
 const mockPush = jest.fn();
 const mockBack = jest.fn();
@@ -29,7 +34,9 @@ jest.mock("@/features/recipes/application/recipes.use-cases", () => ({
 }));
 
 jest.mock("@/features/batches/application/batches.use-cases", () => ({
-  startBatch: jest.fn(),
+  launchBatch: jest.fn(),
+  prepareBatch: jest.fn(),
+  updateBatchPrepChecklist: jest.fn(),
 }));
 
 jest.mock("expo-router", () => {
@@ -41,12 +48,16 @@ jest.mock("expo-router", () => {
 });
 
 const mockGetViewModel = getRecipeDetailsViewModel as jest.Mock;
-const mockStartBatch = startBatch as jest.Mock;
+const mockPrepareBatch = prepareBatch as jest.Mock;
+const mockLaunchBatch = launchBatch as jest.Mock;
+const mockUpdateChecklist = updateBatchPrepChecklist as jest.Mock;
 
-const PILSNER_ROW = "ingredient-readiness-row-ferm-1-no-timing-0";
-const CASCADE_ROW = "ingredient-readiness-row-hop-1-no-timing-1";
-const PILSNER_MISSING = "ingredient-readiness-missing-ferm-1-no-timing-0";
-const CASCADE_MISSING = "ingredient-readiness-missing-hop-1-no-timing-1";
+const PILSNER_ID = "ferm-1-no-timing-0";
+const CASCADE_ID = "hop-1-no-timing-1";
+const PILSNER_ROW = `ingredient-readiness-row-${PILSNER_ID}`;
+const CASCADE_ROW = `ingredient-readiness-row-${CASCADE_ID}`;
+const PILSNER_MISSING = `ingredient-readiness-missing-${PILSNER_ID}`;
+const CASCADE_MISSING = `ingredient-readiness-missing-${CASCADE_ID}`;
 
 function buildViewModel(ingredients: RecipeDetailsIngredientItem[]) {
   return {
@@ -63,6 +74,22 @@ function buildViewModel(ingredients: RecipeDetailsIngredientItem[]) {
     steps: [],
     equipment: [],
     ingredients,
+  };
+}
+
+// The « en préparation » draft carrying the prep (brew-day/07, F14/F15).
+function buildDraft(prepCheckedIds: string[] = []): Batch {
+  return {
+    id: "draft-1",
+    ownerId: "u1",
+    recipeId: "r1",
+    status: "draft",
+    currentStepOrder: null,
+    startedAt: null,
+    steps: [],
+    prepCheckedIds,
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
   };
 }
 
@@ -118,25 +145,28 @@ function confirmLaunchAlert() {
   buttons.find((button) => button.text === "Lancer")?.onPress?.();
 }
 
-describe("BrewPrepScreen — pre-launch gate", () => {
+describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
   let alertSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
     alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
-    mockStartBatch.mockResolvedValue({ id: "b1" });
+    mockPrepareBatch.mockResolvedValue(buildDraft());
+    mockLaunchBatch.mockResolvedValue({ id: "b1" });
+    mockUpdateChecklist.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
     alertSpy.mockRestore();
   });
 
-  it("happy: lists ingredients as missing and keeps the launch gated", async () => {
+  it("happy: prepares the draft, lists ingredients as missing and keeps the launch gated", async () => {
     mockGetViewModel.mockResolvedValue(buildViewModel(TWO_INGREDIENTS));
 
     renderScreen();
 
     expect(await screen.findByText("Pilsner Malt")).toBeTruthy();
+    await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalledWith("r1"));
     expect(screen.getByTestId(PILSNER_ROW)).toBeTruthy();
     expect(screen.getByTestId(CASCADE_ROW)).toBeTruthy();
     expect(screen.getByTestId(PILSNER_MISSING)).toBeTruthy();
@@ -145,7 +175,98 @@ describe("BrewPrepScreen — pre-launch gate", () => {
     // Gate closed: pressing the disabled CTA must not open the dialog.
     fireEvent.press(screen.getByText("Lancer le brassage"));
     expect(Alert.alert).not.toHaveBeenCalled();
-    expect(mockStartBatch).not.toHaveBeenCalled();
+    expect(mockLaunchBatch).not.toHaveBeenCalled();
+  });
+
+  it("happy: coches persisted on the draft pre-check their rows (F14 resume)", async () => {
+    mockGetViewModel.mockResolvedValue(buildViewModel(TWO_INGREDIENTS));
+    mockPrepareBatch.mockResolvedValue(buildDraft([PILSNER_ID]));
+
+    renderScreen();
+    await screen.findByText("Pilsner Malt");
+
+    await waitFor(() => {
+      expect(screen.queryByTestId(PILSNER_MISSING)).toBeNull();
+    });
+    expect(screen.getByTestId(CASCADE_MISSING)).toBeTruthy();
+  });
+
+  it("interaction: each tick persists the full checked list on the draft", async () => {
+    mockGetViewModel.mockResolvedValue(buildViewModel(TWO_INGREDIENTS));
+
+    renderScreen();
+    await screen.findByText("Pilsner Malt");
+    await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalled());
+
+    fireEvent.press(screen.getAllByRole("checkbox")[0]);
+    await waitFor(() => {
+      expect(mockUpdateChecklist).toHaveBeenCalledWith("draft-1", [PILSNER_ID]);
+    });
+
+    fireEvent.press(screen.getAllByRole("checkbox")[1]);
+    await waitFor(() => {
+      expect(mockUpdateChecklist).toHaveBeenLastCalledWith("draft-1", [
+        PILSNER_ID,
+        CASCADE_ID,
+      ]);
+    });
+  });
+
+  it("edge: ticks landing while a save is in flight coalesce into one ordered PATCH", async () => {
+    mockGetViewModel.mockResolvedValue(buildViewModel(TWO_INGREDIENTS));
+    let resolveFirstSave: () => void = () => {};
+    mockUpdateChecklist.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirstSave = () => resolve(undefined);
+        }),
+    );
+
+    renderScreen();
+    await screen.findByText("Pilsner Malt");
+    await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalled());
+
+    fireEvent.press(screen.getAllByRole("checkbox")[0]);
+    fireEvent.press(screen.getAllByRole("checkbox")[1]);
+
+    // The second tick must NOT fire a concurrent PATCH (full-replacement
+    // writes reaching the server out of order would lose the last tick).
+    await waitFor(() => {
+      expect(mockUpdateChecklist).toHaveBeenCalledWith("draft-1", [PILSNER_ID]);
+    });
+    expect(mockUpdateChecklist).toHaveBeenCalledTimes(1);
+
+    resolveFirstSave();
+
+    // Once the first save settles, the queued latest list goes out — one
+    // coalesced PATCH carrying both ticks, in order.
+    await waitFor(() => {
+      expect(mockUpdateChecklist).toHaveBeenCalledTimes(2);
+    });
+    expect(mockUpdateChecklist).toHaveBeenLastCalledWith("draft-1", [
+      PILSNER_ID,
+      CASCADE_ID,
+    ]);
+  });
+
+  it("sad: a failed coche save rolls the tick back and alerts the brewer", async () => {
+    mockGetViewModel.mockResolvedValue(buildViewModel(TWO_INGREDIENTS));
+    mockUpdateChecklist.mockRejectedValueOnce(new Error("offline"));
+
+    renderScreen();
+    await screen.findByText("Pilsner Malt");
+    await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalled());
+
+    fireEvent.press(screen.getAllByRole("checkbox")[0]);
+
+    await waitFor(() => {
+      expect(Alert.alert).toHaveBeenCalledWith(
+        "Coche non enregistrée",
+        expect.stringMatching(/offline/i),
+      );
+    });
+    // The optimistic tick was rolled back → the item is missing again.
+    expect(screen.getByTestId(PILSNER_MISSING)).toBeTruthy();
   });
 
   it("interaction: ticking everything opens the gate (Prêt), unticking re-closes it", async () => {
@@ -168,11 +289,12 @@ describe("BrewPrepScreen — pre-launch gate", () => {
     expect(screen.queryByText("PRÊT")).toBeNull();
   });
 
-  it("launch: confirming the dialog starts the batch and navigates to it", async () => {
+  it("launch: confirming the dialog launches the draft and navigates to the batch", async () => {
     mockGetViewModel.mockResolvedValue(buildViewModel(TWO_INGREDIENTS));
 
     renderScreen();
     await screen.findByText("Pilsner Malt");
+    await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalled());
 
     tickAll();
     fireEvent.press(screen.getByText("Lancer le brassage"));
@@ -183,17 +305,18 @@ describe("BrewPrepScreen — pre-launch gate", () => {
     });
 
     await waitFor(() => {
-      expect(mockStartBatch).toHaveBeenCalledWith("r1");
+      expect(mockLaunchBatch).toHaveBeenCalledWith("draft-1");
       expect(mockPush).toHaveBeenCalledWith("/(app)/batches/b1");
     });
   });
 
   it("sad: a failed launch surfaces the error banner and does not navigate", async () => {
     mockGetViewModel.mockResolvedValue(buildViewModel(TWO_INGREDIENTS));
-    mockStartBatch.mockRejectedValueOnce(new Error("Backend down"));
+    mockLaunchBatch.mockRejectedValueOnce(new Error("Backend down"));
 
     renderScreen();
     await screen.findByText("Pilsner Malt");
+    await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalled());
 
     tickAll();
     fireEvent.press(screen.getByText("Lancer le brassage"));
@@ -205,6 +328,16 @@ describe("BrewPrepScreen — pre-launch gate", () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
+  it("sad: a failed draft preparation surfaces the error banner", async () => {
+    mockGetViewModel.mockResolvedValue(buildViewModel(TWO_INGREDIENTS));
+    mockPrepareBatch.mockRejectedValue(new Error("prep down"));
+
+    renderScreen();
+
+    expect(await screen.findByText(/prep down/i)).toBeTruthy();
+    expect(mockLaunchBatch).not.toHaveBeenCalled();
+  });
+
   it("edge: an empty ingredient list shows the empty state but still allows launch", async () => {
     mockGetViewModel.mockResolvedValue(buildViewModel([]));
 
@@ -212,6 +345,7 @@ describe("BrewPrepScreen — pre-launch gate", () => {
 
     expect(await screen.findByText("Aucun ingrédient listé")).toBeTruthy();
     expect(screen.queryByText("Ce qu'il te manque")).toBeNull();
+    await waitFor(() => expect(mockPrepareBatch).toHaveBeenCalled());
 
     // Nothing to check → the gate is vacuously open and the launch proceeds.
     fireEvent.press(screen.getByText("Lancer le brassage"));
@@ -220,7 +354,7 @@ describe("BrewPrepScreen — pre-launch gate", () => {
       confirmLaunchAlert();
     });
     await waitFor(() => {
-      expect(mockStartBatch).toHaveBeenCalledWith("r1");
+      expect(mockLaunchBatch).toHaveBeenCalledWith("draft-1");
       expect(mockPush).toHaveBeenCalledWith("/(app)/batches/b1");
     });
   });


### PR DESCRIPTION
## Summary

A batch can now exist as a **draft (« en préparation »)** before the brew is launched — fixing novice-journey frictions **F14** (prep checklist persisted per batch) and **F15** (the prep is visible in the batch list and resumable).

- **Model** — additive nullable `launched_at` + `prep_checked_ids` columns (same soft-lifecycle pattern as cancelled/archived, #1292). Effective status precedence: `archived > cancelled > draft > raw status`. Reversible migration backfills `launched_at = started_at` for legacy rows.
- **API** — domain `startBatch` split into `prepareBatch()` / `launchBatch()` (steps snapshotted at launch, not at prepare). Service: `prepareMine()` (idempotent — resumes the existing unlaunched draft), `updateMinePrepChecklist()`, `launchMine()`; draft guards reject all journal operations on drafts. New endpoints: `POST /batches/prepare`, `PATCH /batches/:id/prep-checklist`, `PATCH /batches/:id/launch`.
- **Mobile** — `BrewPrepScreen` is now backed by the persisted draft (prepare/resume on mount, optimistic checklist toggles, launch CTA); `BatchesScreen` shows drafts as « En préparation » and routes them back to the prepare screen.
- **UML kept in sync** (conception-is-contract): brew-day `07-state-batch-lifecycle`, brew-prep `02-sequence-plan-and-confirm` + `04-class`.

## Context

Slice 07b of the brew-day structural block (novice-journey audit 2026-06-29). Hardening added by the local pre-push review (Claude + Codex):

- **Partial unique index** (one unlaunched draft per owner+recipe) makes `prepareMine`'s idempotency hold under concurrent calls, with race recovery in the service.
- **Demo seed stamps `launched_at`** so the completed demo brew never derives as a draft.
- **Checklist PATCHes serialized client-side** (one in flight, latest list coalesced) so out-of-order full replacements cannot lose ticks on slow networks.

## Checklist

- [x] Happy + sad + edge tests at every layer (domain, service, controller, seed, mobile screens) — API 908 ✅, mobile 1163 ✅
- [x] `npm run ci:all` green (lint + typecheck + format)
- [x] Reversible migration; additive columns only, no CHECK rebuild
- [x] UML diagrams updated in the same commit
- [x] Local pre-push review ritual passed (0 Must Have)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
