### PR TITLE
feat(batches): T-minus pre-announce + calm elapsed timer state (F9a)

### DIFF
--- a/docs/architecture/diagrams/brew-day/06-state-brew-step.md
+++ b/docs/architecture/diagrams/brew-day/06-state-brew-step.md
@@ -78,6 +78,15 @@ stateDiagram-v2
   **T-minus pre-announce** of the *next* step's PRÉP (F9, in-app cue for v1 — real background
   notifications are a later epic), and the *overdue* alert (`now > plannedEnd` while `active`)
   are all **derived** from the step + timer state; they are not modelled as transitions.
+  **Amended 2026-07-02 (F9a realised):** two derived cues ship on the batch screen —
+  (1) **T-minus pre-announce**: when a timed ACTIF step has ≤ 5 min remaining, a card announces
+  the *next* step and its first PRÉP gesture (« Bientôt : … — profites-en pour préparer : … »),
+  so the brewer anticipates instead of enduring; (2) **overdue state**: at 00:00 the timer card
+  switches to « Temps écoulé » and points at the step's `doneWhen` end condition (F5) + the ✋
+  Complete — the elapsed timer never auto-completes anything (unified end). Both are computed
+  from `remainingSec` + the steps snapshot, nothing persisted. The **cross-screen persistent
+  reminder (F9b) is deferred** to the background-notifications epic — during a live brew the
+  brewer lives on the batch screen; the away-from-app case is the notifications epic's job.
 - **Pause / Skip** are inherited from `brewing-session/05-state-batch-step.md`: `Pause` freezes
   the timer (stays inside `in_progress`); `Skip` (with a reason, confirm) is for optional phases
   only (whirlpool, dry hop). This diagram subsumes that one for the brew-day scope.

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -714,7 +714,15 @@ export function BatchDetailsScreen({ batchId }: Props) {
       ) : null}
 
       {!isCompletedLive && activeStep ? (
-        <BrewStepTimer step={activeStep} useDemoData={dataSource.useDemoData} />
+        <BrewStepTimer
+          step={activeStep}
+          useDemoData={dataSource.useDemoData}
+          nextStep={
+            batch?.steps?.find(
+              (s) => s.stepOrder === activeStep.stepOrder + 1,
+            ) ?? null
+          }
+        />
       ) : null}
 
       {/* End condition (F5, brew-day/01+06): shown only in ACTIF — the brewer

--- a/packages/mobile-app/src/features/batches/presentation/BrewStepTimer.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BrewStepTimer.tsx
@@ -14,7 +14,14 @@ import {
 type Props = {
   step: BatchStep;
   useDemoData: boolean;
+  // Next step in the workflow, for the T-minus pre-announce (F9a,
+  // brew-day/06). Null/omitted on the last step: nothing to announce.
+  nextStep?: BatchStep | null;
 };
+
+// T-minus threshold for announcing the next step's PRÉP (F9a). Fixed 5 min:
+// enough to heat/sanitize ahead, short enough to stay relevant.
+const T_MINUS_ANNOUNCE_SEC = 5 * 60;
 
 // Dynamic width can't live in StyleSheet.create() (runtime percentage); keeping
 // it in a tiny helper keeps the JSX free of inline style literals (project rule).
@@ -27,7 +34,11 @@ function progressFillWidth(percent: number) {
  * Renders nothing when the step declares no planned duration (e.g. fermentation,
  * which has its own day-based tracker).
  */
-export function BrewStepTimer({ step, useDemoData }: Readonly<Props>) {
+export function BrewStepTimer({
+  step,
+  useDemoData,
+  nextStep = null,
+}: Readonly<Props>) {
   const countdown = useStepCountdown(step, useDemoData);
   if (!countdown) {
     return null;
@@ -37,6 +48,16 @@ export function BrewStepTimer({ step, useDemoData }: Readonly<Props>) {
     (countdown.totalSec - countdown.remainingSec) / 60,
   );
   const totalMin = Math.round(countdown.totalSec / 60);
+
+  // Derived anticipation cues (F9a, brew-day/06) — nothing persisted:
+  // elapsed timer = calm hand-off to the F5 end condition (never an alarm,
+  // overrunning is NORMAL in brewing); T-minus window = announce the next
+  // step's PRÉP so the brewer anticipates instead of enduring.
+  const isElapsed = countdown.remainingSec <= 0;
+  const announcedNext =
+    !isElapsed && countdown.remainingSec <= T_MINUS_ANNOUNCE_SEC
+      ? nextStep
+      : null;
 
   return (
     <Card style={styles.card}>
@@ -52,10 +73,36 @@ export function BrewStepTimer({ step, useDemoData }: Readonly<Props>) {
         </Text>
       </View>
 
-      <Text style={styles.countdown}>
-        {formatCountdown(countdown.remainingSec)}
-      </Text>
-      <Text style={styles.remainingHint}>restantes</Text>
+      {isElapsed ? (
+        <View style={styles.elapsedBlock}>
+          <Text style={styles.elapsedTitle}>Temps écoulé</Text>
+          <Text style={styles.elapsedHint}>
+            Vérifie la condition de fin ci-dessous, puis termine l'étape quand
+            c'est bon.
+          </Text>
+        </View>
+      ) : (
+        <>
+          <Text style={styles.countdown}>
+            {formatCountdown(countdown.remainingSec)}
+          </Text>
+          <Text style={styles.remainingHint}>restantes</Text>
+        </>
+      )}
+
+      {announcedNext ? (
+        <View style={styles.announceBlock} testID="next-step-announce">
+          <Text style={styles.announceTitle}>
+            Bientôt : {announcedNext.label}
+          </Text>
+          {announcedNext.prepActions?.length ? (
+            <Text style={styles.announceHint}>
+              Profites-en pour préparer : «{" "}
+              {announcedNext.prepActions[0].action} »
+            </Text>
+          ) : null}
+        </View>
+      ) : null}
 
       <View style={styles.progressTrack}>
         <View
@@ -128,5 +175,41 @@ const styles = StyleSheet.create({
     lineHeight: typography.lineHeight.caption,
     marginTop: spacing.xxs,
     textAlign: "center",
+  },
+  elapsedBlock: {
+    alignItems: "center",
+    marginBottom: spacing.sm,
+    gap: spacing.xxs,
+  },
+  elapsedTitle: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+    textAlign: "center",
+  },
+  elapsedHint: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    textAlign: "center",
+  },
+  announceBlock: {
+    borderRadius: radius.md,
+    backgroundColor: colors.state.infoBackground,
+    padding: spacing.sm,
+    marginBottom: spacing.sm,
+    gap: spacing.xxs,
+  },
+  announceTitle: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+  },
+  announceHint: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
   },
 });

--- a/packages/mobile-app/src/features/batches/presentation/BrewStepTimer.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BrewStepTimer.tsx
@@ -76,9 +76,12 @@ export function BrewStepTimer({
       {isElapsed ? (
         <View style={styles.elapsedBlock}>
           <Text style={styles.elapsedTitle}>Temps écoulé</Text>
+          {/* Point at the F5 doneWhen card only when the step carries one —
+              legacy steps have none, so the pointer would mislead. */}
           <Text style={styles.elapsedHint}>
-            Vérifie la condition de fin ci-dessous, puis termine l'étape quand
-            c'est bon.
+            {step.doneWhen
+              ? "Vérifie la condition de fin ci-dessous, puis termine l'étape quand c'est bon."
+              : "Termine l'étape quand c'est bon — le chrono est une aide, pas un ordre."}
           </Text>
         </View>
       ) : (

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -291,6 +291,31 @@ describe("BatchDetailsScreen", () => {
     expect(screen.queryByText("Avant de démarrer")).toBeNull();
   });
 
+  it("wires the workflow's next step into the T-minus announce (F9a, happy)", async () => {
+    const anticipationBatch: Batch = {
+      ...mashBatch,
+      steps: mashBatch.steps.map((step) =>
+        step.stepOrder === 0
+          ? {
+              ...step,
+              plannedDurationMin: 60,
+              // 56 min elapsed on a 60-min step → inside the T-5 min window.
+              startedAt: new Date(Date.now() - 56 * 60 * 1000).toISOString(),
+            }
+          : step,
+      ),
+    };
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel(anticipationBatch, "Ma recette test"),
+    );
+
+    renderBatchDetailsScreen();
+
+    // The announce names the ACTUAL next step of the workflow (stepOrder 1),
+    // proving the screen-level lookup — not just the leaf component.
+    expect(await screen.findByText("Bientôt : Ébullition 60 min")).toBeTruthy();
+  });
+
   it("ACTIF shows the step's end condition near the complete CTA (F5, happy)", async () => {
     const activeBatch: Batch = {
       ...mashBatch,

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BrewStepTimer.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BrewStepTimer.test.tsx
@@ -49,4 +49,83 @@ describe("BrewStepTimer", () => {
 
     expect(screen.queryByText("Minuterie d'étape")).toBeNull();
   });
+
+  // A live 60-min step whose startedAt puts the countdown at `remainingMin`.
+  function liveStepAt(remainingMin: number): BatchStep {
+    return makeStep({
+      plannedDurationMin: 60,
+      startedAt: new Date(
+        Date.now() - (60 - remainingMin) * 60 * 1000,
+      ).toISOString(),
+    });
+  }
+
+  const NEXT_STEP = makeStep({
+    stepOrder: 1,
+    type: "boil",
+    label: "Ébullition",
+    prepActions: [
+      { action: "Retire le sac de grain.", why: "Il ne doit pas cuire." },
+    ],
+  });
+
+  it("announces the next step's PRÉP inside the T-minus window (F9a, happy)", () => {
+    render(
+      <BrewStepTimer
+        step={liveStepAt(4)}
+        useDemoData={false}
+        nextStep={NEXT_STEP}
+      />,
+    );
+
+    expect(screen.getByText("Bientôt : Ébullition")).toBeTruthy();
+    expect(
+      screen.getByText(/Profites-en pour préparer .*Retire le sac de grain/),
+    ).toBeTruthy();
+    // The countdown keeps running — the announce complements it.
+    expect(screen.getByText("restantes")).toBeTruthy();
+  });
+
+  it("stays silent outside the T-minus window (F9a, edge)", () => {
+    render(
+      <BrewStepTimer
+        step={liveStepAt(6)}
+        useDemoData={false}
+        nextStep={NEXT_STEP}
+      />,
+    );
+
+    expect(screen.queryByText(/Bientôt/)).toBeNull();
+  });
+
+  it("announces nothing on the last step (F9a, edge)", () => {
+    render(
+      <BrewStepTimer
+        step={liveStepAt(4)}
+        useDemoData={false}
+        nextStep={null}
+      />,
+    );
+
+    expect(screen.queryByText(/Bientôt/)).toBeNull();
+  });
+
+  it("switches to a calm elapsed state at 00:00 and hands off to the end condition (F9a)", () => {
+    render(
+      <BrewStepTimer
+        step={liveStepAt(-1)}
+        useDemoData={false}
+        nextStep={NEXT_STEP}
+      />,
+    );
+
+    expect(screen.getByText("Temps écoulé")).toBeTruthy();
+    expect(
+      screen.getByText(/Vérifie la condition de fin ci-dessous/),
+    ).toBeTruthy();
+    // No running countdown, and the announce yields to the hand-off (the next
+    // step's PRÉP will greet the brewer right after Terminer anyway).
+    expect(screen.queryByText("restantes")).toBeNull();
+    expect(screen.queryByText(/Bientôt/)).toBeNull();
+  });
 });

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BrewStepTimer.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BrewStepTimer.test.tsx
@@ -113,7 +113,7 @@ describe("BrewStepTimer", () => {
   it("switches to a calm elapsed state at 00:00 and hands off to the end condition (F9a)", () => {
     render(
       <BrewStepTimer
-        step={liveStepAt(-1)}
+        step={{ ...liveStepAt(-1), doneWhen: "Quand les ~60 min sont là." }}
         useDemoData={false}
         nextStep={NEXT_STEP}
       />,
@@ -127,5 +127,20 @@ describe("BrewStepTimer", () => {
     // step's PRÉP will greet the brewer right after Terminer anyway).
     expect(screen.queryByText("restantes")).toBeNull();
     expect(screen.queryByText(/Bientôt/)).toBeNull();
+  });
+
+  it("elapsed on a legacy step points nowhere — no doneWhen card exists (F9a, edge)", () => {
+    render(
+      <BrewStepTimer
+        step={liveStepAt(-1)}
+        useDemoData={false}
+        nextStep={null}
+      />,
+    );
+
+    expect(screen.getByText("Temps écoulé")).toBeTruthy();
+    // The hint must not reference a card that is not on the screen.
+    expect(screen.queryByText(/condition de fin ci-dessous/)).toBeNull();
+    expect(screen.getByText(/Termine l'étape quand c'est bon/)).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

Closes structural block B of the novice-journey audit with **F9a — anticipation cues**, two purely **derived** behaviours on the batch screen (mobile-only, nothing persisted, no API change):

- **T-minus pre-announce**: when a timed ACTIF step has ≤ 5 min remaining, the timer card announces the NEXT step — « Bientôt : Ébullition » — plus its first PRÉP gesture (from the F4 `prepActions` already on the snapshot), so the brewer anticipates instead of enduring. Last step: nothing to announce.
- **Calm elapsed state**: at 00:00 the countdown yields to « Temps écoulé — vérifie la condition de fin ci-dessous, puis termine l'étape quand c'est bon », handing off to the F5 `doneWhen` card and the hand-confirmed « Terminer ». No alarm styling (overrunning is normal in brewing), nothing auto-completes — the ✋ stays sovereign.

**Conception-first** (commit 1): [brew-day/06-state-brew-step.md](docs/architecture/diagrams/brew-day/06-state-brew-step.md) amended and validated before code — both cues are realised as derived state per the existing note (no new transitions). **F9b** (cross-screen persistent reminder) is explicitly **deferred** to the background-notifications epic, recorded in the same note.

With F1 (PRÉP/ACTIF), F4 (prep gestures + whys), F5 (end conditions), F6 (confirm) and F7/F7b assessed covered, a brew step now guides the novice end-to-end: what to do before, when to start, what is happening, what is coming next, and when it is over.

## Checklist

- [x] Conception amended and validated BEFORE code (conception-is-contract)
- [x] Happy + sad + edge tests: T-4 announce with the real gesture, T-6 silent, last-step silent, elapsed hand-off (no countdown, no announce), screen-level integration test for the next-step lookup, existing no-duration/demo cases untouched — mobile 1175 ✅
- [x] `npm run ci:all` green locally before push
- [x] No migration, no API change (pure derived state)
- [x] Local pre-push review ritual: Claude 0 Must Have, Should Have (integration test) implemented; Codex leg NOT run (OpenAI workspace out of credits — flagged, not skipped silently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
