### PR TITLE
chore(review): align review pipeline with reversed AI-attribution policy

### DIFF
--- a/.claude/agents/pr-pre-reviewer.md
+++ b/.claude/agents/pr-pre-reviewer.md
@@ -70,7 +70,6 @@ For every file in the diff, check the points below. Group findings by priority.
 - **Imports out of order** (React/RN → third-party → `@/core` → `@/features` → relative)
 - **Missing French/English mirror** in `packages/website/` (a public page edited only on one language side)
 - **No PROJECT_LOG.md entry** drafted when this PR would merge a significant change
-- **AI attribution** (`Co-Authored-By`, "Generated with", "Claude", "Copilot", "Codex", "GPT") in any commit message or file under git
 
 ### Nice to Have — cosmetic / optional
 
@@ -132,5 +131,5 @@ If there are no findings in a section, write `_None._` rather than omitting the 
 - **Cite, don't paraphrase.** When flagging an ADR violation, quote the ADR clause briefly.
 - **Be specific.** Always provide `file:line`. Never say "somewhere in the recipes module".
 - **English only** in the report. The developer reads it in the editor; GitHub-bound artefacts are English.
-- **No AI attribution** in any text you produce.
+- **AI attribution is allowed** (policy reversed 2026-07-02): `Co-Authored-By` trailers, "Generated with", or AI-tool mentions in commits/files are permitted, not mandatory — never flag them as a finding.
 - **Stop early** if the diff is empty (no commits between `origin/main` and `HEAD`). Report it and exit.

--- a/.claude/skills/pre-push-review/SKILL.md
+++ b/.claude/skills/pre-push-review/SKILL.md
@@ -99,5 +99,6 @@ Otherwise, loop back to Step 4. The human triggers the actual `git push`.
 - **Read-only reviewers.** Steps 1–2 never mutate the working tree. Fixes happen
   in Step 4, attributed to the reconciled list.
 - **No silent skips.** If a reviewer could not run, say so in the output.
-- **English** in all review artefacts and commit messages; **no AI attribution**.
+- **English** in all review artefacts and commit messages. AI attribution
+  (`Co-Authored-By`, "Generated with") is allowed, not mandatory — never a finding.
 - **Never push automatically.** Step 5 authorises; the human pushes.

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -72,7 +72,8 @@ git fetch origin "$BASE" --quiet 2>/dev/null || true
 # .claude/agents/pr-pre-reviewer.md.
 read -r -d '' INSTRUCTIONS <<'PROMPT' || true
 You are a strict, read-only reviewer for the brasse-bouillon monorepo.
-Review ONLY the diff against the base branch. Output English, no AI attribution.
+Review ONLY the diff against the base branch. Output English. AI attribution
+(Co-Authored-By, "Generated with") is allowed, not mandatory — never flag it.
 
 Group findings as Must Have / Should Have / Nice to Have / Disagree, each with
 a `path/to/file.ts:line` anchor and a one-line suggested fix.
@@ -91,8 +92,7 @@ Must Have (blocking) — flag any of:
   mobile calling a third-party HTTP service directly instead of via the API.
 
 Should Have — tests not following Happy/Sad/Edge, missing Swagger decorator on a
-new endpoint, naming/import-order deviations, Conventional Commits not respected,
-any AI attribution in commit messages or files.
+new endpoint, naming/import-order deviations, Conventional Commits not respected.
 
 Nice to Have — readability, extraction, WHY-not-WHAT comments.
 


### PR DESCRIPTION
## Summary

The AI-attribution policy was reversed on 2026-07-02: attribution (`Co-Authored-By` trailers, "Generated with Claude Code" in PR bodies) is now **allowed** for transparency — permitted, not mandatory (repo `CLAUDE.md` aligned in #1296). The local review pipeline still flagged it as a Should Have finding and forbade it in reviewer output. This PR aligns the three in-sync surfaces:

- `.claude/agents/pr-pre-reviewer.md` — removed the "AI attribution" Should Have checklist item; replaced the "No AI attribution in any text you produce" rule with "allowed, never flag it as a finding".
- `scripts/codex-review.sh` — same two changes in the INSTRUCTIONS heredoc (kept in sync with the agent, as the script's own comment requires); condensed style preserved.
- `.claude/skills/pre-push-review/SKILL.md` — dropped the contradicting "no AI attribution" rule that drives both reviewers.

Left intentionally unchanged: `.claude/skills/adr-new/SKILL.md` ("`Deciders:` lists humans, not agents") — that rule is about decision authorship, not transparency attribution.

## Checklist

- [x] `bash -n scripts/codex-review.sh` passes
- [x] `shellcheck scripts/codex-review.sh` passes (no findings)
- [x] Pre-push review ritual run (Claude `pr-pre-reviewer` + Codex local review): no Must Have / Should Have findings
- [x] No code paths touched — docs/prompt-instruction text only

🤖 Generated with [Claude Code](https://claude.com/claude-code)