### PR TITLE
docs(academy): design generated knowledge base architecture

### DIFF
--- a/docs/architecture/academy/architecture-decisions.md
+++ b/docs/architecture/academy/architecture-decisions.md
@@ -1,0 +1,35 @@
+# Brewing Academy Architecture Decision Summary
+
+## Canonical Decision
+
+The canonical architecture decision is:
+
+- `docs/architecture/decisions/0023-brewing-academy-knowledge-base.md`
+
+This file exists only as a local index for the Academy design pack. It avoids
+duplicating ADR content while keeping the implementation package easy to browse.
+
+## Decision Summary
+
+ADR-0023 establishes that:
+
+- Markdown/front matter is the V1 editorial source.
+- The mobile app consumes generated typed payloads.
+- No database, CMS, or backend publishing surface is introduced in V1.
+- Local search is used first.
+- Article, glossary, calculator, and app-context links resolve through one
+  semantic resolver.
+- The future chatbot is prepared through stable source IDs and retrieval-ready
+  sections, but not implemented in V1.
+- SOLID and design patterns are applied pragmatically.
+
+## Related Design Files
+
+- `design-pack.md`
+- `requirements-matrix.md`
+- `domain-contracts.md`
+- `business-rules.md`
+- `content-pipeline.md`
+- `test-strategy.md`
+- `security-and-rgpd.md`
+- `migration-plan.md`

--- a/docs/architecture/academy/business-rules.md
+++ b/docs/architecture/academy/business-rules.md
@@ -1,0 +1,55 @@
+# Brewing Academy Business Rules
+
+## Content Lifecycle
+
+| Rule | Description | Validation |
+| --- | --- | --- |
+| ACAD-BR-001 | Only `published` articles appear in the mobile Academy index. | Generator excludes other states from published payload. |
+| ACAD-BR-002 | `draft` and `review` articles may be generated for preview only. | Preview mode must be explicit. |
+| ACAD-BR-003 | `deprecated` articles must keep stable slugs if still referenced. | Link validator rejects unresolved references. |
+| ACAD-BR-004 | Article slugs are stable once published. | Slug changes require explicit migration notes. |
+
+## Source And Review Rules
+
+| Rule | Description | Validation |
+| --- | --- | --- |
+| ACAD-BR-010 | Sensitive articles require at least one source. | Generator fails on missing source metadata. |
+| ACAD-BR-011 | Sensitive articles require review metadata before publication. | `review.confidenceLevel` cannot be `draft` for published sensitive content. |
+| ACAD-BR-012 | Source IDs must resolve in the source registry. | Link validator checks every `SourceReference.id`. |
+| ACAD-BR-013 | Formulas and safety guidance must cite a source when sensitive. | Block-level validation checks source references. |
+
+## Link Rules
+
+| Rule | Description | Validation |
+| --- | --- | --- |
+| ACAD-BR-020 | Article links must resolve to existing article slugs. | Generator fails on broken article links. |
+| ACAD-BR-021 | Section links must resolve to existing stable section IDs. | Generator fails on broken section IDs. |
+| ACAD-BR-022 | Glossary references must resolve to central glossary terms. | Generator fails on missing glossary slugs. |
+| ACAD-BR-023 | Calculator links must use known calculator slugs. | Link resolver test covers known calculator mapping. |
+| ACAD-BR-024 | Calculator links are bidirectional when a calculator is related to an article. | Test asserts article-to-calculator and calculator-to-article relationship. |
+
+## Rendering Rules
+
+| Rule | Description | Validation |
+| --- | --- | --- |
+| ACAD-BR-030 | Screens render content blocks, not article-specific UI branches. | Renderer tests use multiple article fixtures. |
+| ACAD-BR-031 | Unsupported blocks fail generation or render a controlled fallback. | Tests cover unsupported block handling. |
+| ACAD-BR-032 | Raw Markdown is not parsed at runtime. | Screen code review and imports check. |
+| ACAD-BR-033 | Visual content must include accessible text or be explicitly decorative. | Renderer validation checks diagram/image metadata. |
+
+## Search Rules
+
+| Rule | Description | Validation |
+| --- | --- | --- |
+| ACAD-BR-040 | Search indexes only published content by default. | Generated search index excludes draft and review content. |
+| ACAD-BR-041 | Search results resolve through `AcademyLinkResolver`. | Search result tests assert semantic targets. |
+| ACAD-BR-042 | Empty queries show curated entry points instead of noisy results. | Hub tests cover empty search state. |
+
+## Future Chatbot Rules
+
+| Rule | Description | Validation |
+| --- | --- | --- |
+| ACAD-BR-050 | Chatbot must answer from validated Academy or glossary content only. | Future RAG eval gate rejects unsupported answers. |
+| ACAD-BR-051 | Chatbot must cite article sections or source references. | Future answer contract includes citations. |
+| ACAD-BR-052 | Chatbot must abstain when retrieval confidence is insufficient. | Future eval tests include unknown questions. |
+| ACAD-BR-053 | No persistent conversation history in first chatbot version. | API and storage review. |

--- a/docs/architecture/academy/content-pipeline.md
+++ b/docs/architecture/academy/content-pipeline.md
@@ -1,0 +1,135 @@
+# Brewing Academy Content Pipeline
+
+## Pipeline Goal
+
+The pipeline transforms editorial source files into validated mobile-ready
+payloads. It must fail loudly on broken content.
+
+```text
+Markdown + registries
+  -> read source files
+  -> parse front matter
+  -> validate schemas
+  -> validate links and source references
+  -> normalize content blocks
+  -> generate typed payloads
+  -> generate search index
+  -> optionally generate retrieval chunks for future chatbot
+```
+
+## Source Inputs
+
+Recommended structure:
+
+```text
+docs/academy/
+  ingredients/
+    houblons.md
+    levures.md
+  water/
+    eau.md
+  glossary/
+    terms.yml
+  sources/
+    references.yml
+```
+
+## Validation Phases
+
+### Phase 1 - File Discovery
+
+- Detect article Markdown files.
+- Detect glossary registry.
+- Detect source registry.
+- Fail if expected pilot files are missing for V1.
+
+### Phase 2 - Front Matter Validation
+
+- Required fields are present.
+- Enums are valid.
+- Dates use ISO format.
+- Reading time is positive.
+- Slug matches file or configured canonical slug rule.
+- Published articles include summary, tags, update date, and review metadata.
+
+### Phase 3 - Body Parsing
+
+- Convert Markdown into controlled block families.
+- Reject arbitrary embedded React.
+- Reject unsupported custom blocks.
+- Preserve stable section IDs.
+
+### Phase 4 - Link Validation
+
+- Article references resolve.
+- Section references resolve.
+- Glossary references resolve.
+- Calculator slugs are known.
+- Source IDs resolve.
+- Bidirectional calculator relationships are checked where required.
+
+### Phase 5 - Source And Safety Validation
+
+- Sensitive articles require source metadata.
+- Sensitive formula, safety, sanitation, fermentation health, and chemical
+  guidance must carry source support.
+- Unsupported risk topics fail validation.
+
+### Phase 6 - Generation
+
+Generated outputs:
+
+```text
+packages/mobile-app/src/features/academy/data/generated/
+  academy-index.generated.ts
+  articles/
+    houblons.generated.ts
+    levures.generated.ts
+    eau.generated.ts
+  glossary.generated.ts
+  search-index.generated.ts
+```
+
+Future optional output:
+
+```text
+retrieval-chunks.generated.ts
+```
+
+## Error Quality
+
+Generator errors must be actionable:
+
+- file path;
+- article slug;
+- section ID if relevant;
+- invalid field;
+- expected value or known choices;
+- suggested fix when obvious.
+
+Example:
+
+```text
+docs/academy/ingredients/houblons.md
+Invalid related_glossary_terms[1]: "alpha-acid"
+Known terms include: "alpha-acids", "ibu", "dry-hop"
+```
+
+## Design Patterns In Pipeline
+
+- `Adapter`: source parser adapts Markdown/YAML into raw content objects.
+- `Specification`: validation rules are isolated and testable.
+- `Factory` or `Builder`: validated raw blocks become `AcademyContentBlock`
+  values.
+- `Template Method`: useful only if the generator pipeline becomes complex
+  enough to justify a fixed sequence.
+
+## CI Expectations
+
+At minimum, CI should eventually run:
+
+- content validation;
+- typecheck;
+- generator deterministic output check;
+- renderer tests;
+- link resolution tests.

--- a/docs/architecture/academy/content-pipeline.md
+++ b/docs/architecture/academy/content-pipeline.md
@@ -51,6 +51,10 @@ docs/academy/
 - Reading time is positive.
 - Slug matches file or configured canonical slug rule.
 - Published articles include summary, tags, update date, and review metadata.
+- Editorial front matter uses snake_case; generated TypeScript payloads use
+  camelCase. The generator owns this mapping and validates both sides through
+  schemas. The source `slug` is promoted to `AcademyArticle.slug` in generated
+  payloads to avoid duplicated slug state.
 
 ### Phase 3 - Body Parsing
 

--- a/docs/architecture/academy/design-pack.md
+++ b/docs/architecture/academy/design-pack.md
@@ -1,0 +1,114 @@
+# Brewing Academy Design Pack
+
+## Status
+
+Draft implementation design for the Brewing Academy knowledge base refactor.
+
+## Purpose
+
+This pack turns the product framing and UML study into coding-ready guidance.
+The implementation phase should use it as the reference contract before writing
+or reviewing code.
+
+Related documents:
+
+- `docs/product/academy/academy-knowledge-base-framing.md`
+- `docs/architecture/decisions/0023-brewing-academy-knowledge-base.md`
+- `docs/architecture/traceability-matrix.md`
+- `docs/architecture/diagrams/academy/00-overview.md`
+- `docs/architecture/diagrams/academy/10-implementation-notes.md`
+- `docs/project-management/definition-of-ready.md`
+- `docs/project-management/definition-of-done.md`
+
+## Target Outcome
+
+The Brewing Academy becomes a versioned, validated, mobile-first knowledge base:
+
+- content is authored as Markdown with strict front matter;
+- the mobile app consumes generated typed payloads;
+- articles, glossary, calculators, search, and future chatbot retrieval share
+  one coherent domain model;
+- hardcoded article JSX is treated as legacy and phased out;
+- the first implementation ships a high-quality vertical slice for `houblons`,
+  `levures`, and `eau`.
+
+## Design Pack Index
+
+1. [Requirements matrix](requirements-matrix.md)
+2. [Architecture decisions](architecture-decisions.md)
+3. [Domain contracts](domain-contracts.md)
+4. [Business rules](business-rules.md)
+5. [UX flows](ux-flows.md)
+6. [Content pipeline](content-pipeline.md)
+7. [Test strategy](test-strategy.md)
+8. [Security and RGPD](security-and-rgpd.md)
+9. [Migration plan](migration-plan.md)
+
+## Non-Negotiable Constraints
+
+- No new hardcoded Academy article content in React Native screens.
+- No `any` TypeScript type.
+- No default exports.
+- No inline styles in React Native screens.
+- No hardcoded colors, spacing, or typography values.
+- No chatbot answer without source support in the future assistant.
+- No persistent chatbot history in V1.
+- No database or CMS in Academy V1 unless a later ADR supersedes this pack.
+
+## Implementation Principles
+
+- Clean Architecture: domain contracts do not depend on React Native, Expo
+  Router, generated files, or markdown parsing libraries.
+- SOLID: renderers depend on content block abstractions, not article slugs.
+- KISS: the V1 ships three excellent pilot articles before expanding scope.
+- YAGNI: vector search, CMS, backend publishing, quizzes, and chatbot UI are
+  deferred.
+- DRY: one glossary model, one source registry, one link resolver, one content
+  block model.
+- Design patterns are used only when they reduce coupling, improve testability,
+  or clarify a real responsibility.
+
+## Recommended PR Split
+
+1. Documentation and design pack.
+2. Domain contracts and schema validation.
+3. Markdown content generator.
+4. Mobile renderer and pilot articles.
+5. Hub/search UX.
+6. Calculator/article bidirectional links.
+7. Future chatbot retrieval preparation, if still desired.
+
+## Academy Addendum To Definition Of Ready
+
+The global Definition of Ready remains
+`docs/project-management/definition-of-ready.md`. For Academy coding stories,
+the following extra checks apply.
+
+An Academy coding story is ready only when:
+
+- the affected domain contracts are identified;
+- the source content format is known;
+- the generated payload shape is known;
+- routing expectations are explicit;
+- acceptance criteria are testable;
+- mobile and tablet states are defined;
+- security, RGPD, accessibility, and source requirements are checked.
+
+## Academy Addendum To Definition Of Done
+
+The global Definition of Done remains
+`docs/project-management/definition-of-done.md`. For Academy implementation
+work, the following extra checks apply.
+
+An Academy implementation story is done only when:
+
+- typecheck passes;
+- existing tests pass;
+- new tests cover new domain, generator, renderer, or navigation behavior;
+- no `any` is introduced;
+- no article content is hardcoded in screens;
+- invalid content fails generation with actionable errors;
+- article screens handle loading, empty, invalid slug, and render states;
+- accessible labels or image alternative text exist where needed;
+- links to glossary, articles, and calculators resolve through one resolver;
+- source-sensitive content cannot be published without source metadata.

--- a/docs/architecture/academy/domain-contracts.md
+++ b/docs/architecture/academy/domain-contracts.md
@@ -53,7 +53,6 @@ export interface AcademyReviewMetadata {
 }
 
 export interface AcademyArticleMetadata {
-  readonly slug: string;
   readonly title: string;
   readonly summary: string;
   readonly category: AcademyCategory;
@@ -80,7 +79,12 @@ export interface AcademyArticleMetadata {
 
 ```ts
 export interface AcademyArticle {
+  readonly slug: string;
   readonly metadata: AcademyArticleMetadata;
+  readonly body: AcademyArticleBody;
+}
+
+export interface AcademyArticleBody {
   readonly sections: readonly AcademySection[];
 }
 
@@ -244,6 +248,7 @@ export interface CalculatorLink {
   readonly slug: string;
   readonly label: string;
   readonly reason: string;
+  readonly target: Extract<AcademyLinkTarget, { readonly type: 'calculator' }>;
 }
 
 export type AcademyLinkTarget =
@@ -259,7 +264,12 @@ targets into navigation actions.
 ## Search
 
 ```ts
-export type AcademySearchResultKind = 'article' | 'section' | 'glossary';
+export type AcademySearchResultKind =
+  | 'article'
+  | 'section'
+  | 'glossary'
+  | 'faq'
+  | 'calculator';
 
 export interface AcademySearchEntry {
   readonly id: string;

--- a/docs/architecture/academy/domain-contracts.md
+++ b/docs/architecture/academy/domain-contracts.md
@@ -1,0 +1,291 @@
+# Brewing Academy Domain Contracts
+
+## Scope
+
+This document describes the expected TypeScript contracts. Names may be adjusted
+to match project conventions during implementation, but the responsibilities
+should remain stable.
+
+## Contract Rules
+
+- Domain contracts must not import React Native, Expo Router, Markdown parser
+  types, or generated file paths.
+- Use named exports only.
+- Do not use `any`.
+- Prefer discriminated unions for content blocks.
+- Use literal unions for stable enums where practical.
+- Keep runtime validation schemas aligned with these contracts.
+
+## Core Types
+
+```ts
+export type AcademyArticleStatus =
+  | 'draft'
+  | 'review'
+  | 'published'
+  | 'deprecated';
+
+export type AcademyLevel = 'beginner' | 'intermediate' | 'advanced';
+
+export type AcademyCategory =
+  | 'getting-started'
+  | 'ingredients'
+  | 'process'
+  | 'fermentation'
+  | 'water'
+  | 'equipment'
+  | 'beer-styles'
+  | 'safety'
+  | 'troubleshooting'
+  | 'glossary';
+```
+
+## Article Metadata
+
+```ts
+export type AcademyReviewConfidence = 'draft' | 'reviewed' | 'validated';
+
+export interface AcademyReviewMetadata {
+  readonly confidenceLevel: AcademyReviewConfidence;
+  readonly reviewedBy: string | null;
+  readonly reviewedAt: string | null;
+  readonly notes: readonly string[];
+}
+
+export interface AcademyArticleMetadata {
+  readonly slug: string;
+  readonly title: string;
+  readonly summary: string;
+  readonly category: AcademyCategory;
+  readonly level: AcademyLevel;
+  readonly status: AcademyArticleStatus;
+  readonly version: string;
+  readonly estimatedReadTimeMinutes: number;
+  readonly tags: readonly string[];
+  readonly updatedAt: string;
+  readonly relatedArticles: readonly string[];
+  readonly relatedGlossaryTerms: readonly string[];
+  readonly relatedCalculators: readonly CalculatorLink[];
+  readonly learningObjectives: readonly string[];
+  readonly prerequisites: readonly string[];
+  readonly teaches: readonly string[];
+  readonly sensitive: boolean;
+  readonly riskTopics: readonly string[];
+  readonly sources: readonly SourceReference[];
+  readonly review: AcademyReviewMetadata;
+}
+```
+
+## Article Body
+
+```ts
+export interface AcademyArticle {
+  readonly metadata: AcademyArticleMetadata;
+  readonly sections: readonly AcademySection[];
+}
+
+export interface AcademySection {
+  readonly id: string;
+  readonly title: string;
+  readonly blocks: readonly AcademyContentBlock[];
+}
+```
+
+## Content Blocks
+
+```ts
+export type AcademyContentBlock =
+  | ParagraphBlock
+  | HeadingBlock
+  | BulletListBlock
+  | TableBlock
+  | FormulaBlock
+  | CalloutBlock
+  | DiagramBlock
+  | GlossaryReferenceBlock
+  | CalculatorCtaBlock
+  | RelatedArticleBlock
+  | SourceReferenceBlock;
+```
+
+Each block must include:
+
+- `id`: stable within an article;
+- `type`: discriminant;
+- enough data to render without parsing raw Markdown at runtime.
+
+```ts
+export interface BaseContentBlock {
+  readonly id: string;
+  readonly sourceIds: readonly string[];
+}
+
+export interface ParagraphBlock extends BaseContentBlock {
+  readonly type: 'paragraph';
+  readonly text: string;
+}
+
+export interface HeadingBlock extends BaseContentBlock {
+  readonly type: 'heading';
+  readonly level: 2 | 3 | 4;
+  readonly text: string;
+}
+
+export interface BulletListBlock extends BaseContentBlock {
+  readonly type: 'bulletList';
+  readonly items: readonly string[];
+}
+
+export interface TableBlock extends BaseContentBlock {
+  readonly type: 'table';
+  readonly caption: string | null;
+  readonly columns: readonly string[];
+  readonly rows: readonly (readonly string[])[];
+}
+
+export interface FormulaBlock extends BaseContentBlock {
+  readonly type: 'formula';
+  readonly label: string;
+  readonly expression: string;
+  readonly variables: readonly FormulaVariable[];
+}
+
+export interface FormulaVariable {
+  readonly symbol: string;
+  readonly label: string;
+  readonly unit: string | null;
+}
+
+export type CalloutTone = 'info' | 'tip' | 'warning' | 'safety' | 'technical';
+
+export interface CalloutBlock extends BaseContentBlock {
+  readonly type: 'callout';
+  readonly tone: CalloutTone;
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface DiagramBlock extends BaseContentBlock {
+  readonly type: 'diagram';
+  readonly title: string;
+  readonly description: string;
+  readonly accessibilityLabel: string;
+  readonly assetKey: string | null;
+}
+
+export interface GlossaryReferenceBlock extends BaseContentBlock {
+  readonly type: 'glossaryReference';
+  readonly termSlug: string;
+  readonly label: string;
+}
+
+export interface CalculatorCtaBlock extends BaseContentBlock {
+  readonly type: 'calculatorCta';
+  readonly calculatorSlug: string;
+  readonly title: string;
+  readonly description: string;
+}
+
+export interface RelatedArticleBlock extends BaseContentBlock {
+  readonly type: 'relatedArticle';
+  readonly articleSlug: string;
+  readonly sectionId: string | null;
+}
+
+export interface SourceReferenceBlock extends BaseContentBlock {
+  readonly type: 'sourceReference';
+  readonly sourceId: string;
+  readonly note: string | null;
+}
+```
+
+## Glossary
+
+```ts
+export interface GlossaryTerm {
+  readonly slug: string;
+  readonly label: string;
+  readonly aliases: readonly string[];
+  readonly shortDefinition: string;
+  readonly detailedDefinition: string;
+  readonly relatedTerms: readonly string[];
+  readonly sources: readonly SourceReference[];
+}
+```
+
+## Sources
+
+```ts
+export type SourceKind =
+  | 'book'
+  | 'standard'
+  | 'article'
+  | 'website'
+  | 'course'
+  | 'manufacturer-documentation';
+
+export interface SourceReference {
+  readonly id: string;
+  readonly kind: SourceKind;
+  readonly title: string;
+  readonly authors: readonly string[];
+  readonly publisher: string | null;
+  readonly url: string | null;
+  readonly accessedAt: string | null;
+  readonly year: number | null;
+  readonly notes: string | null;
+}
+```
+
+## Links
+
+```ts
+export interface CalculatorLink {
+  readonly slug: string;
+  readonly label: string;
+  readonly reason: string;
+}
+
+export type AcademyLinkTarget =
+  | { readonly type: 'article'; readonly slug: string; readonly sectionId?: string }
+  | { readonly type: 'glossary'; readonly slug: string }
+  | { readonly type: 'calculator'; readonly slug: string }
+  | { readonly type: 'app-context'; readonly target: string };
+```
+
+Routes are not part of the domain object. The application layer resolves link
+targets into navigation actions.
+
+## Search
+
+```ts
+export type AcademySearchResultKind = 'article' | 'section' | 'glossary';
+
+export interface AcademySearchEntry {
+  readonly id: string;
+  readonly kind: AcademySearchResultKind;
+  readonly title: string;
+  readonly excerpt: string;
+  readonly target: AcademyLinkTarget;
+  readonly keywords: readonly string[];
+  readonly level: AcademyLevel | null;
+  readonly category: AcademyCategory | null;
+}
+```
+
+## Future Retrieval
+
+```ts
+export interface RetrievalChunk {
+  readonly id: string;
+  readonly articleSlug: string;
+  readonly sectionId: string;
+  readonly text: string;
+  readonly sourceIds: readonly string[];
+  readonly glossaryTermSlugs: readonly string[];
+  readonly sensitive: boolean;
+}
+```
+
+Retrieval chunks are generated artifacts for a future chatbot. They are not a
+V1 runtime dependency unless explicitly added later.

--- a/docs/architecture/academy/domain-contracts.md
+++ b/docs/architecture/academy/domain-contracts.md
@@ -71,7 +71,7 @@ export interface AcademyArticleMetadata {
   readonly sensitive: boolean;
   readonly riskTopics: readonly string[];
   readonly sources: readonly SourceReference[];
-  readonly review: AcademyReviewMetadata;
+  readonly review: AcademyReviewMetadata | null;
 }
 ```
 

--- a/docs/architecture/academy/migration-plan.md
+++ b/docs/architecture/academy/migration-plan.md
@@ -1,0 +1,153 @@
+# Brewing Academy Migration Plan
+
+## Migration Goal
+
+Move from hardcoded React Native Academy content to a generated, validated,
+mobile-first knowledge base without breaking existing user flows.
+
+## Current State
+
+- Academy article content is mixed with UI code.
+- The Academy lives near tool-related screens.
+- Article organization is limited by screen implementation.
+- Glossary and source concepts are not yet central enough for future chatbot
+  retrieval.
+
+## Target State
+
+- Academy has a clear feature boundary.
+- Markdown/front matter is the canonical editorial source.
+- Generated typed payloads power mobile screens.
+- The article renderer is generic.
+- Search and glossary are data-driven.
+- Calculator links are bidirectional.
+- Future chatbot retrieval can be generated from validated sections.
+
+## Step 1 - Contracts
+
+Create domain contracts for:
+
+- article metadata;
+- article body and sections;
+- content blocks;
+- glossary terms;
+- source references;
+- link targets;
+- search entries;
+- future retrieval chunks.
+
+Exit criteria:
+
+- contracts compile;
+- no `any`;
+- no React Native imports in domain contracts;
+- initial fixtures can satisfy the contracts.
+
+## Step 2 - Content Source And Validation
+
+Create source files for pilot articles and registries:
+
+- `houblons`;
+- `levures`;
+- `eau`;
+- glossary terms;
+- sources.
+
+Exit criteria:
+
+- invalid metadata fails validation;
+- broken links fail validation;
+- sensitive missing sources fail validation;
+- drafts are excluded from published output.
+
+## Step 3 - Generator
+
+Generate typed content and indexes.
+
+Exit criteria:
+
+- deterministic output;
+- generated article payloads;
+- generated Academy index;
+- generated glossary payload;
+- generated search index;
+- actionable errors.
+
+## Step 4 - Repository And Use Cases
+
+Add read APIs:
+
+- get published article list;
+- get article by slug;
+- search Academy;
+- get glossary term;
+- resolve semantic link target.
+
+Exit criteria:
+
+- screens do not import generated files directly;
+- repositories are easy to fake in tests;
+- link resolver owns route mapping.
+
+## Step 5 - Article Renderer
+
+Render generic `AcademyContentBlock[]`.
+
+Exit criteria:
+
+- no article-specific render branches;
+- blocks render consistently;
+- accessibility requirements are covered;
+- invalid slug has controlled state.
+
+## Step 6 - Hub And Search UX
+
+Replace hardcoded discovery UI with generated index and search.
+
+Exit criteria:
+
+- hub shows pilot articles;
+- search returns articles and glossary terms;
+- empty and no-result states are controlled;
+- mobile and tablet layouts are checked.
+
+## Step 7 - Calculator Links
+
+Wire bidirectional links between Academy and calculators.
+
+Exit criteria:
+
+- article CTAs open calculators;
+- calculators link back to related Academy sections;
+- route mapping is tested.
+
+## Step 8 - Legacy Cleanup
+
+Remove or quarantine hardcoded legacy article content after generated content is
+validated.
+
+Exit criteria:
+
+- no duplicate source of truth;
+- no broken route;
+- tests still pass.
+
+## Step 9 - Future Chatbot Preparation
+
+Generate retrieval chunks only if still valuable before chatbot implementation.
+
+Exit criteria:
+
+- chunk IDs stable;
+- chunk citations map to article sections and source IDs;
+- sensitive chunks carry source metadata;
+- no chatbot UI or provider dependency added in this step.
+
+## Rollback Strategy
+
+- Keep the existing Academy route working until generated pilot articles are
+  verified.
+- Introduce generated content behind a small implementation boundary.
+- Avoid deleting legacy content until parity is proven.
+- Use focused commits so a failed step can be reverted without losing the whole
+  design direction.

--- a/docs/architecture/academy/requirements-matrix.md
+++ b/docs/architecture/academy/requirements-matrix.md
@@ -8,7 +8,7 @@ It is intentionally implementation-oriented.
 | ID | Need | Decision | Technical impact | Acceptance criteria | Priority |
 | --- | --- | --- | --- | --- | --- |
 | ACAD-REQ-001 | The Academy is a reference base, not the active tutorial. | Keep complete explanations in Academy and short contextual help in app flows. | Academy feature gets its own domain boundary. | Article pages can be opened independently from brew flows. | V1 |
-| ACAD-REQ-002 | Users need beginner-first explanations without losing depth. | Articles include levels and optional deeper sections. | Metadata includes `level`, `prerequisites`, `learningObjectives`, and `teaches`. | A beginner article can still link to advanced notes. | V1 |
+| ACAD-REQ-002 | Users need beginner-first explanations without losing depth. | Articles include levels and optional deeper sections. | Front matter includes `level`, `prerequisites`, `learning_objectives`, and `teaches`; generated payloads expose camelCase equivalents. | A beginner article can still link to advanced notes. | V1 |
 | ACAD-REQ-003 | Content must not remain hardcoded in screens. | Markdown/front matter is the canonical source. | Add parser, validator, and generated typed payloads. | New pilot articles render without article-specific JSX. | V1 |
 | ACAD-REQ-004 | The app must work offline for core Academy content. | Generated content is bundled in the mobile app. | Repository reads local generated payloads. | Pilot articles open without network access. | V1 |
 | ACAD-REQ-005 | Users need fast lookup on mobile. | Hub is search-first and category-aware. | Add local search index and compact mobile cards. | Search returns article and glossary results under normal mobile constraints. | V1 |

--- a/docs/architecture/academy/requirements-matrix.md
+++ b/docs/architecture/academy/requirements-matrix.md
@@ -1,0 +1,32 @@
+# Brewing Academy Requirements Matrix
+
+## Scope
+
+This matrix maps product needs to technical decisions and acceptance criteria.
+It is intentionally implementation-oriented.
+
+| ID | Need | Decision | Technical impact | Acceptance criteria | Priority |
+| --- | --- | --- | --- | --- | --- |
+| ACAD-REQ-001 | The Academy is a reference base, not the active tutorial. | Keep complete explanations in Academy and short contextual help in app flows. | Academy feature gets its own domain boundary. | Article pages can be opened independently from brew flows. | V1 |
+| ACAD-REQ-002 | Users need beginner-first explanations without losing depth. | Articles include levels and optional deeper sections. | Metadata includes `level`, `prerequisites`, `learningObjectives`, and `teaches`. | A beginner article can still link to advanced notes. | V1 |
+| ACAD-REQ-003 | Content must not remain hardcoded in screens. | Markdown/front matter is the canonical source. | Add parser, validator, and generated typed payloads. | New pilot articles render without article-specific JSX. | V1 |
+| ACAD-REQ-004 | The app must work offline for core Academy content. | Generated content is bundled in the mobile app. | Repository reads local generated payloads. | Pilot articles open without network access. | V1 |
+| ACAD-REQ-005 | Users need fast lookup on mobile. | Hub is search-first and category-aware. | Add local search index and compact mobile cards. | Search returns article and glossary results under normal mobile constraints. | V1 |
+| ACAD-REQ-006 | Brewing terms must be explained consistently. | Glossary is central and structured. | Add `GlossaryTerm` contract and glossary repository. | The same term definition can be reused in article and future chatbot contexts. | V1 |
+| ACAD-REQ-007 | Calculators and articles must reinforce each other. | Calculator links are bidirectional. | Add calculator link metadata and resolver. | Hops article links to IBU calculator and calculator links back to the article. | V1 |
+| ACAD-REQ-008 | Brewing advice must be credible. | Sensitive topics require source metadata and review state. | Validation fails if required sources are missing. | Sensitive article cannot reach `published` without valid sources. | V1 |
+| ACAD-REQ-009 | The future chatbot needs a reliable corpus. | Generate retrieval chunks from validated content later. | Content model includes source IDs, stable section IDs, and chunk candidates. | Article sections have stable identifiers usable as citations. | V1 prep |
+| ACAD-REQ-010 | Chatbot must be safe and sourced. | Future RAG answers must cite Academy sources and abstain when unsupported. | Add future `RetrievalChunk` and `ChatbotAnswer` contracts only as prep. | Future chatbot sequence never answers from unsourced free text. | V2 |
+| ACAD-REQ-011 | UX must work on phones and tablets. | Mobile-first layout with tablet-aware constraints. | Renderer supports compact and wider article layouts. | No overlap, clipping, or unreadable dense content on common mobile widths. | V1 |
+| ACAD-REQ-012 | Accessibility must be treated as a requirement. | Visuals and controls carry accessible text. | Renderer maps image and diagram metadata to accessibility props. | Image blocks have useful accessible text or are marked decorative by design. | V1 |
+| ACAD-REQ-013 | Editorial workflow must be simple. | Use Git review and article lifecycle states. | Front matter includes `status`, `version`, and review metadata. | Draft content does not appear in the published mobile index. | V1 |
+| ACAD-REQ-014 | Implementation must remain maintainable. | Use Clean boundaries and pragmatic design patterns. | Domain, data, application, presentation layers are separated. | Screens do not parse Markdown, validate schemas, or resolve raw paths. | V1 |
+| ACAD-REQ-015 | The system must be easy to test. | Validation and rendering behavior are deterministic. | Parser/generator and repositories expose pure testable functions where possible. | Unit tests can run without network or LLM calls. | V1 |
+
+## Requirement Traceability
+
+- ACAD-REQ-001 to ACAD-REQ-005 map to hub and article reader work.
+- ACAD-REQ-006 to ACAD-REQ-008 map to domain validation work.
+- ACAD-REQ-009 and ACAD-REQ-010 prepare the chatbot without implementing it.
+- ACAD-REQ-011 and ACAD-REQ-012 map to mobile UX and accessibility.
+- ACAD-REQ-013 to ACAD-REQ-015 map to quality gates and maintainability.

--- a/docs/architecture/academy/security-and-rgpd.md
+++ b/docs/architecture/academy/security-and-rgpd.md
@@ -1,0 +1,92 @@
+# Brewing Academy Security And RGPD
+
+## Scope
+
+The Academy V1 is local generated content, so the immediate security surface is
+smaller than a backend publishing system or chatbot. The design still needs
+privacy and safety constraints because the corpus prepares a future assistant.
+
+## V1 Security Rules
+
+- Do not commit secrets, credentials, `.env` files, or private API keys.
+- Do not load article content from untrusted remote URLs.
+- Do not render arbitrary HTML or embedded React from Markdown.
+- Do not execute code from content files.
+- Validate all custom blocks before generation.
+- Treat generated files as build artifacts derived from reviewed source.
+- Keep navigation targets semantic and centrally resolved.
+
+## Markdown Safety
+
+Allowed:
+
+- controlled Markdown subset;
+- controlled custom blocks;
+- source references;
+- glossary references;
+- calculator CTAs.
+
+Rejected:
+
+- inline scripts;
+- raw HTML unless explicitly sanitized and approved later;
+- arbitrary JSX;
+- remote executable embeds;
+- unvalidated external links in safety-critical content.
+
+## RGPD For V1 Academy
+
+V1 Academy content does not need to collect personal data.
+
+Rules:
+
+- no user tracking inside Academy reading flows unless covered by existing
+  product analytics consent;
+- no personal notes or reading history in V1;
+- no chatbot conversation storage in V1 because chatbot is deferred;
+- if analytics are added later, collect minimal aggregated events only after
+  consent rules are satisfied.
+
+## Future Chatbot Privacy Rules
+
+Future chatbot must follow privacy by design:
+
+- no persistent server-side conversation history in first chatbot version;
+- no personal brewing context unless the user gives explicit consent;
+- no request for unnecessary personal data;
+- visible notice telling users not to share personal information;
+- logs must avoid storing raw conversation content by default;
+- provider terms must be checked for retention, training, and EU/RGPD posture;
+- deletion/export expectations must be defined before personalization.
+
+## AI Safety Rules
+
+The future brewing assistant must:
+
+- answer only from validated Academy, glossary, and approved source content;
+- cite article sections or source references;
+- abstain when retrieval does not support an answer;
+- avoid presenting uncertain technical guidance as fact;
+- handle safety-sensitive topics conservatively;
+- avoid medical, legal, or hazardous operational advice outside the verified
+  brewing scope;
+- never reveal system prompts or internal policy text.
+
+## Source Integrity
+
+- Source registry entries must be reviewed.
+- Sensitive articles require source metadata.
+- Formula blocks should identify their source when not common domain knowledge.
+- Deprecated sources should not silently disappear if still cited.
+
+## Abuse Considerations For Future Chatbot
+
+When chatbot implementation starts, the design must include:
+
+- server-side provider calls;
+- rate limiting;
+- input length limits;
+- output length limits;
+- budget cap or kill switch;
+- prompt injection tests;
+- abuse monitoring that does not retain personal content unnecessarily.

--- a/docs/architecture/academy/test-strategy.md
+++ b/docs/architecture/academy/test-strategy.md
@@ -1,0 +1,128 @@
+# Brewing Academy Test Strategy
+
+## Goals
+
+Testing must prove that the Academy is generated, validated, navigable,
+accessible enough for V1, and safe to use as a future chatbot corpus.
+
+## Test Pyramid
+
+### Unit Tests
+
+Target:
+
+- domain type guards or schema validators;
+- source registry validation;
+- glossary registry validation;
+- link resolver;
+- search ranking helpers;
+- content block factories;
+- sensitive content specifications.
+
+Acceptance:
+
+- no network;
+- no LLM;
+- deterministic fixtures;
+- fast enough for normal CI.
+
+### Generator Tests
+
+Target:
+
+- valid pilot article generation;
+- missing required metadata;
+- invalid enum;
+- broken article link;
+- broken glossary term;
+- broken calculator slug;
+- missing source for sensitive article;
+- unsupported block.
+
+Acceptance:
+
+- generator fails with actionable error messages;
+- generated payload shape is stable;
+- drafts do not enter published index.
+
+### Renderer Tests
+
+Target:
+
+- article screen renders title, summary, sections, blocks, callouts, formulas,
+  glossary references, calculator CTAs, and sources;
+- unsupported block fallback if allowed;
+- invalid slug empty state;
+- glossary modal or sheet;
+- search result rendering.
+
+Acceptance:
+
+- no article-specific render branches;
+- no raw Markdown parsing in screen tests;
+- accessibility labels are present for icon-only controls.
+
+### Navigation Tests
+
+Target:
+
+- article route opens by slug;
+- section anchors are preserved if implemented;
+- glossary target opens expected UI;
+- calculator CTA opens expected calculator;
+- calculator can link back to related article.
+
+Acceptance:
+
+- routes are resolved through `AcademyLinkResolver`;
+- invalid target does not crash the app.
+
+### UX Regression Checks
+
+Target screens:
+
+- Academy hub;
+- article reader;
+- search results;
+- glossary modal;
+- calculator CTA state.
+
+Checks:
+
+- mobile width;
+- tablet width;
+- no clipping;
+- no overlapping controls;
+- readable line lengths;
+- stable loading and empty states.
+
+### Future Chatbot Evaluation
+
+Not V1, but design should prepare:
+
+- known-answer questions from Academy content;
+- unknown questions that must abstain;
+- source citation checks;
+- jailbreak and off-topic prompts;
+- privacy prompts asking the bot to store personal data.
+
+## Pilot Fixture Set
+
+Minimum fixtures:
+
+- `houblons`: calculator CTA, formula/source reference, glossary links.
+- `levures`: fermentation vocabulary, callout, process explanation.
+- `eau`: sensitive/source-heavy content, table, ion glossary links.
+
+## Quality Gates
+
+Before PR:
+
+- content validation passes;
+- TypeScript typecheck passes;
+- tests for changed layers pass;
+- no `any`;
+- no default exports;
+- no inline React Native styles;
+- no hardcoded design tokens;
+- no new article-specific screen logic.

--- a/docs/architecture/academy/ux-flows.md
+++ b/docs/architecture/academy/ux-flows.md
@@ -1,0 +1,108 @@
+# Brewing Academy UX Flows
+
+## UX Principles
+
+- The first screen should be useful immediately, not a marketing page.
+- Mobile is the primary layout target; tablet gets better density without
+  changing the mental model.
+- Search, categories, and common questions are the main entry points.
+- Articles should be readable in short sessions.
+- Technical depth is progressive: beginner summary first, deeper material later.
+- Controls must be familiar, accessible, and stable.
+
+## Academy Hub
+
+### Primary Content
+
+- Search input visible near the top.
+- Pilot article cards: `houblons`, `levures`, `eau`.
+- Category chips or a compact category grid.
+- Frequent questions linked to article sections, glossary terms, or calculators.
+- Recently updated or recommended references if useful after V1.
+
+### States
+
+| State | Expected behavior |
+| --- | --- |
+| Ready | Search, categories, pilot cards, FAQ links visible. |
+| Empty corpus | Controlled empty state explaining that Academy content is unavailable. |
+| Search empty | Show curated article/category suggestions. |
+| Search no result | Show clear no-result message and category shortcuts. |
+| Invalid link | Show controlled error and return action. |
+
+## Article Reader
+
+### Layout
+
+- Title, summary, level, reading time, category, and update date above content.
+- Optional table of contents for long articles.
+- Section headings with stable anchors.
+- Inline glossary references.
+- Callouts for warnings, tips, and technical notes.
+- Calculator CTAs placed near relevant concepts.
+- Source references visible without overwhelming beginners.
+
+### Mobile Constraints
+
+- No nested cards for ordinary sections.
+- Text wraps before shrinking.
+- Tables must be horizontally scrollable or transformed into readable rows.
+- Formula blocks must avoid clipping.
+- Diagrams must scale inside parent width.
+- Touch targets must remain comfortable.
+
+### Tablet Constraints
+
+- Use extra width for table of contents, source side notes, or glossary preview
+  only if readability improves.
+- Do not create a desktop-only interaction model.
+
+## Glossary Interaction
+
+V1 recommended behavior:
+
+- Inline glossary term opens a modal or bottom sheet.
+- The modal shows short definition first.
+- Detailed definition and related terms are secondary.
+- A link to the full glossary entry can be added later.
+
+Required states:
+
+- Known term.
+- Missing term fallback.
+- Related term navigation.
+
+## Calculator Links
+
+User flow:
+
+1. User reads a concept in an article.
+2. Article shows a calculator CTA.
+3. User opens calculator through resolved route.
+4. Calculator offers a contextual link back to the article or section.
+
+Rules:
+
+- CTAs must explain why the calculator is relevant.
+- Routes must be resolved centrally.
+- Calculator screens should not duplicate long Academy explanations.
+
+## Future Chatbot Entry
+
+The chatbot is not V1, but UX preparation should reserve a future entry point:
+
+- Suggested location: Academy hub or article-level "Ask about this topic".
+- The bot must clearly indicate that it answers from Academy sources.
+- The bot must warn users not to share personal data.
+- Citations must be visible in answer UI.
+- Abstention must feel intentional, not broken.
+
+## Accessibility Checklist
+
+- Search input has accessible label and clear placeholder.
+- Icon-only controls have labels.
+- Images and diagrams have useful alternative text unless decorative.
+- Links have visible text explaining destination.
+- Color is not the only way to convey callout meaning.
+- Screen reader order follows visual order.
+- Focus does not get trapped in glossary modal or future chatbot panel.

--- a/docs/architecture/decisions/0023-brewing-academy-knowledge-base.md
+++ b/docs/architecture/decisions/0023-brewing-academy-knowledge-base.md
@@ -1,0 +1,92 @@
+# ADR-0023 - Brewing Academy as a generated knowledge base
+
+**Status**  Proposed
+**Date**    2026-07-02
+**Owners**  @benoit-bremaud
+
+---
+
+## Context
+
+The current Brewing Academy content is mixed with React Native UI. This makes
+articles harder to review, source, search, reuse, and prepare for a future
+specialized brewing chatbot.
+
+The product decision is clear:
+
+- the mobile app remains the active pedagogical guide;
+- the Academy becomes a complete reference knowledge base;
+- users can leave an app flow, consult a detailed concept, then return to tools
+  or calculators;
+- future chatbot answers must come from a validated and sourced corpus.
+
+The first implementation must stay proportionate: three pilot articles
+(`houblons`, `levures`, `eau`), local search, central glossary, calculator
+links, mobile-first reading, and no backend publishing surface.
+
+## Decision
+
+1. **Markdown/front matter is the V1 editorial source.** Academy articles are
+   authored as Markdown files with strict YAML front matter and reviewed through
+   Git.
+
+2. **The mobile app consumes generated typed content.** A build-time pipeline
+   parses, validates, and generates TypeScript payloads for articles, glossary,
+   search, and future retrieval preparation. React Native screens do not contain
+   article-specific JSX.
+
+3. **No database, CMS, or backend publishing in V1.** The immediate problem is
+   content structure and maintainability, not multi-author runtime publishing.
+
+4. **Local search first.** The initial corpus is small and must be available
+   offline, so V1 uses a generated local search index. The search behavior sits
+   behind a strategy boundary to allow later evolution.
+
+5. **One semantic link resolver.** Article, glossary, calculator, and app
+   context links are represented as semantic targets and resolved centrally.
+
+6. **Future chatbot is prepared, not implemented.** The content model includes
+   stable section IDs, source references, and optional retrieval chunk
+   generation so a later sourced RAG assistant can cite Academy content and
+   abstain when unsupported.
+
+7. **SOLID and design patterns are pragmatic constraints.** Repository,
+   Adapter, Factory/Builder, Strategy, Resolver, Presenter/ViewModel,
+   Specification, and Template Method may be used only when they reduce
+   coupling, improve testability, or clarify a concrete responsibility.
+
+## Consequences
+
+Positive:
+
+- Academy content becomes reviewable and versioned.
+- Core Academy content stays offline-capable.
+- Broken metadata, links, glossary terms, and sources can fail before runtime.
+- Screens become simpler and more testable.
+- The same corpus can later support a sourced chatbot.
+
+Negative:
+
+- Non-technical editing remains less comfortable than a CMS.
+- Content updates require a generation and app release path.
+- The generator and schemas become required project tooling.
+- Generated files need a clear policy: committed artifacts or deterministic CI
+  output.
+
+## Roadmap
+
+1. Add Academy domain contracts and validation schemas.
+2. Add Markdown/front matter source files for the pilot articles.
+3. Add generator for typed article, glossary, and search payloads.
+4. Replace hardcoded pilot article UI with a generic renderer.
+5. Add hub/search UX and bidirectional calculator links.
+6. Generate retrieval chunks only when chatbot preparation becomes useful.
+7. Revisit backend publishing or CMS only after the Git-based workflow becomes
+   a real limitation.
+
+## References
+
+- `docs/product/academy/academy-knowledge-base-framing.md`
+- `docs/architecture/academy/design-pack.md`
+- `docs/architecture/diagrams/academy/00-overview.md`
+- `docs/architecture/diagrams/academy/10-implementation-notes.md`

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -60,6 +60,7 @@ Every ADR follows the same skeleton (inspired by Michael Nygard's template):
 | [0020](0020-equipment-driven-volume-planning.md) | Equipment-driven batch sizing & volume planning (computed in the backend) | Accepted | 2026-06-19 |
 | [0021](0021-equipment-readiness-cleaning-and-adaptive-pedagogy.md) | Equipment readiness = reusable profile + capacity fit-check + cleaning ritual; adaptive pedagogy | Proposed | 2026-06-24 |
 | [0022](0022-public-faq-chatbot-llm.md) | Public project FAQ chatbot on the website, backed by Mistral (EU/RGPD), prompt-as-spec with an eval gate | Proposed | 2026-07-01 |
+| [0023](0023-brewing-academy-knowledge-base.md) | Brewing Academy as a generated knowledge base | Proposed | 2026-07-02 |
 
 > **Numbers 0006–0008 are reserved** (not yet drafted) for decisions already
 > referenced by open epics: 0006 — private journal vs. social product (#833),

--- a/docs/architecture/diagrams/academy/00-overview.md
+++ b/docs/architecture/diagrams/academy/00-overview.md
@@ -1,0 +1,70 @@
+# Academy knowledge base UML study
+
+> **Feature**: Brewing Academy refactor as a versioned knowledge base.
+> **Scope**: V1 Markdown/front matter content pipeline, mobile reader, glossary,
+> local search, calculator links. Future: sourced RAG chatbot.
+> **Product framing**:
+> `docs/product/academy/academy-knowledge-base-framing.md`.
+
+## Context
+
+The current Academy implementation mixes article content with React Native UI.
+The target architecture separates editorial content, validation, generated
+mobile payloads, presentation, search, glossary reuse, and future chatbot
+retrieval.
+
+This UML package is the coding support for the next implementation phase. Code
+should implement the contracts and flows described here, not re-invent them in
+screen components.
+
+## Design Principles
+
+- Clean boundaries: editorial source, generation, domain model, use cases, and
+  presentation stay distinct.
+- SOLID: renderers depend on block contracts, not article slugs.
+- KISS: V1 ships a vertical slice with three pilot articles.
+- YAGNI: no CMS, backend publishing, vector search, or chatbot implementation in
+  V1.
+- DRY: one glossary model, one content model, one calculator-link contract.
+
+## V1 Decisions
+
+- The Academy is a reference knowledge base, not the app's active tutorial.
+- The mobile app remains the pedagogical guide in operational flows.
+- Canonical Academy content is Markdown with strict front matter.
+- The app consumes generated typed content, not raw hardcoded article JSX.
+- Core content remains available offline in the mobile bundle.
+- Pilot articles are `houblons`, `levures`, and `eau`.
+- The hub is mobile-first, search-first, and tablet-aware.
+- The glossary is central and reusable across app surfaces.
+- Calculator links are bidirectional.
+
+## Future Decisions Represented But Not Implemented In V1
+
+- The chatbot is a sourced RAG assistant over Academy and glossary content.
+- V1 chatbot has no persistent server-side conversation history.
+- User-specific brewing context requires explicit consent and is a later phase.
+- Vector search is only introduced if lexical search is insufficient.
+
+## Diagram Index
+
+1. [Context](01-context.md)
+2. [Use cases](02-use-case.md)
+3. [Domain class model](03-domain-class.md)
+4. [Components](04-components.md)
+5. [Sequence: open article](05-sequence-open-article.md)
+6. [Sequence: generate content](06-sequence-generate-content.md)
+7. [State: article lifecycle](07-state-article-lifecycle.md)
+8. [Activity: local search](08-activity-search.md)
+9. [Sequence: future chatbot RAG](09-sequence-chatbot-rag.md)
+10. [Implementation notes](10-implementation-notes.md)
+
+## Implementation Order Suggested By This Study
+
+1. Domain contracts for articles, blocks, glossary, links, sources, and search.
+2. Markdown/front matter validation.
+3. Generated Academy index and generated article content.
+4. Mobile article renderer.
+5. Mobile Academy hub and local search.
+6. Bidirectional calculator/article links.
+7. Retrieval chunk generation for the future chatbot.

--- a/docs/architecture/diagrams/academy/00-overview.md
+++ b/docs/architecture/diagrams/academy/00-overview.md
@@ -59,6 +59,22 @@ screen components.
 9. [Sequence: future chatbot RAG](09-sequence-chatbot-rag.md)
 10. [Implementation notes](10-implementation-notes.md)
 
+## Documentation Check
+
+Context7 was requested but is not available in this Codex session. The review
+therefore used current official documentation directly:
+
+- Mermaid 11.16.0 syntax documentation for flowchart, class, sequence, and state
+  diagrams.
+- Expo Router documentation for file-based routing, dynamic route parameters,
+  `Link asChild`, and route prefetch constraints.
+- React Native documentation for accessibility labels, hints, and image `alt`
+  support.
+
+The diagrams intentionally use conservative Mermaid syntax. Newer flowchart
+shape aliases and ambiguous labels such as lowercase `end` are avoided until the
+project renderer version is confirmed.
+
 ## Implementation Order Suggested By This Study
 
 1. Domain contracts for articles, blocks, glossary, links, sources, and search.

--- a/docs/architecture/diagrams/academy/00-overview.md
+++ b/docs/architecture/diagrams/academy/00-overview.md
@@ -5,6 +5,8 @@
 > local search, calculator links. Future: sourced RAG chatbot.
 > **Product framing**:
 > `docs/product/academy/academy-knowledge-base-framing.md`.
+> **Implementation design pack**:
+> `docs/architecture/academy/design-pack.md`.
 
 ## Context
 
@@ -21,11 +23,29 @@ screen components.
 
 - Clean boundaries: editorial source, generation, domain model, use cases, and
   presentation stay distinct.
+- Clean dependency rule: domain contracts stay framework-agnostic; use cases
+  depend on ports; adapters implement ports; React Native and Expo Router stay
+  at the outer layer.
 - SOLID: renderers depend on block contracts, not article slugs.
 - KISS: V1 ships a vertical slice with three pilot articles.
 - YAGNI: no CMS, backend publishing, vector search, or chatbot implementation in
   V1.
 - DRY: one glossary model, one content model, one calculator-link contract.
+
+## Clean Architecture Mapping
+
+- Entities: `AcademyArticle`, `AcademySection`, `AcademyContentBlock`,
+  `GlossaryTerm`, `SourceReference`, `AcademyLinkTarget`.
+- Use cases: article opening, Academy search, glossary lookup, semantic link
+  resolution.
+- Interface adapters: generated content repository, local search strategy,
+  presenters/view models, link resolver adapter.
+- Frameworks and drivers: Markdown parser, generated files, React Native
+  screens, Expo Router navigation, future LLM provider.
+
+Dependencies must point inward. Screens and generated adapters can depend on
+application contracts; domain contracts must not depend on screens, routers,
+Markdown parser types, or generated file paths.
 
 ## V1 Decisions
 

--- a/docs/architecture/diagrams/academy/00-overview.md
+++ b/docs/architecture/diagrams/academy/00-overview.md
@@ -81,8 +81,7 @@ Markdown parser types, or generated file paths.
 
 ## Documentation Check
 
-Context7 was requested but is not available in this Codex session. The review
-therefore used current official documentation directly:
+The design review used current official documentation directly:
 
 - Mermaid 11.16.0 syntax documentation for flowchart, class, sequence, and state
   diagrams.
@@ -93,7 +92,9 @@ therefore used current official documentation directly:
 
 The diagrams intentionally use conservative Mermaid syntax. Newer flowchart
 shape aliases and ambiguous labels such as lowercase `end` are avoided until the
-project renderer version is confirmed.
+project renderer version is confirmed. Before implementation, verify these notes
+against the Mermaid, Expo Router, and React Native versions actually installed
+in the repository.
 
 ## Implementation Order Suggested By This Study
 

--- a/docs/architecture/diagrams/academy/01-context.md
+++ b/docs/architecture/diagrams/academy/01-context.md
@@ -1,0 +1,80 @@
+# Context diagram - Academy knowledge base
+
+> **Feature**: Brewing Academy as a reference knowledge base.
+> **Scope**: Mobile-first V1 with future chatbot path.
+
+## Context
+
+The app guides users through brewing workflows. The Academy answers deeper
+questions raised by those workflows. The future chatbot is a conversational
+interface over the same validated Academy and glossary corpus.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer"))
+  Editor(("Content editor"))
+
+  subgraph Repo ["Git repository"]
+    MD["Markdown articles<br/>docs/academy/**/*.md"]
+    GlossarySrc["Glossary source<br/>structured content"]
+    Sources["Source references<br/>books, standards, docs"]
+  end
+
+  subgraph Build ["Build-time content pipeline"]
+    Parser["Academy parser"]
+    Validator["Front matter and link validator"]
+    Generator["Typed content generator"]
+  end
+
+  subgraph Mobile ["Brasse-Bouillon mobile app"]
+    AppGuide["Active brewing guidance<br/>recipes, batches, calculators"]
+    AcademyHub["Academy hub"]
+    ArticleReader["Article reader"]
+    Glossary["Glossary lookup"]
+    LocalSearch["Local Academy search"]
+    Calculators["Brewing calculators"]
+  end
+
+  subgraph Future ["Future cloud-assisted features"]
+    SearchIndex["Search / retrieval index"]
+    Chatbot["Sourced brewing chatbot"]
+    Backend["Optional product backend APIs"]
+  end
+
+  Editor --> MD
+  Editor --> GlossarySrc
+  Editor --> Sources
+
+  MD --> Parser
+  GlossarySrc --> Parser
+  Parser --> Validator
+  Validator --> Generator
+  Generator --> AcademyHub
+  Generator --> ArticleReader
+  Generator --> Glossary
+  Generator --> LocalSearch
+  Generator -. future chunks .-> SearchIndex
+
+  Brewer --> AppGuide
+  Brewer --> AcademyHub
+  Brewer --> LocalSearch
+  AcademyHub --> ArticleReader
+  ArticleReader --> Glossary
+  ArticleReader --> Calculators
+  Calculators --> ArticleReader
+  AppGuide --> ArticleReader
+
+  Brewer -. future question .-> Chatbot
+  Chatbot -. retrieve .-> SearchIndex
+  SearchIndex -. source content .-> Generator
+  Chatbot -. optional APIs .-> Backend
+```
+
+## Notes
+
+- V1 does not require a backend for Academy content.
+- V1 content is bundled/generated for mobile offline access.
+- The future chatbot must cite generated article/glossary sources.
+- App guidance remains separate from Academy reference content.

--- a/docs/architecture/diagrams/academy/02-use-case.md
+++ b/docs/architecture/diagrams/academy/02-use-case.md
@@ -1,0 +1,84 @@
+# Use-case diagram - Academy knowledge base
+
+> **Feature**: Academy reference content, mobile reader, glossary, search, and
+> future chatbot.
+
+## Context
+
+The V1 user needs to find and read trusted brewing explanations. Future users
+can ask a chatbot that answers from the same validated content.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brewer"))
+  Editor(("Content editor"))
+  Reviewer(("Technical reviewer"))
+
+  subgraph Academy ["Brasse-Bouillon Academy"]
+    UC1(("Browse the Academy hub"))
+    UC2(("Search a brewing concept"))
+    UC3(("Filter by category or tag"))
+    UC4(("Open an article"))
+    UC5(("Read quick summary"))
+    UC6(("Read detailed sections"))
+    UC7(("Open glossary term"))
+    UC8(("Open related calculator"))
+    UC9(("Return from calculator to article"))
+    UC10(("Open contextual Academy help from app flow"))
+  end
+
+  subgraph Editorial ["Editorial workflow"]
+    UC11(("Create or edit Markdown article"))
+    UC12(("Validate metadata and links"))
+    UC13(("Review technical accuracy"))
+    UC14(("Publish article"))
+    UC15(("Deprecate obsolete article"))
+  end
+
+  subgraph FutureChatbot ["Future chatbot"]
+    UC16(("Ask brewing question"))
+    UC17(("Receive sourced answer"))
+    UC18(("Open cited article section"))
+    UC19(("Get no-answer when source is missing"))
+    UC20(("Ask troubleshooting question"))
+  end
+
+  Brewer --> UC1
+  Brewer --> UC2
+  Brewer --> UC3
+  Brewer --> UC4
+  Brewer --> UC5
+  Brewer --> UC6
+  Brewer --> UC7
+  Brewer --> UC8
+  Brewer --> UC9
+  Brewer --> UC10
+
+  Editor --> UC11
+  Editor --> UC12
+  Reviewer --> UC13
+  Editor --> UC14
+  Editor --> UC15
+
+  Brewer -. future .-> UC16
+  Brewer -. future .-> UC17
+  Brewer -. future .-> UC18
+  Brewer -. future .-> UC19
+  Brewer -. future .-> UC20
+```
+
+## V1 Boundary
+
+V1 includes UC1 to UC15 for the pilot content slice.
+
+UC16 to UC20 are modeled so the content design remains compatible with a future
+sourced chatbot, but they are not implemented in the first refactor.
+
+## Notes
+
+- The hub must not hide the search function behind navigation.
+- The reader must support quick comprehension and deep reference reading.
+- Glossary and calculator links must be metadata-driven, not hardcoded per slug.
+- Editorial validation should fail fast before content reaches the app bundle.

--- a/docs/architecture/diagrams/academy/03-domain-class.md
+++ b/docs/architecture/diagrams/academy/03-domain-class.md
@@ -42,7 +42,7 @@ classDiagram
   }
 
   class AcademyContentBlock {
-    <<union>>
+    <<enumeration>>
     paragraph
     heading
     bulletList

--- a/docs/architecture/diagrams/academy/03-domain-class.md
+++ b/docs/architecture/diagrams/academy/03-domain-class.md
@@ -26,7 +26,7 @@ classDiagram
     +AcademyLevel level
     +AcademyStatus status
     +string version
-    +int estimatedReadTime
+    +int estimatedReadTimeMinutes
     +Date updatedAt
     +boolean sensitive
   }
@@ -58,19 +58,22 @@ classDiagram
 
   class GlossaryTerm {
     +string slug
-    +string term
+    +string label
     +string[] aliases
     +string shortDefinition
-    +string longDefinition
-    +AcademyLevel level
+    +string detailedDefinition
   }
 
   class SourceReference {
     +string id
+    +SourceKind kind
     +string title
+    +string[] authors
+    +string publisher
     +string url
-    +SourceType type
-    +string note
+    +Date accessedAt
+    +int year
+    +string notes
   }
 
   class ReviewMetadata {
@@ -81,17 +84,20 @@ classDiagram
   }
 
   class CalculatorLink {
-    +CalculatorSlug slug
+    +string slug
     +string label
+    +string reason
     +AcademyLinkTarget target
   }
 
-  class SearchIndexEntry {
+  class AcademySearchEntry {
     +string id
-    +SearchEntryType type
+    +AcademySearchResultKind kind
     +string title
-    +string summary
-    +string[] tokens
+    +string excerpt
+    +string[] keywords
+    +AcademyLevel level
+    +AcademyCategory category
     +AcademyLinkTarget target
   }
 
@@ -99,9 +105,10 @@ classDiagram
     +string id
     +string articleSlug
     +string sectionId
-    +string content
+    +string text
     +string[] sourceIds
-    +string version
+    +string[] glossaryTermSlugs
+    +boolean sensitive
   }
 
   class ChatbotAnswer {
@@ -140,10 +147,10 @@ classDiagram
   AcademyArticleMetadata "*" --> "*" CalculatorLink
   AcademyArticleMetadata "*" --> "*" GlossaryTerm
   CalculatorLink ..> AcademyLinkTarget : targets
-  SearchIndexEntry ..> AcademyLinkTarget : targets
+  AcademySearchEntry ..> AcademyLinkTarget : targets
   RelatedAction ..> AcademyLinkTarget : targets
-  SearchIndexEntry ..> AcademyArticle : indexes
-  SearchIndexEntry ..> GlossaryTerm : indexes
+  AcademySearchEntry ..> AcademyArticle : indexes
+  AcademySearchEntry ..> GlossaryTerm : indexes
   RetrievalChunk ..> AcademySection : chunks
   RetrievalChunk ..> SourceReference : cites
   ChatbotAnswer "1" --> "*" ChatbotCitation
@@ -206,7 +213,7 @@ classDiagram
   LocalAcademySearchStrategy ..|> AcademySearchPort
   ExpoAcademyLinkResolver ..|> AcademyLinkResolverPort
   AcademyArticlePresenter ..> AcademyArticle
-  AcademyHubPresenter ..> SearchIndexEntry
+  AcademyHubPresenter ..> AcademySearchEntry
 ```
 
 ## Enumerations
@@ -221,7 +228,7 @@ classDiagram
     fermentation
     water
     equipment
-    styles
+    beer_styles
     safety
     troubleshooting
     glossary
@@ -249,21 +256,23 @@ classDiagram
     validated
   }
 
-  class SourceType {
+  class SourceKind {
     <<enumeration>>
     book
     standard
-    technical_article
-    manufacturer_doc
-    internal_note
+    article
+    website
+    course
+    manufacturer_documentation
   }
 
-  class SearchEntryType {
+  class AcademySearchResultKind {
     <<enumeration>>
     article
     section
-    glossary_term
+    glossary
     faq
+    calculator
   }
 
   class RelatedActionType {
@@ -278,6 +287,9 @@ classDiagram
 ## Notes
 
 - `AcademyContentBlock` is a discriminated union in TypeScript.
+- Mermaid enumeration entries use underscore-safe labels where TypeScript
+  literals may use hyphenated values, for example `beer_styles` maps to
+  `'beer-styles'`.
 - `RetrievalChunk` is generated for future chatbot retrieval, not manually edited.
 - `ChatbotAnswer` is future-facing and must not drive V1 scope.
 - `CalculatorLink` and search entries expose semantic targets, not concrete

--- a/docs/architecture/diagrams/academy/03-domain-class.md
+++ b/docs/architecture/diagrams/academy/03-domain-class.md
@@ -1,0 +1,213 @@
+# Class diagram - Academy domain model
+
+> **Feature**: typed Academy content, glossary, search, and future chatbot
+> retrieval contracts.
+
+## Context
+
+This domain model is intentionally UI-agnostic. Presentation components render
+these objects, but article meaning, metadata, links, sources, and search data do
+not belong to React Native screens.
+
+## Diagram
+
+```mermaid
+classDiagram
+  class AcademyArticle {
+    +string slug
+    +AcademyArticleMetadata metadata
+    +AcademyArticleBody body
+  }
+
+  class AcademyArticleMetadata {
+    +string title
+    +string summary
+    +AcademyCategory category
+    +AcademyLevel level
+    +AcademyStatus status
+    +string version
+    +int estimatedReadTime
+    +Date updatedAt
+    +boolean sensitive
+  }
+
+  class AcademyArticleBody {
+    +AcademySection[] sections
+  }
+
+  class AcademySection {
+    +string id
+    +string title
+    +AcademyContentBlock[] blocks
+  }
+
+  class AcademyContentBlock {
+    <<union>>
+    paragraph
+    heading
+    bulletList
+    table
+    formula
+    callout
+    diagram
+    glossaryReference
+    calculatorCta
+    relatedArticle
+    sourceReference
+  }
+
+  class GlossaryTerm {
+    +string slug
+    +string term
+    +string[] aliases
+    +string shortDefinition
+    +string longDefinition
+    +AcademyLevel level
+  }
+
+  class SourceReference {
+    +string id
+    +string title
+    +string url
+    +SourceType type
+    +string note
+  }
+
+  class ReviewMetadata {
+    +ConfidenceLevel confidenceLevel
+    +string reviewedBy
+    +Date reviewedAt
+    +string[] notes
+  }
+
+  class CalculatorLink {
+    +CalculatorSlug slug
+    +string label
+    +string route
+  }
+
+  class SearchIndexEntry {
+    +string id
+    +SearchEntryType type
+    +string title
+    +string summary
+    +string[] tokens
+    +string route
+  }
+
+  class RetrievalChunk {
+    +string id
+    +string articleSlug
+    +string sectionId
+    +string content
+    +string[] sourceIds
+    +string version
+  }
+
+  class ChatbotAnswer {
+    +string answer
+    +ChatbotCitation[] citations
+    +RelatedAction[] relatedActions
+    +boolean answeredFromSources
+  }
+
+  class ChatbotCitation {
+    +string articleSlug
+    +string sectionId
+    +string sourceId
+  }
+
+  class RelatedAction {
+    +string label
+    +string route
+    +RelatedActionType type
+  }
+
+  AcademyArticle "1" --> "1" AcademyArticleMetadata
+  AcademyArticle "1" --> "1" AcademyArticleBody
+  AcademyArticleBody "1" --> "*" AcademySection
+  AcademySection "1" --> "*" AcademyContentBlock
+  AcademyArticleMetadata "1" --> "0..1" ReviewMetadata
+  AcademyArticleMetadata "*" --> "*" SourceReference
+  AcademyArticleMetadata "*" --> "*" CalculatorLink
+  AcademyArticleMetadata "*" --> "*" GlossaryTerm
+  SearchIndexEntry ..> AcademyArticle : indexes
+  SearchIndexEntry ..> GlossaryTerm : indexes
+  RetrievalChunk ..> AcademySection : chunks
+  RetrievalChunk ..> SourceReference : cites
+  ChatbotAnswer "1" --> "*" ChatbotCitation
+  ChatbotAnswer "1" --> "*" RelatedAction
+```
+
+## Enumerations
+
+```mermaid
+classDiagram
+  class AcademyCategory {
+    <<enumeration>>
+    getting_started
+    ingredients
+    process
+    fermentation
+    water
+    equipment
+    styles
+    safety
+    troubleshooting
+    glossary
+  }
+
+  class AcademyLevel {
+    <<enumeration>>
+    beginner
+    intermediate
+    advanced
+  }
+
+  class AcademyStatus {
+    <<enumeration>>
+    draft
+    review
+    published
+    deprecated
+  }
+
+  class ConfidenceLevel {
+    <<enumeration>>
+    draft
+    reviewed
+    validated
+  }
+
+  class SourceType {
+    <<enumeration>>
+    book
+    standard
+    technical_article
+    manufacturer_doc
+    internal_note
+  }
+
+  class SearchEntryType {
+    <<enumeration>>
+    article
+    section
+    glossary_term
+    faq
+  }
+
+  class RelatedActionType {
+    <<enumeration>>
+    article
+    glossary
+    calculator
+    app_context
+  }
+```
+
+## Notes
+
+- `AcademyContentBlock` is a discriminated union in TypeScript.
+- `RetrievalChunk` is generated for future chatbot retrieval, not manually edited.
+- `ChatbotAnswer` is future-facing and must not drive V1 scope.
+- `CalculatorLink` replaces slug convention-only wiring over time.

--- a/docs/architecture/diagrams/academy/03-domain-class.md
+++ b/docs/architecture/diagrams/academy/03-domain-class.md
@@ -83,7 +83,7 @@ classDiagram
   class CalculatorLink {
     +CalculatorSlug slug
     +string label
-    +string route
+    +AcademyLinkTarget target
   }
 
   class SearchIndexEntry {
@@ -92,7 +92,7 @@ classDiagram
     +string title
     +string summary
     +string[] tokens
-    +string route
+    +AcademyLinkTarget target
   }
 
   class RetrievalChunk {
@@ -119,8 +119,16 @@ classDiagram
 
   class RelatedAction {
     +string label
-    +string route
+    +AcademyLinkTarget target
     +RelatedActionType type
+  }
+
+  class AcademyLinkTarget {
+    <<enumeration>>
+    article
+    glossary
+    calculator
+    app_context
   }
 
   AcademyArticle "1" --> "1" AcademyArticleMetadata
@@ -131,12 +139,74 @@ classDiagram
   AcademyArticleMetadata "*" --> "*" SourceReference
   AcademyArticleMetadata "*" --> "*" CalculatorLink
   AcademyArticleMetadata "*" --> "*" GlossaryTerm
+  CalculatorLink ..> AcademyLinkTarget : targets
+  SearchIndexEntry ..> AcademyLinkTarget : targets
+  RelatedAction ..> AcademyLinkTarget : targets
   SearchIndexEntry ..> AcademyArticle : indexes
   SearchIndexEntry ..> GlossaryTerm : indexes
   RetrievalChunk ..> AcademySection : chunks
   RetrievalChunk ..> SourceReference : cites
   ChatbotAnswer "1" --> "*" ChatbotCitation
   ChatbotAnswer "1" --> "*" RelatedAction
+```
+
+## SOLID-Oriented Application Contracts
+
+```mermaid
+classDiagram
+  class AcademyContentRepositoryPort {
+    <<Interface>>
+    +listPublishedArticles()
+    +getArticleBySlug(slug)
+    +getGlossaryTerm(slug)
+  }
+
+  class AcademySearchPort {
+    <<Interface>>
+    +search(query)
+  }
+
+  class AcademyLinkResolverPort {
+    <<Interface>>
+    +resolve(target)
+  }
+
+  class AcademyArticlePresenter {
+    +toArticleViewModel(article)
+  }
+
+  class AcademyHubPresenter {
+    +toHubViewModel(index)
+  }
+
+  class GeneratedAcademyRepository {
+    +listPublishedArticles()
+    +getArticleBySlug(slug)
+    +getGlossaryTerm(slug)
+  }
+
+  class LocalAcademySearchStrategy {
+    +search(query)
+  }
+
+  class ExpoAcademyLinkResolver {
+    +resolve(target)
+  }
+
+  class AcademyUseCases {
+    +openArticle(slug)
+    +search(query)
+    +openSemanticTarget(target)
+  }
+
+  AcademyUseCases ..> AcademyContentRepositoryPort : DIP
+  AcademyUseCases ..> AcademySearchPort : DIP
+  AcademyUseCases ..> AcademyLinkResolverPort : DIP
+  GeneratedAcademyRepository ..|> AcademyContentRepositoryPort
+  LocalAcademySearchStrategy ..|> AcademySearchPort
+  ExpoAcademyLinkResolver ..|> AcademyLinkResolverPort
+  AcademyArticlePresenter ..> AcademyArticle
+  AcademyHubPresenter ..> SearchIndexEntry
 ```
 
 ## Enumerations
@@ -210,4 +280,13 @@ classDiagram
 - `AcademyContentBlock` is a discriminated union in TypeScript.
 - `RetrievalChunk` is generated for future chatbot retrieval, not manually edited.
 - `ChatbotAnswer` is future-facing and must not drive V1 scope.
-- `CalculatorLink` replaces slug convention-only wiring over time.
+- `CalculatorLink` and search entries expose semantic targets, not concrete
+  routes. Route mapping belongs to the link resolver.
+- SOLID application contracts make Dependency Inversion explicit: use cases
+  depend on ports, while generated repositories, search strategies, and route
+  resolvers implement those ports.
+- Single Responsibility is enforced by keeping presenters, repositories, search,
+  and link resolution separate.
+- Open/Closed is supported by content block discriminants and search/link
+  strategy interfaces: new block renderers or search strategies should not
+  require rewriting screens.

--- a/docs/architecture/diagrams/academy/04-components.md
+++ b/docs/architecture/diagrams/academy/04-components.md
@@ -35,10 +35,15 @@ flowchart TB
   end
 
   subgraph MobileDomain ["Mobile domain/application"]
-    AcademyRepository["AcademyRepository"]
+    RepositoryPort["AcademyContentRepositoryPort"]
+    SearchPort["AcademySearchPort"]
+    LinkResolverPort["AcademyLinkResolverPort"]
+    AcademyRepository["GeneratedAcademyRepository"]
     AcademyUseCases["Academy use cases"]
-    SearchService["AcademySearchService"]
-    LinkResolver["AcademyLinkResolver"]
+    SearchService["LocalAcademySearchStrategy"]
+    LinkResolver["ExpoAcademyLinkResolver"]
+    ArticlePresenter["AcademyArticlePresenter"]
+    HubPresenter["AcademyHubPresenter"]
   end
 
   subgraph MobilePresentation ["Mobile presentation"]
@@ -73,16 +78,22 @@ flowchart TB
   GlossaryPayload --> AcademyRepository
   SearchPayload --> SearchService
 
-  AcademyRepository --> AcademyUseCases
-  SearchService --> AcademyUseCases
-  LinkResolver --> AcademyUseCases
+  AcademyRepository -.-> RepositoryPort
+  SearchService -.-> SearchPort
+  LinkResolver -.-> LinkResolverPort
+
+  AcademyUseCases --> RepositoryPort
+  AcademyUseCases --> SearchPort
+  AcademyUseCases --> LinkResolverPort
+  AcademyUseCases --> ArticlePresenter
+  AcademyUseCases --> HubPresenter
 
   AcademyUseCases --> HubScreen
   AcademyUseCases --> ArticleScreen
   AcademyUseCases --> SearchResults
   ArticleScreen --> ArticleRenderer
   ArticleRenderer --> GlossaryModal
-  ArticleRenderer --> LinkResolver
+  ArticleRenderer --> LinkResolverPort
 
   RetrievalChunks -.-> RetrievalService
   RetrievalService -.-> ChatbotService
@@ -95,3 +106,23 @@ flowchart TB
 - Presentation components must not parse Markdown.
 - Use cases must not know about raw Markdown paths.
 - Future retrieval chunks are generated from the same validated content.
+- SOLID is represented through explicit ports. `AcademyUseCases` depend on
+  repository, search, and link resolver abstractions, not generated-file or
+  Expo Router details.
+- Presenters prepare screen view models so React Native components keep a narrow
+  rendering responsibility.
+- Search is modeled as a strategy so V1 local search can evolve without changing
+  hub or article screens.
+
+## Clean Architecture Layering
+
+- Domain entities are represented by the contracts in the class diagram. They
+  are not shown as framework components because they must remain independent.
+- Application use cases depend on repository, search, and link resolver ports.
+- Generated repositories, local search, and Expo route resolution are interface
+  adapters implementing those ports.
+- React Native screens and Expo Router are outer-layer details. They can depend
+  on use cases and presenters, but use cases must not import screens or router
+  APIs.
+- The build-time pipeline is outside the mobile runtime. It produces data for
+  adapters; it does not become part of the presentation layer.

--- a/docs/architecture/diagrams/academy/04-components.md
+++ b/docs/architecture/diagrams/academy/04-components.md
@@ -1,0 +1,97 @@
+# Component diagram - Academy content architecture
+
+> **Feature**: build-time content generation and mobile runtime consumption.
+
+## Context
+
+The V1 architecture separates authoring, validation, generated content, use
+cases, and presentation. This prevents article text from returning to hardcoded
+screen branches.
+
+## Diagram
+
+```mermaid
+flowchart TB
+  subgraph Source ["Editorial source"]
+    ArticleMd["Article Markdown files"]
+    GlossaryMd["Glossary source files"]
+    SourceRefs["Source reference files"]
+  end
+
+  subgraph Pipeline ["Build-time pipeline"]
+    Parser["Content parser"]
+    SchemaValidator["Schema validator"]
+    LinkValidator["Link validator"]
+    BlockTransformer["Block transformer"]
+    ContentGenerator["Typed content generator"]
+  end
+
+  subgraph Generated ["Generated mobile content"]
+    AcademyIndex["Academy index"]
+    ArticlePayloads["Article payloads"]
+    GlossaryPayload["Glossary payload"]
+    SearchPayload["Search payload"]
+    RetrievalChunks["Retrieval chunks (future)"]
+  end
+
+  subgraph MobileDomain ["Mobile domain/application"]
+    AcademyRepository["AcademyRepository"]
+    AcademyUseCases["Academy use cases"]
+    SearchService["AcademySearchService"]
+    LinkResolver["AcademyLinkResolver"]
+  end
+
+  subgraph MobilePresentation ["Mobile presentation"]
+    HubScreen["AcademyHubScreen"]
+    ArticleScreen["AcademyArticleScreen"]
+    ArticleRenderer["AcademyArticleRenderer"]
+    GlossaryModal["GlossaryTermModal"]
+    SearchResults["AcademySearchResults"]
+  end
+
+  subgraph Future ["Future services"]
+    RetrievalService["Retrieval service"]
+    ChatbotService["Sourced chatbot service"]
+  end
+
+  ArticleMd --> Parser
+  GlossaryMd --> Parser
+  SourceRefs --> Parser
+  Parser --> SchemaValidator
+  SchemaValidator --> LinkValidator
+  LinkValidator --> BlockTransformer
+  BlockTransformer --> ContentGenerator
+
+  ContentGenerator --> AcademyIndex
+  ContentGenerator --> ArticlePayloads
+  ContentGenerator --> GlossaryPayload
+  ContentGenerator --> SearchPayload
+  ContentGenerator -.-> RetrievalChunks
+
+  AcademyIndex --> AcademyRepository
+  ArticlePayloads --> AcademyRepository
+  GlossaryPayload --> AcademyRepository
+  SearchPayload --> SearchService
+
+  AcademyRepository --> AcademyUseCases
+  SearchService --> AcademyUseCases
+  LinkResolver --> AcademyUseCases
+
+  AcademyUseCases --> HubScreen
+  AcademyUseCases --> ArticleScreen
+  AcademyUseCases --> SearchResults
+  ArticleScreen --> ArticleRenderer
+  ArticleRenderer --> GlossaryModal
+  ArticleRenderer --> LinkResolver
+
+  RetrievalChunks -.-> RetrievalService
+  RetrievalService -.-> ChatbotService
+```
+
+## Notes
+
+- Generated files may be committed or generated in CI depending on the final
+  implementation decision. The contract is the important point.
+- Presentation components must not parse Markdown.
+- Use cases must not know about raw Markdown paths.
+- Future retrieval chunks are generated from the same validated content.

--- a/docs/architecture/diagrams/academy/05-sequence-open-article.md
+++ b/docs/architecture/diagrams/academy/05-sequence-open-article.md
@@ -1,0 +1,57 @@
+# Sequence diagram - open an Academy article
+
+> **Feature**: mobile article opening and rendering from generated content.
+
+## Context
+
+The hub loads lightweight metadata. The article screen loads the selected
+article payload and renders blocks through a reusable renderer.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant H as "Mobile - AcademyHubScreen"
+  participant UC as "Academy use cases"
+  participant Repo as "AcademyRepository"
+  participant Index as "Generated academy index"
+  participant Screen as "Mobile - AcademyArticleScreen"
+  participant Payload as "Generated article payload"
+  participant Renderer as "AcademyArticleRenderer"
+  participant Links as "AcademyLinkResolver"
+
+  B->>H: Open Academy
+  H->>UC: getAcademyIndex()
+  UC->>Repo: loadIndex()
+  Repo->>Index: read metadata
+  Index-->>Repo: article cards, categories, FAQ
+  Repo-->>UC: AcademyIndex
+  UC-->>H: display hub
+
+  B->>H: Tap article slug
+  H->>Screen: navigate(slug)
+  Screen->>UC: getArticle(slug)
+  UC->>Repo: loadArticle(slug)
+  Repo->>Payload: read generated article content
+  alt article found
+    Payload-->>Repo: AcademyArticle
+    Repo-->>UC: AcademyArticle
+    UC-->>Screen: AcademyArticle
+    Screen->>Renderer: render(article.body.sections)
+    Renderer->>Links: resolve glossary / calculator / related routes
+    Links-->>Renderer: resolved actions
+    Renderer-->>B: article UI
+  else article missing
+    Repo-->>UC: not found
+    UC-->>Screen: not found result
+    Screen-->>B: not found state + back to Academy
+  end
+```
+
+## Notes
+
+- The screen receives article data, not slug-specific JSX.
+- Missing articles must render a controlled empty state.
+- Glossary and calculator links are resolved by a shared resolver.
+- Tablet behavior may change layout, not data flow.

--- a/docs/architecture/diagrams/academy/05-sequence-open-article.md
+++ b/docs/architecture/diagrams/academy/05-sequence-open-article.md
@@ -12,14 +12,28 @@ article payload and renders blocks through a reusable renderer.
 ```mermaid
 sequenceDiagram
   actor B as Brewer
-  participant H as "Mobile - AcademyHubScreen"
-  participant UC as "Academy use cases"
-  participant Repo as "AcademyRepository"
-  participant Index as "Generated academy index"
-  participant Screen as "Mobile - AcademyArticleScreen"
-  participant Payload as "Generated article payload"
-  participant Renderer as "AcademyArticleRenderer"
-  participant Links as "AcademyLinkResolver"
+  box Presentation
+    participant H as "AcademyHubScreen"
+    participant Screen as "AcademyArticleScreen"
+    participant Renderer as "AcademyArticleRenderer"
+  end
+  box Application
+    participant UC as "AcademyArticleUseCases"
+    participant Presenter as "AcademyArticlePresenter"
+    participant LinkPort as "AcademyLinkResolverPort"
+  end
+  box Domain
+    participant Article as "AcademyArticle"
+    participant Blocks as "AcademyContentBlock[]"
+  end
+  box Adapter
+    participant Repo as "GeneratedAcademyRepository"
+    participant Links as "ExpoAcademyLinkResolver"
+  end
+  box Framework_Driver
+    participant Index as "Generated academy index"
+    participant Payload as "Generated article payload"
+  end
 
   B->>H: Open Academy
   H->>UC: getAcademyIndex()
@@ -35,11 +49,18 @@ sequenceDiagram
   UC->>Repo: loadArticle(slug)
   Repo->>Payload: read generated article content
   alt article found
-    Payload-->>Repo: AcademyArticle
+    Payload-->>Repo: raw generated article data
+    Repo-->>Article: map to domain article
+    Article-->>Repo: AcademyArticle
     Repo-->>UC: AcademyArticle
-    UC-->>Screen: AcademyArticle
-    Screen->>Renderer: render(article.body.sections)
-    Renderer->>Links: resolve glossary / calculator / related routes
+    UC->>Presenter: toArticleViewModel(article)
+    Presenter->>Blocks: read block contracts
+    Blocks-->>Presenter: renderable sections
+    Presenter-->>UC: ArticleViewModel
+    UC-->>Screen: ArticleViewModel
+    Screen->>Renderer: render(viewModel.sections)
+    Renderer->>LinkPort: resolve semantic link targets
+    LinkPort->>Links: resolve with Expo Router mapping
     Links-->>Renderer: resolved actions
     Renderer-->>B: article UI
   else article missing
@@ -55,3 +76,7 @@ sequenceDiagram
 - Missing articles must render a controlled empty state.
 - Glossary and calculator links are resolved by a shared resolver.
 - Tablet behavior may change layout, not data flow.
+- Clean Architecture is shown only because this scenario crosses presentation,
+  application, domain, adapter, and generated-driver boundaries.
+- Presentation depends on use cases and presenters; the domain does not depend
+  on React Native, Expo Router, or generated files.

--- a/docs/architecture/diagrams/academy/05-sequence-open-article.md
+++ b/docs/architecture/diagrams/academy/05-sequence-open-article.md
@@ -23,8 +23,7 @@ sequenceDiagram
     participant LinkPort as "AcademyLinkResolverPort"
   end
   box Domain
-    participant Article as "AcademyArticle"
-    participant Blocks as "AcademyContentBlock[]"
+    participant DomainModel as "AcademyArticle + blocks"
   end
   box Adapter
     participant Repo as "GeneratedAcademyRepository"
@@ -50,12 +49,13 @@ sequenceDiagram
   Repo->>Payload: read generated article content
   alt article found
     Payload-->>Repo: raw generated article data
-    Repo-->>Article: map to domain article
-    Article-->>Repo: AcademyArticle
+    Repo->>Repo: map to domain article
+    Repo-->>DomainModel: creates immutable domain data
+    DomainModel-->>Repo: AcademyArticle
     Repo-->>UC: AcademyArticle
     UC->>Presenter: toArticleViewModel(article)
-    Presenter->>Blocks: read block contracts
-    Blocks-->>Presenter: renderable sections
+    Presenter->>DomainModel: read block contracts
+    DomainModel-->>Presenter: renderable sections
     Presenter-->>UC: ArticleViewModel
     UC-->>Screen: ArticleViewModel
     Screen->>Renderer: render(viewModel.sections)
@@ -80,3 +80,4 @@ sequenceDiagram
   application, domain, adapter, and generated-driver boundaries.
 - Presentation depends on use cases and presenters; the domain does not depend
   on React Native, Expo Router, or generated files.
+- Domain participants represent immutable data and rules, not active services.

--- a/docs/architecture/diagrams/academy/06-sequence-generate-content.md
+++ b/docs/architecture/diagrams/academy/06-sequence-generate-content.md
@@ -1,0 +1,66 @@
+# Sequence diagram - generate Academy content
+
+> **Feature**: build-time Markdown/front matter validation and typed payload
+> generation.
+
+## Context
+
+The content pipeline converts editorial Markdown into data that the mobile app
+can import safely. It catches broken metadata, unknown categories, invalid
+glossary references, broken article links, and unsupported blocks before runtime.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor E as Editor
+  participant Git as "Git repository"
+  participant Parser as "Content parser"
+  participant Schema as "Schema validator"
+  participant Links as "Link validator"
+  participant Blocks as "Block transformer"
+  participant Gen as "Content generator"
+  participant Mobile as "Generated mobile content"
+
+  E->>Git: Add or edit Markdown article
+  Git->>Parser: read docs/academy/**/*.md
+  Parser->>Parser: split front matter and Markdown body
+  Parser-->>Schema: parsed article documents
+
+  Schema->>Schema: validate required metadata
+  Schema->>Schema: validate enums and dates
+  Schema->>Schema: validate review/source fields
+
+  alt metadata invalid
+    Schema-->>E: fail with actionable errors
+  else metadata valid
+    Schema-->>Links: validated documents
+    Links->>Links: validate article slugs
+    Links->>Links: validate glossary terms
+    Links->>Links: validate calculator slugs
+    Links->>Links: validate source references
+
+    alt links invalid
+      Links-->>E: fail with broken-link report
+    else links valid
+      Links-->>Blocks: linked documents
+      Blocks->>Blocks: convert Markdown/custom blocks
+      Blocks->>Blocks: reject unsupported blocks
+      Blocks-->>Gen: normalized article model
+      Gen->>Mobile: write academy index
+      Gen->>Mobile: write article payloads
+      Gen->>Mobile: write glossary payload
+      Gen->>Mobile: write search entries
+      Gen->>Mobile: write retrieval chunks (future)
+      Mobile-->>E: generated content ready
+    end
+  end
+```
+
+## Notes
+
+- Validation must be deterministic and CI-friendly.
+- The parser should produce clear errors with file path and line/field context
+  where possible.
+- Retrieval chunk generation can be present as a future-facing artifact, but the
+  chatbot remains out of V1 runtime scope.

--- a/docs/architecture/diagrams/academy/06-sequence-generate-content.md
+++ b/docs/architecture/diagrams/academy/06-sequence-generate-content.md
@@ -14,22 +14,35 @@ glossary references, broken article links, and unsupported blocks before runtime
 ```mermaid
 sequenceDiagram
   actor E as Editor
-  participant Git as "Git repository"
-  participant Parser as "Content parser"
-  participant Schema as "Schema validator"
-  participant Links as "Link validator"
-  participant Blocks as "Block transformer"
-  participant Gen as "Content generator"
-  participant Mobile as "Generated mobile content"
+  box Source_Driver
+    participant Git as "Git repository"
+    participant Markdown as "Markdown/front matter files"
+  end
+  box Pipeline_Adapter
+    participant Parser as "ContentParserAdapter"
+    participant Blocks as "ContentBlockFactory"
+    participant Gen as "TypedContentGenerator"
+  end
+  box Domain_Validation
+    participant Schema as "AcademySchemaSpecifications"
+    participant Links as "AcademyLinkSpecifications"
+    participant Safety as "AcademySafetySpecifications"
+  end
+  box Generated_Driver
+    participant Mobile as "Generated mobile content"
+    participant Retrieval as "Retrieval chunks (future)"
+  end
 
   E->>Git: Add or edit Markdown article
-  Git->>Parser: read docs/academy/**/*.md
+  Git->>Markdown: version content source
+  Markdown->>Parser: read docs/academy/**/*.md
   Parser->>Parser: split front matter and Markdown body
   Parser-->>Schema: parsed article documents
 
   Schema->>Schema: validate required metadata
   Schema->>Schema: validate enums and dates
   Schema->>Schema: validate review/source fields
+  Schema->>Safety: validate sensitive content rules
 
   alt metadata invalid
     Schema-->>E: fail with actionable errors
@@ -39,6 +52,7 @@ sequenceDiagram
     Links->>Links: validate glossary terms
     Links->>Links: validate calculator slugs
     Links->>Links: validate source references
+    Links->>Safety: validate source requirements
 
     alt links invalid
       Links-->>E: fail with broken-link report
@@ -51,7 +65,7 @@ sequenceDiagram
       Gen->>Mobile: write article payloads
       Gen->>Mobile: write glossary payload
       Gen->>Mobile: write search entries
-      Gen->>Mobile: write retrieval chunks (future)
+      Gen->>Retrieval: write retrieval chunks (future)
       Mobile-->>E: generated content ready
     end
   end
@@ -64,3 +78,8 @@ sequenceDiagram
   where possible.
 - Retrieval chunk generation can be present as a future-facing artifact, but the
   chatbot remains out of V1 runtime scope.
+- This sequence shows Clean boundaries because generation crosses source
+  drivers, parser/generator adapters, domain validation specifications, and
+  generated drivers.
+- Domain validation specifications must not depend on filesystem, Markdown
+  parser, or mobile output details.

--- a/docs/architecture/diagrams/academy/07-state-article-lifecycle.md
+++ b/docs/architecture/diagrams/academy/07-state-article-lifecycle.md
@@ -1,0 +1,48 @@
+# State diagram - Academy article lifecycle
+
+> **Feature**: Git-based editorial workflow with strict front matter status.
+
+## Context
+
+V1 keeps workflow lightweight but structured. It must remain compatible with
+future technical and editorial reviews.
+
+## Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> Draft: create article
+
+  Draft --> Review: submit for review
+  Review --> Draft: request changes
+  Review --> Published: approve and publish
+
+  Published --> Review: substantial update
+  Published --> Deprecated: obsolete or superseded
+
+  Deprecated --> Review: restore with update
+  Deprecated --> [*]: remove from public index
+
+  state Published {
+    [*] --> Current
+    Current --> VersionedUpdate: patch/minor/major edit
+    VersionedUpdate --> Current: publish new version
+  }
+```
+
+## Transition Rules
+
+| Transition | Required checks |
+|---|---|
+| Draft -> Review | Required metadata, no broken internal links |
+| Review -> Published | Sources present when technical/sensitive, review metadata updated |
+| Published -> Review | Version change declared |
+| Published -> Deprecated | Replacement article or deprecation note preferred |
+| Deprecated -> Review | Content updated and re-reviewed |
+
+## Notes
+
+- `status` lives in front matter and drives generated visibility.
+- `published` articles can ship in the mobile index.
+- `draft` and `review` can be generated only for dev/test builds if needed.
+- Sensitive content requires stronger source/review checks before publishing.

--- a/docs/architecture/diagrams/academy/08-activity-search.md
+++ b/docs/architecture/diagrams/academy/08-activity-search.md
@@ -1,0 +1,60 @@
+# Activity diagram - Academy local search
+
+> **Feature**: V1 local search over generated Academy index and glossary.
+
+## Context
+
+V1 search should help a mobile user quickly find concepts, articles, FAQ items,
+and glossary definitions. It is lexical and local. Full-text and semantic search
+are future phases.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  Start([User types query]) --> Normalize["Normalize query<br/>lowercase, trim, accents strategy, tokenization"]
+  Normalize --> Empty{"Query empty?"}
+  Empty -->|yes| Suggestions["Show default suggestions<br/>pilot articles, categories, FAQ"]
+  Empty -->|no| SearchTitle["Search title and slug"]
+
+  SearchTitle --> SearchSummary["Search summary"]
+  SearchSummary --> SearchTags["Search tags and category"]
+  SearchTags --> SearchGlossary["Search glossary terms and aliases"]
+  SearchGlossary --> SearchFaq["Search FAQ prompts"]
+
+  SearchFaq --> Score["Score matches"]
+  Score --> HasResults{"Has results?"}
+
+  HasResults -->|yes| Group["Group by type<br/>articles, glossary, FAQ, calculators"]
+  Group --> Render["Render mobile search results"]
+  Render --> Open{"User selects result"}
+  Open -->|article| Article["Open article route"]
+  Open -->|glossary| Glossary["Open glossary term"]
+  Open -->|calculator| Calculator["Open calculator"]
+  Open -->|faq| FaqTarget["Open target article section"]
+
+  HasResults -->|no| NoResult["Show no-result state<br/>suggest categories and future chatbot entry"]
+
+  Suggestions --> End([Done])
+  Article --> End
+  Glossary --> End
+  Calculator --> End
+  FaqTarget --> End
+  NoResult --> End
+```
+
+## V1 Ranking Rules
+
+1. Exact title or glossary term match.
+2. Exact alias match.
+3. Tag/category match.
+4. Summary match.
+5. FAQ prompt match.
+
+## Notes
+
+- V1 search must not require network access.
+- Results should be compact and thumb-friendly.
+- Query logs must not be persisted by default.
+- Future no-result flows can feed anonymized content-gap analysis only with a
+  clear RGPD-compliant consent path.

--- a/docs/architecture/diagrams/academy/08-activity-search.md
+++ b/docs/architecture/diagrams/academy/08-activity-search.md
@@ -33,7 +33,7 @@ flowchart TD
   Open -->|calculator| Calculator["Open calculator"]
   Open -->|faq| FaqTarget["Open target article section"]
 
-  HasResults -->|no| NoResult["Show no-result state<br/>suggest categories and future chatbot entry"]
+  HasResults -->|no| NoResult["Show no-result state<br/>suggest categories and future help placeholder if enabled"]
 
   Suggestions --> End([Done])
   Article --> End

--- a/docs/architecture/diagrams/academy/09-sequence-chatbot-rag.md
+++ b/docs/architecture/diagrams/academy/09-sequence-chatbot-rag.md
@@ -1,0 +1,61 @@
+# Sequence diagram - future sourced chatbot RAG
+
+> **Feature**: future Academy chatbot.
+> **Status**: design target only, out of V1 implementation.
+
+## Context
+
+The chatbot should answer only from validated Academy and glossary content. If
+the retrieval layer cannot find a reliable source, the chatbot should refuse to
+answer affirmatively and suggest related reading.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Brewer
+  participant UI as "Mobile - AcademyChatbotScreen"
+  participant API as "API - Academy assistant"
+  participant Guard as "Privacy and safety guard"
+  participant Retrieve as "Retrieval service"
+  participant Index as "Academy retrieval index"
+  participant LLM as "LLM provider"
+  participant Citations as "Citation builder"
+
+  B->>UI: Ask brewing question
+  UI->>API: POST question (session only)
+  API->>Guard: validate request and privacy policy
+  Guard-->>API: allowed
+  API->>Retrieve: retrieve relevant chunks
+  Retrieve->>Index: search Academy + glossary chunks
+  Index-->>Retrieve: ranked chunks + sources
+
+  alt no reliable source
+    Retrieve-->>API: insufficient evidence
+    API-->>UI: no sourced answer + related articles
+    UI-->>B: "No validated Academy source yet"
+  else sources found
+    Retrieve-->>API: contextual chunks
+    API->>LLM: answer with strict source-only prompt
+    LLM-->>API: draft answer
+    API->>Citations: attach article/section/source citations
+    Citations-->>API: sourced answer
+    API-->>UI: answer + citations + related actions
+    UI-->>B: display sourced answer
+  end
+```
+
+## V1 Chatbot Constraints When Built
+
+- No unsourced affirmative answers.
+- No persistent conversation history by default.
+- No user-specific brew data in the first assistant version.
+- Sensitive topics require caution blocks.
+- Answers should link back to article sections and glossary terms.
+
+## Future Extensions
+
+- V2: troubleshooting decision trees and guided diagnostics.
+- V3: explicit-consent access to brew session, recipe, equipment, and
+  measurements.
+- Later: vector search if lexical retrieval is not enough.

--- a/docs/architecture/diagrams/academy/09-sequence-chatbot-rag.md
+++ b/docs/architecture/diagrams/academy/09-sequence-chatbot-rag.md
@@ -14,32 +14,56 @@ answer affirmatively and suggest related reading.
 ```mermaid
 sequenceDiagram
   actor B as Brewer
-  participant UI as "Mobile - AcademyChatbotScreen"
-  participant API as "API - Academy assistant"
-  participant Guard as "Privacy and safety guard"
-  participant Retrieve as "Retrieval service"
-  participant Index as "Academy retrieval index"
-  participant LLM as "LLM provider"
-  participant Citations as "Citation builder"
+  box Presentation
+    participant UI as "AcademyChatbotScreen"
+  end
+  box Application
+    participant API as "AcademyAssistantUseCase"
+    participant Guard as "PrivacySafetyGuard"
+    participant RetrievalPort as "RetrievalPort"
+    participant LlmPort as "LlmPort"
+    participant Citations as "CitationBuilder"
+  end
+  box Domain
+    participant Policy as "SourcedAnswerPolicy"
+    participant Answer as "ChatbotAnswer"
+  end
+  box Adapter
+    participant Retrieve as "AcademyRetrievalAdapter"
+    participant LLM as "LlmProviderAdapter"
+  end
+  box Framework_Driver
+    participant Index as "Academy retrieval index"
+    participant Provider as "External LLM provider"
+  end
 
   B->>UI: Ask brewing question
   UI->>API: POST question (session only)
   API->>Guard: validate request and privacy policy
   Guard-->>API: allowed
-  API->>Retrieve: retrieve relevant chunks
+  API->>RetrievalPort: retrieve relevant chunks
+  RetrievalPort->>Retrieve: retrieve with configured strategy
   Retrieve->>Index: search Academy + glossary chunks
   Index-->>Retrieve: ranked chunks + sources
 
   alt no reliable source
     Retrieve-->>API: insufficient evidence
+    API->>Policy: build abstention
+    Policy-->>Answer: no sourced answer
     API-->>UI: no sourced answer + related articles
     UI-->>B: "No validated Academy source yet"
   else sources found
     Retrieve-->>API: contextual chunks
-    API->>LLM: answer with strict source-only prompt
+    API->>Policy: validate source coverage
+    Policy-->>API: source-only prompt constraints
+    API->>LlmPort: answer with strict source-only prompt
+    LlmPort->>LLM: call provider adapter
+    LLM->>Provider: request completion
+    Provider-->>LLM: provider response
     LLM-->>API: draft answer
     API->>Citations: attach article/section/source citations
-    Citations-->>API: sourced answer
+    Citations-->>Answer: sourced answer
+    Answer-->>API: ChatbotAnswer
     API-->>UI: answer + citations + related actions
     UI-->>B: display sourced answer
   end
@@ -52,6 +76,11 @@ sequenceDiagram
 - No user-specific brew data in the first assistant version.
 - Sensitive topics require caution blocks.
 - Answers should link back to article sections and glossary terms.
+- Clean Architecture is shown because the future chatbot crosses UI,
+  application policy, domain answer rules, retrieval/LLM adapters, and external
+  providers.
+- The use case depends on `RetrievalPort` and `LlmPort`, not directly on vector
+  storage or LLM provider SDKs.
 
 ## Future Extensions
 

--- a/docs/architecture/diagrams/academy/09-sequence-chatbot-rag.md
+++ b/docs/architecture/diagrams/academy/09-sequence-chatbot-rag.md
@@ -26,7 +26,6 @@ sequenceDiagram
   end
   box Domain
     participant Policy as "SourcedAnswerPolicy"
-    participant Answer as "ChatbotAnswer"
   end
   box Adapter
     participant Retrieve as "AcademyRetrievalAdapter"
@@ -49,7 +48,7 @@ sequenceDiagram
   alt no reliable source
     Retrieve-->>API: insufficient evidence
     API->>Policy: build abstention
-    Policy-->>Answer: no sourced answer
+    Policy-->>API: no sourced answer
     API-->>UI: no sourced answer + related articles
     UI-->>B: "No validated Academy source yet"
   else sources found
@@ -62,8 +61,7 @@ sequenceDiagram
     Provider-->>LLM: provider response
     LLM-->>API: draft answer
     API->>Citations: attach article/section/source citations
-    Citations-->>Answer: sourced answer
-    Answer-->>API: ChatbotAnswer
+    Citations-->>API: ChatbotAnswer
     API-->>UI: answer + citations + related actions
     UI-->>B: display sourced answer
   end
@@ -81,6 +79,8 @@ sequenceDiagram
   providers.
 - The use case depends on `RetrievalPort` and `LlmPort`, not directly on vector
   storage or LLM provider SDKs.
+- Domain policy is modeled as behavior; `ChatbotAnswer` remains a returned data
+  contract, not an active service participant.
 
 ## Future Extensions
 

--- a/docs/architecture/diagrams/academy/10-implementation-notes.md
+++ b/docs/architecture/diagrams/academy/10-implementation-notes.md
@@ -1,0 +1,134 @@
+# Implementation notes - Academy knowledge base V1
+
+> **Feature**: implementation guidance derived from the UML study.
+
+## Preferred Package Shape
+
+The current code places Academy screens under `features/tools`. The refactor can
+start conservatively by reusing routes and gradually introducing a cleaner
+Academy boundary.
+
+Target mobile shape:
+
+```text
+packages/mobile-app/src/features/academy/
+  domain/
+    academy.types.ts
+    glossary.types.ts
+  data/
+    generated/
+      academy-index.generated.ts
+      articles/
+      glossary.generated.ts
+      search-index.generated.ts
+    academy.repository.ts
+  application/
+    academy.use-cases.ts
+    academy-search.use-cases.ts
+    academy-link-resolver.ts
+  presentation/
+    AcademyHubScreen.tsx
+    AcademyArticleScreen.tsx
+    AcademyArticleRenderer.tsx
+    AcademySearchResults.tsx
+    GlossaryTermModal.tsx
+```
+
+If moving files in one PR is too broad, the first implementation may keep route
+files in place and introduce the new feature boundary incrementally.
+
+## Content Source Shape
+
+Recommended source structure:
+
+```text
+docs/academy/
+  ingredients/
+    houblons.md
+    levures.md
+  water/
+    eau.md
+  glossary/
+    terms.yml
+  sources/
+    references.yml
+```
+
+The exact glossary/source file format can be decided in the technical plan. The
+important constraint is that article references validate against one central
+glossary and one source registry.
+
+## Generator Shape
+
+Recommended script responsibilities:
+
+1. Read Markdown and structured glossary/source files.
+2. Parse front matter.
+3. Validate schemas and enums.
+4. Validate links.
+5. Normalize article blocks.
+6. Generate mobile TypeScript payloads.
+7. Generate local search entries.
+8. Optionally generate retrieval chunks for future chatbot.
+
+The generator should fail with actionable errors. It should not silently drop
+invalid links or unsupported blocks.
+
+## Renderer Shape
+
+The renderer should accept `AcademyContentBlock[]` and render by block type.
+
+It should not:
+
+- Switch on article slug.
+- Import article-specific components.
+- Parse raw Markdown at runtime.
+- Hardcode calculator routes outside the link resolver.
+
+## V1 Test Focus
+
+Minimum tests for the pilot slice:
+
+- Hub renders generated pilot cards.
+- Search returns article and glossary results.
+- Article screen renders a generated article.
+- Invalid slug renders a controlled empty state.
+- Calculator CTA routes to the expected calculator.
+- Calculator screen links back to the related Academy article.
+- Glossary reference resolves from central glossary data.
+- Sensitive article metadata requires source metadata.
+
+## Commit Strategy
+
+Recommended implementation commit sequence:
+
+1. `docs(academy): frame knowledge base direction`
+2. `docs(academy): add knowledge base UML study`
+3. `feat(academy): add content domain contracts`
+4. `feat(academy): add markdown content generator`
+5. `feat(academy): render generated pilot articles`
+6. `feat(academy): refactor academy hub search`
+7. `test(academy): cover generated content flows`
+
+Each commit should keep a coherent review boundary.
+
+## PR Strategy
+
+Do not open a PR until explicitly validated by the user.
+
+Recommended PR split:
+
+1. Documentation and UML design only.
+2. Content schema and generator.
+3. Mobile renderer and pilot articles.
+4. Hub/search UX.
+5. Future chatbot preparation artifacts, if still desired.
+
+## Open Technical Decisions
+
+- Whether generated files are committed or produced in CI.
+- Whether Markdown is parsed by a Node script or a TypeScript build tool.
+- Whether source/glossary registries use YAML, JSON, or Markdown front matter.
+- Whether retrieval chunks are generated in V1 or deferred until chatbot work.
+- Whether the Academy feature gets moved out of `features/tools` immediately or
+  through a staged migration.

--- a/docs/architecture/diagrams/academy/10-implementation-notes.md
+++ b/docs/architecture/diagrams/academy/10-implementation-notes.md
@@ -37,6 +37,24 @@ packages/mobile-app/src/features/academy/
 If moving files in one PR is too broad, the first implementation may keep route
 files in place and introduce the new feature boundary incrementally.
 
+## Routing Notes
+
+The Academy should follow Expo Router conventions already used by the mobile
+app.
+
+- Prefer canonical app routes such as `/(app)/academy/[slug]` and
+  `/(app)/tools/[slug]/calculator` when the implementation phase defines final
+  route names.
+- Use dynamic route parameters for article, glossary, and calculator slugs
+  instead of building paths through string concatenation in screens.
+- Use `Link asChild` when a card, chip, or custom `Pressable` acts as a link,
+  because `Link` renders text-oriented children by default.
+- Keep route resolution inside `AcademyLinkResolver`; screens should request an
+  action for a semantic link target.
+- Treat prefetch as an optimization only. Expo Router preloaded screens have
+  restrictions before navigation, so loaders and analytics must work correctly
+  without depending on prefetch.
+
 ## Content Source Shape
 
 Recommended source structure:
@@ -84,6 +102,10 @@ It should not:
 - Import article-specific components.
 - Parse raw Markdown at runtime.
 - Hardcode calculator routes outside the link resolver.
+
+Image blocks should expose accessible text through React Native `Image` `alt`
+where available. Interactive controls should use meaningful accessibility labels
+and hints when the visible text is not enough.
 
 ## V1 Test Focus
 

--- a/docs/architecture/diagrams/academy/10-implementation-notes.md
+++ b/docs/architecture/diagrams/academy/10-implementation-notes.md
@@ -37,6 +37,35 @@ packages/mobile-app/src/features/academy/
 If moving files in one PR is too broad, the first implementation may keep route
 files in place and introduce the new feature boundary incrementally.
 
+## Clean Architecture Guardrails
+
+Clean Architecture applies to the Academy where it creates useful boundaries:
+
+- `domain/` contains framework-agnostic entities, value objects, literal unions,
+  and discriminated unions.
+- `application/` contains use cases, ports, link resolution contracts, search
+  contracts, and presenter/view-model preparation.
+- `data/` contains generated payloads and adapters that implement application
+  ports.
+- `presentation/` contains React Native screens, renderers, modal components,
+  and view state.
+
+Dependency rule:
+
+```text
+presentation -> application -> domain
+data adapter -> application ports -> domain
+```
+
+Forbidden dependencies:
+
+- `domain/` importing React Native, Expo Router, Markdown parser, generated
+  files, or storage APIs.
+- `application/` importing React Native screens or Expo Router APIs directly.
+- `presentation/` importing Markdown source files or parsing raw content.
+- screens importing generated article files directly instead of using a
+  repository/use-case boundary.
+
 ## Routing Notes
 
 The Academy should follow Expo Router conventions already used by the mobile

--- a/docs/architecture/diagrams/academy/10-implementation-notes.md
+++ b/docs/architecture/diagrams/academy/10-implementation-notes.md
@@ -55,6 +55,36 @@ app.
   restrictions before navigation, so loaders and analytics must work correctly
   without depending on prefetch.
 
+## Design Patterns Guidance
+
+Use design patterns when they reduce coupling, improve testability, or clarify a
+business responsibility. Do not introduce a pattern only to make the architecture
+look more formal.
+
+Recommended patterns for the Academy implementation:
+
+- `Repository`: expose article, glossary, search index, and source data through
+  stable read APIs. Screens and use cases should not import generated files
+  directly.
+- `Adapter`: convert Markdown/front matter, YAML, or generated payloads into the
+  domain contracts consumed by the app.
+- `Factory` or `Builder`: create validated `AcademyContentBlock[]` structures
+  from parsed content during generation.
+- `Strategy`: isolate search behavior so V1 lexical search can later evolve
+  toward hybrid or retrieval-backed search without rewriting screens.
+- `Resolver`: centralize article, glossary, calculator, and app-context links in
+  `AcademyLinkResolver`.
+- `Presenter` or view model: prepare dense mobile article and hub data for UI
+  components without leaking business rules into React Native views.
+- `Specification`: express validation rules such as required sources for
+  sensitive content, allowed article states, and valid bidirectional links.
+- `Template Method`: structure the content generation pipeline only if the
+  implementation needs a repeatable sequence of read, parse, validate, generate,
+  and index steps.
+
+Pattern usage must remain concrete. If a pattern adds files without removing
+real duplication or coupling, keep the simpler implementation.
+
 ## Content Source Shape
 
 Recommended source structure:

--- a/docs/architecture/diagrams/academy/10-implementation-notes.md
+++ b/docs/architecture/diagrams/academy/10-implementation-notes.md
@@ -195,7 +195,8 @@ Each commit should keep a coherent review boundary.
 
 ## PR Strategy
 
-Do not open a PR until explicitly validated by the user.
+Do not start implementation work until the Academy design pack and ADR-0023 have
+been reviewed and accepted for the implementation slice.
 
 Recommended PR split:
 

--- a/docs/architecture/traceability-matrix.md
+++ b/docs/architecture/traceability-matrix.md
@@ -14,7 +14,8 @@ Couvre le domaine **beer-encyclopedia** (backend), la **réalisation mobile du c
 au fil des revues. Études de cas d'usage :
 [`beer-encyclopedia/01-use-case.md`](diagrams/beer-encyclopedia/01-use-case.md) (backend) ·
 [`mobile-catalog/01-use-case.md`](diagrams/mobile-catalog/01-use-case.md) (mobile) ·
-[`catalog-moderation/01-use-case.md`](diagrams/catalog-moderation/01-use-case.md) (modération).
+[`catalog-moderation/01-use-case.md`](diagrams/catalog-moderation/01-use-case.md) (modération) ·
+[`academy/00-overview.md`](diagrams/academy/00-overview.md) (Académie brassicole, ADR-0023).
 
 ## État des diagrammes — beer-encyclopedia
 
@@ -77,6 +78,25 @@ Légende : ✅ fait · 🎯 conçu (cible, code à venir) · ⬜ à venir · —
 | UC7 Gérer le catalogue (C/U/D) | Curer | 🎯 `catalog-moderation/02` (M3 dépublier = suppression logique) | `catalog-moderation/03` 🎯 | Beer, Brewery | `catalog-moderation/04` 🎯 | — | livré (CRUD) · modération in-app 🎯 | #1151 (auth), #1152 (re-cadré ADR-0018), #1175 |
 | UC8 Alimenter les référentiels | Curer | — | 03 ⬜ | Style, LegalDenomination, Source | — | — | livré | #1152 |
 | UC9 Modérer les corrections / promouvoir | Curer | 🎯 `catalog-moderation/02` (M2 promouvoir) · corrections ⬜ | `catalog-moderation/03` 🎯 | CommunityCorrection, Beer (is_verified) | `catalog-moderation/04` 🎯 · corrections (05 ⬜) | — | planifié · promotion in-app 🎯 | #1153, #1154, #1155, ADR-0015 D4 |
+
+## État des diagrammes — academy
+
+Réalisation **mobile** de l'Académie brassicole comme base de connaissances générée
+(ADR-0023). Étude conçue avant code : tous les diagrammes sont 🎯 cible.
+
+| Diagramme | Fichier | État |
+|-----------|---------|------|
+| Vue d'ensemble | [`00-overview.md`](diagrams/academy/00-overview.md) | 🎯 cible |
+| Contexte | [`01-context.md`](diagrams/academy/01-context.md) | 🎯 cible |
+| Cas d'usage | [`02-use-case.md`](diagrams/academy/02-use-case.md) | 🎯 cible |
+| Classes domaine | [`03-domain-class.md`](diagrams/academy/03-domain-class.md) | 🎯 cible |
+| Composants | [`04-components.md`](diagrams/academy/04-components.md) | 🎯 cible |
+| Séquence — ouvrir un article | [`05-sequence-open-article.md`](diagrams/academy/05-sequence-open-article.md) | 🎯 cible |
+| Séquence — générer le contenu | [`06-sequence-generate-content.md`](diagrams/academy/06-sequence-generate-content.md) | 🎯 cible |
+| États — cycle de vie article | [`07-state-article-lifecycle.md`](diagrams/academy/07-state-article-lifecycle.md) | 🎯 cible |
+| Activité — recherche locale | [`08-activity-search.md`](diagrams/academy/08-activity-search.md) | 🎯 cible |
+| Séquence — futur chatbot RAG | [`09-sequence-chatbot-rag.md`](diagrams/academy/09-sequence-chatbot-rag.md) | 🎯 cible V2 |
+| Notes d'implémentation | [`10-implementation-notes.md`](diagrams/academy/10-implementation-notes.md) | 🎯 cible |
 
 ## Règles de traçabilité
 

--- a/docs/product/academy/academy-knowledge-base-framing.md
+++ b/docs/product/academy/academy-knowledge-base-framing.md
@@ -1,0 +1,526 @@
+# Brewing Academy knowledge base framing
+
+## Status
+
+Draft framing validated in conversation before implementation.
+
+This document defines the product and design direction for the Brasse-Bouillon
+Brewing Academy refactor. It is intentionally implementation-oriented: the
+subsequent UML study, backlog, and code should implement the boundaries and
+flows described here.
+
+## Product Positioning
+
+The Brasse-Bouillon mobile app remains the active pedagogical guide. It helps a
+novice brewer progress through recipes, brew preparation, live batch guidance,
+calculators, measurements, and contextual help.
+
+The Brewing Academy is different. It is the reference knowledge base:
+
+- It explains brewing concepts in depth.
+- It answers questions raised by app workflows.
+- It gives examples, sources, formulas, glossary links, and related tools.
+- It provides a stable corpus for the future brewing chatbot.
+- It should eventually be credible enough for brewing training centers to
+  recommend as a pedagogical reference.
+
+Product rule:
+
+```text
+Short help lives in the app flow.
+Complete explanations live in the Academy.
+Conversational answers later come from the Academy corpus.
+```
+
+## Target Audience
+
+The default user experience must be beginner-first, but the Academy must support
+all levels over time.
+
+The first reading layer should be simple, reassuring, and explicit. Intermediate
+and advanced content should remain available through "go deeper" sections,
+technical notes, formulas, source references, and cross-links.
+
+This avoids two failure modes:
+
+- A beginner-only Academy that becomes shallow.
+- An expert-first Academy that loses novice users on mobile.
+
+## Scope Principles
+
+### V1 Scope
+
+V1 focuses on a high-quality vertical slice:
+
+- Markdown + front matter as the editorial source.
+- Git as the versioning and review mechanism.
+- Three pilot articles: `houblons`, `levures`, `eau`.
+- Mobile-first article reading UX, tablet-aware layout constraints.
+- A lightweight hub with search, categories, reference articles, and FAQ links.
+- A central structured glossary model.
+- Bidirectional links between Academy articles and calculators.
+- Strong source and review metadata.
+- A generation and validation path that prevents hardcoded article content in
+  React Native screens.
+
+### Explicitly Out Of V1
+
+The following are important but intentionally deferred:
+
+- Backend-powered article publishing.
+- Headless CMS or editorial back office.
+- Persistent chatbot history.
+- User-specific chatbot personalization.
+- Full diagnostic chatbot.
+- Vector search.
+- Certification or quiz features.
+- Public website publishing.
+
+The V1 must be shaped so these can be added later without replacing the content
+model.
+
+## Architecture Direction
+
+The canonical editorial source is Markdown with strict front matter.
+
+```text
+docs/academy/**/*.md
+  -> parser and validator
+  -> generated typed content for the mobile app
+  -> Academy hub, article renderer, glossary, search
+  -> future search index and chatbot retrieval corpus
+```
+
+This keeps editorial work separate from UI code while preserving offline
+availability for core content.
+
+The current hardcoded JSX article blocks should be treated as transitional
+legacy content. New Academy content must be content data rendered by reusable
+components, not conditional UI code tied to individual slugs.
+
+## Editorial Source
+
+V1 should use Markdown files with strict YAML front matter.
+
+Example:
+
+```yaml
+---
+title: "Hops"
+slug: "houblons"
+category: "ingredients"
+level: "beginner"
+status: "published"
+version: "1.0.0"
+estimated_read_time: 10
+tags: ["hop", "ibu", "aroma", "boil-addition"]
+related_calculators: ["houblons"]
+related_glossary_terms: ["ibu", "dry-hop", "alpha-acids"]
+sensitive: false
+---
+```
+
+The article body should use Markdown plus a small controlled set of custom
+blocks. The source must not become arbitrary embedded React components.
+
+Allowed V1 block families:
+
+- Paragraphs.
+- Headings.
+- Bullet lists.
+- Tables.
+- Formulas.
+- Callouts.
+- Calculator calls to action.
+- Glossary references.
+- Related article references.
+- Source references.
+
+## Article Metadata
+
+Every article should carry enough metadata to support:
+
+- Hub display.
+- Search.
+- Filtering.
+- Related content.
+- Source quality.
+- Future chatbot citations.
+- Future pedagogical paths.
+
+Required article metadata:
+
+```yaml
+title: string
+slug: string
+category: AcademyCategory
+level: beginner | intermediate | advanced
+status: draft | review | published | deprecated
+version: string
+summary: string
+estimated_read_time: number
+tags: string[]
+updated_at: YYYY-MM-DD
+```
+
+Recommended article metadata:
+
+```yaml
+related_calculators: string[]
+related_glossary_terms: string[]
+related_articles: string[]
+faq_questions: string[]
+learning_objectives: string[]
+prerequisites: string[]
+teaches: string[]
+sensitive: boolean
+risk_topics: string[]
+sources: SourceReference[]
+review:
+  confidence_level: draft | reviewed | validated
+  reviewed_by: string | null
+  reviewed_at: YYYY-MM-DD | null
+  notes: string[]
+```
+
+## Categories And Discovery
+
+The Academy should be organized as a reference knowledge base, not primarily as
+a learning path. Categories form the main structure; tags, levels, journeys, and
+related app features act as secondary dimensions.
+
+Recommended category backbone:
+
+- Getting started.
+- Ingredients.
+- Process.
+- Fermentation.
+- Water.
+- Equipment.
+- Beer styles.
+- Safety.
+- Troubleshooting.
+- Glossary.
+
+Each article can also be attached to future learning paths:
+
+```yaml
+journeys:
+  - "first-brew"
+  - "improve-a-recipe"
+related_features:
+  - "calculator:houblons"
+  - "brew-step:boil"
+```
+
+## Glossary Strategy
+
+The glossary is a central structured knowledge object, not only an A-Z article.
+
+Each term should have:
+
+- A canonical slug.
+- A display term.
+- Aliases and acronyms.
+- A short definition.
+- Optional long explanation.
+- Related articles.
+- Related calculators.
+- Level.
+- Category.
+
+Example:
+
+```yaml
+slug: "density"
+term: "Density"
+aliases: ["OG", "FG", "specific gravity", "gravity"]
+short_definition: "A measurement of dissolved extract concentration in wort or beer."
+related_articles: ["alcohol-density", "fermentation"]
+related_calculators: ["fermentescibles"]
+level: "beginner"
+```
+
+The glossary must be reusable by:
+
+- Academy articles.
+- Recipe details.
+- Brew guidance.
+- Calculators.
+- Future chatbot answers.
+
+## Article UX
+
+The article experience must be mobile-first and tablet-aware.
+
+Reading principle:
+
+```text
+Understand quickly.
+Go deeper without getting lost.
+Return to the original app context easily.
+```
+
+Recommended article layout:
+
+- Title and badges.
+- Quick summary.
+- Key takeaways.
+- Compact table of contents.
+- Progressive detailed sections.
+- Concrete example.
+- Common mistakes.
+- Related glossary terms.
+- Related calculator CTA.
+- Related articles.
+- Sources and review notes.
+
+Long sections may be collapsible when useful. The design must avoid dense
+desktop documentation patterns on mobile.
+
+Tablet layout can add a side summary or table of contents, but the V1 should
+not require a separate tablet implementation.
+
+## Hub UX
+
+The Academy hub should behave like a mobile knowledge base entrypoint.
+
+Recommended hub structure:
+
+```text
+Brewing Academy
+
+[Search a concept, step, or term...]
+
+Reference articles
+- Hops
+- Yeast
+- Brewing water
+
+Categories
+[Ingredients] [Process] [Fermentation] [Water]
+[Safety] [Troubleshooting] [Glossary]
+
+Frequent questions
+- What is IBU?
+- Why does fermentation not start?
+- How can I avoid flat beer?
+```
+
+Hub requirements:
+
+- Search visible near the top.
+- Compact mobile cards.
+- Category chips or a mobile-friendly grid.
+- No long instructional copy.
+- Fast route to pilot reference articles.
+- FAQ links that route to article sections, glossary terms, or calculators.
+
+## Visuals
+
+The Academy should use purposeful pedagogical visuals, not decoration.
+
+V1 visual direction:
+
+- Hops: boil addition timeline and bitterness/aroma/stability role diagram.
+- Yeast: sugar to alcohol, CO2, and aroma diagram; fermentation activity curve.
+- Water: main brewing ions and their effect on flavor/process.
+
+Visual requirements:
+
+- Mobile optimized.
+- Tablet scalable.
+- Accessible alt text.
+- Lightweight.
+- Prefer simple SVG or native diagram components when appropriate.
+
+## Calculator Links
+
+Academy and calculators must be bidirectionally linked.
+
+Examples:
+
+```text
+Hops article
+  -> Open IBU calculator
+
+IBU calculator
+  -> Understand IBU and hop additions
+```
+
+Embedded mini-calculators inside articles are out of V1. The V1 should use clear
+CTAs and deep links.
+
+## FAQ And Troubleshooting
+
+V1 should include a lightweight FAQ section on the hub. Each question should
+route to an existing article, glossary term, calculator, or section.
+
+V2 can introduce a dedicated troubleshooting category with articles structured
+around brewing problems and safe diagnostic steps.
+
+This is a direct foundation for a future diagnostic chatbot.
+
+## Editorial Workflow
+
+V1 editorial workflow stays lightweight:
+
+```text
+draft -> review -> published -> deprecated
+```
+
+Git branches and PRs provide review and history. Front matter stores visible
+content status and review metadata.
+
+The workflow must be compatible with a stricter future process:
+
+```text
+draft -> technical review -> editorial review -> published
+```
+
+## Source And Review Rigor
+
+The long-term ambition is that brewing training centers can recommend the
+Academy as a credible pedagogical reference.
+
+Therefore V1 must already include source metadata, especially for technical and
+sensitive subjects.
+
+Source requirements:
+
+- Sources are mandatory for sensitive or technical content.
+- Sources may be hidden from the primary article UI at first, but must be stored.
+- Future UI can expose sources more prominently.
+- Chatbot answers must be able to cite article sections and source references.
+
+Sensitive topics include:
+
+- Bottle pressure.
+- CO2.
+- Chemical cleaning.
+- Contamination.
+- Alcohol and health.
+- Safety-critical process advice.
+
+## Chatbot Direction
+
+The chatbot is not a V1 feature. The content architecture must prepare it.
+
+Progression:
+
+```text
+V0: Academy search and article suggestions.
+V1: sourced RAG chatbot over Academy + glossary.
+V2: vector search if lexical search is insufficient.
+V3: contextual chatbot using brew session, recipe, and equipment data.
+```
+
+Chatbot V1 constraints:
+
+- Answers only from validated Academy and glossary content.
+- No unsourced affirmative answer.
+- Display citations and links.
+- No persistent server-side conversation history.
+- No user-specific data usage.
+- Stronger caution for sensitive topics.
+
+Expected V1 answer format:
+
+```text
+Direct answer
+2-4 clear sentences.
+
+Explanation
+Why / how it works.
+
+Sources
+- Academy article: ...
+- Glossary: ...
+
+Go deeper
+- Read the full article
+- Open the related calculator
+
+Caution
+Only when the subject is sensitive.
+```
+
+## RGPD And Privacy
+
+The chatbot and any future analytics must follow privacy-by-design principles:
+
+- No persistent history by default.
+- Explicit consent before any collection.
+- Data minimization.
+- Clear purpose.
+- Limited retention.
+- User deletion path.
+- Strong anonymization or pseudonymization for product learning.
+
+V1 chatbot history, if prototyped, should be session-only.
+
+## Engineering Principles
+
+The implementation must follow project architecture constraints and the
+following principles:
+
+- Clean Architecture boundaries where code is added.
+- SOLID for renderer and use-case contracts.
+- KISS: implement the vertical slice before generalizing.
+- YAGNI: no backend/CMS/vector search before the content model proves itself.
+- DRY: one glossary and one content model reused across Academy, search, and
+  future chatbot.
+
+ADR-0001 applies: build only the V1 need, but name and shape contracts so the
+future chatbot, public web Academy, and stricter editorial workflow can land
+without replacing the foundation.
+
+## Pilot Articles
+
+V1 pilot articles:
+
+- `houblons`.
+- `levures`.
+- `eau`.
+
+These cover:
+
+- Different categories.
+- Rich glossary links.
+- Calculator relationships.
+- Technical content.
+- Source requirements.
+- Visual explanation needs.
+- Future chatbot retrieval needs.
+
+## High-Level Backlog
+
+1. Define Academy content and glossary schemas.
+2. Create Markdown/front matter authoring structure.
+3. Build a validator for article metadata, links, categories, glossary terms, and
+   related calculators.
+4. Generate typed mobile Academy index and article payloads.
+5. Build the mobile article renderer.
+6. Build the mobile hub refactor.
+7. Add local search over titles, summaries, tags, categories, and glossary terms.
+8. Migrate pilot articles: Hops, Yeast, Water.
+9. Add bidirectional calculator links.
+10. Add source and review metadata display rules.
+11. Prepare generated retrieval chunks for future chatbot.
+12. Build backlog and ADRs for backend/search/chatbot only after the V1 slice is
+    validated.
+
+## Definition Of Done For The V1 Slice
+
+- No pilot article content is hardcoded as slug-specific JSX.
+- The hub loads from generated index metadata.
+- Pilot article details load from generated article content.
+- Article renderer supports the required V1 block families.
+- Glossary references resolve from a central glossary model.
+- Calculator CTAs are driven by metadata.
+- Search finds pilot articles and glossary terms.
+- Sources and review metadata are validated.
+- Mobile layout is the primary tested layout.
+- Tablet layout does not regress readability.
+- Tests cover happy path, invalid slug, missing article, glossary link, calculator
+  CTA, and search behavior.

--- a/docs/product/academy/academy-knowledge-base-framing.md
+++ b/docs/product/academy/academy-knowledge-base-framing.md
@@ -330,7 +330,8 @@ Visual requirements:
 
 - Mobile optimized.
 - Tablet scalable.
-- Accessible alt text.
+- Accessible text for visual content, using React Native `Image` `alt` where
+  available and accessibility labels or hints for interactive controls.
 - Lightweight.
 - Prefer simple SVG or native diagram components when appropriate.
 

--- a/docs/product/academy/academy-knowledge-base-framing.md
+++ b/docs/product/academy/academy-knowledge-base-framing.md
@@ -130,6 +130,7 @@ Editorial front matter uses snake_case.
 Generated TypeScript payloads use camelCase.
 The content generator owns the mapping between both shapes.
 The source `slug` is promoted to `AcademyArticle.slug` in generated payloads.
+Glossary source `term` is mapped to `GlossaryTerm.label`.
 ```
 
 Allowed V1 block families:
@@ -140,6 +141,7 @@ Allowed V1 block families:
 - Tables.
 - Formulas.
 - Callouts.
+- Diagrams.
 - Calculator calls to action.
 - Glossary references.
 - Related article references.
@@ -249,6 +251,9 @@ related_articles: ["alcohol-density", "fermentation"]
 related_calculators: ["fermentescibles"]
 level: "beginner"
 ```
+
+Glossary source files use `term` as the editorial display field. Generated
+TypeScript payloads expose this value as `GlossaryTerm.label`.
 
 The glossary must be reusable by:
 

--- a/docs/product/academy/academy-knowledge-base-framing.md
+++ b/docs/product/academy/academy-knowledge-base-framing.md
@@ -123,6 +123,15 @@ sensitive: false
 The article body should use Markdown plus a small controlled set of custom
 blocks. The source must not become arbitrary embedded React components.
 
+Naming rule:
+
+```text
+Editorial front matter uses snake_case.
+Generated TypeScript payloads use camelCase.
+The content generator owns the mapping between both shapes.
+The source `slug` is promoted to `AcademyArticle.slug` in generated payloads.
+```
+
 Allowed V1 block families:
 
 - Paragraphs.


### PR DESCRIPTION
## Summary

- Add the Brewing Academy product framing as a reference knowledge base, distinct from the app's active brewing guidance.
- Add ADR-0023 to define the Academy as a Markdown/front matter driven, generated, typed, mobile-first knowledge base.
- Add a coding-ready Academy design pack covering requirements, domain contracts, business rules, UX flows, content pipeline, tests, security/RGPD, and migration.
- Add UML diagrams for context, use cases, domain model, components, sequences, lifecycle, local search, and future sourced RAG chatbot preparation.
- Make Clean Architecture, SOLID, pragmatic design patterns, source validation, RGPD, and future chatbot constraints explicit before implementation.

## Context

This PR is documentation-only and prepares the implementation of the Brasse-Bouillon Brewing Academy refactor.

The Academy target is a complete reference knowledge base:

- the mobile app remains the active pedagogical guide;
- Academy content becomes Markdown/front matter source instead of hardcoded React Native article JSX;
- generated typed payloads feed the mobile app;
- glossary, sources, calculator links, search, and future chatbot retrieval share coherent contracts;
- V1 remains scoped to a high-quality vertical slice around `houblons`, `levures`, and `eau`;
- chatbot work is prepared through sourced retrieval contracts, but not implemented.

Key architectural decisions:

- no database, CMS, backend publishing, vector search, or chatbot runtime in V1;
- local generated content first, preserving offline availability;
- one semantic link resolver for article, glossary, calculator, and app-context targets;
- Clean Architecture dependencies point inward;
- use cases depend on ports, adapters implement ports, and React Native / Expo Router stay at the outer layer;
- design patterns are allowed only when they reduce coupling, improve testability, or clarify responsibility.

## Checklist

- [x] Happy path + sad path + edge cases covered (tests when code changes)
  - Documentation-only PR. Test strategy and acceptance criteria are documented for the future implementation.
- [ ] `npm run ci:all` (or package-local equivalent) passes locally
  - Not run: documentation-only PR, no code/package changes.
- [x] No `any`, no default exports for screens/use-cases/API modules
  - No TypeScript source files changed.
- [x] No inline styles, no hardcoded colors, spacing, or font values in `packages/mobile-app/`
  - No mobile source files changed.
- [x] No new ADR violations
  - Adds ADR-0023 and links it from the ADR index.
- [ ] `PROJECT_LOG.md` will be updated after merge
  - To be done after the PR is merged.

## Linked issue

No linked issue.
