### PR TITLE
feat(batches): explicit end condition (doneWhen) in the ACTIF phase (F5)

### DIFF
--- a/docs/architecture/diagrams/brew-day/01-sequence-step-enrichment.md
+++ b/docs/architecture/diagrams/brew-day/01-sequence-step-enrichment.md
@@ -1,8 +1,9 @@
-# Sequence diagram — brew-day — Enrich live batch steps with guidance (B1-live, F4 prep actions)
+# Sequence diagram — brew-day — Enrich live batch steps with guidance (B1-live, F4 prep actions, F5 done-when)
 
 > **Feature**: first real brew — making the brew-day step guide work in **LIVE** mode (roadmap P0 "TRACKER → ASSISTANT").
-> **Realizes**: B1-live + **F4 physical prep actions** (novice-journey audit). **Related**: brew-prep state machine ([`../brew-prep/05-state-readiness.md`](../brew-prep/05-state-readiness.md)), step lifecycle ([`06-state-brew-step.md`](06-state-brew-step.md)).
+> **Realizes**: B1-live + **F4 physical prep actions** + **F5 end conditions** (novice-journey audit). **Related**: brew-prep state machine ([`../brew-prep/05-state-readiness.md`](../brew-prep/05-state-readiness.md)), step lifecycle ([`06-state-brew-step.md`](06-state-brew-step.md)).
 > **Amended 2026-07-02 (F4 + 07b sync)**: enrichment now happens at **launch** (steps are snapshotted by `launchBatch`, not at batch creation — brew-day/07 F14/F15) and carries the **physical prep actions** shown in the step's PRÉP phase.
+> **Amended 2026-07-02 (F5)**: enrichment also carries the step's **end condition** (`doneWhen`) — one pedagogical FR sentence per type shown in the **ACTIF** phase, so the brewer always knows *when the step is over* (the timer is an aid, the condition is the truth; event-gated steps like fermentation get their condition instead of a countdown).
 
 ## Context
 
@@ -23,12 +24,12 @@ sequenceDiagram
   API->>API: load recipe steps (order, type, label, description)
   API->>D: launchBatch(draft, steps)
   loop each step
-    D->>D: getStepGuidance(step.type) gives tip + duration + prepActions, or none
+    D->>D: getStepGuidance(step.type) gives tip + duration + prepActions + doneWhen, or none
   end
-  D-->>API: BatchStep[] enriched (tip + duration + prepActions)
-  API->>API: persist batch_steps (pedagogical_tip, planned_duration_min, prep_actions)
-  API-->>M: BatchDto (steps carry tip + duration + prepActions)
-  M-->>B: PRÉP shows the physical actions; Start begins ACTIF (+ timer)
+  D-->>API: BatchStep[] enriched (tip + duration + prepActions + doneWhen)
+  API->>API: persist batch_steps (pedagogical_tip, planned_duration_min, prep_actions, done_when)
+  API-->>M: BatchDto (steps carry tip + duration + prepActions + doneWhen)
+  M-->>B: PRÉP shows the physical actions; ACTIF shows the timer + « C'est terminé quand… »
 ```
 
 ## Notes
@@ -44,6 +45,7 @@ sequenceDiagram
   transfer/aerate/pitch + airlock & temperature; PACKAGING = **none** — bottling already has the
   richer B3 gate (`03-sequence-bottle-and-close.md`), prep actions must not duplicate it.
 - **Not a gate:** the PRÉP checklist is guidance; `Start` stays a single ✋ confirmation (brew-day/06). Ticks are local UI state — nothing new persisted per tick (unlike the brew-prep ingredient checklist F14, which is a launch gate).
+- **End condition per type (F5):** `doneWhen` — one pedagogical FR sentence stating when the step is over, rendered in the **ACTIF** phase near the ✋ Complete CTA. For timed steps it frames the countdown as an aid, not an order (MASH/BOIL/WHIRLPOOL); for event-gated steps it IS the end signal (FERMENTATION: stable gravity over 2-3 days, never a fixed date). Like the prep actions it never gates `Complete` — the ✋ stays sovereign (unified end, brew-day/06).
 - **Description preserved:** the recipe-authored `description` is untouched; only type-level guidance is added.
 - **Backward compatible:** the `batch_steps` columns are nullable; steps launched before this carry no enrichment (mobile falls back to the bare card).
 - **Mobile:** `BatchDetailsScreen` already derives the PRÉP phase (`startedAt == null`, F1) — the PRÉP block renders `prepActions` above the Start CTA.

--- a/docs/architecture/diagrams/brew-day/06-state-brew-step.md
+++ b/docs/architecture/diagrams/brew-day/06-state-brew-step.md
@@ -70,7 +70,10 @@ stateDiagram-v2
 - **ACTIF end is unified (F5).** A step always ends on ✋ `Complete`; the timer is an optional
   aid when `plannedDurationMin` is known. Event-gated steps (e.g. "chill to 20°C", "gravity
   stable") simply have no timer and state the end condition in the guidance — no separate step
-  *type* is introduced.
+  *type* is introduced. **Amended 2026-07-02:** the end condition is now explicit content —
+  `doneWhen`, one pedagogical FR sentence per type carried by the launch-time enrichment
+  (`01-sequence-step-enrichment.md`) and rendered in ACTIF near the `Complete` CTA. It never
+  gates `Complete` (the ✋ stays sovereign).
 - **Derived state, not transitions (from brewing-session/05).** The hop-addition cues, the
   **T-minus pre-announce** of the *next* step's PRÉP (F9, in-app cue for v1 — real background
   notifications are a later epic), and the *overdue* alert (`now > plannedEnd` while `active`)

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -1156,11 +1156,15 @@ describe('BatchService', () => {
     }
     // Packaging (last step) has none — the B3 bottling gate covers it.
     expect(steps[steps.length - 1].prep_actions).toBeNull();
+    // F5: every launched step carries its end condition.
+    expect(steps[0].done_when?.trim().length).toBeGreaterThan(0);
+    expect(steps[steps.length - 1].done_when?.trim().length).toBeGreaterThan(0);
 
-    // A step transition re-saves the whole snapshot: the prep actions must
+    // A step transition re-saves the whole snapshot: the guidance must
     // survive the domain round-trip (regression guard against silent drops).
     const started = await batchService.startMineCurrentStep(ownerId, batch.id);
     expect(started.steps[0].prep_actions).toEqual(steps[0].prep_actions);
+    expect(started.steps[0].done_when).toBe(steps[0].done_when);
   });
 
   it('launchMine() rejects a double launch with Conflict-free 400 and keeps the journal intact (sad)', async () => {

--- a/packages/api/src/batch/domain/batch.domain.spec.ts
+++ b/packages/api/src/batch/domain/batch.domain.spec.ts
@@ -89,6 +89,8 @@ describe('BatchDomainService', () => {
     expect(mash?.prepActions?.length).toBeGreaterThan(0);
     expect(mash?.prepActions?.[0].action).toBeTruthy();
     expect(mash?.prepActions?.[0].why).toBeTruthy();
+    // F5: the snapshot also carries the step's end condition.
+    expect(mash?.doneWhen).toBeTruthy();
   });
 
   it('leaves prepActions undefined on packaging — B3 covers it (edge, F4)', () => {

--- a/packages/api/src/batch/domain/entities/batch-step.entity.ts
+++ b/packages/api/src/batch/domain/entities/batch-step.entity.ts
@@ -54,4 +54,10 @@ export interface BatchStep {
    * Undefined when the type carries none (e.g. packaging — B3 covers it).
    */
   readonly prepActions?: readonly StepPrepAction[];
+
+  /**
+   * ACTIF-phase end condition (F5) — when the step is over, one pedagogical
+   * sentence. Never gates Complete. Undefined on legacy steps.
+   */
+  readonly doneWhen?: string;
 }

--- a/packages/api/src/batch/domain/services/batch-domain.service.ts
+++ b/packages/api/src/batch/domain/services/batch-domain.service.ts
@@ -118,6 +118,7 @@ export class BatchDomainService {
         prepActions: guidance?.prepActions.length
           ? guidance.prepActions
           : undefined,
+        doneWhen: guidance?.doneWhen,
       };
     });
   }

--- a/packages/api/src/batch/domain/services/step-guidance.spec.ts
+++ b/packages/api/src/batch/domain/services/step-guidance.spec.ts
@@ -57,4 +57,12 @@ describe('getStepGuidance', () => {
   it('carries NO PRÉP actions for packaging — the B3 bottling gate covers it (edge)', () => {
     expect(getStepGuidance(RecipeStepType.PACKAGING)?.prepActions).toEqual([]);
   });
+
+  it('states a non-empty end condition (doneWhen) on every type (happy, F5)', () => {
+    for (const type of Object.values(RecipeStepType)) {
+      // Every step must tell the brewer WHEN it is over — the timer is an
+      // aid, the condition is the truth (brew-day/06 unified end).
+      expect(getStepGuidance(type)?.doneWhen.trim().length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/packages/api/src/batch/domain/services/step-guidance.ts
+++ b/packages/api/src/batch/domain/services/step-guidance.ts
@@ -28,6 +28,13 @@ export interface StepGuidance {
    * step needs none (PACKAGING: the richer B3 bottling gate already covers it).
    */
   readonly prepActions: readonly StepPrepAction[];
+  /**
+   * The step's end condition (F5) — one pedagogical FR sentence stating when
+   * the step is over, shown in ACTIF near the Complete CTA. For timed steps it
+   * frames the countdown as an aid; for event-gated steps it IS the end signal.
+   * Never gates Complete (the ✋ stays sovereign — brew-day/06).
+   */
+  readonly doneWhen: string;
 }
 
 const STEP_TYPE_GUIDANCE: Readonly<Record<RecipeStepType, StepGuidance>> = {
@@ -35,6 +42,8 @@ const STEP_TYPE_GUIDANCE: Readonly<Record<RecipeStepType, StepGuidance>> = {
     pedagogicalTip:
       "L'empâtage fait infuser le grain concassé dans l'eau chaude (~65-67°C) : les enzymes y convertissent l'amidon en sucres fermentescibles. Plus chaud donne une bière plus ronde, plus froid une bière plus sèche.",
     plannedDurationMin: 60,
+    doneWhen:
+      'Terminé quand les ~60 minutes sont écoulées. Le chrono est une aide, pas un ordre : quelques minutes de plus ne gâchent rien — les enzymes ont simplement fini leur travail de conversion.',
     prepActions: [
       {
         action: "Chauffe ~7 L d'eau à ~72 °C (pour ~4 L de bière).",
@@ -54,6 +63,8 @@ const STEP_TYPE_GUIDANCE: Readonly<Record<RecipeStepType, StepGuidance>> = {
     pedagogicalTip:
       "L'ébullition stérilise le moût, isomérise les acides alpha du houblon (l'amertume) et concentre les sucres. Les houblons d'amertume vont tôt, les houblons d'arôme en toute fin d'ébullition.",
     plannedDurationMin: 60,
+    doneWhen:
+      "Terminé quand les ~60 minutes d'ébullition sont écoulées ET que tous tes ajouts de houblon prévus sont faits. Si un ajout a été oublié, mieux vaut prolonger de quelques minutes que de le sauter.",
     prepActions: [
       {
         action:
@@ -74,6 +85,8 @@ const STEP_TYPE_GUIDANCE: Readonly<Record<RecipeStepType, StepGuidance>> = {
     pedagogicalTip:
       "Le whirlpool fait tourner le moût pour rassembler les résidus (le trub) au centre, puis on refroidit vite avant d'ensemencer la levure. À partir d'ici, tout ce qui touche le moût refroidi doit être désinfecté.",
     plannedDurationMin: 15,
+    doneWhen:
+      "Terminé quand le tourbillon s'est calmé et que les dépôts (le trub) forment un cône au centre — environ 15 minutes. Plus le moût repose, plus il sera clair au transfert.",
     prepActions: [
       {
         action: 'Coupe le feu et remue le moût en cercle.',
@@ -90,6 +103,8 @@ const STEP_TYPE_GUIDANCE: Readonly<Record<RecipeStepType, StepGuidance>> = {
     pedagogicalTip:
       'La levure transforme les sucres en alcool et CO₂. Maintiens 18-20°C : trop chaud, elle stresse et produit des arômes indésirables. La fermentation est finie quand la densité est stable, pas à une date fixe.',
     plannedDurationMin: null,
+    doneWhen:
+      "Terminée quand la densité est STABLE sur 2-3 jours d'affilée — jamais à une date fixe. Sans densimètre, un barboteur silencieux depuis plusieurs jours est un indice, mais moins fiable qu'une mesure.",
     prepActions: [
       {
         action: 'Refroidis le moût à ~20 °C, aussi vite que possible.',
@@ -115,6 +130,8 @@ const STEP_TYPE_GUIDANCE: Readonly<Record<RecipeStepType, StepGuidance>> = {
     pedagogicalTip:
       "À l'embouteillage, on ajoute une dose précise de sucre (priming) pour la carbonatation : trop de sucre et les bouteilles explosent. Désinfecte les bouteilles, remplis, capsule, puis laisse conditionner ~2 semaines.",
     plannedDurationMin: null,
+    doneWhen:
+      "Terminé quand toutes les bouteilles sont remplies, capsulées et rangées à température ambiante, à l'abri de la lumière, pour ~2 semaines de refermentation.",
     // No PRÉP actions: the bottling flow already carries the richer B3 gate
     // (sanitize bottles + priming + bottle-bomb checkbox) — never duplicated.
     prepActions: [],

--- a/packages/api/src/batch/dtos/batch-step.dto.spec.ts
+++ b/packages/api/src/batch/dtos/batch-step.dto.spec.ts
@@ -52,4 +52,12 @@ describe('BatchStepDto.fromEntity', () => {
       BatchStepDto.fromEntity(makeEntity({ prep_actions: null })).prep_actions,
     ).toBeNull();
   });
+
+  it('maps the end condition and nulls it for legacy steps (happy/edge, F5)', () => {
+    expect(
+      BatchStepDto.fromEntity(makeEntity({ done_when: 'Quand ~60 min.' }))
+        .done_when,
+    ).toBe('Quand ~60 min.');
+    expect(BatchStepDto.fromEntity(makeEntity()).done_when).toBeNull();
+  });
 });

--- a/packages/api/src/batch/dtos/batch-step.dto.ts
+++ b/packages/api/src/batch/dtos/batch-step.dto.ts
@@ -48,6 +48,12 @@ export class BatchStepDto {
   @ApiPropertyOptional({ type: [StepPrepActionDto], nullable: true })
   prep_actions?: StepPrepActionDto[] | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    description: "The step's pedagogical end condition (F5), shown in ACTIF",
+  })
+  done_when?: string | null;
+
   @ApiProperty()
   created_at: Date;
 
@@ -67,6 +73,7 @@ export class BatchStepDto {
       planned_duration_min: e.planned_duration_min ?? null,
       pedagogical_tip: e.pedagogical_tip ?? null,
       prep_actions: e.prep_actions ?? null,
+      done_when: e.done_when ?? null,
       created_at: e.created_at,
       updated_at: e.updated_at,
     };

--- a/packages/api/src/batch/entities/batch-step.orm.entity.ts
+++ b/packages/api/src/batch/entities/batch-step.orm.entity.ts
@@ -59,6 +59,11 @@ export class BatchStepOrmEntity {
   @Column({ type: 'simple-json', nullable: true })
   prep_actions?: { action: string; why: string }[] | null;
 
+  // ACTIF-phase end condition (F5, brew-day/01+06) — when the step is over.
+  // Snapshotted at launch like the tip; null on legacy steps.
+  @Column({ type: 'text', nullable: true })
+  done_when?: string | null;
+
   @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
   created_at: Date;
 

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -535,6 +535,7 @@ export class BatchService {
           planned_duration_min: step.plannedDurationMin ?? null,
           pedagogical_tip: step.pedagogicalTip ?? null,
           prep_actions: step.prepActions ? [...step.prepActions] : null,
+          done_when: step.doneWhen ?? null,
         }),
       );
 
@@ -579,6 +580,7 @@ export class BatchService {
         planned_duration_min: step.plannedDurationMin ?? null,
         pedagogical_tip: step.pedagogicalTip ?? null,
         prep_actions: step.prepActions ? [...step.prepActions] : null,
+        done_when: step.doneWhen ?? null,
       }),
     );
 
@@ -622,6 +624,7 @@ export class BatchService {
       // Round-trip matters: step transitions re-save the full snapshot, so a
       // missing mapping here would silently drop prep_actions on first use.
       prepActions: step.prep_actions ?? undefined,
+      doneWhen: step.done_when ?? undefined,
     };
   }
 
@@ -839,6 +842,7 @@ export class BatchService {
           planned_duration_min: step.plannedDurationMin ?? null,
           pedagogical_tip: step.pedagogicalTip ?? null,
           prep_actions: step.prepActions ? [...step.prepActions] : null,
+          done_when: step.doneWhen ?? null,
         }),
       );
 

--- a/packages/api/src/database/migrations/1807000000000-AddBatchStepDoneWhen.ts
+++ b/packages/api/src/database/migrations/1807000000000-AddBatchStepDoneWhen.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds `done_when` to `batch_steps` (brew-day/01+06, F5).
+ *
+ * Nullable text holding the step's end condition snapshotted at launch — one
+ * pedagogical FR sentence stating when the step is over, shown in the ACTIF
+ * phase (the timer is an aid, the condition is the truth; event-gated steps
+ * like fermentation get their condition instead of a countdown). No backfill:
+ * steps launched before this simply carry no end condition, same additive
+ * model as `pedagogical_tip` / `prep_actions`.
+ */
+export class AddBatchStepDoneWhen1807000000000 implements MigrationInterface {
+  name = 'AddBatchStepDoneWhen1807000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batch_steps" ADD COLUMN "done_when" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "batch_steps" DROP COLUMN "done_when"`,
+    );
+  }
+}

--- a/packages/mobile-app/src/features/batches/data/batches.api.ts
+++ b/packages/mobile-app/src/features/batches/data/batches.api.ts
@@ -41,6 +41,7 @@ type BatchStepDto = {
   planned_duration_min?: number | null;
   pedagogical_tip?: string | null;
   prep_actions?: { action: string; why: string }[] | null;
+  done_when?: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -98,6 +99,7 @@ function mapBatchStep(dto: BatchStepDto): BatchStep {
     plannedDurationMin: dto.planned_duration_min ?? null,
     pedagogicalTip: dto.pedagogical_tip ?? null,
     prepActions: dto.prep_actions ?? null,
+    doneWhen: dto.done_when ?? null,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
   };

--- a/packages/mobile-app/src/features/batches/domain/batch.types.ts
+++ b/packages/mobile-app/src/features/batches/domain/batch.types.ts
@@ -58,6 +58,9 @@ export type BatchStep = {
   // PRÉP-phase physical gestures, each with its pedagogical why (F4,
   // brew-day/01+06). Null on legacy steps and types without prep (packaging).
   prepActions?: StepPrepAction[] | null;
+  // ACTIF-phase end condition (F5): when the step is over, one pedagogical
+  // sentence. Never gates Complete. Null on legacy steps.
+  doneWhen?: string | null;
 };
 
 // One PRÉP gesture + its one-line why — the app teaches, a novice must learn

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -717,6 +717,16 @@ export function BatchDetailsScreen({ batchId }: Props) {
         <BrewStepTimer step={activeStep} useDemoData={dataSource.useDemoData} />
       ) : null}
 
+      {/* End condition (F5, brew-day/01+06): shown only in ACTIF — the brewer
+          always knows when the step is over. The timer is an aid, this is the
+          truth; it never gates « Terminer » (the ✋ stays sovereign). */}
+      {!isCompletedLive && activeStep && !isPrepPhase && activeStep.doneWhen ? (
+        <Card>
+          <Text style={styles.sectionTitle}>C'est terminé quand…</Text>
+          <Text style={styles.doneWhenText}>{activeStep.doneWhen}</Text>
+        </Card>
+      ) : null}
+
       {isPrepPhase && activeStep?.prepActions?.length ? (
         <Card>
           <Text style={styles.sectionTitle}>Avant de démarrer</Text>
@@ -868,6 +878,11 @@ const styles = StyleSheet.create({
     color: colors.neutral.textPrimary,
     fontSize: typography.size.body,
     lineHeight: typography.lineHeight.body,
+  },
+  doneWhenText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
   },
   list: {},
   stepsList: {

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -291,6 +291,72 @@ describe("BatchDetailsScreen", () => {
     expect(screen.queryByText("Avant de démarrer")).toBeNull();
   });
 
+  it("ACTIF shows the step's end condition near the complete CTA (F5, happy)", async () => {
+    const activeBatch: Batch = {
+      ...mashBatch,
+      steps: mashBatch.steps.map((step) =>
+        step.stepOrder === 0
+          ? {
+              ...step,
+              doneWhen:
+                "Terminé quand les ~60 minutes sont écoulées. Le chrono est une aide, pas un ordre.",
+            }
+          : step,
+      ),
+    };
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(activeBatch, "Ma recette test"),
+    );
+
+    renderBatchDetailsScreen();
+
+    // mashBatch step 0 carries a startedAt → ACTIF: the end condition shows,
+    // and « Terminer » stays available regardless (never gated on it).
+    expect(await screen.findByText("C'est terminé quand…")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Terminé quand les ~60 minutes sont écoulées. Le chrono est une aide, pas un ordre.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("Terminer l'étape en cours")).toBeTruthy();
+  });
+
+  it("PRÉP hides the end condition — it belongs to the running step (F5, edge)", async () => {
+    const prepBatch: Batch = {
+      ...mashBatch,
+      steps: mashBatch.steps.map((step) =>
+        step.stepOrder === 0
+          ? { ...step, startedAt: null, doneWhen: "Quand ~60 min." }
+          : step,
+      ),
+    };
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(prepBatch, "Ma recette test"),
+    );
+
+    renderBatchDetailsScreen();
+
+    expect(await screen.findByText("Démarrer l'étape")).toBeTruthy();
+    expect(screen.queryByText("C'est terminé quand…")).toBeNull();
+  });
+
+  it("ACTIF without an end condition renders no F5 card (edge: legacy step)", async () => {
+    const legacyBatch: Batch = {
+      ...mashBatch,
+      steps: mashBatch.steps.map((step) =>
+        step.stepOrder === 0 ? { ...step, doneWhen: null } : step,
+      ),
+    };
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(legacyBatch, "Ma recette test"),
+    );
+
+    renderBatchDetailsScreen();
+
+    expect(await screen.findByText("Terminer l'étape en cours")).toBeTruthy();
+    expect(screen.queryByText("C'est terminé quand…")).toBeNull();
+  });
+
   it("confirms before completing a step, then completes on confirm (F6)", async () => {
     (completeCurrentBatchStep as jest.Mock).mockClear();
     const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});


### PR DESCRIPTION
## Summary

Fixes novice-journey friction **F5** (the step model was timer-only — nothing ever told the brewer *when a step is over*): the ACTIF phase now displays an explicit, pedagogical **end condition** per step type.

**Conception-first** (commit 1, `docs(conception)`): contract amended and validated with the owner before any code — [brew-day/01-sequence-step-enrichment.md](docs/architecture/diagrams/brew-day/01-sequence-step-enrichment.md) (launch-time enrichment also carries `doneWhen`) and [06-state-brew-step.md](docs/architecture/diagrams/brew-day/06-state-brew-step.md) (the F5 unified-end note now points at explicit content).

**Implementation** (commit 2), same pattern as the merged F4 (#1305):
- `StepGuidance.doneWhen` — one FR sentence per type: timed steps frame the countdown as an aid, not an order (MASH/BOIL/WHIRLPOOL); event-gated steps get their condition as THE end signal (FERMENTATION: gravity stable over 2-3 days, never a fixed date; PACKAGING: bottles capped and conditioning).
- Snapshot at launch persists `batch_steps.done_when` (nullable text; additive reversible migration `1807…`, no backfill) and the domain round-trip preserves it across step transitions.
- `BatchStepDto.done_when` exposed (Swagger-documented).
- Mobile: « C'est terminé quand… » card in the **ACTIF** phase near the complete CTA — hidden in PRÉP and on legacy steps, and it **never gates « Terminer »** (the ✋ stays sovereign, brew-day/06).

With F7/F7b assessed as covered by F1+F4 (to be re-verified at the next live novice test), the remaining block-B item after this is **F9** (T-minus pre-announce + persistent current-action reminder).

## Checklist

- [x] Conception amended and validated BEFORE code (conception-is-contract)
- [x] Happy + sad + edge tests: guidance invariant (every type states a non-empty condition), domain enrichment, DTO mapping, service launch + transition round-trip, 3 mobile scenarios (ACTIF shows / PRÉP hides / legacy hides) — API 917 ✅, mobile 1169 ✅
- [x] `npm run ci:all` green locally before push (lint + typecheck + format)
- [x] Additive reversible migration, no backfill needed
- [x] Local pre-push review ritual: Claude 0 Must Have; Codex leg NOT run (OpenAI workspace out of credits — flagged, not skipped silently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)