### PR TITLE
feat(mobile/recipes): add-to-carnet undo snackbar + lighter Water tab for unsaved recipes (Tranche A)

### DIFF
--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -3,6 +3,7 @@ import "react-native-reanimated";
 import { AuthProvider, useAuth } from "@/core/auth/auth-context";
 
 import { ConfirmProvider } from "@/core/ui/confirm-provider";
+import { SnackbarProvider } from "@/core/ui/snackbar-provider";
 import { QueryProvider } from "@/core/query/query-provider";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Stack } from "expo-router";
@@ -15,8 +16,10 @@ function AppShell() {
   return (
     <QueryProvider key={queryScopeKey}>
       <ConfirmProvider>
-        <Stack screenOptions={{ headerShown: false }} />
-        <StatusBar style="auto" />
+        <SnackbarProvider>
+          <Stack screenOptions={{ headerShown: false }} />
+          <StatusBar style="auto" />
+        </SnackbarProvider>
       </ConfirmProvider>
     </QueryProvider>
   );

--- a/packages/mobile-app/src/core/ui/Snackbar.tsx
+++ b/packages/mobile-app/src/core/ui/Snackbar.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { colors, radius, shadows, spacing, typography } from "@/core/theme";
+import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+
+export type SnackbarProps = Readonly<{
+  visible: boolean;
+  message: string;
+  /** Optional single inline action (e.g. « Annuler » to undo). */
+  actionLabel?: string;
+  onAction?: () => void;
+}>;
+
+/**
+ * Branded transient snackbar — a bottom bar with an optional single action.
+ * App-level, one at a time, driven imperatively through `useSnackbar()` (see
+ * `snackbar-provider`). Sits above the floating nav footer so it never hides
+ * the primary navigation, and lets touches through everywhere but the bar.
+ */
+export function Snackbar({
+  visible,
+  message,
+  actionLabel,
+  onAction,
+}: SnackbarProps) {
+  const footerOffset = useNavigationFooterOffset();
+  if (!visible) {
+    return null;
+  }
+  return (
+    <View
+      style={[styles.overlay, { paddingBottom: footerOffset }]}
+      pointerEvents="box-none"
+    >
+      <View style={styles.bar} accessibilityRole="alert">
+        <Text style={styles.message} numberOfLines={2}>
+          {message}
+        </Text>
+        {actionLabel ? (
+          <Pressable
+            onPress={onAction}
+            accessibilityRole="button"
+            accessibilityLabel={actionLabel}
+            style={styles.action}
+          >
+            <Text style={styles.actionText}>{actionLabel}</Text>
+          </Pressable>
+        ) : null}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "flex-end",
+    paddingHorizontal: spacing.md,
+  },
+  bar: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.md,
+    backgroundColor: colors.neutral.textPrimary,
+    borderRadius: radius.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    ...shadows.sm,
+  },
+  message: {
+    flex: 1,
+    color: colors.neutral.white,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  action: {
+    paddingVertical: spacing.xxs,
+    paddingHorizontal: spacing.xs,
+  },
+  actionText: {
+    color: colors.brand.background,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+  },
+});

--- a/packages/mobile-app/src/core/ui/__tests__/snackbar-provider.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/snackbar-provider.test.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { Pressable, Text } from "react-native";
+import { act, fireEvent, render, screen } from "@testing-library/react-native";
+
+import {
+  SnackbarProvider,
+  useSnackbar,
+  type SnackbarOptions,
+} from "@/core/ui/snackbar-provider";
+
+function ShowButton({ options }: { options: SnackbarOptions }) {
+  const show = useSnackbar();
+  return (
+    <Pressable accessibilityRole="button" onPress={() => show(options)}>
+      <Text>show</Text>
+    </Pressable>
+  );
+}
+
+function renderWithProvider(options: SnackbarOptions) {
+  return render(
+    <SnackbarProvider>
+      <ShowButton options={options} />
+    </SnackbarProvider>,
+  );
+}
+
+describe("SnackbarProvider / useSnackbar", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("shows the message (and action label) when show() is called", () => {
+    renderWithProvider({ message: "Recette ajoutée", actionLabel: "Annuler" });
+
+    expect(screen.queryByText("Recette ajoutée")).toBeNull();
+
+    fireEvent.press(screen.getByText("show"));
+
+    expect(screen.getByText("Recette ajoutée")).toBeTruthy();
+    expect(screen.getByLabelText("Annuler")).toBeTruthy();
+  });
+
+  it("fires onAction and dismisses when the action is tapped", () => {
+    const onAction = jest.fn();
+    renderWithProvider({
+      message: "Recette ajoutée",
+      actionLabel: "Annuler",
+      onAction,
+    });
+
+    fireEvent.press(screen.getByText("show"));
+    fireEvent.press(screen.getByLabelText("Annuler"));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText("Recette ajoutée")).toBeNull();
+  });
+
+  it("auto-dismisses after the duration", () => {
+    jest.useFakeTimers();
+    renderWithProvider({ message: "Recette ajoutée", durationMs: 5000 });
+
+    fireEvent.press(screen.getByText("show"));
+    expect(screen.getByText("Recette ajoutée")).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+
+    expect(screen.queryByText("Recette ajoutée")).toBeNull();
+  });
+
+  it("renders no action button when no actionLabel is given", () => {
+    renderWithProvider({ message: "Résultats copiés" });
+
+    fireEvent.press(screen.getByText("show"));
+
+    expect(screen.getByText("Résultats copiés")).toBeTruthy();
+    expect(screen.queryByLabelText("Annuler")).toBeNull();
+  });
+
+  it("throws when useSnackbar is used outside a SnackbarProvider", () => {
+    // Silence the expected React error log for the thrown render.
+    const spy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<ShowButton options={{ message: "x" }} />)).toThrow(
+      "useSnackbar must be used within a SnackbarProvider",
+    );
+    spy.mockRestore();
+  });
+});

--- a/packages/mobile-app/src/core/ui/snackbar-provider.tsx
+++ b/packages/mobile-app/src/core/ui/snackbar-provider.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+
+import { Snackbar } from "@/core/ui/Snackbar";
+
+export type SnackbarOptions = Readonly<{
+  message: string;
+  /** Optional single inline action (e.g. « Annuler » to undo). */
+  actionLabel?: string;
+  onAction?: () => void;
+  /** Auto-dismiss delay in ms (default 5000). */
+  durationMs?: number;
+}>;
+
+type ShowFn = (options: SnackbarOptions) => void;
+
+const SnackbarContext = React.createContext<ShowFn | null>(null);
+
+const DEFAULT_DURATION_MS = 5000;
+
+/**
+ * Hosts the single app-level snackbar and exposes an imperative `show()` — so a
+ * screen can confirm an action and offer an undo (« Recette ajoutée · Annuler »)
+ * without wiring transient UI itself. Mounted once near the app root, above the
+ * navigator, so the snackbar survives a `router.replace` (the undo can run after
+ * the originating screen has navigated away).
+ */
+export function SnackbarProvider({ children }: { children: React.ReactNode }) {
+  const [options, setOptions] = React.useState<SnackbarOptions | null>(null);
+  const timerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = React.useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const show = React.useCallback<ShowFn>(
+    (opts) => {
+      // Replace any visible snackbar with the newest one (and reset its timer).
+      clearTimer();
+      setOptions(opts);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        setOptions(null);
+      }, opts.durationMs ?? DEFAULT_DURATION_MS);
+    },
+    [clearTimer],
+  );
+
+  // Fire the action, then dismiss — so a double-tap can't run it twice.
+  const handleAction = React.useCallback(() => {
+    const action = options?.onAction;
+    clearTimer();
+    setOptions(null);
+    action?.();
+  }, [options, clearTimer]);
+
+  // Never leak the auto-dismiss timer if the provider unmounts.
+  React.useEffect(() => clearTimer, [clearTimer]);
+
+  return (
+    <SnackbarContext.Provider value={show}>
+      {children}
+      <Snackbar
+        visible={options !== null}
+        message={options?.message ?? ""}
+        actionLabel={options?.actionLabel}
+        onAction={handleAction}
+      />
+    </SnackbarContext.Provider>
+  );
+}
+
+/**
+ * Imperative snackbar: `const snackbar = useSnackbar(); snackbar({ message })`.
+ * Throws if used outside a `SnackbarProvider` (a wiring bug, caught in dev/tests).
+ */
+export function useSnackbar(): ShowFn {
+  const show = React.useContext(SnackbarContext);
+  if (!show) {
+    throw new Error("useSnackbar must be used within a SnackbarProvider");
+  }
+  return show;
+}

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -13,6 +13,7 @@ import { colors, spacing } from "@/core/theme";
 import { getErrorMessage, HttpError } from "@/core/http/http-error";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { useConfirm } from "@/core/ui/confirm-provider";
+import { useSnackbar } from "@/core/ui/snackbar-provider";
 
 import {
   RecipeDetailsViewModel,
@@ -112,6 +113,7 @@ function isRecipeReferencedByBatch(
 export function RecipeDetailsScreen({ recipeId }: Props) {
   const router = useRouter();
   const confirm = useConfirm();
+  const snackbar = useSnackbar();
   const bottomPadding = useNavigationFooterOffset();
   const queryClient = useQueryClient();
 
@@ -358,15 +360,44 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
   const isOwned = recipe != null && recipe.ownerId != null;
   const canImportToCarnet = recipe != null && recipe.ownerId == null;
 
+  // Undo for the just-imported copy: remove it and return to the source
+  // community recipe. Invoked from the app-level snackbar, so it must not depend
+  // on this screen still being mounted — it calls the use-case directly, then
+  // the stable queryClient / router.
+  const undoImport = async (importedRecipeId: string) => {
+    try {
+      await deleteRecipeFromCarnet(importedRecipeId);
+      void queryClient.invalidateQueries({ queryKey: ["recipes", "list"] });
+      void queryClient.invalidateQueries({ queryKey: ["recipes", "catalog"] });
+      router.replace({
+        pathname: "/(app)/recipes/[id]",
+        params: { id: recipeId },
+      });
+    } catch {
+      Alert.alert(
+        "Annulation impossible",
+        "La recette n'a pas pu être retirée. Tu peux la supprimer depuis ton carnet.",
+      );
+    }
+  };
+
   const importMutation = useMutation({
     mutationFn: () => importRecipeFromCommunity(recipeId),
     onSuccess: (result) => {
       void queryClient.invalidateQueries({ queryKey: ["recipes", "list"] });
       void queryClient.invalidateQueries({ queryKey: ["recipes", "catalog"] });
-      // Land on the freshly owned copy, ready to prepare.
+      // Land on the freshly owned copy, ready to prepare...
       router.replace({
         pathname: "/(app)/recipes/[id]",
         params: { id: result.recipeId },
+      });
+      // ...and confirm the (previously silent) import with an undo affordance.
+      snackbar({
+        message: "Recette ajoutée à ton carnet",
+        actionLabel: "Annuler",
+        onAction: () => {
+          void undoImport(result.recipeId);
+        },
       });
     },
     onError: () => {
@@ -524,6 +555,7 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
                     localWaterProfile={localWaterProfile}
                     compatibility={waterCompatibility}
                     targetVolumeLiters={targetVolumeLiters}
+                    canCompare={isOwned}
                     nonPublicWaterPreference={nonPublicWaterPreference}
                     onChangeNonPublicWaterPreference={
                       setNonPublicWaterPreference

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -10,6 +10,7 @@ import {
 
 import { RecipeDetailsScreen } from "@/features/recipes/presentation/RecipeDetailsScreen";
 import { ConfirmProvider } from "@/core/ui/confirm-provider";
+import { SnackbarProvider } from "@/core/ui/snackbar-provider";
 import { HttpError } from "@/core/http/http-error";
 import {
   deleteRecipeFromCarnet,
@@ -162,7 +163,9 @@ function renderRecipeDetails(recipeId = "r1") {
   return render(
     <QueryClientProvider client={queryClient}>
       <ConfirmProvider>
-        <RecipeDetailsScreen recipeId={recipeId} />
+        <SnackbarProvider>
+          <RecipeDetailsScreen recipeId={recipeId} />
+        </SnackbarProvider>
       </ConfirmProvider>
     </QueryClientProvider>,
   );
@@ -252,6 +255,67 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     );
     // The prepare action is not offered for a recipe the user does not own yet.
     expect(screen.queryByText("Préparer mon brassin")).toBeNull();
+  });
+
+  it("Tranche A: confirms the import with a snackbar and undoes it (deletes the copy, returns to source)", async () => {
+    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue(publicViewModel);
+    renderRecipeDetails("pub-1");
+
+    fireEvent.press(await screen.findByText("Ajouter à mon carnet"));
+
+    // The import is confirmed by a snackbar rather than navigating silently.
+    expect(
+      await screen.findByText("Recette ajoutée à ton carnet"),
+    ).toBeTruthy();
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: "/(app)/recipes/[id]",
+        params: { id: "r-owned-9" },
+      }),
+    );
+
+    // Undo: delete the just-created copy and return to the source recipe.
+    fireEvent.press(screen.getByLabelText("Annuler"));
+
+    await waitFor(() =>
+      expect(deleteRecipeFromCarnet).toHaveBeenCalledWith("r-owned-9"),
+    );
+    await waitFor(() =>
+      expect(mockReplace).toHaveBeenCalledWith({
+        pathname: "/(app)/recipes/[id]",
+        params: { id: "pub-1" },
+      }),
+    );
+  });
+
+  it("Tranche A: alerts and does not navigate back when the undo delete fails (sad)", async () => {
+    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue(publicViewModel);
+    (deleteRecipeFromCarnet as jest.Mock).mockRejectedValueOnce(
+      new Error("boom"),
+    );
+    const alertSpy = jest.spyOn(Alert, "alert").mockImplementation(() => {});
+    renderRecipeDetails("pub-1");
+
+    fireEvent.press(await screen.findByText("Ajouter à mon carnet"));
+    expect(
+      await screen.findByText("Recette ajoutée à ton carnet"),
+    ).toBeTruthy();
+
+    // Ignore the import navigation; isolate the undo's own navigation.
+    mockReplace.mockClear();
+    fireEvent.press(screen.getByLabelText("Annuler"));
+
+    // The undo delete failed → alert the user and do NOT return to the source.
+    await waitFor(() =>
+      expect(alertSpy).toHaveBeenCalledWith(
+        "Annulation impossible",
+        expect.any(String),
+      ),
+    );
+    expect(mockReplace).not.toHaveBeenCalledWith({
+      pathname: "/(app)/recipes/[id]",
+      params: { id: "pub-1" },
+    });
   });
 
   it("F23: an owned recipe does not show the import CTA (it shows prepare)", async () => {
@@ -489,6 +553,25 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
       pathname: "/(app)/tools/[slug]/calculator",
       params: { slug: "eau" },
     });
+  });
+
+  it("Tranche A: lightens the Water tab for a community recipe not yet saved", async () => {
+    (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue(publicViewModel);
+    renderRecipeDetails("pub-1");
+
+    await screen.findByText("Ajouter à mon carnet");
+    switchToTab("water");
+
+    // The recommended profile stays; the local-water comparison, calculator
+    // button and salts section are hidden until the recipe is saved.
+    expect(screen.getByTestId("recipe-water-tab")).toBeTruthy();
+    expect(screen.getByText("Profil eau")).toBeTruthy();
+    expect(screen.queryByText("Comparer dans le Calculateur Eau")).toBeNull();
+    expect(screen.queryByText("Ton eau locale")).toBeNull();
+    expect(screen.queryByText("Ajouter pour matcher")).toBeNull();
+    expect(
+      screen.getByText(/Enregistre cette recette dans ton carnet/),
+    ).toBeTruthy();
   });
 
   it("renders the Brewing tab with the process preview modes", async () => {

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/WaterTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/WaterTab.tsx
@@ -36,6 +36,13 @@ type WaterTabProps = Readonly<{
   localWaterProfile: WaterProfile;
   compatibility: CompatibilityScore;
   targetVolumeLiters: number;
+  /**
+   * When false (a community recipe the user has not saved to their carnet yet),
+   * the tab shows only the recommended profile + a « save to compare » hint; the
+   * local-water comparison, compatibility score and salt additions are hidden
+   * until the recipe is owned.
+   */
+  canCompare: boolean;
   nonPublicWaterPreference: NonPublicWaterPreference;
   onChangeNonPublicWaterPreference: (value: NonPublicWaterPreference) => void;
   selectedWaterStylePresetId: WaterStylePresetId;
@@ -65,6 +72,7 @@ export function WaterTab(props: WaterTabProps) {
     localWaterProfile,
     compatibility,
     targetVolumeLiters,
+    canCompare,
     nonPublicWaterPreference,
     onChangeNonPublicWaterPreference,
     selectedWaterStylePresetId,
@@ -75,11 +83,14 @@ export function WaterTab(props: WaterTabProps) {
   } = props;
 
   const isPublic = recipe.visibility === "public";
-  const additions = computeWaterSaltAdditions(
-    recommendedWaterProfile,
-    localWaterProfile,
-    targetVolumeLiters,
-  );
+  // Salt additions only make sense once we can compare against local water.
+  const additions = canCompare
+    ? computeWaterSaltAdditions(
+        recommendedWaterProfile,
+        localWaterProfile,
+        targetVolumeLiters,
+      )
+    : [];
 
   return (
     <ScrollView
@@ -91,100 +102,106 @@ export function WaterTab(props: WaterTabProps) {
       <Card style={styles.card}>
         <Text style={styles.helperText}>{recommendedWaterLabel}</Text>
 
-        {!isPublic ? (
-          <View style={styles.toggleRow}>
-            {NON_PUBLIC_WATER_PREFERENCE_OPTIONS.map((option) => (
-              <Pressable
-                key={option.id}
-                accessibilityRole="button"
-                accessibilityLabel={`Use ${option.label.toLowerCase()} recommendation`}
-                style={[
-                  styles.toggleChip,
-                  nonPublicWaterPreference === option.id &&
-                    styles.toggleChipActive,
-                ]}
-                onPress={() => onChangeNonPublicWaterPreference(option.id)}
-              >
-                <Text
-                  style={[
-                    styles.toggleChipText,
-                    nonPublicWaterPreference === option.id &&
-                      styles.toggleChipTextActive,
-                  ]}
-                >
-                  {option.label}
-                </Text>
-              </Pressable>
-            ))}
-          </View>
-        ) : null}
-
-        {!isPublic && nonPublicWaterPreference === "style" ? (
-          <View style={styles.choiceWrap}>
-            {WATER_STYLE_PRESETS.map((preset) => {
-              const isSelected = preset.id === selectedWaterStylePresetId;
-              return (
-                <Pressable
-                  key={preset.id}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Select water style preset ${preset.name}`}
-                  style={[
-                    styles.choiceChip,
-                    isSelected && styles.choiceChipActive,
-                  ]}
-                  onPress={() => onChangeWaterStylePreset(preset.id)}
-                >
-                  <Text
+        {canCompare ? (
+          <>
+            {!isPublic ? (
+              <View style={styles.toggleRow}>
+                {NON_PUBLIC_WATER_PREFERENCE_OPTIONS.map((option) => (
+                  <Pressable
+                    key={option.id}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Use ${option.label.toLowerCase()} recommendation`}
                     style={[
-                      styles.choiceChipText,
-                      isSelected && styles.choiceChipTextActive,
+                      styles.toggleChip,
+                      nonPublicWaterPreference === option.id &&
+                        styles.toggleChipActive,
                     ]}
+                    onPress={() => onChangeNonPublicWaterPreference(option.id)}
                   >
-                    {preset.name}
-                  </Text>
-                </Pressable>
-              );
-            })}
-          </View>
+                    <Text
+                      style={[
+                        styles.toggleChipText,
+                        nonPublicWaterPreference === option.id &&
+                          styles.toggleChipTextActive,
+                      ]}
+                    >
+                      {option.label}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            ) : null}
+
+            {!isPublic && nonPublicWaterPreference === "style" ? (
+              <View style={styles.choiceWrap}>
+                {WATER_STYLE_PRESETS.map((preset) => {
+                  const isSelected = preset.id === selectedWaterStylePresetId;
+                  return (
+                    <Pressable
+                      key={preset.id}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Select water style preset ${preset.name}`}
+                      style={[
+                        styles.choiceChip,
+                        isSelected && styles.choiceChipActive,
+                      ]}
+                      onPress={() => onChangeWaterStylePreset(preset.id)}
+                    >
+                      <Text
+                        style={[
+                          styles.choiceChipText,
+                          isSelected && styles.choiceChipTextActive,
+                        ]}
+                      >
+                        {preset.name}
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ) : null}
+
+            <Text style={styles.fieldLabel}>Ton eau locale</Text>
+            <View style={styles.choiceWrap}>
+              {WATER_LOCATION_PROFILES.map((profile) => {
+                const isSelected =
+                  profile.name === selectedLocalWaterProfileName;
+                return (
+                  <Pressable
+                    key={profile.name}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Select water location ${profile.name}`}
+                    style={[
+                      styles.choiceChip,
+                      isSelected && styles.choiceChipActive,
+                    ]}
+                    onPress={() => onChangeLocalWaterProfileName(profile.name)}
+                  >
+                    <Text
+                      style={[
+                        styles.choiceChipText,
+                        isSelected && styles.choiceChipTextActive,
+                      ]}
+                    >
+                      {profile.name}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+
+            <View style={styles.compatibilityCard}>
+              <Text style={styles.compatibilityTitle}>
+                Score compatibilité : {compatibility.score}% (
+                {compatibility.label})
+              </Text>
+              <Text style={styles.compatibilitySubtitle}>
+                {compatibility.matchedMetrics}/{compatibility.totalMetrics}{" "}
+                métriques dans la zone cible
+              </Text>
+            </View>
+          </>
         ) : null}
-
-        <Text style={styles.fieldLabel}>Ton eau locale</Text>
-        <View style={styles.choiceWrap}>
-          {WATER_LOCATION_PROFILES.map((profile) => {
-            const isSelected = profile.name === selectedLocalWaterProfileName;
-            return (
-              <Pressable
-                key={profile.name}
-                accessibilityRole="button"
-                accessibilityLabel={`Select water location ${profile.name}`}
-                style={[
-                  styles.choiceChip,
-                  isSelected && styles.choiceChipActive,
-                ]}
-                onPress={() => onChangeLocalWaterProfileName(profile.name)}
-              >
-                <Text
-                  style={[
-                    styles.choiceChipText,
-                    isSelected && styles.choiceChipTextActive,
-                  ]}
-                >
-                  {profile.name}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
-
-        <View style={styles.compatibilityCard}>
-          <Text style={styles.compatibilityTitle}>
-            Score compatibilité : {compatibility.score}% ({compatibility.label})
-          </Text>
-          <Text style={styles.compatibilitySubtitle}>
-            {compatibility.matchedMetrics}/{compatibility.totalMetrics}{" "}
-            métriques dans la zone cible
-          </Text>
-        </View>
 
         {(Object.keys(WATER_METRIC_LABELS) as WaterMineralKey[]).map(
           (metric) => (
@@ -193,46 +210,60 @@ export function WaterTab(props: WaterTabProps) {
                 {WATER_METRIC_LABELS[metric]}
               </Text>
               <Text style={styles.metricValue}>
-                {recommendedWaterProfile[metric]} / {localWaterProfile[metric]}{" "}
-                ppm
+                {canCompare
+                  ? `${recommendedWaterProfile[metric]} / ${localWaterProfile[metric]} ppm`
+                  : `${recommendedWaterProfile[metric]} ppm`}
               </Text>
             </View>
           ),
         )}
 
-        <PrimaryButton
-          label="Comparer dans le Calculateur Eau"
-          onPress={onOpenWaterCalculator}
-        />
+        {canCompare ? (
+          <PrimaryButton
+            label="Comparer dans le Calculateur Eau"
+            onPress={onOpenWaterCalculator}
+          />
+        ) : (
+          <View style={styles.saveHint}>
+            <Text style={styles.saveHintText}>
+              Enregistre cette recette dans ton carnet pour la comparer à ton
+              eau locale et voir les sels à ajouter.
+            </Text>
+          </View>
+        )}
       </Card>
 
-      <Text style={styles.sectionTitle}>Ajouter pour matcher</Text>
-      <Card style={styles.card}>
-        {additions.length === 0 ? (
-          <Text style={styles.emptyText}>
-            Ton eau locale est déjà alignée sur le profil cible (ou les écarts
-            ne sont pas couvrables par ajout de sels).
-          </Text>
-        ) : (
-          additions.map((addition) => (
-            <View key={addition.id} style={styles.additionRow}>
-              <View style={styles.additionMain}>
-                <Text style={styles.additionName}>
-                  {addition.name} ({addition.formula})
-                </Text>
-                <Text style={styles.additionRationale}>
-                  {addition.rationale}
-                </Text>
-              </View>
-              <Text style={styles.additionGrams}>+{addition.grams} g</Text>
-            </View>
-          ))
-        )}
-        <Text style={styles.additionFootnote}>
-          Quantités calculées pour {targetVolumeLiters} L. Pour aller plus loin
-          (pH du mash, dilution), utilise le Calculateur Eau.
-        </Text>
-      </Card>
+      {canCompare ? (
+        <>
+          <Text style={styles.sectionTitle}>Ajouter pour matcher</Text>
+          <Card style={styles.card}>
+            {additions.length === 0 ? (
+              <Text style={styles.emptyText}>
+                Ton eau locale est déjà alignée sur le profil cible (ou les
+                écarts ne sont pas couvrables par ajout de sels).
+              </Text>
+            ) : (
+              additions.map((addition) => (
+                <View key={addition.id} style={styles.additionRow}>
+                  <View style={styles.additionMain}>
+                    <Text style={styles.additionName}>
+                      {addition.name} ({addition.formula})
+                    </Text>
+                    <Text style={styles.additionRationale}>
+                      {addition.rationale}
+                    </Text>
+                  </View>
+                  <Text style={styles.additionGrams}>+{addition.grams} g</Text>
+                </View>
+              ))
+            )}
+            <Text style={styles.additionFootnote}>
+              Quantités calculées pour {targetVolumeLiters} L. Pour aller plus
+              loin (pH du mash, dilution), utilise le Calculateur Eau.
+            </Text>
+          </Card>
+        </>
+      ) : null}
     </ScrollView>
   );
 }
@@ -399,5 +430,16 @@ const styles = StyleSheet.create({
     color: colors.neutral.textSecondary,
     fontSize: typography.size.label,
     lineHeight: typography.lineHeight.label,
+  },
+  saveHint: {
+    marginTop: spacing.sm,
+    borderRadius: radius.md,
+    backgroundColor: colors.brand.background,
+    padding: spacing.sm,
+  },
+  saveHintText: {
+    color: colors.brand.secondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
   },
 });


### PR DESCRIPTION
## Summary

**Tranche A** of the screen-by-screen UX review — two community-recipe improvements on the mobile app.

### 1. Add-to-carnet confirmation + undo (new Snackbar primitive)
Importing a community recipe from its detail screen was **silent** (it just navigated to the owned copy). Now:
- A new **app-level `SnackbarProvider` / `useSnackbar()`** primitive (`core/ui`) — one branded bottom bar with an optional single action, auto-dismiss (5s), mounted at the app root. It mirrors the existing `ConfirmProvider` pattern 1:1 (imperative hook, single instance, throw-outside-provider guard, unmount-safe timer).
- On import, the app still lands on the owned copy **and** shows « Recette ajoutée à ton carnet · Annuler ». The undo deletes the just-created copy and returns to the source recipe.

### 2. Lighter Water tab for an unsaved (community) recipe
A community recipe not yet in your carnet now shows **only the recommended profile + a « enregistre pour comparer » hint**. The local-water comparison, compatibility score, salt additions and the calculator button are revealed once the recipe is owned (`canCompare = isOwned`).

## Context / notes

- The undo runs from the **app-level snackbar**, so `undoImport` and its `onAction` must survive this screen unmounting after the navigation — they call the use-case directly and use the stable `queryClient` / `router` (no state on the unmounted screen). Reviewed and confirmed sound.
- **Test caveat**: the "survives navigation" property is exercised only at the unit level — `useRouter` is a flat mock, so the undo test proves the logic runs, not a real Expo Router param swap/unmount. A router-navigation harness would be needed to assert that end-to-end.
- **Follow-up (out of scope, tracked)**: when the snackbar is visible on a screen that also has a sticky CTA (the owned copy's « Préparer mon brassin »), the two bars share the same bottom offset and overlap for the ~5s window — cosmetic, to fix separately.

## Verification

- `tsc --noEmit` clean, `eslint` clean on all touched files, **full mobile-app jest suite green** (1196+; adds 5 SnackbarProvider tests + import-undo happy/sad + lightened-Water-tab test).
- Live emulator: login keyboard fix + the **full (owned) Water tab render with no regression**; the unsaved-recipe paths are unit-tested only (the demo dataset has no non-owned recipe to drive them on-screen).
- Reviews: local `pr-pre-reviewer` — 0 Must Have; the flagged undo sad-path test was added. Local Codex CLI was unavailable this run (arg incompatibility); GitHub Codex will review.

## Checklist

- [x] New Snackbar primitive follows the ConfirmProvider precedent; theme tokens only (no hardcoded colors/spacing)
- [x] Undo deletes the copy + returns to source; sad path (delete fails) alerts and does not navigate
- [x] Water tab full/owned view preserved 1:1; lightened view gated on `canCompare`
- [x] No forbidden patterns (no `any`, no default export, no inline styles, no hardcoded tokens)
