### PR TITLE
feat(mobile/demo): non-owned community recipe so community flows are demoable

### DIFF
--- a/packages/mobile-app/src/features/recipes/application/__tests__/recipes.use-cases.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/recipes.use-cases.test.ts
@@ -1,6 +1,7 @@
 import {
   getRecipeDetailsViewModel,
   listPublicRecipes,
+  listRecipes,
 } from "@/features/recipes/application/recipes.use-cases";
 import { dataSource } from "@/core/data/data-source";
 import { getMineById, listSteps } from "@/features/recipes/data/recipes.api";
@@ -46,16 +47,26 @@ describe("recipes use-cases — listPublicRecipes (Issue #779)", () => {
     }
   });
 
-  // sad: every recipe returned has the well-formed shape the
-  // CatalogScreen relies on (id, name, ownerId, visibility).
+  // sad: every recipe returned has the well-formed shape the CatalogScreen
+  // relies on (id, name, visibility). A public/community recipe legitimately
+  // has NO ownerId — the backend strips it (ownerId present ⟺ owned), which is
+  // exactly what drives « Ajouter à mon carnet » — so we do not require it here.
   it("sad: every returned recipe carries the minimum shape the screen relies on", async () => {
     const recipes = await listPublicRecipes();
 
     for (const recipe of recipes) {
       expect(recipe.id).toBeTruthy();
       expect(recipe.name).toBeTruthy();
-      expect(recipe.ownerId).toBeTruthy();
+      expect(recipe.visibility).toBe("public");
     }
+  });
+
+  it("keeps a community recipe (no ownerId) out of « Mes recettes » but in « Découvrir »", async () => {
+    const mine = await listRecipes();
+    const discover = await listPublicRecipes();
+
+    expect(mine.some((r) => r.id === "r-demo-community-1")).toBe(false);
+    expect(discover.some((r) => r.id === "r-demo-community-1")).toBe(true);
   });
 
   // edge: no PRIVATE or UNLISTED recipe leaks even when the demo

--- a/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
@@ -54,9 +54,9 @@ export type RecipeDetailsViewModel = {
 };
 
 export async function listRecipes(): Promise<Recipe[]> {
-  // « Mes recettes » = owned only. Demo recipes without an `ownerId` are
-  // community recipes (they surface in « Découvrir » via `listPublicRecipes`);
-  // no-op for the seeded recipes, which all carry an owner.
+  // « Mes recettes » = owned only. A demo recipe without an `ownerId` is a
+  // community recipe: it is excluded here and surfaces in « Découvrir » via
+  // `listPublicRecipes` (e.g. "Blonde de la Communauté", r-demo-community-1).
   return dataSource.useDemoData
     ? demoRecipes.filter((recipe) => recipe.ownerId != null)
     : listMine();

--- a/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
@@ -54,7 +54,12 @@ export type RecipeDetailsViewModel = {
 };
 
 export async function listRecipes(): Promise<Recipe[]> {
-  return dataSource.useDemoData ? demoRecipes : listMine();
+  // « Mes recettes » = owned only. Demo recipes without an `ownerId` are
+  // community recipes (they surface in « Découvrir » via `listPublicRecipes`);
+  // no-op for the seeded recipes, which all carry an owner.
+  return dataSource.useDemoData
+    ? demoRecipes.filter((recipe) => recipe.ownerId != null)
+    : listMine();
 }
 
 /**

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2317,6 +2317,45 @@ export const demoRecipes: Recipe[] = [
     createdAt: "2026-04-15T10:00:00.000Z",
     updatedAt: "2026-04-20T10:00:00.000Z",
   },
+  {
+    // A community recipe the demo user does NOT own: no `ownerId`, so
+    // `isOwned = ownerId != null` is false → it shows « Ajouter à mon carnet »,
+    // the lightened Water tab, and the import snackbar. It stays OUT of « Mes
+    // recettes » (listRecipes filters on ownerId) but appears in « Découvrir ».
+    id: "r-demo-community-1",
+    name: "Blonde de la Communauté",
+    description:
+      "Une blonde légère et désaltérante, partagée par la communauté",
+    stats: {
+      ibu: 20,
+      abv: 4.8,
+      og: 1.046,
+      fg: 1.008,
+      volumeLiters: 20,
+      colorEbc: 8,
+    },
+    ingredients: [
+      { ingredientId: "malt-1", amount: 4, unit: "kg", timing: "mash" },
+      { ingredientId: "hop-3", amount: 20, unit: "g", timing: "boil - 60 min" },
+      {
+        ingredientId: "yeast-1",
+        amount: 1,
+        unit: "unit",
+        timing: "fermentation",
+        notes: "Pitch at 18°C",
+      },
+    ],
+    equipment: [
+      { equipmentId: "eq-1", role: "Mash & boil" },
+      { equipmentId: "eq-3", role: "Fermentation" },
+    ],
+    visibility: "public",
+    version: 1,
+    rootRecipeId: "r-demo-community-1",
+    parentRecipeId: null,
+    createdAt: "2026-05-01T10:00:00.000Z",
+    updatedAt: "2026-05-01T10:00:00.000Z",
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Demo mode (`useDemoData`) treated **every** recipe as owned — every `demoRecipe` had an `ownerId`, so `isOwned` was always true and nothing showed « Ajouter à mon carnet ». The Tranche A features (import undo snackbar, lightened Water tab) and the scan import couldn't be exercised on-screen in demo mode.

- Adds one demo recipe « Blonde de la Communauté » with **no `ownerId`** + `visibility: public`.
- Filters `listRecipes()` (« Mes recettes ») on `ownerId != null` — a no-op for the seeded recipes (all owned); the community recipe surfaces in « Découvrir » only.
- Corrects the `listPublicRecipes` shape test (a public recipe legitimately has **no** `ownerId` — the backend strips it via `PublicRecipeDto`, which is exactly what drives « Ajouter à mon carnet ») and adds a positive « in Découvrir, not in Mes recettes » test.

The demo `importRecipeFromCommunity` is left as-is (navigates to the same recipe — the snackbar still shows); synthesizing an owned copy is a documented follow-up.

## Verification
- `tsc` clean; full mobile suite 1198/1198 green.
- Live emulator check to follow (demo login): the recipe shows in Découvrir with « Ajouter à mon carnet », its Water tab is lightened, and importing shows the « Recette ajoutée · Annuler » snackbar.