### PR TITLE
feat(ui): branded ConfirmDialog + useConfirm hook (replaces native Alert)

### DIFF
--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -2,6 +2,7 @@ import "react-native-reanimated";
 
 import { AuthProvider, useAuth } from "@/core/auth/auth-context";
 
+import { ConfirmProvider } from "@/core/ui/confirm-provider";
 import { QueryProvider } from "@/core/query/query-provider";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Stack } from "expo-router";
@@ -13,8 +14,10 @@ function AppShell() {
 
   return (
     <QueryProvider key={queryScopeKey}>
-      <Stack screenOptions={{ headerShown: false }} />
-      <StatusBar style="auto" />
+      <ConfirmProvider>
+        <Stack screenOptions={{ headerShown: false }} />
+        <StatusBar style="auto" />
+      </ConfirmProvider>
     </QueryProvider>
   );
 }

--- a/packages/mobile-app/src/core/ui/ConfirmDialog.tsx
+++ b/packages/mobile-app/src/core/ui/ConfirmDialog.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+
+import { colors, radius, shadows, spacing, typography } from "@/core/theme";
+
+export type ConfirmDialogProps = Readonly<{
+  visible: boolean;
+  title: string;
+  message?: string | null;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Red confirm button for irreversible/destructive actions (delete, cancel a brew…). */
+  destructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}>;
+
+/**
+ * Branded, in-app confirmation dialog — the house replacement for the OS-native
+ * `Alert.alert()` (which is unstylable and ignores the app's charte). Mirrors the
+ * existing tip-modal look (scrim + white rounded card). Driven declaratively;
+ * screens reach it imperatively through `useConfirm()` (see `confirm-provider`).
+ */
+export function ConfirmDialog({
+  visible,
+  title,
+  message,
+  confirmLabel = "Confirmer",
+  cancelLabel = "Annuler",
+  destructive = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onCancel}
+    >
+      <Pressable
+        style={styles.backdrop}
+        onPress={onCancel}
+        accessibilityRole="button"
+        accessibilityLabel="Fermer"
+      >
+        {/* Capture touches so a tap inside the card doesn't bubble to the
+            backdrop and dismiss the dialog (same guard as the tip modal). */}
+        <View style={styles.card} onStartShouldSetResponder={() => true}>
+          <Text style={styles.title}>{title}</Text>
+          {message ? <Text style={styles.message}>{message}</Text> : null}
+
+          <View style={styles.actions}>
+            <Pressable
+              style={styles.cancelButton}
+              onPress={onCancel}
+              accessibilityRole="button"
+              accessibilityLabel={cancelLabel}
+            >
+              <Text style={styles.cancelText}>{cancelLabel}</Text>
+            </Pressable>
+            <Pressable
+              style={[
+                styles.confirmButton,
+                destructive && styles.confirmButtonDestructive,
+              ]}
+              onPress={onConfirm}
+              accessibilityRole="button"
+              accessibilityLabel={confirmLabel}
+            >
+              <Text style={styles.confirmText}>{confirmLabel}</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: colors.overlay.scrim,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: spacing.lg,
+  },
+  card: {
+    backgroundColor: colors.neutral.white,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    width: "100%",
+    maxWidth: 420,
+    ...shadows.sm,
+  },
+  title: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+  },
+  message: {
+    marginTop: spacing.xs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+  },
+  actions: {
+    marginTop: spacing.lg,
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  cancelButton: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+  },
+  cancelText: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+  },
+  confirmButton: {
+    backgroundColor: colors.brand.primary,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+  },
+  confirmButtonDestructive: {
+    backgroundColor: colors.semantic.error,
+  },
+  confirmText: {
+    color: colors.neutral.white,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+  },
+});

--- a/packages/mobile-app/src/core/ui/__tests__/confirm-provider.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/confirm-provider.test.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { Text, Pressable } from "react-native";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+
+import { ConfirmProvider, useConfirm } from "@/core/ui/confirm-provider";
+
+// A tiny harness that calls confirm() and records the resolved value.
+function Harness({
+  options,
+  onResult,
+}: {
+  options: Parameters<ReturnType<typeof useConfirm>>[0];
+  onResult: (value: boolean) => void;
+}) {
+  const confirm = useConfirm();
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="ask"
+      onPress={() => {
+        void confirm(options).then(onResult);
+      }}
+    >
+      <Text>ask</Text>
+    </Pressable>
+  );
+}
+
+describe("ConfirmProvider / useConfirm", () => {
+  it("shows the branded dialog and resolves true on confirm (happy)", async () => {
+    const onResult = jest.fn();
+    render(
+      <ConfirmProvider>
+        <Harness
+          options={{
+            title: "Lancer le brassage ?",
+            message: "Action irréversible.",
+            confirmLabel: "Lancer",
+          }}
+          onResult={onResult}
+        />
+      </ConfirmProvider>,
+    );
+
+    fireEvent.press(screen.getByLabelText("ask"));
+
+    expect(await screen.findByText("Lancer le brassage ?")).toBeTruthy();
+    expect(screen.getByText("Action irréversible.")).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText("Lancer"));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(true));
+    // Dialog is dismissed after the choice.
+    expect(screen.queryByText("Lancer le brassage ?")).toBeNull();
+  });
+
+  it("resolves false on cancel (sad)", async () => {
+    const onResult = jest.fn();
+    render(
+      <ConfirmProvider>
+        <Harness
+          options={{ title: "Supprimer ?", confirmLabel: "Supprimer" }}
+          onResult={onResult}
+        />
+      </ConfirmProvider>,
+    );
+
+    fireEvent.press(screen.getByLabelText("ask"));
+    await screen.findByText("Supprimer ?");
+    fireEvent.press(screen.getByLabelText("Annuler"));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(false));
+  });
+
+  it("settles the pending promise as declined when a second confirm opens (edge: re-entrancy)", async () => {
+    const first = jest.fn();
+    const second = jest.fn();
+
+    function TwoAsks() {
+      const confirm = useConfirm();
+      return (
+        <>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="ask-1"
+            onPress={() => void confirm({ title: "Premier ?" }).then(first)}
+          >
+            <Text>ask-1</Text>
+          </Pressable>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="ask-2"
+            onPress={() =>
+              void confirm({ title: "Second ?", confirmLabel: "OK" }).then(
+                second,
+              )
+            }
+          >
+            <Text>ask-2</Text>
+          </Pressable>
+        </>
+      );
+    }
+
+    render(
+      <ConfirmProvider>
+        <TwoAsks />
+      </ConfirmProvider>,
+    );
+
+    fireEvent.press(screen.getByLabelText("ask-1"));
+    await screen.findByText("Premier ?");
+    // Second request while the first dialog is open: the first promise must
+    // resolve (declined), never hang, and the dialog switches to the second.
+    fireEvent.press(screen.getByLabelText("ask-2"));
+
+    await waitFor(() => expect(first).toHaveBeenCalledWith(false));
+    expect(await screen.findByText("Second ?")).toBeTruthy();
+    expect(screen.queryByText("Premier ?")).toBeNull();
+
+    fireEvent.press(screen.getByLabelText("OK"));
+    await waitFor(() => expect(second).toHaveBeenCalledWith(true));
+  });
+
+  it("throws when useConfirm is used outside a ConfirmProvider (edge)", () => {
+    const Bare = () => {
+      useConfirm();
+      return null;
+    };
+    // Silence the expected React error boundary log for this render.
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<Bare />)).toThrow(/ConfirmProvider/);
+    spy.mockRestore();
+  });
+});

--- a/packages/mobile-app/src/core/ui/__tests__/confirm-provider.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/confirm-provider.test.tsx
@@ -127,6 +127,24 @@ describe("ConfirmProvider / useConfirm", () => {
     await waitFor(() => expect(second).toHaveBeenCalledWith(true));
   });
 
+  it("resolves a pending promise as declined when the provider unmounts (edge)", async () => {
+    const onResult = jest.fn();
+    const { unmount } = render(
+      <ConfirmProvider>
+        <Harness options={{ title: "Encore ouvert ?" }} onResult={onResult} />
+      </ConfirmProvider>,
+    );
+
+    fireEvent.press(screen.getByLabelText("ask"));
+    await screen.findByText("Encore ouvert ?");
+
+    // Tearing down the provider (e.g. logout / root remount) must not leave an
+    // awaiting caller hanging forever.
+    unmount();
+
+    await waitFor(() => expect(onResult).toHaveBeenCalledWith(false));
+  });
+
   it("throws when useConfirm is used outside a ConfirmProvider (edge)", () => {
     const Bare = () => {
       useConfirm();

--- a/packages/mobile-app/src/core/ui/confirm-provider.tsx
+++ b/packages/mobile-app/src/core/ui/confirm-provider.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+
+import { ConfirmDialog } from "@/core/ui/ConfirmDialog";
+
+export type ConfirmOptions = Readonly<{
+  title: string;
+  message?: string | null;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+}>;
+
+type ConfirmFn = (options: ConfirmOptions) => Promise<boolean>;
+
+const ConfirmContext = React.createContext<ConfirmFn | null>(null);
+
+/**
+ * Hosts the single branded confirmation dialog and exposes an imperative
+ * `confirm()` that resolves to the user's choice — so call sites migrate from
+ * `Alert.alert(title, msg, [cancel, confirm])` to
+ * `if (await confirm({ … })) { … }` with minimal churn, while the UI stays on
+ * the app's charte. Mounted once near the app root.
+ */
+export function ConfirmProvider({ children }: { children: React.ReactNode }) {
+  const [options, setOptions] = React.useState<ConfirmOptions | null>(null);
+  const resolverRef = React.useRef<((value: boolean) => void) | null>(null);
+
+  const confirm = React.useCallback<ConfirmFn>((opts) => {
+    return new Promise<boolean>((resolve) => {
+      // Re-entrancy: if a dialog is already pending, settle its promise as
+      // declined before replacing it — never leak the previous caller's
+      // promise (a double-tap or two racing flows would otherwise hang).
+      resolverRef.current?.(false);
+      resolverRef.current = resolve;
+      setOptions(opts);
+    });
+  }, []);
+
+  const settle = React.useCallback((value: boolean) => {
+    setOptions(null);
+    const resolve = resolverRef.current;
+    resolverRef.current = null;
+    resolve?.(value);
+  }, []);
+
+  // Resolve any still-pending promise as declined if the provider unmounts,
+  // so a caller awaiting confirm() never hangs forever.
+  React.useEffect(() => {
+    return () => {
+      resolverRef.current?.(false);
+      resolverRef.current = null;
+    };
+  }, []);
+
+  return (
+    <ConfirmContext.Provider value={confirm}>
+      {children}
+      <ConfirmDialog
+        visible={options !== null}
+        title={options?.title ?? ""}
+        message={options?.message}
+        confirmLabel={options?.confirmLabel}
+        cancelLabel={options?.cancelLabel}
+        destructive={options?.destructive}
+        onConfirm={() => settle(true)}
+        onCancel={() => settle(false)}
+      />
+    </ConfirmContext.Provider>
+  );
+}
+
+/**
+ * Imperative confirmation: `const confirm = useConfirm(); if (await confirm({…}))`.
+ * Throws if used outside a `ConfirmProvider` (a wiring bug, caught in dev/tests).
+ */
+export function useConfirm(): ConfirmFn {
+  const confirm = React.useContext(ConfirmContext);
+  if (!confirm) {
+    throw new Error("useConfirm must be used within a ConfirmProvider");
+  }
+  return confirm;
+}

--- a/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
@@ -331,7 +331,7 @@ export function BrewPrepScreen({ recipeId }: Props) {
       <RecipeStickyCta
         label={ctaLabel}
         helperText={ctaHelper}
-        onPress={handleLaunch}
+        onPress={() => void handleLaunch()}
         disabled={
           !complete || isStarting || isSavingChecklist || !viewModel || !draft
         }

--- a/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { colors, spacing, typography } from "@/core/theme";
 import { getErrorMessage } from "@/core/http/http-error";
+import { useConfirm } from "@/core/ui/confirm-provider";
 import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
 import { ChecklistRow } from "@/core/ui/ChecklistRow";
@@ -53,6 +54,7 @@ type Props = Readonly<{ recipeId: string }>;
  */
 export function BrewPrepScreen({ recipeId }: Props) {
   const router = useRouter();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const footerOffset = useNavigationFooterOffset();
   const hasRecipeId = recipeId.trim().length > 0;
@@ -193,22 +195,19 @@ export function BrewPrepScreen({ recipeId }: Props) {
   // The launch is irreversible (phase B = point of no return), so it is
   // gated twice: the CTA is disabled until the checklist is complete AND
   // persisted, and a final confirmation dialog guards the batch creation.
-  const handleLaunch = () => {
+  const handleLaunch = async () => {
     if (!complete || isStarting || isSavingChecklist || !draft) {
       return;
     }
-    Alert.alert(
-      "Lancer le brassage ?",
-      "Cette action démarre le suivi du brassin et n'est pas réversible.",
-      [
-        { text: "Annuler", style: "cancel" },
-        {
-          text: "Lancer",
-          style: "default",
-          onPress: () => launchMutation.mutate(draft.id),
-        },
-      ],
-    );
+    const confirmed = await confirm({
+      title: "Lancer le brassage ?",
+      message:
+        "Cette action démarre le suivi du brassin et n'est pas réversible.",
+      confirmLabel: "Lancer",
+    });
+    if (confirmed) {
+      launchMutation.mutate(draft.id);
+    }
   };
 
   const handleRetry = () => {

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
@@ -11,6 +11,7 @@ import React from "react";
 import { Alert } from "react-native";
 
 import { BrewPrepScreen } from "@/features/recipes/presentation/BrewPrepScreen";
+import { ConfirmProvider } from "@/core/ui/confirm-provider";
 import {
   getRecipeDetailsViewModel,
   type RecipeDetailsIngredientItem,
@@ -125,7 +126,9 @@ function renderScreen(recipeId = "r1") {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <BrewPrepScreen recipeId={recipeId} />
+      <ConfirmProvider>
+        <BrewPrepScreen recipeId={recipeId} />
+      </ConfirmProvider>
     </QueryClientProvider>,
   );
 }
@@ -134,15 +137,10 @@ function tickAll() {
   screen.getAllByRole("checkbox").forEach((box) => fireEvent.press(box));
 }
 
-// The launch confirmation is a native Alert; grab the "Lancer" button from the
-// last Alert.alert call and invoke its onPress to simulate the user confirming.
-function confirmLaunchAlert() {
-  const calls = (Alert.alert as jest.Mock).mock.calls;
-  const buttons = calls[calls.length - 1][2] as Array<{
-    text: string;
-    onPress?: () => void;
-  }>;
-  buttons.find((button) => button.text === "Lancer")?.onPress?.();
+// The launch confirmation is the branded in-app ConfirmDialog; press its
+// « Lancer » button (accessibilityLabel) to simulate the user confirming.
+async function confirmLaunch() {
+  fireEvent.press(await screen.findByLabelText("Lancer"));
 }
 
 describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
@@ -174,7 +172,7 @@ describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
 
     // Gate closed: pressing the disabled CTA must not open the dialog.
     fireEvent.press(screen.getByText("Lancer le brassage"));
-    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(screen.queryByText("Lancer le brassage ?")).toBeNull();
     expect(mockLaunchBatch).not.toHaveBeenCalled();
   });
 
@@ -307,11 +305,9 @@ describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
     );
     await act(async () => {});
     fireEvent.press(screen.getByText("Lancer le brassage"));
-    expect(Alert.alert).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Lancer le brassage ?")).toBeTruthy();
 
-    await act(async () => {
-      confirmLaunchAlert();
-    });
+    await confirmLaunch();
 
     await waitFor(() => {
       expect(mockLaunchBatch).toHaveBeenCalledWith("draft-1");
@@ -336,9 +332,7 @@ describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
     );
     await act(async () => {});
     fireEvent.press(screen.getByText("Lancer le brassage"));
-    await act(async () => {
-      confirmLaunchAlert();
-    });
+    await confirmLaunch();
 
     expect(await screen.findByText(/Backend down/i)).toBeTruthy();
     expect(mockPush).not.toHaveBeenCalled();
@@ -365,10 +359,8 @@ describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
 
     // Nothing to check → the gate is vacuously open and the launch proceeds.
     fireEvent.press(screen.getByText("Lancer le brassage"));
-    expect(Alert.alert).toHaveBeenCalledTimes(1);
-    await act(async () => {
-      confirmLaunchAlert();
-    });
+    expect(await screen.findByText("Lancer le brassage ?")).toBeTruthy();
+    await confirmLaunch();
     await waitFor(() => {
       expect(mockLaunchBatch).toHaveBeenCalledWith("draft-1");
       expect(mockPush).toHaveBeenCalledWith("/(app)/batches/b1");
@@ -401,12 +393,12 @@ describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
     // the in-flight PATCH gets rejected ("already launched") — so the CTA
     // must stay inert until the save settles.
     fireEvent.press(screen.getByText("Lancer le brassage"));
-    expect(Alert.alert).not.toHaveBeenCalled();
+    expect(screen.queryByText("Lancer le brassage ?")).toBeNull();
 
     resolveSave();
     await waitFor(() => {
       fireEvent.press(screen.getByText("Lancer le brassage"));
-      expect(Alert.alert).toHaveBeenCalled();
+      expect(screen.getByText("Lancer le brassage ?")).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
## Summary

Live-review point (« le pop-up est dégueulasse ») : the app's confirmation dialogs used React Native's `Alert.alert()`, which renders the **unstylable OS-native dialog** — off-brand (grey, teal system buttons), ignoring the app's charte.

This adds a house replacement:
- **`ConfirmDialog`** (`core/ui`) — a branded modal (scrim + white rounded card, brand buttons, red **destructive** variant), mirroring the existing tip-modal look.
- **`ConfirmProvider` + `useConfirm()`** (`core/ui/confirm-provider`) — a single dialog mounted at the app root, reached imperatively: call sites move from `Alert.alert(title, msg, [cancel, confirm])` to `if (await confirm({…})) {…}`.

**First migration**: `BrewPrepScreen` « Lancer le brassage ? » (the exact screen from the screenshot). The **remaining confirmations** (delete recipe/batch, cancel, archive, equipment delete, scan) migrate in follow-ups tracked by #1324 — all before the next APK build. Single-button info/error alerts are intentionally left as-is (separate concern).

## Review hardening (pre-push)

- **Re-entrancy** fixed: a second `confirm()` while a dialog is open now settles the first promise as declined (never leaks/hangs) + covered by a test.
- **Unmount-while-pending**: pending promise resolved as declined on provider unmount.
- Backdrop `accessibilityRole="button"` added.

## Checklist

- [x] Happy/sad/edge tests: provider (confirm / cancel / re-entrancy / used-outside-provider), BrewPrepScreen launch flow rewired to the dialog
- [x] `npm run ci:all` green locally; mobile 1183 tests
- [x] No `any`, named exports, theme tokens + StyleSheet.create, no inline styles
- [x] Pre-push review ritual: 0 Must Have (2 Should Have addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
