### PR TITLE
test(mobile/scan): regression test for the concurrent-import guard (#766)

### DIFF
--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -536,6 +536,55 @@ describe("BeerInfoCardScreen", () => {
       });
     }
 
+    it("does not launch a second import while one is already pending (concurrent-import guard)", async () => {
+      mockedLookup.mockResolvedValueOnce(buildResult());
+      // A deferred import that never resolves on its own — the first import
+      // stays pending so the guard has something to block against.
+      let resolveImport!: (value: { recipeId: string; name: string }) => void;
+      mockedImport.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveImport = resolve;
+        }),
+      );
+
+      renderScreen(<BeerInfoCardScreen barcodeParam="5060277380019" />);
+
+      const row = await screen.findByLabelText(/Importer Session IPA Citra/);
+      await act(async () => {
+        fireEvent.press(row);
+      });
+      await confirmImportInDialog(); // fires the (pending) import
+
+      await waitFor(() => expect(mockedImport).toHaveBeenCalledTimes(1));
+      // Flush the pending-state re-render so the handlers observe isPending=true.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Second attempt while the first is still pending. Whether the top-of-
+      // handler guard blocks the dialog or the post-confirm `!isPending` re-check
+      // blocks the mutation, the net effect must be the same: no concurrent
+      // import fires.
+      await act(async () => {
+        fireEvent.press(row);
+      });
+      const secondConfirm = screen.queryByLabelText("Importer");
+      if (secondConfirm) {
+        await act(async () => {
+          fireEvent.press(secondConfirm);
+        });
+      }
+      expect(mockedImport).toHaveBeenCalledTimes(1);
+
+      // Let the deferred import settle so no state update leaks past the test.
+      await act(async () => {
+        resolveImport({
+          recipeId: "imported-uuid-1",
+          name: "Session IPA Citra",
+        });
+      });
+    });
+
     it("imports the recipe and navigates to the new detail page on success", async () => {
       mockedLookup.mockResolvedValueOnce(buildResult());
       mockedImport.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

Adds the missing regression test for the concurrent-import guard in `MatchingRecipesSection.handleImport` (BeerInfoCardScreen): a second community-recipe import must not fire while the first is still pending (top guard `if (importMutation.isPending) return` + the post-confirm `!importMutation.isPending` re-check).

Pre-existing gap (confirmed on `main`), flagged during the Tranche A review. Uses a deferred (never-resolving) promise — no real timers, non-flaky; a micro-task flush lets the pending-state re-render propagate before the second attempt. Full BeerInfoCardScreen suite 36/36 green.

## Checklist
- [x] No production code changed — test only
- [x] Non-flaky (deferred promise, no real timers)