### PR TITLE
fix(recipes): explain why a recipe used by a batch cannot be deleted

### DIFF
--- a/packages/api/src/recipe/recipe-steps.service.spec.ts
+++ b/packages/api/src/recipe/recipe-steps.service.spec.ts
@@ -164,7 +164,7 @@ describe('RecipeService (steps)', () => {
     expect(await stepRepo.count({ where: { recipe_id: recipe.id } })).toBe(0);
   });
 
-  it('deleteMine() should throw BadRequestException when recipe is referenced by a batch', async () => {
+  it('deleteMine() should throw BadRequestException with a structured errorCode when referenced by a batch', async () => {
     const ownerId = 'user-1';
     const recipe = await service.create(ownerId, { name: 'Protected recipe' });
 
@@ -173,11 +173,16 @@ describe('RecipeService (steps)', () => {
       [randomUUID(), recipe.id],
     );
 
-    await expect(service.deleteMine(ownerId, recipe.id)).rejects.toThrow(
-      new BadRequestException(
-        'Recipe cannot be deleted because it is referenced by at least one batch',
-      ),
-    );
+    const error = await service
+      .deleteMine(ownerId, recipe.id)
+      .then(() => null)
+      .catch((thrown: unknown) => thrown);
+
+    expect(error).toBeInstanceOf(BadRequestException);
+    // The errorCode lets the mobile client discriminate this from other 400s.
+    expect((error as BadRequestException).getResponse()).toMatchObject({
+      errorCode: 'RECIPE_REFERENCED_BY_BATCH',
+    });
   });
 
   it('updateMineStep() should reject negative order values', async () => {

--- a/packages/api/src/recipe/services/recipe.service.ts
+++ b/packages/api/src/recipe/services/recipe.service.ts
@@ -196,9 +196,14 @@ export class RecipeService {
           error instanceof QueryFailedError &&
           this.isForeignKeyViolation(error)
         ) {
-          throw new BadRequestException(
-            'Recipe cannot be deleted because it is referenced by at least one batch',
-          );
+          // Structured errorCode (mirrors NotABeerException) so the mobile
+          // client discriminates this from other 400s (e.g. a malformed-id
+          // ParseUUIDPipe rejection) and shows the right message.
+          throw new BadRequestException({
+            message:
+              'Recipe cannot be deleted because it is referenced by at least one batch',
+            errorCode: 'RECIPE_REFERENCED_BY_BATCH',
+          });
         }
         throw error;
       }

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -82,7 +82,9 @@ const DEFAULT_TARGET_VOLUME_LITRES = 20;
  * NOT_A_BEER guard). The filter spreads the errorCode to the top level of
  * the response body, which `http-client` stores on `HttpError.details`.
  */
-function isRecipeReferencedByBatch(details: unknown): boolean {
+function isRecipeReferencedByBatch(
+  details: unknown,
+): details is { errorCode: "RECIPE_REFERENCED_BY_BATCH" } {
   return (
     typeof details === "object" &&
     details !== null &&

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -10,7 +10,7 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 import { colors, spacing } from "@/core/theme";
-import { getErrorMessage } from "@/core/http/http-error";
+import { getErrorMessage, HttpError } from "@/core/http/http-error";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 
 import {
@@ -75,6 +75,22 @@ const DEFAULT_NON_PUBLIC_WATER_PREFERENCE: NonPublicWaterPreference =
   NON_PUBLIC_WATER_PREFERENCE_OPTIONS[0]?.id ?? "style";
 
 const DEFAULT_TARGET_VOLUME_LITRES = 20;
+
+/**
+ * Type guard for the DELETE /recipes/:id 400 body carrying the
+ * `RECIPE_REFERENCED_BY_BATCH` errorCode (mirrors the scan flow's
+ * NOT_A_BEER guard). The filter spreads the errorCode to the top level of
+ * the response body, which `http-client` stores on `HttpError.details`.
+ */
+function isRecipeReferencedByBatch(details: unknown): boolean {
+  return (
+    typeof details === "object" &&
+    details !== null &&
+    "errorCode" in details &&
+    (details as { errorCode: unknown }).errorCode ===
+      "RECIPE_REFERENCED_BY_BATCH"
+  );
+}
 
 /**
  * Redesigned recipe detail screen — Issue #740 Round 4 v2.
@@ -366,10 +382,19 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
       void queryClient.invalidateQueries({ queryKey: ["recipes", "catalog"] });
       router.replace("/recipes");
     },
-    onError: () => {
+    onError: (error) => {
+      // The API returns 400 with errorCode RECIPE_REFERENCED_BY_BATCH when a
+      // batch still references this recipe (its journal points at it). Key off
+      // the errorCode, NOT the status alone — a malformed id also 400s via
+      // ParseUUIDPipe. Tell the brewer the real reason: the generic « connexion »
+      // copy sent them retrying in vain (live-test point).
+      const isReferencedByBatch =
+        error instanceof HttpError && isRecipeReferencedByBatch(error.details);
       Alert.alert(
         "Suppression impossible",
-        "La recette n'a pas pu être supprimée. Vérifie ta connexion et réessaie.",
+        isReferencedByBatch
+          ? "Cette recette est utilisée par un brassin. Tu ne peux pas la supprimer tant que ce brassin existe : supprime ou archive d'abord le brassin correspondant dans « Mes brassins »."
+          : "La recette n'a pas pu être supprimée. Vérifie ta connexion et réessaie.",
       );
     },
   });

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -395,7 +395,7 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
       Alert.alert(
         "Suppression impossible",
         isReferencedByBatch
-          ? "Cette recette est utilisée par un brassin. Tu ne peux pas la supprimer tant que ce brassin existe : supprime ou archive d'abord le brassin correspondant dans « Mes brassins »."
+          ? "Cette recette est utilisée par un brassin. Tu ne peux pas la supprimer tant que ce brassin existe : supprime d'abord le brassin correspondant dans « Mes brassins »."
           : "La recette n'a pas pu être supprimée. Vérifie ta connexion et réessaie.",
       );
     },

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@testing-library/react-native";
 
 import { RecipeDetailsScreen } from "@/features/recipes/presentation/RecipeDetailsScreen";
+import { HttpError } from "@/core/http/http-error";
 import {
   deleteRecipeFromCarnet,
   getRecipeDetailsViewModel,
@@ -280,7 +281,7 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     expect(screen.queryByLabelText("Supprimer cette recette")).toBeNull();
   });
 
-  it("F24: surfaces an alert and does not navigate when the delete fails (sad path)", async () => {
+  it("F24: surfaces the generic error and does not navigate when the delete fails (sad path)", async () => {
     (deleteRecipeFromCarnet as jest.Mock).mockRejectedValueOnce(
       new Error("boom"),
     );
@@ -294,9 +295,53 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
     buttons.find((button) => button.text === "Supprimer")?.onPress?.();
 
-    // The failure surfaces a second alert and never navigates away.
+    // A non-HTTP failure surfaces the generic connection message and never
+    // navigates away.
     await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(2));
+    expect(alertSpy.mock.calls[1][1]).toMatch(/Vérifie ta connexion/);
     expect(mockReplace).not.toHaveBeenCalledWith("/recipes");
+  });
+
+  it("F24: explains the real reason when a batch still references the recipe (400 errorCode, edge)", async () => {
+    // The API returns 400 + errorCode RECIPE_REFERENCED_BY_BATCH when a batch's
+    // journal points at this recipe. The brewer must see that reason, not the
+    // misleading « connexion » copy.
+    (deleteRecipeFromCarnet as jest.Mock).mockRejectedValueOnce(
+      new HttpError(400, "referenced by at least one batch", {
+        errorCode: "RECIPE_REFERENCED_BY_BATCH",
+      }),
+    );
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    fireEvent.press(screen.getByLabelText("Supprimer cette recette"));
+
+    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
+    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(2));
+    expect(alertSpy.mock.calls[1][1]).toMatch(/utilisée par un brassin/);
+    expect(mockReplace).not.toHaveBeenCalledWith("/recipes");
+  });
+
+  it("F24: keeps the generic message for an unrelated 400, e.g. a malformed id (edge)", async () => {
+    // A ParseUUIDPipe rejection is also a 400 but carries no errorCode — it
+    // must NOT masquerade as « utilisée par un brassin ».
+    (deleteRecipeFromCarnet as jest.Mock).mockRejectedValueOnce(
+      new HttpError(400, "Validation failed (uuid is expected)"),
+    );
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+    fireEvent.press(screen.getByLabelText("Supprimer cette recette"));
+
+    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
+    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(2));
+    expect(alertSpy.mock.calls[1][1]).toMatch(/Vérifie ta connexion/);
   });
 
   it("switches to the Ingredients tab and shows the ingredient list", async () => {


### PR DESCRIPTION
## Summary

Live-test blocking point (screen-by-screen review): deleting a recipe still referenced by a batch showed a **misleading** « La recette n'a pas pu être supprimée. Vérifie ta connexion et réessaie. », so the brewer kept retrying a non-connection fault. The API already rejects it correctly with 400; the mobile `onError` ignored the reason.

- **Backend**: the FK-violation `BadRequestException` now carries a structured `errorCode: 'RECIPE_REFERENCED_BY_BATCH'` (mirrors `NotABeerException`), so the client can discriminate it from **other** 400s — notably a malformed-id `ParseUUIDPipe` rejection.
- **Mobile**: the delete `onError` keys off that errorCode (not the bare status) and shows a clear pedagogical message (« Cette recette est utilisée par un brassin… supprime ou archive d'abord le brassin »); every other failure keeps the generic connection copy. Behaviour unchanged (still blocked) — only the message is honest.

Kept the "explain, still block" fix over the bigger "allow deletion by unlinking the batch" product change (out of scope, would need its own conception).

## Checklist

- [x] Happy/sad/edge: backend asserts the structured errorCode; mobile covers generic non-HTTP failure, the errorCode 400 (specific message), and an unrelated 400 without errorCode (stays generic)
- [x] `npm run ci:all` green locally; API 920, mobile 1179
- [x] Pre-push review ritual: 0 Must Have (the status-only ambiguity Must Have from round 1 resolved via the errorCode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)