### PR TITLE
chore(review): fix codex-review.sh for codex-cli >= 0.142 review targets

### DIFF
--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -8,9 +8,11 @@
 # `pr-pre-reviewer` agent + /code-review, Codex reviews here, and the two
 # reports are reconciled before any push.
 #
-# It wraps `codex exec review`, which reviews the diff against a base branch
-# without mutating the working tree. It replays the same checklist as the
-# `pr-pre-reviewer` agent so both reviewers judge against the same rules.
+# It wraps `codex exec review` (custom-prompt target), which reviews without
+# mutating the working tree. Since codex-cli 0.142, `--base` and a custom
+# PROMPT are mutually exclusive review targets, so the base-diff scope is
+# injected into the prompt instead of passed as a flag. It replays the same
+# checklist as the `pr-pre-reviewer` agent so both judge against the same rules.
 #
 # Cost note: each run consumes the OpenAI/ChatGPT quota tied to your Codex
 # CLI auth — a quota SEPARATE from GitHub Copilot premium requests.
@@ -38,7 +40,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -h|--help)
-      sed -n '2,30p' "$0"
+      sed -n '2,25p' "$0"
       exit 0
       ;;
     *)
@@ -115,12 +117,18 @@ PROMPT
 # The heredoc is quoted so its backticks stay literal; inject the runtime base.
 INSTRUCTIONS="${INSTRUCTIONS//__BASE__/$BASE}"
 
+# codex-cli rejects `--base` alongside a custom prompt, so the diff scope
+# rides in the prompt itself.
+printf -v INSTRUCTIONS '%s\n%s' \
+  "Review the diff origin/${BASE}...HEAD (fall back to ${BASE} if the remote ref is missing)." \
+  "$INSTRUCTIONS"
+
 echo "Running Codex review of '$CURRENT_BRANCH' against '$BASE'..." >&2
 
 if [[ -n "$OUT" ]]; then
-  codex exec review --base "$BASE" --output-last-message "$OUT" "$INSTRUCTIONS"
+  codex exec review --output-last-message "$OUT" "$INSTRUCTIONS"
   echo "Report written to: $OUT" >&2
   cat "$OUT"
 else
-  codex exec review --base "$BASE" "$INSTRUCTIONS"
+  codex exec review "$INSTRUCTIONS"
 fi

--- a/scripts/codex-review.sh
+++ b/scripts/codex-review.sh
@@ -118,9 +118,16 @@ PROMPT
 INSTRUCTIONS="${INSTRUCTIONS//__BASE__/$BASE}"
 
 # codex-cli rejects `--base` alongside a custom prompt, so the diff scope
-# rides in the prompt itself.
+# rides in the prompt itself. Resolve the base ref here (prefer the
+# remote-tracking ref when present) so Codex receives ONE concrete range
+# instead of a fallback rule it could misapply.
+if git rev-parse --verify --quiet "refs/remotes/origin/${BASE}" >/dev/null; then
+  DIFF_BASE="origin/${BASE}"
+else
+  DIFF_BASE="${BASE}"
+fi
 printf -v INSTRUCTIONS '%s\n%s' \
-  "Review the diff origin/${BASE}...HEAD (fall back to ${BASE} if the remote ref is missing)." \
+  "Review the diff ${DIFF_BASE}...HEAD." \
   "$INSTRUCTIONS"
 
 echo "Running Codex review of '$CURRENT_BRANCH' against '$BASE'..." >&2


### PR DESCRIPTION
## Summary

`scripts/codex-review.sh` was broken by a Codex CLI interface change: since codex-cli 0.142, `codex exec review` treats `--base`, `--commit`, `--uncommitted`, and a custom `PROMPT` as four **mutually exclusive review targets** (`conflicts_with_all` in the CLI's `ReviewArgs`), so the previous `codex exec review --base "$BASE" "$INSTRUCTIONS"` invocation exits 2 with `error: the argument '--base <BRANCH>' cannot be used with '[PROMPT]'` — the pre-push ritual's Codex side could not run at all.

Fix: use the **custom-prompt target** and fold the base-diff scope into the prompt itself — a `Review the diff origin/<base>...HEAD (fall back to <base> if the remote ref is missing).` line is prepended via `printf -v`, and `--base` is dropped from both codex invocations. The `pr-pre-reviewer` checklist still reaches Codex unchanged (the "keep in sync" contract with `.claude/agents/pr-pre-reviewer.md` holds), and the script's own `--base` CLI option keeps working. The header comment documents the CLI constraint, and the `--help` sed window is tightened to the header's exact extent (`2,25p`).

Deliberately not touched: the AI-attribution lines of the heredoc — those belong to #1301, which this branch avoids overlapping.

## Checklist

- [x] `bash -n scripts/codex-review.sh` passes
- [x] `shellcheck scripts/codex-review.sh` passes (no findings)
- [x] Verified live on codex-cli 0.142.5: the new invocation is accepted and the review session starts with the full checklist (the verification run itself then stopped on an out-of-credits OpenAI quota error, unrelated to the CLI interface)
- [x] Pre-push review ritual run: Claude `pr-pre-reviewer` reports 0 Must Have; Codex side interrupted by the same quota limit (noted, not silently skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)