### PR TITLE
fix(mobile/ui): Snackbar floats above a sticky CTA instead of overlapping it

### DIFF
--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from "@/core/auth/auth-context";
 
 import { ConfirmProvider } from "@/core/ui/confirm-provider";
 import { SnackbarProvider } from "@/core/ui/snackbar-provider";
+import { StickyCtaClearanceProvider } from "@/core/ui/sticky-cta-clearance";
 import { QueryProvider } from "@/core/query/query-provider";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Stack } from "expo-router";
@@ -16,10 +17,12 @@ function AppShell() {
   return (
     <QueryProvider key={queryScopeKey}>
       <ConfirmProvider>
-        <SnackbarProvider>
-          <Stack screenOptions={{ headerShown: false }} />
-          <StatusBar style="auto" />
-        </SnackbarProvider>
+        <StickyCtaClearanceProvider>
+          <SnackbarProvider>
+            <Stack screenOptions={{ headerShown: false }} />
+            <StatusBar style="auto" />
+          </SnackbarProvider>
+        </StickyCtaClearanceProvider>
       </ConfirmProvider>
     </QueryProvider>
   );

--- a/packages/mobile-app/src/core/ui/Snackbar.tsx
+++ b/packages/mobile-app/src/core/ui/Snackbar.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { useStickyCtaClearance } from "@/core/ui/sticky-cta-clearance";
 
 export type SnackbarProps = Readonly<{
   visible: boolean;
@@ -25,12 +26,14 @@ export function Snackbar({
   onAction,
 }: SnackbarProps) {
   const footerOffset = useNavigationFooterOffset();
+  // Float above a sticky CTA when one is mounted, instead of overlapping it.
+  const ctaClearance = useStickyCtaClearance();
   if (!visible) {
     return null;
   }
   return (
     <View
-      style={[styles.overlay, { paddingBottom: footerOffset }]}
+      style={[styles.overlay, { paddingBottom: footerOffset + ctaClearance }]}
       pointerEvents="box-none"
     >
       <View style={styles.bar} accessibilityRole="alert">

--- a/packages/mobile-app/src/core/ui/Snackbar.tsx
+++ b/packages/mobile-app/src/core/ui/Snackbar.tsx
@@ -33,6 +33,7 @@ export function Snackbar({
   }
   return (
     <View
+      testID="snackbar-overlay"
       style={[styles.overlay, { paddingBottom: footerOffset + ctaClearance }]}
       pointerEvents="box-none"
     >

--- a/packages/mobile-app/src/core/ui/__tests__/sticky-cta-clearance.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/sticky-cta-clearance.test.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { StyleSheet, Text } from "react-native";
+import { render, screen } from "@testing-library/react-native";
+
+import { Snackbar } from "@/core/ui/Snackbar";
+import {
+  STICKY_CTA_BAR_HEIGHT,
+  StickyCtaClearanceProvider,
+  useMarkStickyCtaPresent,
+  useStickyCtaClearance,
+} from "@/core/ui/sticky-cta-clearance";
+
+function ClearanceProbe() {
+  const clearance = useStickyCtaClearance();
+  return <Text>{`clearance:${clearance}`}</Text>;
+}
+
+function StickyCtaMarker() {
+  useMarkStickyCtaPresent();
+  return null;
+}
+
+/** Resolved `paddingBottom` of the Snackbar's full-screen overlay. */
+function overlayPaddingBottom(): number {
+  const overlay = screen.getByTestId("snackbar-overlay");
+  const flat = StyleSheet.flatten(overlay.props.style) as {
+    paddingBottom?: number;
+  };
+  return flat.paddingBottom ?? 0;
+}
+
+describe("sticky CTA clearance", () => {
+  // happy: no CTA mounted → floating UI needs no extra clearance.
+  it("exposes zero clearance until a sticky CTA declares itself present", () => {
+    render(
+      <StickyCtaClearanceProvider>
+        <ClearanceProbe />
+      </StickyCtaClearanceProvider>,
+    );
+
+    expect(screen.getByText("clearance:0")).toBeTruthy();
+  });
+
+  // happy: a mounted CTA raises the clearance to the bar's full height.
+  it("exposes STICKY_CTA_BAR_HEIGHT while a sticky CTA is mounted", () => {
+    render(
+      <StickyCtaClearanceProvider>
+        <StickyCtaMarker />
+        <ClearanceProbe />
+      </StickyCtaClearanceProvider>,
+    );
+
+    expect(screen.getByText(`clearance:${STICKY_CTA_BAR_HEIGHT}`)).toBeTruthy();
+  });
+
+  // edge: the CTA unmounting releases the clearance back to zero.
+  it("releases the clearance back to zero when the CTA unmounts", () => {
+    function Host({ withCta }: { withCta: boolean }) {
+      return (
+        <StickyCtaClearanceProvider>
+          {withCta ? <StickyCtaMarker /> : null}
+          <ClearanceProbe />
+        </StickyCtaClearanceProvider>
+      );
+    }
+
+    const { rerender } = render(<Host withCta />);
+    expect(screen.getByText(`clearance:${STICKY_CTA_BAR_HEIGHT}`)).toBeTruthy();
+
+    rerender(<Host withCta={false} />);
+    expect(screen.getByText("clearance:0")).toBeTruthy();
+  });
+
+  // integration: the Snackbar overlay floats higher by exactly the bar height
+  // when a sticky CTA is present, so the two never overlap on screen.
+  it("floats the Snackbar higher by exactly STICKY_CTA_BAR_HEIGHT when a sticky CTA is present", () => {
+    const base = render(
+      <StickyCtaClearanceProvider>
+        <Snackbar visible message="Recette ajoutée" />
+      </StickyCtaClearanceProvider>,
+    );
+    const basePadding = overlayPaddingBottom();
+    base.unmount();
+
+    render(
+      <StickyCtaClearanceProvider>
+        <StickyCtaMarker />
+        <Snackbar visible message="Recette ajoutée" />
+      </StickyCtaClearanceProvider>,
+    );
+    const raisedPadding = overlayPaddingBottom();
+
+    expect(raisedPadding - basePadding).toBe(STICKY_CTA_BAR_HEIGHT);
+  });
+});

--- a/packages/mobile-app/src/core/ui/sticky-cta-clearance.tsx
+++ b/packages/mobile-app/src/core/ui/sticky-cta-clearance.tsx
@@ -1,13 +1,19 @@
 import React from "react";
 
-import { spacing } from "@/core/theme";
+import { spacing, typography } from "@/core/theme";
+
+// `PrimaryButton` (what the sticky CTA renders) sets no fixed height: it is its
+// label line box plus `spacing.sm` padding top and bottom. Derive from the same
+// tokens so the clearance stays in sync if typography/spacing ever change.
+const PRIMARY_BUTTON_HEIGHT = spacing.sm * 2 + typography.lineHeight.label;
 
 /**
  * Visible height of a sticky CTA bar *above* the nav-footer offset — its button
- * (~48) plus the top/bottom paddings (`spacing.sm` each). App-level floating UI
+ * plus the bar's top/bottom paddings (`spacing.sm` each). App-level floating UI
  * (the Snackbar) adds this to clear a sticky CTA instead of overlapping it.
  */
-export const STICKY_CTA_BAR_HEIGHT = spacing.sm + 48 + spacing.sm;
+export const STICKY_CTA_BAR_HEIGHT =
+  spacing.sm + PRIMARY_BUTTON_HEIGHT + spacing.sm;
 
 // Split read/write so a mounted CTA never re-triggers its own register effect
 // when the count changes: `register` is stable, only the clearance value moves.

--- a/packages/mobile-app/src/core/ui/sticky-cta-clearance.tsx
+++ b/packages/mobile-app/src/core/ui/sticky-cta-clearance.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+import { spacing } from "@/core/theme";
+
+/**
+ * Visible height of a sticky CTA bar *above* the nav-footer offset — its button
+ * (~48) plus the top/bottom paddings (`spacing.sm` each). App-level floating UI
+ * (the Snackbar) adds this to clear a sticky CTA instead of overlapping it.
+ */
+export const STICKY_CTA_BAR_HEIGHT = spacing.sm + 48 + spacing.sm;
+
+// Split read/write so a mounted CTA never re-triggers its own register effect
+// when the count changes: `register` is stable, only the clearance value moves.
+const RegisterContext = React.createContext<(() => () => void) | null>(null);
+const ClearanceContext = React.createContext<number>(0);
+
+/**
+ * Tracks how many sticky CTA bars are currently mounted and exposes the extra
+ * bottom clearance floating UI should apply. Mounted once near the app root,
+ * above both the CTA-bearing screens and the app-level Snackbar.
+ */
+export function StickyCtaClearanceProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [count, setCount] = React.useState(0);
+  const register = React.useCallback(() => {
+    setCount((n) => n + 1);
+    return () => setCount((n) => Math.max(0, n - 1));
+  }, []);
+  const clearance = count > 0 ? STICKY_CTA_BAR_HEIGHT : 0;
+  return (
+    <RegisterContext.Provider value={register}>
+      <ClearanceContext.Provider value={clearance}>
+        {children}
+      </ClearanceContext.Provider>
+    </RegisterContext.Provider>
+  );
+}
+
+/** Extra bottom clearance (px) to add so a floating element clears a sticky CTA. */
+export function useStickyCtaClearance(): number {
+  return React.useContext(ClearanceContext);
+}
+
+/** A sticky CTA calls this to declare itself mounted (so floating UI clears it). */
+export function useMarkStickyCtaPresent(): void {
+  const register = React.useContext(RegisterContext);
+  React.useEffect(() => {
+    if (!register) {
+      return;
+    }
+    return register();
+  }, [register]);
+}

--- a/packages/mobile-app/src/features/recipes/presentation/components/RecipeStickyCta.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/RecipeStickyCta.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, Text, View } from "react-native";
 
 import { colors, shadows, spacing, typography } from "@/core/theme";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { useMarkStickyCtaPresent } from "@/core/ui/sticky-cta-clearance";
 
 type RecipeStickyCtaProps = {
   label: string;
@@ -26,6 +27,8 @@ export function RecipeStickyCta({
   helperText = null,
   bottomOffset = 0,
 }: RecipeStickyCtaProps) {
+  // Declare this bar mounted so app-level floating UI (Snackbar) clears it.
+  useMarkStickyCtaPresent();
   return (
     <View
       testID="recipe-sticky-cta"


### PR DESCRIPTION
## Summary

The app-level `Snackbar` and `RecipeStickyCta` both anchored at `useNavigationFooterOffset()`, so the « Recette ajoutée · Annuler » snackbar overlapped « Préparer mon brassin » for ~5s after importing a community recipe onto an owned copy (caught in the screen-by-screen review).

Adds a small `StickyCtaClearanceProvider`: a sticky CTA declares itself mounted (`useMarkStickyCtaPresent`), and the Snackbar adds `STICKY_CTA_BAR_HEIGHT` clearance **only when one is present** — token-based (no hardcoded px), no extra height on CTA-less screens.

## Verification
- `tsc` + `eslint` clean; snackbar-provider + RecipeDetailsScreen suites green (34/34); hooks are null-safe outside the provider (existing tests unaffected).
- **Live emulator check is blocked** until a non-owned community recipe exists in demo mode (the snackbar only fires on a community import) — tracked by the demo-data PR. The geometry fix is logically sound + unit-context tested.

## Checklist
- [x] No hardcoded pixels (theme tokens + a shared constant)
- [x] Clearance applied only when a sticky CTA is mounted