### PR TITLE
fix(faq-bot): fail closed on GET /challenge when the HMAC secret is missing

### DIFF
--- a/packages/api/src/faq-bot/config/faq-bot.config.spec.ts
+++ b/packages/api/src/faq-bot/config/faq-bot.config.spec.ts
@@ -77,13 +77,22 @@ describe('faqBotConfig — botCheckBypassAllowed derivation', () => {
 });
 
 describe('faqBotConfig — altchaHmacKey parsing', () => {
-  const saved = process.env.ALTCHA_HMAC_KEY;
+  // Restore every env key the suite mutates (APP_ENV included) so no state
+  // leaks into other spec files and the suite stays order-independent.
+  const KEYS = ['ALTCHA_HMAC_KEY', 'APP_ENV'] as const;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(KEYS.map((key) => [key, process.env[key]]));
+  });
 
   afterEach(() => {
-    if (saved === undefined) {
-      delete process.env.ALTCHA_HMAC_KEY;
-    } else {
-      process.env.ALTCHA_HMAC_KEY = saved;
+    for (const key of KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
     }
   });
 

--- a/packages/api/src/faq-bot/config/faq-bot.config.spec.ts
+++ b/packages/api/src/faq-bot/config/faq-bot.config.spec.ts
@@ -75,3 +75,30 @@ describe('faqBotConfig — botCheckBypassAllowed derivation', () => {
     expect(() => faqBotConfig()).toThrow(/Invalid APP_ENV/);
   });
 });
+
+describe('faqBotConfig — altchaHmacKey parsing', () => {
+  const saved = process.env.ALTCHA_HMAC_KEY;
+
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env.ALTCHA_HMAC_KEY;
+    } else {
+      process.env.ALTCHA_HMAC_KEY = saved;
+    }
+  });
+
+  it('reads a whitespace-only secret as missing (edge — secrets-UI slip)', () => {
+    process.env.APP_ENV = 'test';
+    process.env.ALTCHA_HMAC_KEY = '   ';
+
+    // A blank secret must hit the fail-closed guards, not reach altcha-lib.
+    expect(faqBotConfig().altchaHmacKey).toBe('');
+  });
+
+  it('trims a padded secret to its usable value (happy)', () => {
+    process.env.APP_ENV = 'test';
+    process.env.ALTCHA_HMAC_KEY = ' real-secret ';
+
+    expect(faqBotConfig().altchaHmacKey).toBe('real-secret');
+  });
+});

--- a/packages/api/src/faq-bot/config/faq-bot.config.ts
+++ b/packages/api/src/faq-bot/config/faq-bot.config.ts
@@ -84,7 +84,10 @@ export const faqBotConfig = (): FaqBotConfig => {
       process.env.FAQ_BOT_MONTHLY_BUDGET_EUR,
       DEFAULT_MONTHLY_BUDGET_EUR,
     ),
-    altchaHmacKey: process.env.ALTCHA_HMAC_KEY ?? '',
+    // Trimmed so a whitespace-only secret (secrets-UI copy-paste slip) reads
+    // as missing and hits the fail-closed guards instead of an opaque
+    // altcha-lib DataError deep inside challenge issuance/verification.
+    altchaHmacKey: process.env.ALTCHA_HMAC_KEY?.trim() ?? '',
     botCheckBypassAllowed: isBotCheckBypassAllowed(),
   };
 };

--- a/packages/api/src/faq-bot/faq-bot.service.spec.ts
+++ b/packages/api/src/faq-bot/faq-bot.service.spec.ts
@@ -140,9 +140,15 @@ describe('FaqBotService', () => {
       // opaque unhandled 500 instead of a clean unavailable signal.
       const service = build(makeConfig({ altchaHmacKey: '' }));
 
-      await expect(service.issueChallenge()).rejects.toThrow(
-        FaqBotUnavailableException,
-      );
+      const error: unknown = await service
+        .issueChallenge()
+        .then(() => null)
+        .catch((thrown: unknown) => thrown);
+
+      expect(error).toBeInstanceOf(FaqBotUnavailableException);
+      // Pin the actual HTTP status: exception type alone would keep passing
+      // if the status ever regressed.
+      expect((error as FaqBotUnavailableException).getStatus()).toBe(503);
     });
   });
 });

--- a/packages/api/src/faq-bot/faq-bot.service.spec.ts
+++ b/packages/api/src/faq-bot/faq-bot.service.spec.ts
@@ -127,11 +127,21 @@ describe('FaqBotService', () => {
   });
 
   describe('issueChallenge', () => {
-    it('delegates to the bot-check port', async () => {
-      const service = build();
+    it('delegates to the bot-check port when the HMAC secret is set (happy)', async () => {
+      const service = build(makeConfig({ altchaHmacKey: 'test-secret' }));
 
       await expect(service.issueChallenge()).resolves.toEqual(
         botCheck.challenge,
+      );
+    });
+
+    it('fails closed with 503 when the HMAC secret is missing (sad)', async () => {
+      // Without this guard, altcha-lib rejects the zero-length key with an
+      // opaque unhandled 500 instead of a clean unavailable signal.
+      const service = build(makeConfig({ altchaHmacKey: '' }));
+
+      await expect(service.issueChallenge()).rejects.toThrow(
+        FaqBotUnavailableException,
       );
     });
   });

--- a/packages/api/src/faq-bot/faq-bot.service.ts
+++ b/packages/api/src/faq-bot/faq-bot.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 
 import { FAQ_BOT_CONFIG, type FaqBotConfig } from './config/faq-bot.config';
 import { FaqBotUnavailableException } from './exceptions/faq-bot-unavailable.exception';
@@ -24,6 +24,8 @@ const MAX_ANSWER_CHARS = 1200;
  */
 @Injectable()
 export class FaqBotService {
+  private readonly logger = new Logger(FaqBotService.name);
+
   constructor(
     @Inject(LLM_PORT) private readonly llm: LlmPort,
     @Inject(BOT_CHECK_PORT) private readonly botCheck: BotCheckPort,
@@ -57,6 +59,16 @@ export class FaqBotService {
 
   /** Issue a fresh anti-bot challenge for the widget (delegates to the bot-check port). */
   async issueChallenge(): Promise<BotChallenge> {
+    if (!this.config.altchaHmacKey) {
+      // Fail closed, mirroring BotCheckGuard: issuing is impossible without
+      // the HMAC secret (altcha-lib rejects a zero-length key with an opaque
+      // unhandled 500) — surface a clean 503 that signals the deploy
+      // misconfiguration instead (ADR-0022).
+      this.logger.error(
+        'ALTCHA HMAC secret missing — cannot issue an anti-bot challenge',
+      );
+      throw new FaqBotUnavailableException('Anti-bot challenge unavailable');
+    }
     return this.botCheck.issueChallenge();
   }
 


### PR DESCRIPTION
## Summary

Discovered on the first post-H3 prod deploy: with no `ALTCHA_HMAC_KEY` secret set, `GET /faq-bot/challenge` returned an **unhandled 500** — altcha-lib rejects a zero-length `hmacKey` (`DataError: Zero-length key is not supported`) inside `issueChallenge`. The `BotCheckGuard` already fails closed (503) for *verification*; this PR mirrors it for *issuance*:

- `FaqBotService.issueChallenge()` — missing secret → logged error + `FaqBotUnavailableException` (503), the bot-check port is never called. Deliberately **independent of the dev/test bypass flag**: verification can be bypassed, but issuing a challenge is cryptographically impossible without a key in any environment (dev widget flow unaffected — it already treats the challenge as best-effort and the bypassed guard accepts an ask without proof).
- `faqBotConfig()` now **trims** `ALTCHA_HMAC_KEY` (review Should-Have): a whitespace-only secret (secrets-UI copy-paste slip) reads as missing and hits the fail-closed guards — in the service AND the guard — instead of the same opaque DataError.

Follow-up filed for the website widget's 400-vs-503 error-message gap surfaced by this incident: #1314.

## Checklist

- [x] Happy + sad + edge tests: service delegates with a secret / 503 without; config trims a padded secret / reads whitespace-only as missing — API 920 ✅
- [x] `npm run ci:all` green locally before push
- [x] Local pre-push review ritual: Claude 0 Must Have, both Should Haves addressed (config trim implemented, widget gap → issue #1314)

🤖 Generated with [Claude Code](https://claude.com/claude-code)