### PR TITLE
docs(recipe-difficulty/architecture): ADR-0024 + spec + UML for the difficulty badge (Tranche B)

### DIFF
--- a/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
+++ b/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
@@ -63,13 +63,16 @@ of truth — like ADR-0020 volume planning), ADR-0013 (canonical beer/recipe mod
 
 ## Decision
 
-### D1 — Rule-based, per-factor tiering, **max-dominates** aggregation
+### D1 — Rule-based, per-factor tiering, **max-dominates + bounded compounding**
 
 The difficulty is computed by a deterministic **rule engine** over the recipe's structured
-fields. Each factor is scored to a tier (`facile=0` / `intermediaire=1` / `avance=2`); the
-recipe tier is the **maximum** of the per-factor tiers, plus a few **hard overrides**
-(any wild/sour culture → Avancé; any lager → at least Intermédiaire). Each factor that raised
-the tier contributes a plain-French **explanation sentence** (the tap-to-explain / pedagogy).
+fields. Each factor is scored to a tier (`facile=0` / `intermediaire=1` / `avance=2`); the recipe
+tier is the **maximum** of the per-factor tiers, with a **bounded compounding** step (when ≥ 3
+factors are at tier 1, bump one level, capped at Avancé — so several moderate stressors outrank a
+single one). The wild-culture → Avancé and lager → ≥ Intermédiaire escalations are **encoded in
+the yeast factor's tier** (not a separate override step, which would double-count). Every factor
+that fires contributes a plain-French **explanation sentence**, and **all** firing factors (not
+only the one at the max) go into the tap-to-explain, so pedagogy is not silently dropped.
 
 Rejected alternatives — see the decision matrix below: a **weighted numeric score** (opaque,
 hard to explain to a novice, arbitrary weights), a **style→tier lookup table** (the same
@@ -81,12 +84,12 @@ over-engineering per ADR-0001).
 
 | Factor | Signal (existing field) | Escalates because |
 |---|---|---|
-| **Fermentation / levure** | `recipe-yeast.type` (+ `temperature_min/max_c`) | wild/sour = Avancé override; lager (or ferment temp < ~14 °C) = ≥ Intermédiaire (cold control) |
+| **Fermentation / levure** | `recipe-yeast.type` (`{wild, brett}` / `lager` / `ale`) + `temperature_max_c` | wild culture = Avancé; lager **or** cold ferment (<14 °C) **or** hot/active ferment (>26 °C, e.g. saison) = ≥ Intermédiaire |
 | **Force / densité** | `og_target`, `abv_estimated` | high-gravity stresses the yeast, needs a starter |
-| **Tolérance aux fautes** | `ebc_target` + `ibu_target` | pale + clean = "no place to hide" — **gated on lager**: a pale *ale* stays Facile (ale-yeast forgiveness, keeps « Blonde Facile »), a pale *lager* (pilsner) → Avancé |
-| **Chimie de l'eau** | `recipe-water` / additives present | salt/pH adjustment is an advanced skill |
-| **Techniques** | mash steps (`recipe-step`), dry-hop (`recipe-hop.use`) | multi-step mash, dry hop = extra handling/timing |
-| **Base (complexité)** | count of fermentables / hops / additives | "kitchen-sink" grain bill and hop schedule multiply error surface |
+| **Tolérance aux fautes** | `ebc_target` (pale ≤ 10) **gated on `lager`** | a pale *lager* = "no place to hide" → Avancé; a pale *ale* stays Facile (keeps « Blonde Facile »). IBU is **not** used — hops don't mask lager faults |
+| **Chimie de l'eau** | `recipe-water` ion/pH **targets** | a real target profile (pH or ≥2 ion targets), not a lone pre-measured sachet |
+| **Base (complexité)** | count of fermentables + hop **varieties** + additives (> 7) | "kitchen-sink" bill multiplies error surface; counts varieties, not timed additions |
+| ~~Empâtage multi-palier~~ | `recipe-step` | **deferred v1** — steps carry no per-rest temperature, so a step/decoction mash is not detectable yet |
 
 Exact thresholds and the explanation strings live in the spec
 (`docs/architecture/specs/recipe-difficulty-algorithm.md`) — they are **v1 defaults, meant to
@@ -109,8 +112,11 @@ deliberately omitted (all-grain baseline, D-context above).
 
 `facile` (green) / `intermediaire` (amber) / `avance` (red). An internal integer score MAY back
 the tiering for calibration, but **only 3 levels are ever exposed** (no false precision). Every
-badge is **tap-to-explain**: the stored reasons render as « Avancé car : c'est une lager
-(fermentation à froid) + densité élevée ». Pedagogy is the point (`feedback_educational_vocation`).
+badge is **tap-to-explain**, and each stored sentence is written in **glossed plain French** (the
+sentence is the deepest layer — nothing behind it — so it must introduce *and* explain each term),
+e.g. « Avancé car : une lager blonde et nette — ni houblon fort ni malt torréfié pour cacher un
+défaut, la moindre erreur se voit ». Pedagogy is the point (`feedback_educational_vocation`); the
+spec holds the exact strings and they must stay at this clarity bar.
 
 ### D5 — Brassage tab (same review)
 
@@ -119,6 +125,11 @@ Separate but adjacent: the Brassage tab replaces its **generic** brewing-phase g
 generic glossary **moves to the Academy** (ADR-0023) — it is education, not recipe-specific.
 The difficulty badge appears here as a reminder. Captured here for traceability; detailed in
 the use-case diagram.
+
+**Emulator-grounded refinement (2026-07-03):** the tab already exposes three modes —
+« Phases de brassage » (the generic glossary, currently default), « Étapes de la recette » (the
+real steps), « Condensé ». So D5 is a re-default + relocation, not a rebuild: **promote « Étapes
+de la recette » as the default**, and **move « Phases de brassage » into the Academy**.
 
 ---
 
@@ -148,12 +159,16 @@ recipe-authoring burden (computed from fields already captured); no data-model c
 omitted extraction axis; backend-owned (ADR-0002) so all clients agree.
 
 **Negative / risks** — thresholds are **judgement calls**; v1 defaults will need calibration
-against real recipes (mitigation: thresholds isolated in the spec + an internal score for
-tuning, plus the author override as an escape hatch). The **fault-tolerance** axis (EBC/IBU) is
-a proxy and can misjudge edge styles (e.g. a malt-forward big beer the sources call "easy") —
-mitigation: max-dominates + override, and we document the known style disagreements in the spec.
-Omitting extraction method is safe **only while the app stays all-grain**; if extract recipes
-are ever modelled, revisit with a `brewMethod` field (noted as a follow-up, not built).
+against real recipes (mitigation: thresholds isolated in the spec + the author override as an
+escape hatch). Documented v1 limitations (spec §6): (a) **fault-tolerance uses `lager` as a coarse
+proxy** and deliberately under-penalises clean pale *ales* (Kölsch, Cream Ale, Bitter…) to keep
+the flagship « Blonde Facile » at Facile; (b) **F5 mash complexity is deferred** — `recipe-step`
+carries no per-rest temperature, so step/decoction mashes are invisible until the mash model
+gains rests; (c) the yeast enum has **no `sour`/`mixed`** value, so a kettle-sour is folded into
+`wild` and scored Avancé (conservative); (d) malt-forward big beers still score up on gravity
+(accepted). Omitting extraction method is safe **only while the app stays all-grain**; if extract
+recipes are ever modelled, revisit with a `brewMethod` field (follow-up, not built). All mitigated
+by max-dominates + author override + the calibration knobs.
 
 ---
 

--- a/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
+++ b/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
@@ -11,8 +11,8 @@
 The screen-by-screen UX review (2026-07-03) activated a **per-recipe brewing-difficulty
 badge**: a novice must see, at a glance, *how hard a recipe is to brew* so they can pick one
 at their level. This is a property of the **recipe** (how hard it is to brew), distinct from
-the **user's declared level** (ADR-0021 D5). It surfaces on the recipe Vue/hero and on the
-recipe cards (« Mes recettes » / catalog), with a tap-to-explain sentence (the app **teaches
+the **user's declared level** (ADR-0021 D5). It surfaces on the recipe « Vue » tab / hero and on
+the recipe cards (« Mes recettes » / catalog), with a tap-to-explain sentence (the app **teaches
 why**), plus an optional reminder on the Brassage tab. See [[project_screen_by_screen_ux_review]]
 and the difficulty-badge decisions in `bb-recipe-hallmark`.
 

--- a/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
+++ b/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
@@ -1,0 +1,169 @@
+# ADR-0024 — Recipe brewing-difficulty badge: rule-based, max-dominates, backend-computed
+
+**Status**  Proposed
+**Date**    2026-07-03
+**Owners**  @benoit-bremaud
+
+---
+
+## Context
+
+The screen-by-screen UX review (2026-07-03) activated a **per-recipe brewing-difficulty
+badge**: a novice must see, at a glance, *how hard a recipe is to brew* so they can pick one
+at their level. This is a property of the **recipe** (how hard it is to brew), distinct from
+the **user's declared level** (ADR-0021 D5). It surfaces on the recipe Vue/hero and on the
+recipe cards (« Mes recettes » / catalog), with a tap-to-explain sentence (the app **teaches
+why**), plus an optional reminder on the Brassage tab. See [[project_screen_by_screen_ux_review]]
+and the difficulty-badge decisions in `bb-recipe-hallmark`.
+
+**Locked before this ADR** (requirements workshop, 2026-07-03):
+
+- **3 levels**: Facile / Intermédiaire / Avancé, colour-coded green / amber / red, each with a
+  tap-to-explain sentence.
+- **Determination = BOTH**: a **backend-computed** default from objective recipe signals,
+  **overridable by the recipe author**.
+- **Factors** the founder retained: base (step/ingredient count) + **techniques**,
+  **force/densité** (gravity/ABV), **fermentation/levure** (yeast), **chimie de l'eau**, plus —
+  added on the strength of the research below — a **fault-tolerance** axis.
+- **Extraction method** (extract → all-grain), the dominant axis in the literature, is
+  **out of scope**: the app is novice-guided and de-facto all-grain, so the axis would be
+  constant (non-discriminating). Baseline = all-grain.
+
+### Documented study (why we are not guessing)
+
+A four-angle web study (homebrew apps, beginner-vs-advanced styles, brewing techniques,
+scoring rubrics) was run to ground the model. Load-bearing sources: **John Palmer, *How to
+Brew*** (progression ladder); the **American Homebrewers Association** (beginner recipe design,
+SMaSH first-brew); **Brew Your Own — "10 easiest / 10 hardest styles"**; **Brulosophy**
+(blind exBEERiments); **Grainfather** (lager control); and — for the aggregation principle —
+**Kusu et al. 2017, *Calculating Cooking Recipe's Difficulty based on Cooking Activities*** (a
+peer-reviewed method that scores a recipe from the difficulty of the *operations* it requires).
+
+Three findings shaped the decision:
+
+1. **No homebrew design app exposes a difficulty score** (verified against Brewfather's docs;
+   inferred for BeerSmith / Brewer's Friend / Grainfather). They compute only objective style
+   metrics (OG, FG, ABV, IBU, SRM/EBC). So difficulty is **not a field to copy — it must be
+   derived** from recipe signals. Explicit difficulty labels exist only on the **kit/retail**
+   side (Homebrew Emporium literally has a 3-tier taxonomy), which are editorial, not a formula
+   — useful only as corroboration of the 3-tier boundaries.
+2. **No formal published point-rubric exists** for homebrew difficulty. Sources instead
+   enumerate the *attributes* that make a brew hard, all derivable from our structured recipe
+   fields.
+3. **The hardest single factor should set the tier** (max-dominates), not an average: a recipe
+   trivial on seven axes but soured, or a light lager, is still hard — averaging would hide it.
+   This is the transferable principle from the 2017 cooking-activities paper and the homebrew
+   "no place to hide" idea.
+
+Repo constraints: ADR-0001 (build for today), ADR-0002 (computation server-side, single source
+of truth — like ADR-0020 volume planning), ADR-0013 (canonical beer/recipe model), ADR-0019
+(testing).
+
+---
+
+## Decision
+
+### D1 — Rule-based, per-factor tiering, **max-dominates** aggregation
+
+The difficulty is computed by a deterministic **rule engine** over the recipe's structured
+fields. Each factor is scored to a tier (`facile=0` / `intermediaire=1` / `avance=2`); the
+recipe tier is the **maximum** of the per-factor tiers, plus a few **hard overrides**
+(any wild/sour culture → Avancé; any lager → at least Intermédiaire). Each factor that raised
+the tier contributes a plain-French **explanation sentence** (the tap-to-explain / pedagogy).
+
+Rejected alternatives — see the decision matrix below: a **weighted numeric score** (opaque,
+hard to explain to a novice, arbitrary weights), a **style→tier lookup table** (the same
+"stout"/"IPA" label spans easy and hard versions — the sources are explicit that a style label
+is a poor proxy), and an **ML/learned model** (no labelled dataset, un-explainable, massive
+over-engineering per ADR-0001).
+
+### D2 — Factors (all derivable from existing fields; **all-grain baseline**)
+
+| Factor | Signal (existing field) | Escalates because |
+|---|---|---|
+| **Fermentation / levure** | `recipe-yeast.type` (+ `temperature_min/max_c`) | wild/sour = Avancé override; lager (or ferment temp < ~14 °C) = ≥ Intermédiaire (cold control) |
+| **Force / densité** | `og_target`, `abv_estimated` | high-gravity stresses the yeast, needs a starter |
+| **Tolérance aux fautes** | `ebc_target` + `ibu_target` | pale + clean = "no place to hide" — **gated on lager**: a pale *ale* stays Facile (ale-yeast forgiveness, keeps « Blonde Facile »), a pale *lager* (pilsner) → Avancé |
+| **Chimie de l'eau** | `recipe-water` / additives present | salt/pH adjustment is an advanced skill |
+| **Techniques** | mash steps (`recipe-step`), dry-hop (`recipe-hop.use`) | multi-step mash, dry hop = extra handling/timing |
+| **Base (complexité)** | count of fermentables / hops / additives | "kitchen-sink" grain bill and hop schedule multiply error surface |
+
+Exact thresholds and the explanation strings live in the spec
+(`docs/architecture/specs/recipe-difficulty-algorithm.md`) — they are **v1 defaults, meant to
+be calibrated** as we see real recipes, not frozen here. The **extraction-method** axis is
+deliberately omitted (all-grain baseline, D-context above).
+
+### D3 — Backend-computed default + author override (ADR-0002)
+
+- The API computes `difficulty_computed` (enum) **on recipe create/update**, storing it plus a
+  **structured breakdown of the reasons** (which factors fired, at which tier, with the
+  explanation string) so the mobile renders the tap-to-explain **without recomputing
+  client-side**.
+- The author may set `difficulty_override` (nullable enum). The **effective** difficulty is
+  `difficulty_override ?? difficulty_computed`; when an override is set, the computed value is
+  kept and shown as a hint (« calculé : Intermédiaire »).
+- The mobile is a **pure consumer** — it never computes difficulty (consistent with ADR-0020:
+  the backend owns the math).
+
+### D4 — 3 levels, explainable, novice-first
+
+`facile` (green) / `intermediaire` (amber) / `avance` (red). An internal integer score MAY back
+the tiering for calibration, but **only 3 levels are ever exposed** (no false precision). Every
+badge is **tap-to-explain**: the stored reasons render as « Avancé car : c'est une lager
+(fermentation à froid) + densité élevée ». Pedagogy is the point (`feedback_educational_vocation`).
+
+### D5 — Brassage tab (same review)
+
+Separate but adjacent: the Brassage tab replaces its **generic** brewing-phase glossary
+(identical for every recipe) with a **condensed overview of THIS recipe's real steps**; the
+generic glossary **moves to the Academy** (ADR-0023) — it is education, not recipe-specific.
+The difficulty badge appears here as a reminder. Captured here for traceability; detailed in
+the use-case diagram.
+
+---
+
+## Decision matrix — how the difficulty is computed (weighted)
+
+Criteria weighted for a **novice-first, explainable, no-dataset** app (5 = best).
+
+| Approach | Explainable to novice (×3) | Faithful to sources (×2) | Effort / YAGNI (×2) | Calibratable (×1) | **Score** |
+|---|---|---|---|---|---|
+| **Rule-based + max-dominates (chosen)** | 5 | 5 | 4 | 4 | **41** |
+| Weighted numeric score + thresholds | 2 | 4 | 3 | 5 | 29 |
+| Style → tier lookup table | 3 | 1 | 5 | 2 | 23 |
+| ML / learned model | 1 | 3 | 1 | 3 | 14 |
+
+Rule-based + max-dominates wins on the two heaviest criteria (explainability, source fidelity):
+every tier decision traces to a named factor with a novice sentence, and "hardest factor sets
+the tier" is exactly what the literature prescribes. A weighted score calibrates more smoothly
+but its weights are arbitrary and it cannot answer "why is this Avancé?" in one sentence.
+
+---
+
+## Consequences
+
+**Positive** — deterministic and testable (H/S/E per ADR-0019); fully explainable (each tier
+traces to a factor + sentence → feeds tap-to-explain and the app's teaching mission); no new
+recipe-authoring burden (computed from fields already captured); no data-model change for the
+omitted extraction axis; backend-owned (ADR-0002) so all clients agree.
+
+**Negative / risks** — thresholds are **judgement calls**; v1 defaults will need calibration
+against real recipes (mitigation: thresholds isolated in the spec + an internal score for
+tuning, plus the author override as an escape hatch). The **fault-tolerance** axis (EBC/IBU) is
+a proxy and can misjudge edge styles (e.g. a malt-forward big beer the sources call "easy") —
+mitigation: max-dominates + override, and we document the known style disagreements in the spec.
+Omitting extraction method is safe **only while the app stays all-grain**; if extract recipes
+are ever modelled, revisit with a `brewMethod` field (noted as a follow-up, not built).
+
+---
+
+## Alternatives considered
+
+- **Weighted numeric score with thresholds** — smoother calibration, but opaque weights and no
+  one-sentence "why"; loses the pedagogical payload. Rejected on explainability.
+- **Style → tier lookup table** — simplest, but the sources are explicit that a style label is a
+  poor proxy (same label spans easy and hard recipes). Rejected on fidelity.
+- **ML / learned difficulty** — no labelled dataset, un-explainable, over-engineering
+  (ADR-0001). Rejected.
+- **Client-side computation** — would let clients disagree and duplicate the rules; violates the
+  backend-owns-the-math principle (ADR-0020). Rejected.

--- a/docs/architecture/diagrams/recipe-difficulty/01-use-case.md
+++ b/docs/architecture/diagrams/recipe-difficulty/01-use-case.md
@@ -1,0 +1,52 @@
+# Use case diagram — recipe-difficulty — who reads/sets a recipe's difficulty
+
+> **Feature**: recipe difficulty badge (screen-review Tranche B)
+> **Source specs**: `docs/architecture/specs/recipe-difficulty-algorithm.md`
+> **Related ADRs**: ADR-0024
+> **Decisions captured**: D1–D5 (ADR-0024)
+
+## Context
+
+Who interacts with the difficulty badge and the simplified Brassage tab, and to what goal.
+Computing the difficulty is a **system behaviour** (triggered by create/update), not an
+actor goal — it is shown in the sequence/component diagrams, **not** here. Grouped by domain,
+never by backend package (UML 2.5).
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Novice(("Novice — Persona Léa la curieuse"))
+  Author(("Recipe author"))
+
+  subgraph SYSTEM ["Brasse-Bouillon"]
+    subgraph Difficulty ["Difficulté recette (domain)"]
+      UC1(("Repérer une recette à mon niveau"))
+      UC2(("Comprendre pourquoi une recette est à ce niveau"))
+      UC3(("Ajuster le niveau de difficulté de ma recette"))
+    end
+    subgraph Brassage ["Brassage (domain)"]
+      UC4(("Consulter les étapes réelles de brassage"))
+      UC5(("Apprendre un geste générique (glossaire)"))
+    end
+  end
+
+  Novice --> UC1
+  Novice --> UC2
+  Novice --> UC4
+  Novice --> UC5
+  Author --> UC3
+  Author -.->|generalises| Novice
+```
+
+## Notes
+
+- **UC1** reads the badge on recipe cards / hero to self-select; **UC2** is the tap-to-explain
+  (« Avancé car : … ») — the pedagogical payload (`feedback_educational_vocation`).
+- **UC3** is the author override (ADR-0024 D3); `Author` is an actor **generalisation** of
+  `Novice` (an author is also a reader) — linked only to its own extra goal.
+- **UC5** « Apprendre un geste générique » lives in the **Academy** (ADR-0023): the generic
+  brewing-phase glossary moves out of the Brassage tab (ADR-0024 D5). Shown here to record the
+  hand-off; its realization is the Academy feature, not this one.
+- No « Recevoir/Voir le badge » use case — a badge is displayed state, not an actor-initiated
+  goal; the reader's goal is UC1 (repérer) / UC2 (comprendre).

--- a/docs/architecture/diagrams/recipe-difficulty/01-use-case.md
+++ b/docs/architecture/diagrams/recipe-difficulty/01-use-case.md
@@ -50,3 +50,6 @@ flowchart LR
   hand-off; its realization is the Academy feature, not this one.
 - No « Recevoir/Voir le badge » use case — a badge is displayed state, not an actor-initiated
   goal; the reader's goal is UC1 (repérer) / UC2 (comprendre).
+- The `Author -.-> Novice` dashed arrow is a Mermaid **approximation** of UML actor
+  generalisation (UML draws a solid line with a hollow triangle, which Mermaid flowcharts
+  cannot render). Read it as "Author is a Novice too", not a dependency.

--- a/docs/architecture/diagrams/recipe-difficulty/02-sequence-compute.md
+++ b/docs/architecture/diagrams/recipe-difficulty/02-sequence-compute.md
@@ -27,9 +27,9 @@ sequenceDiagram
   Note over Author,DB: Write path — compute on create/update
   Author->>M: Save recipe (fields, optional override)
   M->>API: "POST/PUT /recipes"
-  API->>DS: "compute(recipe, yeast, hops, water, steps, stats)"
-  DS->>DS: "per-factor tiers F1..F6 (all-grain baseline)"
-  DS->>DS: "tier = max(...) + overrides (wild→Avancé, lager→≥Interm.)"
+  API->>DS: "compute(recipe, yeast, hops, water, stats)"
+  DS->>DS: "yeastClass + per-factor tiers F1..F6 (F5 deferred, all-grain baseline)"
+  DS->>DS: "tier = max(f1..f6), +1 if ≥3 at tier 1 (capped) — reasons: all firing factors"
   DS-->>API: "{ computed, reasons[] }"
   API->>DB: "persist difficulty_computed + difficulty_reasons (+ override if set)"
   API-->>M: "recipe with effective difficulty (override ?? computed) + reasons"

--- a/docs/architecture/diagrams/recipe-difficulty/02-sequence-compute.md
+++ b/docs/architecture/diagrams/recipe-difficulty/02-sequence-compute.md
@@ -1,0 +1,56 @@
+# Sequence diagram — recipe-difficulty — compute on save & read on display
+
+> **Feature**: recipe difficulty badge (screen-review Tranche B)
+> **Source specs**: `docs/architecture/specs/recipe-difficulty-algorithm.md`
+> **Related ADRs**: ADR-0024, ADR-0002, ADR-0020
+> **Decisions captured**: D1–D4 (ADR-0024)
+
+## Context
+
+The two flows that matter in time: (1) the backend **computes and stores** difficulty +
+reasons when a recipe is created/updated (never on the client), and (2) the mobile **reads**
+the stored effective level + reasons to render the badge and its tap-to-explain. Author
+override is the branch on the write side. A simple read of a static field on other screens is
+trivial and not diagrammed (proportionality).
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor Author as Author
+  participant M as "Mobile (recipe editor)"
+  participant API as "API — RecipeService"
+  participant DS as "API — DifficultyService"
+  participant DB as "DB (recipe + sub-entities)"
+  actor Novice
+
+  Note over Author,DB: Write path — compute on create/update
+  Author->>M: Save recipe (fields, optional override)
+  M->>API: "POST/PUT /recipes"
+  API->>DS: "compute(recipe, yeast, hops, water, steps, stats)"
+  DS->>DS: "per-factor tiers F1..F6 (all-grain baseline)"
+  DS->>DS: "tier = max(...) + overrides (wild→Avancé, lager→≥Interm.)"
+  DS-->>API: "{ computed, reasons[] }"
+  API->>DB: "persist difficulty_computed + difficulty_reasons (+ override if set)"
+  API-->>M: "recipe with effective difficulty (override ?? computed) + reasons"
+
+  Note over Novice,DB: Read path — render badge + tap-to-explain
+  Novice->>M: Open recipe / list
+  M->>API: "GET /recipes(/:id)"
+  API-->>M: "effectiveDifficulty + reasons[] (no client compute)"
+  M->>Novice: "badge (green/amber/red)"
+  Novice->>M: "tap badge"
+  M->>Novice: "« Avancé car : … » (stored reasons)"
+```
+
+## Notes
+
+- **Compute is server-side only** (ADR-0002 / ADR-0020) — the mobile never runs the rules; it
+  consumes `effectiveDifficulty` + `reasons`. This is the anti-pattern the diagram makes
+  visible: any client-side difficulty computation would be a bug.
+- `reasons[]` is **stored** on write (not recomputed on read) so tap-to-explain is a plain read
+  (ADR-0024 D3).
+- **Override branch**: if the author set `difficulty_override`, the API returns it as the
+  effective level but keeps `difficulty_computed` for the « calculé : … » hint.
+- The `compute()` call is synchronous within the create/update transaction — difficulty is a
+  pure function of the recipe, so no async job is warranted (ADR-0001, YAGNI).

--- a/docs/architecture/diagrams/recipe-difficulty/02-sequence-compute.md
+++ b/docs/architecture/diagrams/recipe-difficulty/02-sequence-compute.md
@@ -27,7 +27,7 @@ sequenceDiagram
   Note over Author,DB: Write path — compute on create/update
   Author->>M: Save recipe (fields, optional override)
   M->>API: "POST/PUT /recipes"
-  API->>DS: "compute(recipe, yeast, hops, water, stats)"
+  API->>DS: "compute(recipe + sub-entities: yeast, hops, water)"
   DS->>DS: "yeastClass + per-factor tiers F1..F6 (F5 deferred, all-grain baseline)"
   DS->>DS: "tier = max(f1..f6), +1 if ≥3 at tier 1 (capped) — reasons: all firing factors"
   DS-->>API: "{ computed, reasons[] }"

--- a/docs/architecture/diagrams/recipe-difficulty/03-component.md
+++ b/docs/architecture/diagrams/recipe-difficulty/03-component.md
@@ -1,0 +1,50 @@
+# Component diagram — recipe-difficulty — where the rule engine lives
+
+> **Feature**: recipe difficulty badge (screen-review Tranche B)
+> **Source specs**: `docs/architecture/specs/recipe-difficulty-algorithm.md`
+> **Related ADRs**: ADR-0024, ADR-0002
+> **Decisions captured**: D1, D3 (ADR-0024)
+
+## Context
+
+Structural boundaries: the **`DifficultyService`** rule engine is a backend component owned by
+the recipe module (the math lives server-side, ADR-0002 / ADR-0020); the mobile holds only a
+**presentational** badge that reads the computed field. Grouped by layer.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  subgraph Mobile ["packages/mobile-app"]
+    Card["RecipeCard / Vue (badge)"]
+    Badge["DifficultyBadge (core/ui) — presentational"]
+    UC["recipes use-case"]
+    HTTP["core/http/http-client"]
+    Card --> Badge
+    Card --> UC
+    UC --> HTTP
+  end
+
+  subgraph API ["packages/api — recipe module"]
+    Ctrl["RecipeController"]
+    RSvc["RecipeService"]
+    DSvc["DifficultyService (rule engine F1..F6 + max-dominates)"]
+    Repo["Recipe repository (TypeORM)"]
+    Ctrl --> RSvc
+    RSvc --> DSvc
+    RSvc --> Repo
+  end
+
+  HTTP -->|"GET/POST/PUT /recipes"| Ctrl
+  Repo --> DB[("DB — recipe + yeast/hop/water/step")]
+```
+
+## Notes
+
+- **`DifficultyService`** is a pure function of the recipe + its sub-entities → trivially unit
+  testable (ADR-0019, H/S/E). No external calls, no I/O.
+- The mobile **`DifficultyBadge`** is presentational only (colour + label + tap-to-explain from
+  the stored `reasons`); it does **not** import any scoring logic — the egress point is the
+  single `http-client` (forbidden-pattern guard: no direct `fetch`, no client-side compute).
+- No new package, no new external dependency — the engine is a service inside the existing
+  recipe module (ADR-0001).

--- a/docs/architecture/diagrams/recipe-difficulty/03-component.md
+++ b/docs/architecture/diagrams/recipe-difficulty/03-component.md
@@ -16,7 +16,7 @@ the recipe module (the math lives server-side, ADR-0002 / ADR-0020); the mobile 
 ```mermaid
 flowchart LR
   subgraph Mobile ["packages/mobile-app"]
-    Card["RecipeCard / Vue (badge)"]
+    Card["RecipeCard / recipe « Vue » tab (badge)"]
     Badge["DifficultyBadge (core/ui) — presentational"]
     UC["recipes use-case"]
     HTTP["core/http/http-client"]

--- a/docs/architecture/diagrams/recipe-difficulty/04-class.md
+++ b/docs/architecture/diagrams/recipe-difficulty/04-class.md
@@ -61,6 +61,10 @@ classDiagram
     +Real chloridePpm
     +Real phTarget
   }
+  class DifficultyResult {
+    +DifficultyLevel computed
+    +DifficultyReason[] reasons
+  }
   class DifficultyService {
     +compute(Recipe) DifficultyResult
   }
@@ -68,12 +72,13 @@ classDiagram
   Recipe "1" --> "1" DifficultyLevel : computed
   Recipe "1" --> "0..1" DifficultyLevel : override
   Recipe "1" o-- "0..*" DifficultyReason
-  Recipe "1" o-- "1..*" RecipeYeast
+  Recipe "1" o-- "0..*" RecipeYeast
   RecipeYeast "1" --> "1" RecipeYeastType
   Recipe "1" o-- "0..*" RecipeHop
   Recipe "1" o-- "0..1" RecipeWater
   DifficultyService ..> Recipe : reads
-  DifficultyService ..> DifficultyReason : produces
+  DifficultyService ..> DifficultyResult : returns
+  DifficultyResult o-- "0..*" DifficultyReason
 ```
 
 ## Notes

--- a/docs/architecture/diagrams/recipe-difficulty/04-class.md
+++ b/docs/architecture/diagrams/recipe-difficulty/04-class.md
@@ -41,18 +41,25 @@ classDiagram
   }
   class RecipeYeast {
     +RecipeYeastType type
-    +int temperatureMinC
     +int temperatureMaxC
   }
+  class RecipeYeastType {
+    <<enumeration>>
+    ale
+    lager
+    wild
+    brett
+  }
   class RecipeHop {
-    +HopUse use
-    +int additionTimeMin
+    +String variety
+    +RecipeHopAdditionStage additionStage
   }
   class RecipeWater {
-    +String salts
-  }
-  class RecipeStep {
-    +RecipeStepType type
+    +Real calciumPpm
+    +Real magnesiumPpm
+    +Real sulfatePpm
+    +Real chloridePpm
+    +Real phTarget
   }
   class DifficultyService {
     +compute(Recipe) DifficultyResult
@@ -62,9 +69,9 @@ classDiagram
   Recipe "1" --> "0..1" DifficultyLevel : override
   Recipe "1" o-- "0..*" DifficultyReason
   Recipe "1" o-- "1..*" RecipeYeast
+  RecipeYeast "1" --> "1" RecipeYeastType
   Recipe "1" o-- "0..*" RecipeHop
-  Recipe "1" o-- "0..*" RecipeWater
-  Recipe "1" o-- "1..*" RecipeStep
+  Recipe "1" o-- "0..1" RecipeWater
   DifficultyService ..> Recipe : reads
   DifficultyService ..> DifficultyReason : produces
 ```
@@ -75,8 +82,10 @@ classDiagram
   `difficultyReasons` (json). `difficultyEffective()` = `override ?? computed` (ADR-0024 D3).
 - **`DifficultyReason`** is the stored breakdown that feeds tap-to-explain — computed on write,
   read as-is (no client compute).
-- The sub-entities (`RecipeYeast.type`/temps, `RecipeHop.use`, `RecipeWater`, `RecipeStep.type`,
-  and `ibuTarget`/`ebcTarget`/`ogTarget` on `Recipe`) are the rule-engine inputs (spec §F1–F6) —
-  **unchanged** by this feature.
+- The rule-engine inputs (spec §F1–F6): `RecipeYeast.type` (+ `temperatureMaxC`),
+  `RecipeWater` ion/pH targets, `RecipeHop.variety` (for the F6 variety count),
+  and `ogTarget`/`abvEstimated`/`ebcTarget` on `Recipe`. `RecipeStep` is **not** an input
+  (F5 mash complexity deferred — no per-rest temperature). The sub-entities themselves are
+  **unchanged** by this feature — only `Recipe` gains the three difficulty fields.
 - `DifficultyService` holds no state — a pure function (ADR-0024 D1), which is why it is a
   service, not an entity.

--- a/docs/architecture/diagrams/recipe-difficulty/04-class.md
+++ b/docs/architecture/diagrams/recipe-difficulty/04-class.md
@@ -1,0 +1,82 @@
+# Class diagram — recipe-difficulty — data model & compute inputs
+
+> **Feature**: recipe difficulty badge (screen-review Tranche B)
+> **Source specs**: `docs/architecture/specs/recipe-difficulty-algorithm.md`
+> **Related ADRs**: ADR-0024
+> **Decisions captured**: D2, D3, D4 (ADR-0024)
+
+## Context
+
+The additions to the recipe model (three fields) and the existing sub-entities the rule engine
+reads. Only `Recipe` gains fields; the sub-entities are unchanged (all signals already exist —
+all-grain baseline, no `brewMethod`).
+
+## Diagram
+
+```mermaid
+classDiagram
+  class Recipe {
+    +UUID id
+    +String name
+    +String style
+    +Real ogTarget
+    +Real abvEstimated
+    +Real ibuTarget
+    +Real ebcTarget
+    +DifficultyLevel difficultyComputed
+    +DifficultyLevel~nullable~ difficultyOverride
+    +DifficultyReason[] difficultyReasons
+    +difficultyEffective() DifficultyLevel
+  }
+  class DifficultyLevel {
+    <<enumeration>>
+    facile
+    intermediaire
+    avance
+  }
+  class DifficultyReason {
+    +String factor
+    +int tier
+    +String sentence
+  }
+  class RecipeYeast {
+    +RecipeYeastType type
+    +int temperatureMinC
+    +int temperatureMaxC
+  }
+  class RecipeHop {
+    +HopUse use
+    +int additionTimeMin
+  }
+  class RecipeWater {
+    +String salts
+  }
+  class RecipeStep {
+    +RecipeStepType type
+  }
+  class DifficultyService {
+    +compute(Recipe) DifficultyResult
+  }
+
+  Recipe "1" --> "1" DifficultyLevel : computed
+  Recipe "1" --> "0..1" DifficultyLevel : override
+  Recipe "1" o-- "0..*" DifficultyReason
+  Recipe "1" o-- "1..*" RecipeYeast
+  Recipe "1" o-- "0..*" RecipeHop
+  Recipe "1" o-- "0..*" RecipeWater
+  Recipe "1" o-- "1..*" RecipeStep
+  DifficultyService ..> Recipe : reads
+  DifficultyService ..> DifficultyReason : produces
+```
+
+## Notes
+
+- **New on `Recipe`**: `difficultyComputed` (not null), `difficultyOverride` (nullable),
+  `difficultyReasons` (json). `difficultyEffective()` = `override ?? computed` (ADR-0024 D3).
+- **`DifficultyReason`** is the stored breakdown that feeds tap-to-explain — computed on write,
+  read as-is (no client compute).
+- The sub-entities (`RecipeYeast.type`/temps, `RecipeHop.use`, `RecipeWater`, `RecipeStep.type`,
+  and `ibuTarget`/`ebcTarget`/`ogTarget` on `Recipe`) are the rule-engine inputs (spec §F1–F6) —
+  **unchanged** by this feature.
+- `DifficultyService` holds no state — a pure function (ADR-0024 D1), which is why it is a
+  service, not an entity.

--- a/docs/architecture/specs/recipe-difficulty-algorithm.md
+++ b/docs/architecture/specs/recipe-difficulty-algorithm.md
@@ -1,0 +1,145 @@
+# Spec — recipe brewing-difficulty scoring algorithm
+
+> **Feature**: recipe difficulty badge (screen-review Tranche B)
+> **Related ADRs**: ADR-0024 (the decision + decision matrix), ADR-0002 (backend-computed),
+> ADR-0020 (backend owns the math), ADR-0019 (testing)
+> **Consumed by**: `docs/architecture/diagrams/recipe-difficulty/*`
+
+This spec holds the **exact rules and thresholds** the backend `DifficultyService` implements.
+Per ADR-0024, thresholds are **v1 defaults, calibratable** — the intent is documented so the
+numbers can move without re-litigating the model.
+
+## 0. Output
+
+```
+DifficultyLevel = "facile" | "intermediaire" | "avance"   // tiers 0 / 1 / 2
+```
+
+`effectiveDifficulty = difficultyOverride ?? difficultyComputed`. The badge colour: facile =
+green, intermediaire = amber, avance = red.
+
+## 1. Per-factor tiering
+
+Each factor returns a tier in `{0,1,2}` and, when it fires (tier ≥ 1), one **French
+explanation sentence**. All inputs are existing recipe fields (all-grain baseline — no
+extraction-method axis, ADR-0024 D2).
+
+### F1 — Fermentation / yeast  *(also a hard override)*
+
+| Condition (from `recipe-yeast`) | Tier | Sentence |
+|---|---|---|
+| type ∈ {`wild`, `brett`, `sour`, `mixed`} | **2** | « fermentation sauvage / acide — longue, imprévisible, contrôle microbiologique » |
+| type = `lager`, **or** `temperature_max_c` < 14 | **1** (floor) | « c'est une lager — fermentation à froid contrôlée + garde longue, peu de marge d'erreur » |
+| otherwise (ale) | 0 | — |
+
+Overrides: a wild/sour yeast **forces Avancé**; a lager **forces at least Intermédiaire**
+(applied after aggregation).
+
+### F2 — Force / densité (gravity)
+
+Use `og_target` if present, else derive from `abv_estimated`.
+
+| Condition | Tier | Sentence |
+|---|---|---|
+| OG ≤ 1.055 (≈ ABV < 5.5 %) | 0 | — |
+| 1.055 < OG ≤ 1.075 (≈ 5.5–7.5 %) | **1** | « densité assez élevée — la levure travaille plus, fermentation à surveiller » |
+| OG > 1.075 (≈ ABV > 7.5 %) | **2** | « grosse bière (densité élevée) — pied de levure important, risque de fermentation bloquée » |
+
+### F3 — Tolérance aux fautes (« no place to hide »)  *(EBC + IBU, gated on yeast)*
+
+The homebrew fault-tolerance axis bites hardest on **lagers**: a pale, clean lager exposes
+every flaw. A pale **ale** stays forgiving (ale-yeast tolerance) and is **not penalised** — this
+keeps the app's flagship « Blonde Facile (premier brassin) » at Facile (calibration decided
+2026-07-03). Roast / hops / haze always mask beginner mistakes.
+
+- **fault-exposing** ⇔ `ebc_target` ≤ 15 **and** `ibu_target` ≤ 25.
+
+| Condition | Tier | Sentence |
+|---|---|---|
+| fault-exposing **and** yeast is lager (F1 = lager) | **2** | « lager pâle et nette — le style le moins tolérant, aucune faute pardonnée » |
+| otherwise (a pale **ale**, or any roasty/hoppy beer → flaws masked) | 0 | — |
+
+### F4 — Chimie de l'eau
+
+| Condition | Tier | Sentence |
+|---|---|---|
+| recipe has salt additions / a target water profile / water additives (`recipe-water` non-empty) | **1** | « ajustement de l'eau (sels) requis — mesure et calcul en plus » |
+| otherwise | 0 | — |
+
+### F5 — Techniques (mash)
+
+| Condition (from `recipe-step`) | Tier | Sentence |
+|---|---|---|
+| ≥ 2 mash-type steps (multi-step / decoction mash) | **1** | « empâtage multi-palier — paliers de température à tenir » |
+| single-infusion (1 mash step) or none | 0 | — |
+
+### F6 — Base / recipe complexity  *(counts)*
+
+`complexity = distinctFermentables + distinctHopAdditions + additives + (dryHopPresent ? 1 : 0)`.
+
+| Condition | Tier | Sentence |
+|---|---|---|
+| complexity ≤ 5 (SMaSH-ish) | 0 | — |
+| complexity > 5 | **1** | « recette riche (nombreux ingrédients et ajouts) — plus d'étapes, plus de timing » |
+
+(Dry-hop presence counts here rather than as its own tier — a single dry-hopped pale ale stays
+beginner-friendly; a "kitchen-sink" bill escalates.)
+
+## 2. Aggregation
+
+```
+tier   = max(F1, F2, F3, F4, F5, F6)
+if F1 == wild/sour:      tier = 2          // hard override
+else if F1 == lager:     tier = max(tier, 1)
+computed = ["facile","intermediaire","avance"][tier]
+reasons  = sentences of every factor whose tier == tier   // the ones that SET the level
+```
+
+Max-dominates (ADR-0024 D1): the hardest factor sets the level. `reasons` drives the
+tap-to-explain (« Avancé car : <reasons joined by " + "> »). For **Facile**, a positive line is
+shown instead: « Recette accessible : fermentation haute, densité modérée, peu d'étapes — idéale
+pour débuter. »
+
+## 3. Author override
+
+- `difficultyOverride` (nullable enum). `effective = override ?? computed`.
+- When an override is set, the UI shows the computed value as a hint (« calculé :
+  Intermédiaire »), so the author's choice is transparent, not silent.
+
+## 4. Data model (additions only)
+
+On `recipe`:
+
+- `difficulty_computed` : enum(`facile`,`intermediaire`,`avance`), not null, recomputed on
+  create/update.
+- `difficulty_override` : enum, nullable.
+- `difficulty_reasons`  : json — the structured breakdown `[{ factor, tier, sentence }]` so the
+  mobile renders tap-to-explain without recomputing (ADR-0024 D3). Stores the *computed*
+  breakdown; the effective level is derived at read time.
+
+No change to `recipe-yeast` / `recipe-hop` / `recipe-water` / `recipe-step` — all signals
+already exist. No `brewMethod` field (all-grain baseline, ADR-0024).
+
+## 5. Worked examples (happy / sad / edge — seed the tests)
+
+| Recipe | F1 | F2 | F3 | F4 | F5 | F6 | → computed | Why |
+|---|---|---|---|---|---|---|---|---|
+| **Blonde SMaSH**, ale, OG 1.046, EBC 8, IBU 20, tap water, single mash, 2 ingr. | 0 | 0 | 0 | 0 | 0 | 0 | **Facile** | pale **ale** → forgiving; F3 is gated on lager, so it does not fire. Matches « Blonde Facile ». |
+| **American Pale Ale**, ale, OG 1.052, EBC 12, IBU 38, single mash | 0 | 0 | 0 | 0 | 0 | 0 | **Facile** | hoppy (IBU>25) masks flaws |
+| **Bohemian Pilsner**, lager, OG 1.050, EBC 6, IBU 35 | 1 | 0 | **2** | 0 | 0 | 0 | **Avancé** | pale lager, clean → "no place to hide" (F3 lager combo) |
+| **Russian Imperial Stout**, ale, OG 1.095, EBC 80, IBU 60, salts, multi-mash | 0 | **2** | 0 | 1 | 1 | 1 | **Avancé** | high gravity (F2) |
+| **Berliner Weisse**, sour culture, OG 1.032 | **2**(override) | 0 | — | 0 | 0 | 0 | **Avancé** | wild/sour override |
+
+The **Blonde SMaSH** stays **Facile** by design (calibration decided 2026-07-03): F3 is gated on
+lager, so a pale ale is not penalised for being pale — ale-yeast forgiveness dominates, matching
+the flagship « Blonde Facile (premier brassin) » positioning. The fault-tolerance axis still
+does its job on the **pale lager** case (Bohemian Pilsner → Avancé, F3 lager combo).
+
+## 6. Notes / open calibration
+
+- Thresholds (OG bands, EBC/IBU cut-offs, complexity count) are **v1**; expect to tune against
+  real recipes. The internal max-of-tiers keeps tuning local to each factor.
+- Known source disagreements to respect (ADR-0024): malt-forward big beers can be "easy" despite
+  high gravity; Brulosophy softens the lager-flavour penalty (the durable lager cost is
+  equipment + patience, which is why F1-lager is a *floor of Intermédiaire*, not an automatic
+  Avancé unless also fault-exposing).

--- a/docs/architecture/specs/recipe-difficulty-algorithm.md
+++ b/docs/architecture/specs/recipe-difficulty-algorithm.md
@@ -4,107 +4,138 @@
 > **Related ADRs**: ADR-0024 (the decision + decision matrix), ADR-0002 (backend-computed),
 > ADR-0020 (backend owns the math), ADR-0019 (testing)
 > **Consumed by**: `docs/architecture/diagrams/recipe-difficulty/*`
+> **Revised** 2026-07-03 after a multi-lens review (brewing-domain, adversarial, consistency,
+> pedagogy) — see the CHANGELOG note at the end.
 
 This spec holds the **exact rules and thresholds** the backend `DifficultyService` implements.
 Per ADR-0024, thresholds are **v1 defaults, calibratable** — the intent is documented so the
-numbers can move without re-litigating the model.
+numbers can move without re-litigating the model. All inputs are **existing** recipe fields
+(all-grain baseline — no extraction-method axis, ADR-0024 D2).
 
-## 0. Output
+## 0. Output & inputs
 
 ```
 DifficultyLevel = "facile" | "intermediaire" | "avance"   // tiers 0 / 1 / 2
+effectiveDifficulty = difficultyOverride ?? difficultyComputed
 ```
 
-`effectiveDifficulty = difficultyOverride ?? difficultyComputed`. The badge colour: facile =
-green, intermediaire = amber, avance = red.
+Badge colour: facile = green, intermediaire = amber, avance = red.
+
+`yeastClass` is derived **once** from `RecipeYeastType` (`ale | lager | wild | brett`) and used by
+several factors, so a factor never doubles as a category (kept separate from the integer tiers):
+
+```
+yeastClass = wild   if type ∈ {wild, brett}      // "wild culture" — v1 enum has no sour/mixed
+           = lager  if type == lager
+           = ale    otherwise (incl. no yeast row → assume ale)
+```
+
+**Null / absent inputs**: any factor whose signal is null/absent scores **tier 0** (insufficient
+data ⇒ most permissive — never punish a beginner for a sparse recipe).
 
 ## 1. Per-factor tiering
 
-Each factor returns a tier in `{0,1,2}` and, when it fires (tier ≥ 1), one **French
-explanation sentence**. All inputs are existing recipe fields (all-grain baseline — no
-extraction-method axis, ADR-0024 D2).
+Each factor returns a tier in `{0,1,2}` and, when it fires (tier ≥ 1), one **plain-French
+explanation sentence** — the sentence is the *deepest* pedagogy layer (nothing behind it), so it
+must introduce **and** gloss each brewing term (`feedback_educational_vocation`).
 
-### F1 — Fermentation / yeast  *(also a hard override)*
+### F1 — Fermentation / yeast  *(tier from the signal; sentence from the type)*
 
-| Condition (from `recipe-yeast`) | Tier | Sentence |
+| Condition | Tier | Sentence |
 |---|---|---|
-| type ∈ {`wild`, `brett`, `sour`, `mixed`} | **2** | « fermentation sauvage / acide — longue, imprévisible, contrôle microbiologique » |
-| type = `lager`, **or** `temperature_max_c` < 14 | **1** (floor) | « c'est une lager — fermentation à froid contrôlée + garde longue, peu de marge d'erreur » |
-| otherwise (ale) | 0 | — |
+| `yeastClass = wild` (Brett/wild) | **2** | « levure sauvage (Brett) ou fermentation acide : c'est long, imprévisible, et il faut une hygiène irréprochable » |
+| `yeastClass = lager` **or** `temperature_max_c` < 14 | **1** | lager → « elle fermente au froid (≈10 °C) puis se garde plusieurs semaines : il te faut de quoi refroidir et de la patience » · cold-fermented ale → « elle fermente au froid : il te faut de quoi refroidir, la marge d'erreur est faible » |
+| `temperature_max_c` > 26 (hot/active ferment, e.g. saison) | **1** | « elle fermente au chaud (>26 °C) et finit très sèche : la fermentation peut caler, il faut savoir la relancer » |
+| otherwise (ale, normal temp) or null | 0 | — |
 
-Overrides: a wild/sour yeast **forces Avancé**; a lager **forces at least Intermédiaire**
-(applied after aggregation).
+The tier already encodes the escalation (wild = Avancé, lager/cold/hot = ≥ Intermédiaire) — there
+is **no separate post-aggregation override** (that would double-count). The sentence keys on the
+**type**, so a cold-fermented *ale* is never told « c'est une lager ».
 
 ### F2 — Force / densité (gravity)
 
-Use `og_target` if present, else derive from `abv_estimated`.
+Use `og_target`; else derive from `abv_estimated`; both null ⇒ tier 0.
 
 | Condition | Tier | Sentence |
 |---|---|---|
 | OG ≤ 1.055 (≈ ABV < 5.5 %) | 0 | — |
-| 1.055 < OG ≤ 1.075 (≈ 5.5–7.5 %) | **1** | « densité assez élevée — la levure travaille plus, fermentation à surveiller » |
-| OG > 1.075 (≈ ABV > 7.5 %) | **2** | « grosse bière (densité élevée) — pied de levure important, risque de fermentation bloquée » |
+| 1.055 < OG ≤ 1.075 (≈ 5.5–7.5 %) | **1** | « bière assez forte : il y a beaucoup de sucres à transformer, la fermentation demande plus d'attention » |
+| OG > 1.075 (≈ ABV > 7.5 %) | **2** | « grosse bière : il faut BEAUCOUP de levure au départ (un “pied de levure”), sinon la fermentation risque de s'arrêter avant la fin » |
 
-### F3 — Tolérance aux fautes (« no place to hide »)  *(EBC + IBU, gated on yeast)*
+### F3 — Tolérance aux fautes (« no place to hide »)  *(lager-gated proxy)*
 
-The homebrew fault-tolerance axis bites hardest on **lagers**: a pale, clean lager exposes
-every flaw. A pale **ale** stays forgiving (ale-yeast tolerance) and is **not penalised** — this
-keeps the app's flagship « Blonde Facile (premier brassin) » at Facile (calibration decided
-2026-07-03). Roast / hops / haze always mask beginner mistakes.
+Fault-tolerance uses **`yeastClass = lager` as a coarse proxy** for a clean, exacting
+fermentation where nothing masks a flaw. This deliberately **under-penalises clean pale ales**
+(Kölsch, Cream Ale, Blonde, Ordinary Bitter — genuinely unforgiving too) to keep the flagship
+« Blonde Facile (premier brassin) » at Facile. Known limitation, see §6.
 
-- **fault-exposing** ⇔ `ebc_target` ≤ 15 **and** `ibu_target` ≤ 25.
-
-| Condition | Tier | Sentence |
-|---|---|---|
-| fault-exposing **and** yeast is lager (F1 = lager) | **2** | « lager pâle et nette — le style le moins tolérant, aucune faute pardonnée » |
-| otherwise (a pale **ale**, or any roasty/hoppy beer → flaws masked) | 0 | — |
-
-### F4 — Chimie de l'eau
+- **pale** ⇔ `ebc_target` ≤ 10 (true straw-to-gold; null ⇒ not pale).
 
 | Condition | Tier | Sentence |
 |---|---|---|
-| recipe has salt additions / a target water profile / water additives (`recipe-water` non-empty) | **1** | « ajustement de l'eau (sels) requis — mesure et calcul en plus » |
+| `yeastClass = lager` **and** pale (`ebc_target` ≤ 10) | **2** | « une lager blonde et nette : ni houblon fort ni malt torréfié pour cacher un défaut — la moindre erreur se voit tout de suite » |
 | otherwise | 0 | — |
 
-### F5 — Techniques (mash)
+IBU is intentionally **not** used here: on a lager, hop bitterness does **not** mask diagnostic
+faults (DMS, diacetyl…), so a hoppy pale lager (IPL) is **not** easier than a pilsner.
 
-| Condition (from `recipe-step`) | Tier | Sentence |
+### F4 — Chimie de l'eau  *(a real target, not a single sachet)*
+
+Fires only on a **genuine water-treatment intent**, not the mere presence of a water row (every
+recipe has one for volumes).
+
+| Condition (from `recipe-water`) | Tier | Sentence |
 |---|---|---|
-| ≥ 2 mash-type steps (multi-step / decoction mash) | **1** | « empâtage multi-palier — paliers de température à tenir » |
-| single-infusion (1 mash step) or none | 0 | — |
+| `ph_target` set, **or** ≥ 2 ion targets set among {`calcium_ppm`,`magnesium_ppm`,`sulfate_ppm`,`chloride_ppm`} | **1** | « l'eau est ajustée avec des sels minéraux pour coller au style : il faut mesurer et calculer, une étape que les débutants sautent souvent » |
+| otherwise (volumes only / a lone addition / null) | 0 | — |
 
-### F6 — Base / recipe complexity  *(counts)*
+### F5 — Empâtage multi-palier  *(DEFERRED in v1 — data gap)*
 
-`complexity = distinctFermentables + distinctHopAdditions + additives + (dryHopPresent ? 1 : 0)`.
+`recipe-step` carries only a phase `type` (mash/boil/…), **no per-rest temperature or duration**,
+so a step / decoction mash cannot be detected from the current model. **F5 is fixed at tier 0 in
+v1** and revisited when the mash model carries rests (§6). (Counting raw rows was rejected: a
+mash-out or a sparge is a row but not a temperature rest.)
+
+### F6 — Complexité de la recette  *(distinct varieties, not timed additions)*
+
+`complexity = distinctFermentables + distinctHopVarieties + additives`. Counts **varieties**, not
+timed additions — a 4-addition single-hop pale ale is **one** hop variety, so it is not punished.
 
 | Condition | Tier | Sentence |
 |---|---|---|
-| complexity ≤ 5 (SMaSH-ish) | 0 | — |
-| complexity > 5 | **1** | « recette riche (nombreux ingrédients et ajouts) — plus d'étapes, plus de timing » |
+| complexity ≤ 7 | 0 | — |
+| complexity > 7 | **1** | « recette riche : beaucoup d'ingrédients différents à gérer et à minuter, plus d'occasions de se tromper » |
 
-(Dry-hop presence counts here rather than as its own tier — a single dry-hopped pale ale stays
-beginner-friendly; a "kitchen-sink" bill escalates.)
-
-## 2. Aggregation
+## 2. Aggregation  *(max-dominates + bounded compounding)*
 
 ```
-tier   = max(F1, F2, F3, F4, F5, F6)
-if F1 == wild/sour:      tier = 2          // hard override
-else if F1 == lager:     tier = max(tier, 1)
+f1..f6 = per-factor integer tiers    // f5 == 0 in v1
+base   = max(f1, f2, f3, f4, f5, f6)
+moderateCount = count(fi == 1)
+tier   = (moderateCount >= 3) ? min(base + 1, 2) : base   // several moderate stressors ⇒ a notch up
 computed = ["facile","intermediaire","avance"][tier]
-reasons  = sentences of every factor whose tier == tier   // the ones that SET the level
+reasons  = [sentence(fi) for fi where tier(fi) >= 1], ordered by tier desc
+if tier == 0: reasons = [ positiveFacileReason ]          // stored, not synthesised client-side
 ```
 
-Max-dominates (ADR-0024 D1): the hardest factor sets the level. `reasons` drives the
-tap-to-explain (« Avancé car : <reasons joined by " + "> »). For **Facile**, a positive line is
-shown instead: « Recette accessible : fermentation haute, densité modérée, peu d'étapes — idéale
-pour débuter. »
+- **Max-dominates** (ADR-0024 D1): the hardest factor sets the level. The **compounding** rule
+  fixes the "five tier-1 stressors read the same as one" mis-ordering (a decoction strong lager
+  must beat a salted pale ale) while staying explainable — `reasons` still names each firing
+  factor.
+- **reasons = every firing factor** (tier ≥ 1), not only the max — so a lager that is also strong
+  still shows the lager sentence (pedagogy, ADR-0024 D4). Rendered as
+  « <niveau> car : <reasons joined by " · "> ».
+- **Facile** stores a positive reason (`factor:"facile", tier:0`, sentence « Recette accessible :
+  fermentation haute, densité modérée, pas de technique avancée — idéale pour un premier brassin. »)
+  so the mobile stays a pure renderer (no client-side text logic). An **Intermédiaire** lead-in
+  frames it as reachable: « Un cran au-dessus de débutant, accessible après un premier brassin. Ce
+  qui la corse : <reasons> ».
 
 ## 3. Author override
 
 - `difficultyOverride` (nullable enum). `effective = override ?? computed`.
-- When an override is set, the UI shows the computed value as a hint (« calculé :
-  Intermédiaire »), so the author's choice is transparent, not silent.
+- When set, the UI shows the computed value as a hint (« calculé : Intermédiaire »), so the
+  author's choice is transparent.
 
 ## 4. Data model (additions only)
 
@@ -113,33 +144,54 @@ On `recipe`:
 - `difficulty_computed` : enum(`facile`,`intermediaire`,`avance`), not null, recomputed on
   create/update.
 - `difficulty_override` : enum, nullable.
-- `difficulty_reasons`  : json — the structured breakdown `[{ factor, tier, sentence }]` so the
-  mobile renders tap-to-explain without recomputing (ADR-0024 D3). Stores the *computed*
-  breakdown; the effective level is derived at read time.
+- `difficulty_reasons`  : json — `[{ factor, tier, sentence }]` (the computed breakdown, incl. the
+  positive Facile reason), so the mobile renders tap-to-explain without recomputing (ADR-0024 D3).
 
-No change to `recipe-yeast` / `recipe-hop` / `recipe-water` / `recipe-step` — all signals
-already exist. No `brewMethod` field (all-grain baseline, ADR-0024).
+No change to `recipe-yeast` / `recipe-hop` / `recipe-water` / `recipe-step` — all v1 signals
+already exist. No `brewMethod` field (all-grain baseline). `RecipeYeastType` has no `sour`/`mixed`
+today (kettle-sour is folded into `wild`); an enum extension is a documented follow-up (§6).
 
 ## 5. Worked examples (happy / sad / edge — seed the tests)
 
-| Recipe | F1 | F2 | F3 | F4 | F5 | F6 | → computed | Why |
+Assumed bills are stated so each number is auditable. F5 = 0 (deferred) throughout.
+
+| Recipe | yeastClass | F1 | F2 | F3 | F4 | F6 | → computed | Why |
 |---|---|---|---|---|---|---|---|---|
-| **Blonde SMaSH**, ale, OG 1.046, EBC 8, IBU 20, tap water, single mash, 2 ingr. | 0 | 0 | 0 | 0 | 0 | 0 | **Facile** | pale **ale** → forgiving; F3 is gated on lager, so it does not fire. Matches « Blonde Facile ». |
-| **American Pale Ale**, ale, OG 1.052, EBC 12, IBU 38, single mash | 0 | 0 | 0 | 0 | 0 | 0 | **Facile** | hoppy (IBU>25) masks flaws |
-| **Bohemian Pilsner**, lager, OG 1.050, EBC 6, IBU 35 | 1 | 0 | **2** | 0 | 0 | 0 | **Avancé** | pale lager, clean → "no place to hide" (F3 lager combo) |
-| **Russian Imperial Stout**, ale, OG 1.095, EBC 80, IBU 60, salts, multi-mash | 0 | **2** | 0 | 1 | 1 | 1 | **Avancé** | high gravity (F2) |
-| **Berliner Weisse**, sour culture, OG 1.032 | **2**(override) | 0 | — | 0 | 0 | 0 | **Avancé** | wild/sour override |
+| **Blonde SMaSH** — ale, OG 1.046, EBC 8, IBU 20, no water target, 2 ferm + 1 hop var. | ale | 0 | 0 | 0 | 0 | 0 | **Facile** | nothing fires; matches « Blonde Facile » |
+| **American Pale Ale** — ale, OG 1.052, EBC 12, IBU 38, 4 additions but 2 hop var., 3 ferm | ale | 0 | 0 | 0 | 0 | 0 | **Facile** | complexity = 2+2+0 = 4 ≤ 7; ale so F3 off |
+| **Bohemian Pilsner** — lager, OG 1.050, EBC 6, IBU 35 | lager | 1 | 0 | **2** | 0 | 0 | **Avancé** | pale lager (EBC 6 ≤ 10) → F3; IBU irrelevant |
+| **Italian Pilsner (IPL)** — lager, OG 1.052, EBC 7, IBU 45, dry-hopped | lager | 1 | 0 | **2** | 0 | 0 | **Avancé** | regression lock: a hoppy pale lager is still Avancé |
+| **Saison (Dupont clone)** — ale, OG 1.054, IBU 30, ferment 30 °C | ale | **1** | 0 | 0 | 0 | 0 | **Intermédiaire** | hot/active ferment (F1 >26 °C) — no longer a false Facile |
+| **Amber kit + 1 gypsum sachet** — ale, OG 1.048, no pH/ion target | ale | 0 | 0 | 0 | 0 | 0 | **Facile** | a lone sachet with no target ⇒ F4 = 0 |
+| **Russian Imperial Stout** — ale, OG 1.095, EBC 80, IBU 60, water targets, 6 ferm + 3 hop var. | ale | 0 | **2** | 0 | 1 | 1 | **Avancé** | high gravity (F2); reasons also name water + rich bill |
+| **Decoction Strong Bock** — lager, OG 1.070, EBC 30, water targets, 8 var. bill | lager | 1 | 1 | 0 | 1 | 1 | **Avancé** | base = 1 but 4 factors at tier 1 (≥3) ⇒ compounding +1 |
+| **Brett IPA** — wild culture | wild | **2** | 0 | 0 | 0 | 0 | **Avancé** | wild-culture (F1) |
 
-The **Blonde SMaSH** stays **Facile** by design (calibration decided 2026-07-03): F3 is gated on
-lager, so a pale ale is not penalised for being pale — ale-yeast forgiveness dominates, matching
-the flagship « Blonde Facile (premier brassin) » positioning. The fault-tolerance axis still
-does its job on the **pale lager** case (Bohemian Pilsner → Avancé, F3 lager combo).
+The Decoction Bock vs a salted pale ale (one tier-1 factor → Intermédiaire) shows the compounding
+rule working. The Bock's F3 = 0 because EBC 30 > 10 (not pale).
 
-## 6. Notes / open calibration
+## 6. Known limitations & calibration knobs (v1)
 
-- Thresholds (OG bands, EBC/IBU cut-offs, complexity count) are **v1**; expect to tune against
-  real recipes. The internal max-of-tiers keeps tuning local to each factor.
-- Known source disagreements to respect (ADR-0024): malt-forward big beers can be "easy" despite
-  high gravity; Brulosophy softens the lager-flavour penalty (the durable lager cost is
-  equipment + patience, which is why F1-lager is a *floor of Intermédiaire*, not an automatic
-  Avancé unless also fault-exposing).
+- **Pale clean ALES** (Kölsch, Cream Ale, Blonde, Ordinary Bitter, American Wheat) are genuinely
+  unforgiving but score Facile — a deliberate calibration to protect the beginner flagship. `lager`
+  is a coarse proxy for "clean/exacting", accepted for v1.
+- **F5 mash complexity is deferred** — `recipe-step` has no per-rest temperature; step/decoction
+  mashes are invisible until the mash model carries rests.
+- **Wild-culture gradient** — a kettle-sour (Lacto, then clean ferment) is closer to Intermédiaire
+  than a Brett/mixed sour, but the v1 enum can't tell them apart, so all score Avancé
+  (conservative). Split when `sour`/`mixed` enum values exist.
+- **Malt-forward big beers** — some high-gravity malt-forward styles (Dubbel, Old Ale) are called
+  "easy" by BYO because malt hides flaws; F2 still scores them up. Accepted (max-dominates + author
+  override are the escape hatch).
+- **Calibration knobs**: OG bands (F2), EBC ≤ 10 pale cut-off (F3), complexity > 7 (F6),
+  compounding threshold (≥ 3). All v1 defaults, expected to move against real recipes.
+
+## CHANGELOG
+
+- **2026-07-03 — post multi-lens review**: fixed the Bohemian Pilsner contradiction; removed IBU
+  from F3 (was making hoppy lagers *easier*); F3 pale cut-off tightened to EBC ≤ 10; F6 counts hop
+  **varieties** (threshold > 7) instead of timed additions (was over-scoring APAs); added a hot-
+  ferment clause to F1 (saison); F4 now needs a real target, not a lone sachet; F5 (mash) deferred
+  (no per-rest data); separated `yeastClass` from the integer tiers; removed the no-op override step
+  and broadened `reasons` to every firing factor; added bounded compounding; rewrote every
+  tap-to-explain string in glossed plain French; corrected the yeast enum to `{wild, brett}`.

--- a/docs/architecture/specs/recipe-difficulty-algorithm.md
+++ b/docs/architecture/specs/recipe-difficulty-algorithm.md
@@ -114,7 +114,7 @@ base   = max(f1, f2, f3, f4, f5, f6)
 moderateCount = count(fi == 1)
 tier   = (moderateCount >= 3) ? min(base + 1, 2) : base   // several moderate stressors ⇒ a notch up
 computed = ["facile","intermediaire","avance"][tier]
-reasons  = [sentence(fi) for fi where tier(fi) >= 1], ordered by tier desc
+reasons  = [sentence(fi) for fi where tier(fi) >= 1], ordered by tier desc, ties by factor id F1→F6
 if tier == 0: reasons = [ positiveFacileReason ]          // stored, not synthesised client-side
 ```
 


### PR DESCRIPTION
## Summary

**Conception-first (UML-first) for the per-recipe brewing-difficulty badge** (screen-review
Tranche B), plus the Brassage-tab simplification. No code — this is the conception contract to
validate before building.

Deliverables:
- **ADR-0024** — rule-based scoring, **max-dominates + bounded compounding**, backend-computed
  with an author override, 3 levels (Facile/Intermédiaire/Avancé), all-grain baseline. Includes
  a weighted **decision matrix** and a **documented web study** (Palmer, AHA, Brew Your Own,
  Brulosophy, Grainfather, and the peer-reviewed Kusu et al. 2017 cooking-difficulty method).
- **Spec** `recipe-difficulty-algorithm.md` — the exact factor rules (F1 yeast, F2 gravity,
  F3 fault-tolerance *lager-gated*, F4 water, F5 mash *deferred*, F6 complexity), v1 thresholds,
  glossed plain-French explanation strings, aggregation, data model (3 fields on `recipe`),
  worked H/S/E examples.
- **4 diagrams** `diagrams/recipe-difficulty/` — use-case, sequence (compute-on-save /
  read-on-display), component (backend `DifficultyService`), class. All render clean (mmdc).

## Context

- The model was **grounded in a sourced study** and **calibrated to the app** (a pale ale/blonde
  stays Facile to protect « Blonde Facile (premier brassin) »; a pale lager → Avancé).
- It was then **hardened by two independent reviews** (a generalist pre-reviewer + a 4-lens
  adversarial workflow: brewing-domain, adversarial-break, consistency, pedagogy) — 20+ confirmed
  findings fixed in the second commit (Pilsner contradiction, the IBU-makes-lagers-easier bug,
  F6 over-scoring APAs, saison blindness, jargon in the tap-to-explain strings, enum/field-name
  drift…). See the spec CHANGELOG and the second commit message.
- **Emulator-grounded**: the Brassage tab already exposes « Phases de brassage / Étapes de la
  recette / Condensé », so D5 is a re-default + relocation, not a rebuild.
- ADR-0024 is **Proposed** — it moves to Accepted and joins the CLAUDE.md ADR index on merge.

## Checklist

- [x] UML 2.5 orthodox (use cases = actor goals, grouped by domain; no fabricated state/data-flow)
- [x] Diagrams render (mmdc); no trailing fences; worked examples arithmetically consistent
- [x] Signals verified against the real schema (`RecipeYeastType`, `RecipeHopAdditionStage`, `recipe-water` ions)
- [x] Documented v1 limitations (spec §6): pale clean ales, mash deferred, kettle-sour gradient
- [x] Docs-only — no code touched

No tracked issue closed by this conception. Build follows in a separate PR once validated.
