### PR TITLE
refactor(mobile): migrate remaining native confirmations to the branded ConfirmDialog (#1324)

### DIFF
--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -1,5 +1,4 @@
 import {
-  Alert,
   Modal,
   Pressable,
   ScrollView,
@@ -37,6 +36,7 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { Ionicons } from "@expo/vector-icons";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { useConfirm } from "@/core/ui/confirm-provider";
 // Reused sticky-CTA bar (same pattern as BrewPrepScreen). Generic despite the
 // « Recipe » name — a promotion to core/ui is a sensible follow-up.
 import { RecipeStickyCta } from "@/features/recipes/presentation/components/RecipeStickyCta";
@@ -161,6 +161,7 @@ function useFermentationTrackerInfo(batch: Batch | null) {
 export function BatchDetailsScreen({ batchId }: Props) {
   const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
+  const confirm = useConfirm();
   const queryClient = useQueryClient();
   const [mutationError, setMutationError] = React.useState<string | null>(null);
   const missingBatchId = !batchId;
@@ -316,7 +317,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
     }
   };
 
-  const handleComplete = () => {
+  const handleComplete = async () => {
     if (missingBatchId) {
       return;
     }
@@ -324,21 +325,16 @@ export function BatchDetailsScreen({ batchId }: Props) {
     // the next step and is not undoable, so gate it behind an acknowledgment
     // (the ✋ pattern already used on the bottling step) instead of firing on
     // a single tap.
-    Alert.alert(
-      "Terminer cette étape ?",
-      "Tu confirmes avoir terminé l'étape en cours ? L'étape suivante démarrera.",
-      [
-        { text: "Annuler", style: "cancel" },
-        {
-          text: "Terminer",
-          style: "default",
-          onPress: () => {
-            setMutationError(null);
-            mutateCompleteCurrentStep();
-          },
-        },
-      ],
-    );
+    const confirmed = await confirm({
+      title: "Terminer cette étape ?",
+      message:
+        "Tu confirmes avoir terminé l'étape en cours ? L'étape suivante démarrera.",
+      confirmLabel: "Terminer",
+    });
+    if (confirmed) {
+      setMutationError(null);
+      mutateCompleteCurrentStep();
+    }
   };
 
   const handleStart = () => {
@@ -356,73 +352,62 @@ export function BatchDetailsScreen({ batchId }: Props) {
     router.replace("/batches");
   };
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (missingBatchId) {
       return;
     }
     // F25 — destructive + irreversible, so gate it behind a confirm (recovers
     // an accidental/phantom batch). Cancel (F16) and archive (F25) are the soft
     // alternatives that keep the journal (see handleCancel / handleArchive).
-    Alert.alert(
-      "Supprimer ce brassin ?",
-      "Il sera définitivement retiré de tes brassins. Cette action est irréversible.",
-      [
-        { text: "Annuler", style: "cancel" },
-        {
-          text: "Supprimer",
-          style: "destructive",
-          onPress: () => {
-            setMutationError(null);
-            mutateDeleteBatch();
-          },
-        },
-      ],
-    );
+    const confirmed = await confirm({
+      title: "Supprimer ce brassin ?",
+      message:
+        "Il sera définitivement retiré de tes brassins. Cette action est irréversible.",
+      confirmLabel: "Supprimer",
+      destructive: true,
+    });
+    if (confirmed) {
+      setMutationError(null);
+      mutateDeleteBatch();
+    }
   };
 
-  const handleCancel = () => {
+  const handleCancel = async () => {
     if (missingBatchId) {
       return;
     }
     // F16 — stop a launched brew. Soft (keeps the journal), so a confirm is
     // enough; it is not the irreversible delete.
-    Alert.alert(
-      "Annuler ce brassin ?",
-      "Le brassin sera arrêté et retiré de tes brassins actifs, mais son journal est conservé.",
-      [
-        { text: "Retour", style: "cancel" },
-        {
-          text: "Annuler le brassin",
-          style: "destructive",
-          onPress: () => {
-            setMutationError(null);
-            mutateCancelBatch();
-          },
-        },
-      ],
-    );
+    const confirmed = await confirm({
+      title: "Annuler ce brassin ?",
+      message:
+        "Le brassin sera arrêté et retiré de tes brassins actifs, mais son journal est conservé.",
+      confirmLabel: "Annuler le brassin",
+      cancelLabel: "Retour",
+      destructive: true,
+    });
+    if (confirmed) {
+      setMutationError(null);
+      mutateCancelBatch();
+    }
   };
 
-  const handleArchive = () => {
+  const handleArchive = async () => {
     if (missingBatchId) {
       return;
     }
     // F25 — declutter: soft-hide a finished brew; its journal is kept.
-    Alert.alert(
-      "Archiver ce brassin ?",
-      "Il sera retiré de tes brassins actifs mais conservé dans ton historique.",
-      [
-        { text: "Retour", style: "cancel" },
-        {
-          text: "Archiver",
-          style: "default",
-          onPress: () => {
-            setMutationError(null);
-            mutateArchiveBatch();
-          },
-        },
-      ],
-    );
+    const confirmed = await confirm({
+      title: "Archiver ce brassin ?",
+      message:
+        "Il sera retiré de tes brassins actifs mais conservé dans ton historique.",
+      confirmLabel: "Archiver",
+      cancelLabel: "Retour",
+    });
+    if (confirmed) {
+      setMutationError(null);
+      mutateArchiveBatch();
+    }
   };
 
   const handleRecordMeasurement = () => {
@@ -545,7 +530,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
       : !isCompletedLive
         ? {
             label: completeButtonLabel,
-            onPress: handleComplete,
+            onPress: () => void handleComplete(),
             disabled: isCompleting || isCompleted || isLoading,
           }
         : null;
@@ -567,7 +552,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
             />
             {batch ? (
               <Pressable
-                onPress={handleDelete}
+                onPress={() => void handleDelete()}
                 disabled={isDeleting}
                 accessibilityRole="button"
                 accessibilityLabel="Supprimer ce brassin"
@@ -831,7 +816,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Annuler ce brassin"
-              onPress={handleCancel}
+              onPress={() => void handleCancel()}
               disabled={isCancelling}
               style={styles.softAction}
             >
@@ -845,7 +830,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="Archiver ce brassin"
-              onPress={handleArchive}
+              onPress={() => void handleArchive()}
               disabled={isArchiving}
               style={styles.softAction}
             >

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -500,6 +500,18 @@ describe("BatchDetailsScreen", () => {
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/batches"));
   });
 
+  it("surfaces an error and does not navigate when the batch cancel fails (F16, sad)", async () => {
+    (cancelBatch as jest.Mock).mockRejectedValueOnce(new Error("boom-cancel"));
+    renderBatchDetailsScreen();
+
+    fireEvent.press(await screen.findByLabelText("Annuler ce brassin"));
+    await pressDialogButton("Annuler le brassin");
+
+    // onError surfaces the error's own message over the fallback copy.
+    expect(await screen.findByText("boom-cancel")).toBeTruthy();
+    expect(mockReplace).not.toHaveBeenCalledWith("/batches");
+  });
+
   it("archives a completed batch after confirmation and navigates back (F25)", async () => {
     (archiveBatch as jest.Mock).mockClear();
     (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
@@ -514,6 +526,23 @@ describe("BatchDetailsScreen", () => {
 
     await waitFor(() => expect(archiveBatch).toHaveBeenCalledWith("b1"));
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/batches"));
+  });
+
+  it("surfaces an error and does not navigate when the batch archive fails (F25, sad)", async () => {
+    (archiveBatch as jest.Mock).mockRejectedValueOnce(
+      new Error("boom-archive"),
+    );
+    (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
+      viewModel({ ...mashBatch, status: "completed" }, "Ma recette test"),
+    );
+    renderBatchDetailsScreen();
+
+    fireEvent.press(await screen.findByLabelText("Archiver ce brassin"));
+    await pressDialogButton("Archiver");
+
+    // onError surfaces the error's own message over the fallback copy.
+    expect(await screen.findByText("boom-archive")).toBeTruthy();
+    expect(mockReplace).not.toHaveBeenCalledWith("/batches");
   });
 
   it("renders French status, step index, badges and phase labels", async () => {

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -1,4 +1,4 @@
-import { Alert, type AlertButton } from "react-native";
+import { ConfirmProvider } from "@/core/ui/confirm-provider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   fireEvent,
@@ -132,9 +132,17 @@ function renderBatchDetailsScreen(batchId = "b1") {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <BatchDetailsScreen batchId={batchId} />
+      <ConfirmProvider>
+        <BatchDetailsScreen batchId={batchId} />
+      </ConfirmProvider>
     </QueryClientProvider>,
   );
+}
+
+// The batch confirmations are the branded in-app ConfirmDialog; press a button
+// by its accessibilityLabel to confirm or cancel.
+async function pressDialogButton(label: string) {
+  fireEvent.press(await screen.findByLabelText(label));
 }
 
 describe("BatchDetailsScreen", () => {
@@ -146,8 +154,8 @@ describe("BatchDetailsScreen", () => {
     );
   });
 
-  // Always restore jest.spyOn spies (e.g. the Alert.alert spy in the F6 tests)
-  // even when an assertion throws, so a spy can never leak into later tests.
+  // Always restore jest.spyOn spies even when an assertion throws, so a spy can
+  // never leak into later tests.
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -415,22 +423,17 @@ describe("BatchDetailsScreen", () => {
 
   it("confirms before completing a step, then completes on confirm (F6)", async () => {
     (completeCurrentBatchStep as jest.Mock).mockClear();
-    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     renderBatchDetailsScreen();
 
     fireEvent.press(await screen.findByText("Terminer l'étape en cours"));
 
-    // The tap opens a confirmation dialog rather than completing immediately.
-    expect(alertSpy).toHaveBeenCalledWith(
-      "Terminer cette étape ?",
-      expect.any(String),
-      expect.any(Array),
-    );
+    // The tap opens the branded confirmation dialog rather than completing
+    // immediately.
+    expect(await screen.findByText("Terminer cette étape ?")).toBeTruthy();
     expect(completeCurrentBatchStep).not.toHaveBeenCalled();
 
     // Confirming the dialog runs the completion.
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((button) => button.text === "Terminer")?.onPress?.();
+    await pressDialogButton("Terminer");
 
     await waitFor(() =>
       expect(completeCurrentBatchStep).toHaveBeenCalledTimes(1),
@@ -439,35 +442,32 @@ describe("BatchDetailsScreen", () => {
 
   it("does not complete the step when the confirmation is cancelled (F6, sad path)", async () => {
     (completeCurrentBatchStep as jest.Mock).mockClear();
-    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     renderBatchDetailsScreen();
 
     fireEvent.press(await screen.findByText("Terminer l'étape en cours"));
 
     // Opening the confirmation dialog must not complete anything on its own.
+    expect(await screen.findByText("Terminer cette étape ?")).toBeTruthy();
     expect(completeCurrentBatchStep).not.toHaveBeenCalled();
 
-    // "Annuler" is a pure native dismiss (no handler), so cancelling can never
-    // reach the completion mutation — assert it carries no onPress.
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    const cancelButton = buttons.find((button) => button.text === "Annuler");
-    expect(cancelButton).toBeDefined();
-    expect(cancelButton?.onPress).toBeUndefined();
+    // Cancelling via « Annuler » dismisses without reaching the completion.
+    await pressDialogButton("Annuler");
+
+    expect(completeCurrentBatchStep).not.toHaveBeenCalled();
   });
 
   it("deletes the batch after confirmation and navigates back (F25)", async () => {
     (deleteBatch as jest.Mock).mockClear();
-    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     renderBatchDetailsScreen();
 
     fireEvent.press(await screen.findByLabelText("Supprimer ce brassin"));
 
-    // The tap opens a confirmation dialog rather than deleting immediately.
-    expect(alertSpy).toHaveBeenCalled();
+    // The tap opens the branded confirmation dialog rather than deleting
+    // immediately.
+    expect(await screen.findByText("Supprimer ce brassin ?")).toBeTruthy();
     expect(deleteBatch).not.toHaveBeenCalled();
 
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+    await pressDialogButton("Supprimer");
 
     await waitFor(() => expect(deleteBatch).toHaveBeenCalledWith("b1"));
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/batches"));
@@ -475,12 +475,10 @@ describe("BatchDetailsScreen", () => {
 
   it("surfaces an error and does not navigate when the batch delete fails (F25, sad)", async () => {
     (deleteBatch as jest.Mock).mockRejectedValueOnce(new Error("boom"));
-    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     renderBatchDetailsScreen();
 
     fireEvent.press(await screen.findByLabelText("Supprimer ce brassin"));
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+    await pressDialogButton("Supprimer");
 
     // The onError sets the shared error banner; getErrorMessage surfaces the
     // error's own message ("boom") over the fallback copy.
@@ -490,15 +488,13 @@ describe("BatchDetailsScreen", () => {
 
   it("cancels an in-progress batch after confirmation and navigates back (F16)", async () => {
     (cancelBatch as jest.Mock).mockClear();
-    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     renderBatchDetailsScreen();
 
     // mashBatch is in_progress → the soft cancel action is offered.
     fireEvent.press(await screen.findByLabelText("Annuler ce brassin"));
     expect(cancelBatch).not.toHaveBeenCalled();
 
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((b) => b.text === "Annuler le brassin")?.onPress?.();
+    await pressDialogButton("Annuler le brassin");
 
     await waitFor(() => expect(cancelBatch).toHaveBeenCalledWith("b1"));
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/batches"));
@@ -509,14 +505,12 @@ describe("BatchDetailsScreen", () => {
     (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
       viewModel({ ...mashBatch, status: "completed" }, "Ma recette test"),
     );
-    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     renderBatchDetailsScreen();
 
     fireEvent.press(await screen.findByLabelText("Archiver ce brassin"));
     expect(archiveBatch).not.toHaveBeenCalled();
 
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((b) => b.text === "Archiver")?.onPress?.();
+    await pressDialogButton("Archiver");
 
     await waitFor(() => expect(archiveBatch).toHaveBeenCalledWith("b1"));
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/batches"));

--- a/packages/mobile-app/src/features/equipment/presentation/EquipmentDetailScreen.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/EquipmentDetailScreen.tsx
@@ -11,6 +11,7 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { useConfirm } from "@/core/ui/confirm-provider";
 
 import {
   deleteEquipmentProfile,
@@ -42,6 +43,7 @@ function DetailRow({ label, value }: { label: string; value: string }) {
 export function EquipmentDetailScreen({ profileId }: Props) {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const confirm = useConfirm();
 
   const {
     data: profile,
@@ -70,19 +72,16 @@ export function EquipmentDetailScreen({ profileId }: Props) {
 
   const goBack = () => router.replace("/equipment");
 
-  const confirmDelete = () => {
-    Alert.alert(
-      "Supprimer ce matériel ?",
-      "Il sera retiré de ton office. Cette action est irréversible.",
-      [
-        { text: "Annuler", style: "cancel" },
-        {
-          text: "Supprimer",
-          style: "destructive",
-          onPress: () => removeProfile(),
-        },
-      ],
-    );
+  const confirmDelete = async () => {
+    const confirmed = await confirm({
+      title: "Supprimer ce matériel ?",
+      message: "Il sera retiré de ton office. Cette action est irréversible.",
+      confirmLabel: "Supprimer",
+      destructive: true,
+    });
+    if (confirmed) {
+      removeProfile();
+    }
   };
 
   const header = (
@@ -149,7 +148,7 @@ export function EquipmentDetailScreen({ profileId }: Props) {
       <PrimaryButton
         testID="equipment-delete-cta"
         label="Supprimer ce matériel"
-        onPress={confirmDelete}
+        onPress={() => void confirmDelete()}
         disabled={isDeleting}
         style={styles.deleteCta}
       />

--- a/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentDetailScreen.test.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/__tests__/EquipmentDetailScreen.test.tsx
@@ -1,4 +1,4 @@
-import { Alert, type AlertButton } from "react-native";
+import { Alert } from "react-native";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   fireEvent,
@@ -9,6 +9,7 @@ import {
 
 import React from "react";
 import { EquipmentDetailScreen } from "@/features/equipment/presentation/EquipmentDetailScreen";
+import { ConfirmProvider } from "@/core/ui/confirm-provider";
 import { EquipmentProfile } from "@/features/equipment/domain/equipment.types";
 import {
   deleteEquipmentProfile,
@@ -80,9 +81,17 @@ function renderScreen(profileId = "eq-1") {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <EquipmentDetailScreen profileId={profileId} />
+      <ConfirmProvider>
+        <EquipmentDetailScreen profileId={profileId} />
+      </ConfirmProvider>
     </QueryClientProvider>,
   );
+}
+
+// The delete confirmation is the branded in-app ConfirmDialog; press its
+// « Supprimer » button (accessibilityLabel) to confirm the deletion.
+async function confirmDeleteInDialog() {
+  fireEvent.press(await screen.findByLabelText("Supprimer"));
 }
 
 describe("EquipmentDetailScreen", () => {
@@ -105,17 +114,16 @@ describe("EquipmentDetailScreen", () => {
   });
 
   it("deletes the profile after confirmation and navigates back (F22)", async () => {
-    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     renderScreen();
 
     fireEvent.press(await screen.findByTestId("equipment-delete-cta"));
 
-    // The tap opens a confirmation dialog rather than deleting immediately.
-    expect(alertSpy).toHaveBeenCalled();
+    // The tap opens the branded confirmation dialog rather than deleting
+    // immediately.
+    expect(await screen.findByText("Supprimer ce matériel ?")).toBeTruthy();
     expect(mockedDelete).not.toHaveBeenCalled();
 
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+    await confirmDeleteInDialog();
 
     await waitFor(() => expect(mockedDelete).toHaveBeenCalledWith("eq-1"));
     await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/equipment"));
@@ -134,9 +142,10 @@ describe("EquipmentDetailScreen", () => {
     renderScreen();
 
     fireEvent.press(await screen.findByTestId("equipment-delete-cta"));
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+    await confirmDeleteInDialog();
 
+    // The failure feedback still uses the native error Alert (not part of this
+    // migration).
     await waitFor(() =>
       expect(alertSpy).toHaveBeenCalledWith(
         "Suppression impossible",

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -12,6 +12,7 @@ import { Screen } from "@/core/ui/Screen";
 import { colors, spacing } from "@/core/theme";
 import { getErrorMessage, HttpError } from "@/core/http/http-error";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { useConfirm } from "@/core/ui/confirm-provider";
 
 import {
   RecipeDetailsViewModel,
@@ -110,6 +111,7 @@ function isRecipeReferencedByBatch(
  */
 export function RecipeDetailsScreen({ recipeId }: Props) {
   const router = useRouter();
+  const confirm = useConfirm();
   const bottomPadding = useNavigationFooterOffset();
   const queryClient = useQueryClient();
 
@@ -401,19 +403,17 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
     },
   });
 
-  const handleDelete = () => {
-    Alert.alert(
-      "Supprimer cette recette ?",
-      "Elle sera retirée de ton carnet. Cette action est irréversible.",
-      [
-        { text: "Annuler", style: "cancel" },
-        {
-          text: "Supprimer",
-          style: "destructive",
-          onPress: () => deleteMutation.mutate(),
-        },
-      ],
-    );
+  const handleDelete = async () => {
+    const confirmed = await confirm({
+      title: "Supprimer cette recette ?",
+      message:
+        "Elle sera retirée de ton carnet. Cette action est irréversible.",
+      confirmLabel: "Supprimer",
+      destructive: true,
+    });
+    if (confirmed) {
+      deleteMutation.mutate();
+    }
   };
 
   const ctaLabel = "Préparer mon brassin";
@@ -461,7 +461,7 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
               />
               {isOwned ? (
                 <Pressable
-                  onPress={handleDelete}
+                  onPress={() => void handleDelete()}
                   disabled={deleteMutation.isPending}
                   accessibilityRole="button"
                   accessibilityLabel="Supprimer cette recette"

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Alert, type AlertButton } from "react-native";
+import { Alert } from "react-native";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   fireEvent,
@@ -9,6 +9,7 @@ import {
 } from "@testing-library/react-native";
 
 import { RecipeDetailsScreen } from "@/features/recipes/presentation/RecipeDetailsScreen";
+import { ConfirmProvider } from "@/core/ui/confirm-provider";
 import { HttpError } from "@/core/http/http-error";
 import {
   deleteRecipeFromCarnet,
@@ -160,13 +161,21 @@ function renderRecipeDetails(recipeId = "r1") {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <RecipeDetailsScreen recipeId={recipeId} />
+      <ConfirmProvider>
+        <RecipeDetailsScreen recipeId={recipeId} />
+      </ConfirmProvider>
     </QueryClientProvider>,
   );
 }
 
 function switchToTab(tabId: string) {
   fireEvent.press(screen.getByTestId(`recipe-detail-tab-${tabId}`));
+}
+
+// The delete confirmation is the branded in-app ConfirmDialog; press its
+// « Supprimer » button (accessibilityLabel) to confirm the deletion.
+async function confirmDeleteInDialog() {
+  fireEvent.press(await screen.findByLabelText("Supprimer"));
 }
 
 describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () => {
@@ -254,18 +263,17 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
   });
 
   it("F24: an owned recipe offers delete and removes it on confirm", async () => {
-    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
     renderRecipeDetails();
 
     await screen.findByTestId("recipe-overview-tab");
     fireEvent.press(screen.getByLabelText("Supprimer cette recette"));
 
-    // The tap opens a confirmation dialog rather than deleting immediately.
-    expect(alertSpy).toHaveBeenCalled();
+    // The tap opens the branded confirmation dialog rather than deleting
+    // immediately.
+    expect(await screen.findByText("Supprimer cette recette ?")).toBeTruthy();
     expect(deleteRecipeFromCarnet).not.toHaveBeenCalled();
 
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+    await confirmDeleteInDialog();
 
     await waitFor(() =>
       expect(deleteRecipeFromCarnet).toHaveBeenCalledWith("r1"),
@@ -291,14 +299,14 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     await screen.findByTestId("recipe-overview-tab");
     fireEvent.press(screen.getByLabelText("Supprimer cette recette"));
 
-    // Confirm the deletion in the first dialog.
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+    // Confirm the deletion in the branded dialog.
+    await confirmDeleteInDialog();
 
-    // A non-HTTP failure surfaces the generic connection message and never
+    // A non-HTTP failure surfaces the generic connection message (via the
+    // native error Alert, which is not part of this migration) and never
     // navigates away.
-    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(2));
-    expect(alertSpy.mock.calls[1][1]).toMatch(/Vérifie ta connexion/);
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(1));
+    expect(alertSpy.mock.calls[0][1]).toMatch(/Vérifie ta connexion/);
     expect(mockReplace).not.toHaveBeenCalledWith("/recipes");
   });
 
@@ -317,11 +325,10 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     await screen.findByTestId("recipe-overview-tab");
     fireEvent.press(screen.getByLabelText("Supprimer cette recette"));
 
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+    await confirmDeleteInDialog();
 
-    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(2));
-    expect(alertSpy.mock.calls[1][1]).toMatch(/utilisée par un brassin/);
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(1));
+    expect(alertSpy.mock.calls[0][1]).toMatch(/utilisée par un brassin/);
     expect(mockReplace).not.toHaveBeenCalledWith("/recipes");
   });
 
@@ -337,11 +344,10 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     await screen.findByTestId("recipe-overview-tab");
     fireEvent.press(screen.getByLabelText("Supprimer cette recette"));
 
-    const buttons = alertSpy.mock.calls[0][2] as AlertButton[];
-    buttons.find((button) => button.text === "Supprimer")?.onPress?.();
+    await confirmDeleteInDialog();
 
-    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(2));
-    expect(alertSpy.mock.calls[1][1]).toMatch(/Vérifie ta connexion/);
+    await waitFor(() => expect(alertSpy).toHaveBeenCalledTimes(1));
+    expect(alertSpy.mock.calls[0][1]).toMatch(/Vérifie ta connexion/);
   });
 
   it("switches to the Ingredients tab and shows the ingredient list", async () => {

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -14,6 +14,7 @@ import { Card } from "@/core/ui/Card";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { useConfirm } from "@/core/ui/confirm-provider";
 
 import {
   getImportSourceId,
@@ -420,6 +421,7 @@ function MatchingRecipesSection({
     staleTime: 0,
   });
   const matching = matchingQuery.data ?? null;
+  const confirm = useConfirm();
 
   const importMutation = useMutation({
     mutationFn: (recipe: ScanRecipeMatch) =>
@@ -462,29 +464,21 @@ function MatchingRecipesSection({
    * vs "Annuler" choice so Léa knows what's about to happen.
    */
   const handleImport = useCallback(
-    (recipe: ScanRecipeMatch) => {
+    async (recipe: ScanRecipeMatch) => {
       if (importMutation.isPending) return;
-      Alert.alert(
-        "Importer cette recette ?",
-        `La recette « ${recipe.name} » sera ajoutée à ton carnet.`,
-        [
-          { text: "Annuler", style: "cancel" },
-          {
-            text: "Importer",
-            // Re-check before firing: a second confirmation (e.g. another
-            // row's Alert opened before this one was answered) must not
-            // launch a concurrent import. Restores the guard the previous
-            // performImport had at call time.
-            onPress: () => {
-              if (importMutation.isPending) return;
-              importMutation.mutate(recipe);
-            },
-          },
-        ],
-        { cancelable: true },
-      );
+      const confirmed = await confirm({
+        title: "Importer cette recette ?",
+        message: `La recette « ${recipe.name} » sera ajoutée à ton carnet.`,
+        confirmLabel: "Importer",
+      });
+      // Re-check before firing: a second confirmation (e.g. another row's
+      // dialog opened before this one was answered) must not launch a
+      // concurrent import. Restores the guard the previous performImport had.
+      if (confirmed && !importMutation.isPending) {
+        importMutation.mutate(recipe);
+      }
     },
-    [importMutation],
+    [importMutation, confirm],
   );
 
   if (matchingQuery.isError) {
@@ -524,7 +518,7 @@ function MatchingRecipesSection({
               importMutation.variables?.recipeId === officialRecipe.recipeId
             }
             isDisabled={importMutation.isPending}
-            onPress={() => handleImport(officialRecipe)}
+            onPress={() => void handleImport(officialRecipe)}
             highlightOfficial
           />
         </Card>
@@ -545,7 +539,7 @@ function MatchingRecipesSection({
                 importMutation.variables?.recipeId === recipe.recipeId
               }
               isDisabled={importMutation.isPending}
-              onPress={() => handleImport(recipe)}
+              onPress={() => void handleImport(recipe)}
             />
           ))}
         </Card>

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { BeerInfoCardScreen } from "@/features/scan/presentation/BeerInfoCardScreen";
+import { ConfirmProvider } from "@/core/ui/confirm-provider";
 import { getMatchingRecipes } from "@/features/scan/application/recipe-matching.use-cases";
 import { importRecipeFromCommunity } from "@/features/recipes/application/recipes.use-cases";
 import {
@@ -78,7 +79,9 @@ function renderScreen(ui: React.ReactElement) {
     },
   });
   return render(
-    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+    <QueryClientProvider client={client}>
+      <ConfirmProvider>{ui}</ConfirmProvider>
+    </QueryClientProvider>,
   );
 }
 
@@ -521,28 +524,15 @@ describe("BeerInfoCardScreen", () => {
 
   describe("import community recipe", () => {
     /**
-     * Issue #766 — every import flow now goes through a pre-flight
-     * confirmation Alert. This helper traverses the confirmation by
-     * pressing "Importer" so the existing happy-path assertions
-     * downstream stay focused on what they were originally testing.
+     * Issue #766 — every import flow goes through a pre-flight confirmation,
+     * now the branded in-app ConfirmDialog. This helper confirms it by pressing
+     * the « Importer » button so the downstream happy-path assertions stay
+     * focused on what they were originally testing.
      */
-    async function pressImporterOnConfirmationAlert(): Promise<void> {
-      await waitFor(() => {
-        expect(alertSpy).toHaveBeenCalledWith(
-          "Importer cette recette ?",
-          expect.any(String),
-          expect.any(Array),
-          expect.any(Object),
-        );
-      });
-      const confirmButtons = alertSpy.mock.calls[0][2] as Array<{
-        text: string;
-        onPress?: () => void;
-      }>;
-      const importerButton = confirmButtons.find((b) => b.text === "Importer");
-      expect(importerButton).toBeDefined();
+    async function confirmImportInDialog(): Promise<void> {
+      const importerButton = await screen.findByLabelText("Importer");
       await act(async () => {
-        importerButton?.onPress?.();
+        fireEvent.press(importerButton);
       });
     }
 
@@ -559,13 +549,13 @@ describe("BeerInfoCardScreen", () => {
       await act(async () => {
         fireEvent.press(row);
       });
-      await pressImporterOnConfirmationAlert();
+      await confirmImportInDialog();
 
       await waitFor(() => {
         expect(mockedImport).toHaveBeenCalledWith("r-demo-1");
       });
-      // The success Alert is the SECOND call (the first was the
-      // confirmation Alert traversed above).
+      // The success Alert is the only native Alert now (the pre-flight
+      // confirmation moved to the branded ConfirmDialog).
       const successCall = alertSpy.mock.calls.find(
         (c) => c[0] === "Recette importée",
       );
@@ -599,7 +589,7 @@ describe("BeerInfoCardScreen", () => {
       await act(async () => {
         fireEvent.press(row);
       });
-      await pressImporterOnConfirmationAlert();
+      await confirmImportInDialog();
 
       await waitFor(() => {
         expect(
@@ -633,7 +623,7 @@ describe("BeerInfoCardScreen", () => {
       await act(async () => {
         fireEvent.press(row);
       });
-      await pressImporterOnConfirmationAlert();
+      await confirmImportInDialog();
 
       await waitFor(() => {
         expect(alertSpy).toHaveBeenCalledWith(
@@ -645,7 +635,7 @@ describe("BeerInfoCardScreen", () => {
     });
 
     describe("pre-flight confirmation modal (Issue #766)", () => {
-      it("opens a confirmation Alert with the recipe name on tap", async () => {
+      it("opens the branded confirmation dialog with the recipe name on tap", async () => {
         mockedLookup.mockResolvedValueOnce(buildResult());
         renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
 
@@ -654,13 +644,14 @@ describe("BeerInfoCardScreen", () => {
           fireEvent.press(row);
         });
 
-        expect(alertSpy).toHaveBeenCalledWith(
-          "Importer cette recette ?",
-          expect.stringContaining("Session IPA Citra"),
-          expect.any(Array),
-          expect.any(Object),
-        );
-        // The API call is NOT yet made — we are blocked on confirmation.
+        // The branded ConfirmDialog appears (title + recipe name); the API call
+        // is NOT yet made — we are blocked on confirmation.
+        expect(
+          await screen.findByText("Importer cette recette ?"),
+        ).toBeTruthy();
+        expect(
+          screen.getByText(/La recette « Session IPA Citra » sera ajoutée/),
+        ).toBeTruthy();
         expect(mockedImport).not.toHaveBeenCalled();
       });
 
@@ -673,16 +664,12 @@ describe("BeerInfoCardScreen", () => {
           fireEvent.press(row);
         });
 
-        const confirmButtons = alertSpy.mock.calls[0][2] as Array<{
-          text: string;
-          style?: string;
-          onPress?: () => void;
-        }>;
-        const cancelButton = confirmButtons.find((b) => b.style === "cancel");
-        expect(cancelButton?.text).toBe("Annuler");
-        // The cancel button has no onPress (per RN Alert convention) —
-        // tapping it just dismisses without firing anything.
-        expect(cancelButton?.onPress).toBeUndefined();
+        // Cancel in the branded dialog: « Annuler » dismisses without importing
+        // or navigating.
+        await act(async () => {
+          fireEvent.press(await screen.findByLabelText("Annuler"));
+        });
+
         expect(mockedImport).not.toHaveBeenCalled();
         expect(mockPush).not.toHaveBeenCalled();
       });


### PR DESCRIPTION
## Summary

Finishes the branded-dialog migration started in #1323. All remaining native
`Alert.alert` **yes/no confirmations** now go through the in-app `ConfirmDialog`
via `useConfirm()`, so no confirmation escapes the app's charte. 7 confirmations
across 4 screens:

| Screen | Confirmation | Destructive |
|--------|--------------|:-----------:|
| RecipeDetails | Delete a recipe | ✅ |
| EquipmentDetail | Delete an equipment profile | ✅ |
| BeerInfoCard (scan) | Import a community recipe (#766) | — |
| BatchDetails | Complete a step (F6) | — |
| BatchDetails | Delete a batch (F25) | ✅ |
| BatchDetails | Cancel a batch (F16) | ✅ |
| BatchDetails | Archive a batch (F25) | — |

## Scope note

Informational **single-OK notices** (`Alert.alert` with no yes/no decision:
onError messages, "coming soon", "results copied", the post-import "Recette
importée" toast) are intentionally **left as native `Alert.alert`** — they are
out of scope for a yes/no `ConfirmDialog` and would need a separate branded
notice/toast component (future work). Every remaining `Alert.alert` in the code
is a genuine notice, verified.

## Context

- Each handler is now `const ok = await confirm({ title, message, confirmLabel, cancelLabel?, destructive? }); if (ok) { …mutate… }`; call sites wrapped as `() => void handler()`. Existing guards preserved (the `missingBatchId` early-returns, the scan concurrent-import re-check, destructive flags matching the prior native styling / #1292).
- `useConfirm()` for the scan import lives in the `MatchingRecipesSection` sub-component (where the mutation lives), not the page root.
- Tests: each screen's suite now renders inside the real `<ConfirmProvider>` and drives the dialog by `accessibilityLabel`; error-path notices keep asserting on the native `Alert`. Added cancel (F16) and archive (F25) failure-path tests (delete already had one).

## Follow-up (out of scope)

- A regression test for the scan concurrent-import guard (`!importMutation.isPending`) — a pre-existing gap (also untested on `main`), tracked separately.

## Checklist

- [x] All 7 yes/no confirmations migrated; informational notices intentionally untouched
- [x] Guards preserved (missingBatchId, concurrent-import re-check, destructive flags)
- [x] `tsc --noEmit` clean, `eslint` clean on all touched files
- [x] Full mobile-app jest suite green (runInBand); per-screen suites green
- [x] No forbidden patterns (no `any`, no default export, no inline styles, no hardcoded tokens)

Closes #1324
