### PR TITLE
chore(mobile): drop the dead encyclopedia URL from EAS build profiles

### DIFF
--- a/packages/mobile-app/eas.json
+++ b/packages/mobile-app/eas.json
@@ -17,7 +17,6 @@
       },
       "env": {
         "EXPO_PUBLIC_API_URL": "https://brasse-bouillon-api.fly.dev",
-        "EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL": "https://brasse-bouillon-encyclopedia.fly.dev",
         "EXPO_PUBLIC_USE_DEMO_DATA": "false"
       }
     },
@@ -29,7 +28,6 @@
       },
       "env": {
         "EXPO_PUBLIC_API_URL": "https://brasse-bouillon-api.fly.dev",
-        "EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL": "https://brasse-bouillon-encyclopedia.fly.dev",
         "EXPO_PUBLIC_USE_DEMO_DATA": "true"
       }
     },


### PR DESCRIPTION
## Summary

The `brasse-bouillon-encyclopedia` Fly app was destroyed 2026-07-02, so `EXPO_PUBLIC_BEER_ENCYCLOPEDIA_URL` in the `preview` and `preview-demo` EAS profiles pointed at a dead host. Removing the var makes `env.encyclopediaUrlIsConfigured` false, so the encyclopedia consumers stop dialing a dead host.

**Behaviour per surface** (verified in the pre-push review):
- **beer-catalog**: fails fast with a clean « encyclopedia not configured » error (the Codex #871 guard).
- **scan**: the guard's 503 is caught and `scan-lookup` falls back to the legacy NestJS `/scan/lookup` path (pre-existing, #1186). So scan does **not** fail-fast — it degrades to the legacy resolver, or surfaces the generic « service indisponible » UI string if that also 503s.

The brew-day novice journey (the purpose of the upcoming `preview` re-test APK) has no encyclopedia dependency, so it is unaffected either way. Re-add a live URL here if the encyclopedia is ever redeployed.

## Checklist

- [x] `eas.json` valid JSON, both dead pointers removed
- [x] Config-only change; no code/logic surface
- [x] Pre-push review ritual run: 0 Must Have; per-surface behaviour corrected in the commit body (scan does not fail-fast — it falls back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)