### PR TITLE
feat(batches): PRÉP-phase physical prep actions with pedagogical why (F4)

### DIFF
--- a/docs/architecture/diagrams/brew-day/01-sequence-step-enrichment.md
+++ b/docs/architecture/diagrams/brew-day/01-sequence-step-enrichment.md
@@ -1,11 +1,14 @@
-# Sequence diagram — brew-day — Enrich live batch steps with guidance (B1-live)
+# Sequence diagram — brew-day — Enrich live batch steps with guidance (B1-live, F4 prep actions)
 
 > **Feature**: first real brew — making the brew-day step guide work in **LIVE** mode (roadmap P0 "TRACKER → ASSISTANT").
-> **Realizes**: B1-live. **Related**: brew-prep state machine ([`../brew-prep/05-state-readiness.md`](../brew-prep/05-state-readiness.md)).
+> **Realizes**: B1-live + **F4 physical prep actions** (novice-journey audit). **Related**: brew-prep state machine ([`../brew-prep/05-state-readiness.md`](../brew-prep/05-state-readiness.md)), step lifecycle ([`06-state-brew-step.md`](06-state-brew-step.md)).
+> **Amended 2026-07-02 (F4 + 07b sync)**: enrichment now happens at **launch** (steps are snapshotted by `launchBatch`, not at batch creation — brew-day/07 F14/F15) and carries the **physical prep actions** shown in the step's PRÉP phase.
 
 ## Context
 
-In live mode, batch steps were bare (`label` + `description`); the ⓘ pedagogical tip + the countdown timer — **already rendered** by the mobile `StepCard` / `BrewStepTimer` — were **demo-only**. This slice adds, **at batch start**, a per-step-type guidance (a beginner "why" tip + a default duration) persisted onto the batch, so the live brew-day is guided. **MVP source = per-step-type defaults** (no recipe↔guidance link yet; deferred).
+In live mode, batch steps were bare (`label` + `description`); the ⓘ pedagogical tip + the countdown timer — **already rendered** by the mobile `StepCard` / `BrewStepTimer` — were **demo-only**. This slice adds, at launch, a per-step-type guidance persisted onto the batch, so the live brew-day is guided. **MVP source = per-step-type defaults** (no recipe↔guidance link yet; deferred).
+
+**F4 (amendment):** the guidance now also carries the step's **physical prep actions** — the concrete gestures the novice must do before starting the technical phase (heat ~X L of strike water, sanitize, dough-in; chill to ~20 °C, transfer, pitch…), **each with its one-line pedagogical why** so the brewer learns the craft, not just the app. They are rendered as a lightweight checklist in the step's **PRÉP** phase (brew-day/06); ticks are UI-local (not persisted) and `Start` is **not hard-gated** on them (guidance + escape hatch, never a lock).
 
 ## Diagram
 
@@ -15,23 +18,34 @@ sequenceDiagram
   participant M as Mobile
   participant API as Backend (BatchService)
   participant D as BatchDomainService
-  B->>M: "Lancer le brassage"
-  M->>API: POST /batches (recipeId)
+  B->>M: "Lancer le brassage" (from the prepared draft)
+  M->>API: PATCH /batches/:id/launch
   API->>API: load recipe steps (order, type, label, description)
-  API->>D: startBatch(steps)
+  API->>D: launchBatch(draft, steps)
   loop each step
-    D->>D: getStepGuidance(step.type) gives tip + duration, or none
+    D->>D: getStepGuidance(step.type) gives tip + duration + prepActions, or none
   end
-  D-->>API: BatchStep[] enriched (tip + duration)
-  API->>API: persist batch_steps (pedagogical_tip, planned_duration_min)
-  API-->>M: BatchDto (steps carry tip + duration)
-  M-->>B: live brew-day with the i tip + countdown timer
+  D-->>API: BatchStep[] enriched (tip + duration + prepActions)
+  API->>API: persist batch_steps (pedagogical_tip, planned_duration_min, prep_actions)
+  API-->>M: BatchDto (steps carry tip + duration + prepActions)
+  M-->>B: PRÉP shows the physical actions; Start begins ACTIF (+ timer)
 ```
 
 ## Notes
 
-- **Per-type defaults (MVP):** `STEP_TYPE_GUIDANCE` maps each `RecipeStepType` to `{ pedagogicalTip, plannedDurationMin }`. Unknown type gives `undefined` (graceful: no tip/timer). `FERMENTATION` / `PACKAGING` carry a tip but a `null` duration (they run over days — no countdown).
-- **Description preserved:** the recipe-authored `description` is untouched; only the tip + duration are added.
-- **Backward compatible:** the new `batch_steps` columns are nullable; batches started before this carry no enrichment.
-- **Mobile already renders:** `StepCard` (ⓘ tip) + `BrewStepTimer` (countdown) consume `pedagogicalTip` + `plannedDurationMin`; only the API mapping (`mapBatchStep`) was un-dropped.
-- **Next (P0):** B2 (measurements OG/FG/ABV) then B3 (bottling + closure). Recipe-level customization (extend `recipe_steps`) and a per-style reference are deferred.
+- **Per-type defaults (MVP):** `STEP_TYPE_GUIDANCE` maps each `RecipeStepType` to `{ pedagogicalTip, plannedDurationMin, prepActions }`. Unknown type gives `undefined` (graceful: no tip/timer/prep). `FERMENTATION` / `PACKAGING` carry a tip but a `null` duration (they run over days — no countdown).
+- **Prep actions per type (F4):** a handful of `{ action, why }` pairs per type — the short
+  imperative gesture PLUS its one-line pedagogical why (the app TEACHES: a novice must learn to
+  brew alone, not just execute — educational vocation + ADR-0021 D5). Mobile renders the action
+  as the primary line and the why as a secondary line beneath it (always visible in v1; adaptive
+  folding by declared brewer level is the D5 iteration). MASH = heat strike water + clean/rinse +
+  dough-in; BOIL = remove the bag (BIAB) + rolling boil uncovered + stage the hop additions;
+  WHIRLPOOL = stir the cone + ready the chiller; FERMENTATION = chill to ~20 °C + sanitize +
+  transfer/aerate/pitch + airlock & temperature; PACKAGING = **none** — bottling already has the
+  richer B3 gate (`03-sequence-bottle-and-close.md`), prep actions must not duplicate it.
+- **Not a gate:** the PRÉP checklist is guidance; `Start` stays a single ✋ confirmation (brew-day/06). Ticks are local UI state — nothing new persisted per tick (unlike the brew-prep ingredient checklist F14, which is a launch gate).
+- **Description preserved:** the recipe-authored `description` is untouched; only type-level guidance is added.
+- **Backward compatible:** the `batch_steps` columns are nullable; steps launched before this carry no enrichment (mobile falls back to the bare card).
+- **Mobile:** `BatchDetailsScreen` already derives the PRÉP phase (`startedAt == null`, F1) — the PRÉP block renders `prepActions` above the Start CTA.
+- **Deferred:** recipe-level override of the guidance (same deferral as tips); **computed figures** in prep actions (real strike-water litres/temperature from the batch volume plan, ADR-0020) — v1 ships plausible static defaults worded as approximations (« ~7 L à ~72 °C pour ~4 L de bière »).
+- ~~**Next (P0):** B2 (measurements OG/FG/ABV) then B3 (bottling + closure).~~ Shipped; superseded by the F-series audit backlog.

--- a/docs/architecture/diagrams/brew-day/06-state-brew-step.md
+++ b/docs/architecture/diagrams/brew-day/06-state-brew-step.md
@@ -81,6 +81,13 @@ stateDiagram-v2
 - **Pedagogy hook (ADR-0021 D5).** Each phase carries the adaptive "why?" (inline + foldable +
   glossary), tuned to the declared brewer level — surfaced in PRÉP (what to do) and ACTIF (what
   is happening). Not a state; an overlay on every phase.
+- **PRÉP content (F4, amended 2026-07-02).** The "guided do X" of PRÉP is realised by the
+  per-step-type **prep actions** carried by the launch-time guidance enrichment (see
+  `01-sequence-step-enrichment.md`): a short physical checklist (heat strike water, sanitize,
+  chill + pitch, …), each action carrying its **one-line pedagogical why** (the app teaches —
+  a novice must learn to brew alone), rendered above the `Start` CTA. Ticks are UI-local and
+  `Start` is **not hard-gated** on them — guidance with an escape hatch, mirroring the unified
+  ✋ philosophy.
 - **Open question.** Reopen semantics when the batch has already advanced several steps — bound
   Reopen to the *current* step only, or allow reopening any completed step? Resolve at
   implementation (baby-step slice).

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -1138,6 +1138,31 @@ describe('BatchService', () => {
     expect(steps[0].started_at).toBeNull();
   });
 
+  it('launchMine() persists PRÉP actions and step transitions preserve them (happy/edge, F4)', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });
+    const draft = await batchService.prepareMine(ownerId, recipe.id);
+
+    const { batch, steps } = await batchService.launchMine(
+      ownerId,
+      draft.batch.id,
+    );
+
+    // Step 0 (mash) carries the gestures, each with its pedagogical why.
+    expect(steps[0].prep_actions?.length).toBeGreaterThan(0);
+    for (const prep of steps[0].prep_actions ?? []) {
+      expect(prep.action.trim().length).toBeGreaterThan(0);
+      expect(prep.why.trim().length).toBeGreaterThan(0);
+    }
+    // Packaging (last step) has none — the B3 bottling gate covers it.
+    expect(steps[steps.length - 1].prep_actions).toBeNull();
+
+    // A step transition re-saves the whole snapshot: the prep actions must
+    // survive the domain round-trip (regression guard against silent drops).
+    const started = await batchService.startMineCurrentStep(ownerId, batch.id);
+    expect(started.steps[0].prep_actions).toEqual(steps[0].prep_actions);
+  });
+
   it('launchMine() rejects a double launch with Conflict-free 400 and keeps the journal intact (sad)', async () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My Blonde' });

--- a/packages/api/src/batch/domain/batch.domain.spec.ts
+++ b/packages/api/src/batch/domain/batch.domain.spec.ts
@@ -73,6 +73,43 @@ describe('BatchDomainService', () => {
     );
   });
 
+  it('enriches steps with PRÉP actions, each gesture with its why (happy, F4)', () => {
+    const service = new BatchDomainService(
+      () => new Date('2026-02-05T09:00:00.000Z'),
+    );
+
+    const batch = service.startBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+      steps: new RecipeWorkflowService().getDefaultWorkflow(),
+    });
+
+    const mash = batch.steps.find((s) => s.type === RecipeStepType.MASH);
+    expect(mash?.prepActions?.length).toBeGreaterThan(0);
+    expect(mash?.prepActions?.[0].action).toBeTruthy();
+    expect(mash?.prepActions?.[0].why).toBeTruthy();
+  });
+
+  it('leaves prepActions undefined on packaging — B3 covers it (edge, F4)', () => {
+    const service = new BatchDomainService(
+      () => new Date('2026-02-05T09:00:00.000Z'),
+    );
+
+    const batch = service.startBatch({
+      id: 'batch-1',
+      ownerId: 'user-1',
+      recipeId: 'recipe-1',
+      steps: new RecipeWorkflowService().getDefaultWorkflow(),
+    });
+
+    const packaging = batch.steps.find(
+      (s) => s.type === RecipeStepType.PACKAGING,
+    );
+    expect(packaging).toBeDefined();
+    expect(packaging?.prepActions).toBeUndefined();
+  });
+
   it('should complete steps and auto-advance until completion', () => {
     const t0 = new Date('2026-02-05T09:00:00.000Z');
     const t1 = new Date('2026-02-05T09:10:00.000Z');

--- a/packages/api/src/batch/domain/entities/batch-step.entity.ts
+++ b/packages/api/src/batch/domain/entities/batch-step.entity.ts
@@ -1,6 +1,7 @@
 import { RecipeStepType } from '../../../recipe/domain/enums/recipe-step-type.enum';
 
 import { BatchStepStatus } from '../enums/batch-step-status.enum';
+import { StepPrepAction } from '../services/step-guidance';
 
 /**
  * BatchStep
@@ -35,4 +36,10 @@ export interface BatchStep {
 
   /** Default planned duration in minutes; null/undefined when not time-boxed. */
   readonly plannedDurationMin?: number | null;
+
+  /**
+   * PRÉP-phase physical gestures + their pedagogical why (F4, brew-day/01+06).
+   * Undefined when the type carries none (e.g. packaging — B3 covers it).
+   */
+  readonly prepActions?: readonly StepPrepAction[];
 }

--- a/packages/api/src/batch/domain/entities/batch-step.entity.ts
+++ b/packages/api/src/batch/domain/entities/batch-step.entity.ts
@@ -1,7 +1,19 @@
 import { RecipeStepType } from '../../../recipe/domain/enums/recipe-step-type.enum';
 
 import { BatchStepStatus } from '../enums/batch-step-status.enum';
-import { StepPrepAction } from '../services/step-guidance';
+
+/**
+ * One physical prep gesture of a step's PRÉP phase (F4), with its one-line
+ * pedagogical why — the app teaches the craft, a novice must learn to brew
+ * alone, not just execute (brew-day/01 + 06, educational vocation).
+ *
+ * Lives with the entities (not the guidance service) so the dependency points
+ * services → entities, never the reverse.
+ */
+export interface StepPrepAction {
+  readonly action: string;
+  readonly why: string;
+}
 
 /**
  * BatchStep

--- a/packages/api/src/batch/domain/services/batch-domain.service.ts
+++ b/packages/api/src/batch/domain/services/batch-domain.service.ts
@@ -112,6 +112,12 @@ export class BatchDomainService {
         completedAt: undefined,
         pedagogicalTip: guidance?.pedagogicalTip,
         plannedDurationMin: guidance?.plannedDurationMin ?? undefined,
+        // An empty list (e.g. PACKAGING — the B3 bottling gate covers it)
+        // stays undefined so the column persists null and mobile renders no
+        // empty PRÉP block.
+        prepActions: guidance?.prepActions.length
+          ? guidance.prepActions
+          : undefined,
       };
     });
   }

--- a/packages/api/src/batch/domain/services/step-guidance.spec.ts
+++ b/packages/api/src/batch/domain/services/step-guidance.spec.ts
@@ -35,4 +35,26 @@ describe('getStepGuidance', () => {
   it('returns undefined for an unknown step type (sad/edge)', () => {
     expect(getStepGuidance('barrel-aging' as RecipeStepType)).toBeUndefined();
   });
+
+  it('carries PRÉP actions with a gesture AND its pedagogical why on brewing steps (happy, F4)', () => {
+    const prepTypes = [
+      RecipeStepType.MASH,
+      RecipeStepType.BOIL,
+      RecipeStepType.WHIRLPOOL,
+      RecipeStepType.FERMENTATION,
+    ];
+    for (const type of prepTypes) {
+      const actions = getStepGuidance(type)?.prepActions ?? [];
+      expect(actions.length).toBeGreaterThan(0);
+      for (const prep of actions) {
+        // The app teaches: a gesture without its why is executing, not learning.
+        expect(prep.action.trim().length).toBeGreaterThan(0);
+        expect(prep.why.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('carries NO PRÉP actions for packaging — the B3 bottling gate covers it (edge)', () => {
+    expect(getStepGuidance(RecipeStepType.PACKAGING)?.prepActions).toEqual([]);
+  });
 });

--- a/packages/api/src/batch/domain/services/step-guidance.ts
+++ b/packages/api/src/batch/domain/services/step-guidance.ts
@@ -1,14 +1,25 @@
 import { RecipeStepType } from '../../../recipe/domain/enums/recipe-step-type.enum';
 
 /**
+ * One physical prep gesture of a step's PRÉP phase (F4), with its one-line
+ * pedagogical why — the app teaches the craft, a novice must learn to brew
+ * alone, not just execute (brew-day/01 + 06, educational vocation).
+ */
+export interface StepPrepAction {
+  readonly action: string;
+  readonly why: string;
+}
+
+/**
  * StepGuidance
  *
  * Beginner-facing guidance attached to a batch step at start time, keyed by the
  * brewing step type. Realises the "B1-live" brew-day assistant content: a
- * vulgarised "why" tip and a default planned duration (minutes) so the mobile
- * step card can show the ⓘ tip and a countdown timer in **live** mode (not only
- * demo data). The recipe-authored `description` is left untouched — this only
- * adds the type-level tip + duration.
+ * vulgarised "why" tip, a default planned duration (minutes) and the PRÉP-phase
+ * physical gestures, so the mobile step card can show the ⓘ tip, a countdown
+ * timer and the pre-start checklist in **live** mode (not only demo data). The
+ * recipe-authored `description` is left untouched — this only adds the
+ * type-level guidance.
  *
  * MVP source = per-step-type defaults (no recipe↔guidance link yet; that is a
  * later iteration). A `null` duration means "no countdown" (fermentation and
@@ -18,6 +29,11 @@ export interface StepGuidance {
   readonly pedagogicalTip: string;
   /** Default planned duration in minutes, or `null` when not time-boxed. */
   readonly plannedDurationMin: number | null;
+  /**
+   * Physical prep actions shown in the step's PRÉP phase (F4). Empty when the
+   * step needs none (PACKAGING: the richer B3 bottling gate already covers it).
+   */
+  readonly prepActions: readonly StepPrepAction[];
 }
 
 const STEP_TYPE_GUIDANCE: Readonly<Record<RecipeStepType, StepGuidance>> = {
@@ -25,26 +41,89 @@ const STEP_TYPE_GUIDANCE: Readonly<Record<RecipeStepType, StepGuidance>> = {
     pedagogicalTip:
       "L'empâtage fait infuser le grain concassé dans l'eau chaude (~65-67°C) : les enzymes y convertissent l'amidon en sucres fermentescibles. Plus chaud donne une bière plus ronde, plus froid une bière plus sèche.",
     plannedDurationMin: 60,
+    prepActions: [
+      {
+        action: "Chauffe ~7 L d'eau à ~72 °C (pour ~4 L de bière).",
+        why: "Le grain versé fera chuter l'eau de 3-5 °C — on vise 66-67 °C dans la cuve, la température où les enzymes convertissent l'amidon en sucre.",
+      },
+      {
+        action: 'Nettoie et rince la cuve, le sac et les ustensiles.',
+        why: "Avant l'ébullition, « propre » suffit : le moût sera stérilisé en bouillant. La désinfection stricte commence après le refroidissement.",
+      },
+      {
+        action: "Verse le grain concassé dans l'eau et mélange bien.",
+        why: "Un grumeau sec, c'est de l'amidon que l'eau n'atteint pas : du sucre perdu, une bière plus légère que prévu.",
+      },
+    ],
   },
   [RecipeStepType.BOIL]: {
     pedagogicalTip:
       "L'ébullition stérilise le moût, isomérise les acides alpha du houblon (l'amertume) et concentre les sucres. Les houblons d'amertume vont tôt, les houblons d'arôme en toute fin d'ébullition.",
     plannedDurationMin: 60,
+    prepActions: [
+      {
+        action:
+          'Retire le sac de grain et laisse-le égoutter, en pressant doucement.',
+        why: "Le sac ne doit pas cuire dans l'ébullition ; presser récupère du moût sucré, mais trop fort, le grain chaud relâche de l'astringence.",
+      },
+      {
+        action: 'Monte le moût à ébullition franche, sans couvercle.',
+        why: "À découvert, le DMS — un composé soufré au goût de maïs cuit — s'évapore au lieu de retomber dans le moût.",
+      },
+      {
+        action: 'Prépare tes doses de houblon, chacune avec son horaire.',
+        why: "Houblon tôt = amertume, houblon tard = arôme. En pleine ébullition tu n'auras pas le temps de peser : tout doit être prêt.",
+      },
+    ],
   },
   [RecipeStepType.WHIRLPOOL]: {
     pedagogicalTip:
       "Le whirlpool fait tourner le moût pour rassembler les résidus (le trub) au centre, puis on refroidit vite avant d'ensemencer la levure. À partir d'ici, tout ce qui touche le moût refroidi doit être désinfecté.",
     plannedDurationMin: 15,
+    prepActions: [
+      {
+        action: 'Coupe le feu et remue le moût en cercle.',
+        why: 'Le tourbillon rassemble le trub (protéines et houblon) en cône au centre : tu transféreras un moût plus clair.',
+      },
+      {
+        action:
+          "Prépare ton refroidissement (serpentin désinfecté ou bain d'eau glacée).",
+        why: 'Chaque minute où le moût reste tiède est une porte ouverte aux microbes : tout doit être prêt avant de refroidir.',
+      },
+    ],
   },
   [RecipeStepType.FERMENTATION]: {
     pedagogicalTip:
       'La levure transforme les sucres en alcool et CO₂. Maintiens 18-20°C : trop chaud, elle stresse et produit des arômes indésirables. La fermentation est finie quand la densité est stable, pas à une date fixe.',
     plannedDurationMin: null,
+    prepActions: [
+      {
+        action: 'Refroidis le moût à ~20 °C, aussi vite que possible.',
+        why: "Ensemencée trop chaud, la levure stresse ou meurt et produit des faux-goûts ; refroidir vite limite aussi le risque d'infection.",
+      },
+      {
+        action:
+          'Désinfecte le fermenteur, le barboteur et tout ce qui touchera le moût.',
+        why: "Le moût ne sera plus jamais bouilli : à partir d'ici, le moindre microbe s'y installe plus vite que la levure.",
+      },
+      {
+        action: "Transfère le moût en l'aérant, puis ensemence la levure.",
+        why: "C'est le seul moment où l'oxygène est utile — la levure en a besoin pour se multiplier. Après, il ne ferait qu'oxyder la bière.",
+      },
+      {
+        action:
+          "Pose le barboteur et place le fermenteur entre 18 et 20 °C, à l'abri de la lumière.",
+        why: 'Une température stable donne un profil propre ; la lumière réagit avec le houblon et donne un goût de renfermé (« lightstruck »).',
+      },
+    ],
   },
   [RecipeStepType.PACKAGING]: {
     pedagogicalTip:
       "À l'embouteillage, on ajoute une dose précise de sucre (priming) pour la carbonatation : trop de sucre et les bouteilles explosent. Désinfecte les bouteilles, remplis, capsule, puis laisse conditionner ~2 semaines.",
     plannedDurationMin: null,
+    // No PRÉP actions: the bottling flow already carries the richer B3 gate
+    // (sanitize bottles + priming + bottle-bomb checkbox) — never duplicated.
+    prepActions: [],
   },
 };
 

--- a/packages/api/src/batch/domain/services/step-guidance.ts
+++ b/packages/api/src/batch/domain/services/step-guidance.ts
@@ -1,14 +1,8 @@
 import { RecipeStepType } from '../../../recipe/domain/enums/recipe-step-type.enum';
 
-/**
- * One physical prep gesture of a step's PRÉP phase (F4), with its one-line
- * pedagogical why — the app teaches the craft, a novice must learn to brew
- * alone, not just execute (brew-day/01 + 06, educational vocation).
- */
-export interface StepPrepAction {
-  readonly action: string;
-  readonly why: string;
-}
+import { StepPrepAction } from '../entities/batch-step.entity';
+
+export type { StepPrepAction };
 
 /**
  * StepGuidance

--- a/packages/api/src/batch/dtos/batch-step.dto.spec.ts
+++ b/packages/api/src/batch/dtos/batch-step.dto.spec.ts
@@ -37,4 +37,19 @@ describe('BatchStepDto.fromEntity', () => {
     expect(dto.planned_duration_min).toBeNull();
     expect(dto.pedagogical_tip).toBeNull();
   });
+
+  it('maps the PRÉP actions with their pedagogical why (happy, F4)', () => {
+    const prep = [
+      { action: 'Chauffe ~7 L à ~72 °C.', why: 'Le grain refroidit l’eau.' },
+    ];
+    const dto = BatchStepDto.fromEntity(makeEntity({ prep_actions: prep }));
+    expect(dto.prep_actions).toEqual(prep);
+  });
+
+  it('nulls prep_actions for legacy or packaging steps (edge)', () => {
+    expect(BatchStepDto.fromEntity(makeEntity()).prep_actions).toBeNull();
+    expect(
+      BatchStepDto.fromEntity(makeEntity({ prep_actions: null })).prep_actions,
+    ).toBeNull();
+  });
 });

--- a/packages/api/src/batch/dtos/batch-step.dto.ts
+++ b/packages/api/src/batch/dtos/batch-step.dto.ts
@@ -5,6 +5,15 @@ import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum'
 import { BatchStepStatus } from '../domain/enums/batch-step-status.enum';
 import { BatchStepOrmEntity } from '../entities/batch-step.orm.entity';
 
+/** One PRÉP-phase gesture with its pedagogical why (F4, brew-day/01+06). */
+export class StepPrepActionDto {
+  @ApiProperty({ description: 'The physical gesture, imperative French' })
+  action: string;
+
+  @ApiProperty({ description: "The gesture's one-line pedagogical why" })
+  why: string;
+}
+
 export class BatchStepDto {
   @ApiProperty()
   batch_id: string;
@@ -36,6 +45,9 @@ export class BatchStepDto {
   @ApiPropertyOptional({ nullable: true })
   pedagogical_tip?: string | null;
 
+  @ApiPropertyOptional({ type: [StepPrepActionDto], nullable: true })
+  prep_actions?: StepPrepActionDto[] | null;
+
   @ApiProperty()
   created_at: Date;
 
@@ -54,6 +66,7 @@ export class BatchStepDto {
       completed_at: e.completed_at ?? null,
       planned_duration_min: e.planned_duration_min ?? null,
       pedagogical_tip: e.pedagogical_tip ?? null,
+      prep_actions: e.prep_actions ?? null,
       created_at: e.created_at,
       updated_at: e.updated_at,
     };

--- a/packages/api/src/batch/entities/batch-step.orm.entity.ts
+++ b/packages/api/src/batch/entities/batch-step.orm.entity.ts
@@ -53,6 +53,12 @@ export class BatchStepOrmEntity {
   @Column({ type: 'text', nullable: true })
   pedagogical_tip?: string | null;
 
+  // PRÉP-phase physical gestures + their pedagogical why (F4, brew-day/01+06).
+  // Snapshotted at launch like the tip; null when the type carries none
+  // (e.g. packaging — the B3 bottling gate already covers it).
+  @Column({ type: 'simple-json', nullable: true })
+  prep_actions?: { action: string; why: string }[] | null;
+
   @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   created_at: Date;
 

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -534,6 +534,7 @@ export class BatchService {
           completed_at: step.completedAt ?? null,
           planned_duration_min: step.plannedDurationMin ?? null,
           pedagogical_tip: step.pedagogicalTip ?? null,
+          prep_actions: step.prepActions ? [...step.prepActions] : null,
         }),
       );
 
@@ -577,6 +578,7 @@ export class BatchService {
         completed_at: step.completedAt ?? null,
         planned_duration_min: step.plannedDurationMin ?? null,
         pedagogical_tip: step.pedagogicalTip ?? null,
+        prep_actions: step.prepActions ? [...step.prepActions] : null,
       }),
     );
 
@@ -617,6 +619,9 @@ export class BatchService {
       completedAt: step.completed_at ?? undefined,
       pedagogicalTip: step.pedagogical_tip ?? undefined,
       plannedDurationMin: step.planned_duration_min ?? undefined,
+      // Round-trip matters: step transitions re-save the full snapshot, so a
+      // missing mapping here would silently drop prep_actions on first use.
+      prepActions: step.prep_actions ?? undefined,
     };
   }
 
@@ -833,6 +838,7 @@ export class BatchService {
           completed_at: step.completedAt ?? null,
           planned_duration_min: step.plannedDurationMin ?? null,
           pedagogical_tip: step.pedagogicalTip ?? null,
+          prep_actions: step.prepActions ? [...step.prepActions] : null,
         }),
       );
 

--- a/packages/api/src/database/migrations/1806000000000-AddBatchStepPrepActions.ts
+++ b/packages/api/src/database/migrations/1806000000000-AddBatchStepPrepActions.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `prep_actions` to `batch_steps` (brew-day/01+06, F4).
+ *
+ * Nullable JSON text holding the PRÉP-phase physical gestures snapshotted at
+ * launch — `{ action, why }` pairs, each gesture carrying its one-line
+ * pedagogical why (the app teaches; a novice must learn to brew alone).
+ * No backfill: steps launched before this simply carry no prep list (mobile
+ * falls back to the bare PRÉP block), same additive model as the 1803-era
+ * `pedagogical_tip` / `planned_duration_min` enrichment columns.
+ */
+export class AddBatchStepPrepActions1806000000000 implements MigrationInterface {
+  name = 'AddBatchStepPrepActions1806000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batch_steps" ADD COLUMN "prep_actions" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batch_steps" DROP COLUMN "prep_actions"`,
+    );
+  }
+}

--- a/packages/mobile-app/src/features/batches/data/batches.api.ts
+++ b/packages/mobile-app/src/features/batches/data/batches.api.ts
@@ -40,6 +40,7 @@ type BatchStepDto = {
   completed_at?: string | null;
   planned_duration_min?: number | null;
   pedagogical_tip?: string | null;
+  prep_actions?: { action: string; why: string }[] | null;
   created_at: string;
   updated_at: string;
 };
@@ -96,6 +97,7 @@ function mapBatchStep(dto: BatchStepDto): BatchStep {
     completedAt: dto.completed_at ?? null,
     plannedDurationMin: dto.planned_duration_min ?? null,
     pedagogicalTip: dto.pedagogical_tip ?? null,
+    prepActions: dto.prep_actions ?? null,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
   };

--- a/packages/mobile-app/src/features/batches/domain/batch.types.ts
+++ b/packages/mobile-app/src/features/batches/domain/batch.types.ts
@@ -55,6 +55,16 @@ export type BatchStep = {
   plannedDurationMin?: number | null;
   // Vulgarized "why" surfaced via the ⓘ icon on the step (brewing assistant).
   pedagogicalTip?: string | null;
+  // PRÉP-phase physical gestures, each with its pedagogical why (F4,
+  // brew-day/01+06). Null on legacy steps and types without prep (packaging).
+  prepActions?: StepPrepAction[] | null;
+};
+
+// One PRÉP gesture + its one-line why — the app teaches, a novice must learn
+// to brew alone (educational vocation).
+export type StepPrepAction = {
+  action: string;
+  why: string;
 };
 
 export type Batch = BatchSummary & {

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -32,6 +32,7 @@ import { BATCH_STATUS_LABELS } from "@/features/batches/presentation/batch-displ
 import { BatchTimeline } from "@/features/batches/presentation/BatchTimeline";
 import { StepCard } from "@/features/batches/presentation/StepCard";
 import { Card } from "@/core/ui/Card";
+import { ChecklistRow } from "@/core/ui/ChecklistRow";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { Ionicons } from "@expo/vector-icons";
 import { ListHeader } from "@/core/ui/ListHeader";
@@ -472,6 +473,12 @@ export function BatchDetailsScreen({ batchId }: Props) {
   // so the timer is idle and the CTA is « Démarrer » rather than « Terminer »
   // (F1; see brew-day/06). Demo steps carry a startedAt, so they read as ACTIF.
   const isPrepPhase = activeStep != null && activeStep.startedAt == null;
+  // PRÉP physical gestures (F4, brew-day/01+06): local ticks only — keyed by
+  // step so advancing resets naturally — and « Démarrer » is never hard-gated
+  // on them (guidance + escape hatch, unlike the F14 ingredient launch gate).
+  const [prepDoneByKey, setPrepDoneByKey] = React.useState<
+    Record<string, boolean>
+  >({});
   const [openTip, setOpenTip] = React.useState<{
     label: string;
     tip: string;
@@ -706,6 +713,30 @@ export function BatchDetailsScreen({ batchId }: Props) {
 
       {!isCompletedLive && activeStep ? (
         <BrewStepTimer step={activeStep} useDemoData={dataSource.useDemoData} />
+      ) : null}
+
+      {isPrepPhase && activeStep?.prepActions?.length ? (
+        <Card>
+          <Text style={styles.sectionTitle}>Avant de démarrer</Text>
+          {activeStep.prepActions.map((prep, index) => {
+            const key = `${activeStep.stepOrder}:${index}`;
+            return (
+              <ChecklistRow
+                key={key}
+                testID={`prep-action-${activeStep.stepOrder}-${index}`}
+                label={prep.action}
+                meta={prep.why}
+                checked={prepDoneByKey[key] ?? false}
+                onToggle={() =>
+                  setPrepDoneByKey((current) => ({
+                    ...current,
+                    [key]: !current[key],
+                  }))
+                }
+              />
+            );
+          })}
+        </Card>
       ) : null}
 
       {showBottlingCta ? (

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -473,9 +473,11 @@ export function BatchDetailsScreen({ batchId }: Props) {
   // so the timer is idle and the CTA is « Démarrer » rather than « Terminer »
   // (F1; see brew-day/06). Demo steps carry a startedAt, so they read as ACTIF.
   const isPrepPhase = activeStep != null && activeStep.startedAt == null;
-  // PRÉP physical gestures (F4, brew-day/01+06): local ticks only — keyed by
-  // step so advancing resets naturally — and « Démarrer » is never hard-gated
-  // on them (guidance + escape hatch, unlike the F14 ingredient launch gate).
+  // PRÉP physical gestures (F4, brew-day/01+06): local ticks only, namespaced
+  // by step order so each step starts unticked. The record is bounded by the
+  // batch's own gestures (~20 booleans) and lives only for this screen mount —
+  // no reset needed. « Démarrer » is never hard-gated on the ticks (guidance +
+  // escape hatch, unlike the F14 ingredient launch gate).
   const [prepDoneByKey, setPrepDoneByKey] = React.useState<
     Record<string, boolean>
   >({});

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -205,6 +205,92 @@ describe("BatchDetailsScreen", () => {
     expect(await screen.findByText("boom")).toBeTruthy();
   });
 
+  it("PRÉP lists the physical gestures with their pedagogical why (F4, happy)", async () => {
+    const prepBatch: Batch = {
+      ...mashBatch,
+      steps: mashBatch.steps.map((step) =>
+        step.stepOrder === 0
+          ? {
+              ...step,
+              startedAt: null,
+              prepActions: [
+                {
+                  action: "Chauffe ~7 L d'eau à ~72 °C.",
+                  why: "Le grain fera chuter l'eau vers 66-67 °C.",
+                },
+                {
+                  action: "Nettoie et rince la cuve.",
+                  why: "Avant l'ébullition, « propre » suffit.",
+                },
+              ],
+            }
+          : step,
+      ),
+    };
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(prepBatch, "Ma recette test"),
+    );
+    (startCurrentBatchStep as jest.Mock).mockClear();
+
+    renderBatchDetailsScreen();
+
+    expect(await screen.findByText("Avant de démarrer")).toBeTruthy();
+    // Gesture AND its why: the app teaches, not just instructs.
+    expect(screen.getByText("Chauffe ~7 L d'eau à ~72 °C.")).toBeTruthy();
+    expect(
+      screen.getByText("Le grain fera chuter l'eau vers 66-67 °C."),
+    ).toBeTruthy();
+    expect(screen.getByText("Nettoie et rince la cuve.")).toBeTruthy();
+
+    // Ticks are local guidance; « Démarrer » is never gated on them (escape
+    // hatch) — starting with one gesture unticked must still work.
+    fireEvent.press(screen.getByTestId("prep-action-0-0"));
+    fireEvent.press(screen.getByText("Démarrer l'étape"));
+    await waitFor(() => expect(startCurrentBatchStep).toHaveBeenCalledTimes(1));
+  });
+
+  it("PRÉP without prep actions renders no gesture block (F4, edge: legacy step)", async () => {
+    const prepBatch: Batch = {
+      ...mashBatch,
+      steps: mashBatch.steps.map((step) =>
+        step.stepOrder === 0
+          ? { ...step, startedAt: null, prepActions: null }
+          : step,
+      ),
+    };
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(prepBatch, "Ma recette test"),
+    );
+
+    renderBatchDetailsScreen();
+
+    expect(await screen.findByText("Démarrer l'étape")).toBeTruthy();
+    expect(screen.queryByText("Avant de démarrer")).toBeNull();
+  });
+
+  it("ACTIF hides the gesture block — prep is over once the step runs (F4, edge)", async () => {
+    const activeBatch: Batch = {
+      ...mashBatch,
+      steps: mashBatch.steps.map((step) =>
+        step.stepOrder === 0
+          ? {
+              ...step,
+              prepActions: [{ action: "Chauffe l'eau.", why: "Strike." }],
+            }
+          : step,
+      ),
+    };
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(activeBatch, "Ma recette test"),
+    );
+
+    renderBatchDetailsScreen();
+
+    // mashBatch step 0 carries a startedAt → ACTIF: complete CTA, no PRÉP list.
+    expect(await screen.findByText("Terminer l'étape en cours")).toBeTruthy();
+    expect(screen.queryByText("Avant de démarrer")).toBeNull();
+  });
+
   it("confirms before completing a step, then completes on confirm (F6)", async () => {
     (completeCurrentBatchStep as jest.Mock).mockClear();
     const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});


### PR DESCRIPTION
## Summary

Fixes novice-journey friction **F4**: the PRÉP phase of each brew step now shows the **physical gestures** the brewer must do before starting the technical phase — and every gesture carries its **one-line pedagogical why**, because the app teaches: a novice must learn to brew alone, not just execute.

**Conception-first** (commit 1, `docs(conception)`): the contract lives in the amended [brew-day/01-sequence-step-enrichment.md](docs/architecture/diagrams/brew-day/01-sequence-step-enrichment.md) (launch-time enrichment now carries `prepActions` `{action, why}` pairs; also re-synced on the 07b prepare/launch flow) and [06-state-brew-step.md](docs/architecture/diagrams/brew-day/06-state-brew-step.md) (PRÉP content note). Architecture + brewing content validated with the owner before any code.

**Implementation** (commit 2):
- `StepGuidance.prepActions` — per-type gestures with their why (MASH heat/clean/dough-in, BOIL bag/rolling-boil/hop-staging, WHIRLPOOL stir/chiller, FERMENTATION chill/sanitize/pitch/airlock); **PACKAGING deliberately empty** — the richer B3 bottling gate already covers it.
- Snapshot at launch persists `batch_steps.prep_actions` (nullable simple-json; additive reversible migration `1806…`, no backfill — legacy steps just render the bare PRÉP block). The domain round-trip preserves the list across step transitions (regression-guarded).
- `BatchStepDto.prep_actions` exposed (Swagger-documented `StepPrepActionDto`).
- Mobile: « Avant de démarrer » checklist in the PRÉP phase of the active step (`ChecklistRow`: gesture as label, why as meta). Ticks are **UI-local** (not persisted, unlike the F14 launch-gating ingredient checklist) and « Démarrer » is **never hard-gated** — guidance + escape hatch.
- Figures are deliberate approximations (« ~7 L à ~72 °C ») — computed values from the batch volume plan (ADR-0020) are a deferred iteration, as is per-recipe override (same deferral as the ⓘ tips).

## Checklist

- [x] Conception amended and validated BEFORE code (conception-is-contract)
- [x] Happy + sad + edge tests: guidance invariants (every gesture has a non-empty action AND why; packaging empty; unknown type), domain enrichment, DTO mapping, service launch + transition round-trip, 3 mobile PRÉP scenarios — API 915 ✅, mobile 1166 ✅
- [x] `npm run ci:all` green (lint + typecheck + format)
- [x] Additive reversible migration, no backfill needed
- [x] Local pre-push review ritual: Claude 0 Must Have; Codex leg NOT run (OpenAI workspace out of credits — flagged, not skipped silently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)