### PR TITLE
feat(api/recipe): brewing-difficulty compute + storage (Tranche B slices 1+2)

### DIFF
--- a/docs/architecture/specs/recipe-difficulty-algorithm.md
+++ b/docs/architecture/specs/recipe-difficulty-algorithm.md
@@ -36,33 +36,33 @@ data ⇒ most permissive — never punish a beginner for a sparse recipe).
 ## 1. Per-factor tiering
 
 Each factor returns a tier in `{0,1,2}` and, when it fires (tier ≥ 1), one **plain-French
-explanation sentence** — the sentence is the *deepest* pedagogy layer (nothing behind it), so it
+explanation sentence** — the sentence is the _deepest_ pedagogy layer (nothing behind it), so it
 must introduce **and** gloss each brewing term (`feedback_educational_vocation`).
 
-### F1 — Fermentation / yeast  *(tier from the signal; sentence from the type)*
+### F1 — Fermentation / yeast _(tier from the signal; sentence from the type)_
 
-| Condition | Tier | Sentence |
-|---|---|---|
-| `yeastClass = wild` (Brett/wild) | **2** | « levure sauvage (Brett) ou fermentation acide : c'est long, imprévisible, et il faut une hygiène irréprochable » |
-| `yeastClass = lager` **or** `temperature_max_c` < 14 | **1** | lager → « elle fermente au froid (≈10 °C) puis se garde plusieurs semaines : il te faut de quoi refroidir et de la patience » · cold-fermented ale → « elle fermente au froid : il te faut de quoi refroidir, la marge d'erreur est faible » |
-| `temperature_max_c` > 26 (hot/active ferment, e.g. saison) | **1** | « elle fermente au chaud (>26 °C) et finit très sèche : la fermentation peut caler, il faut savoir la relancer » |
-| otherwise (ale, normal temp) or null | 0 | — |
+| Condition                                                  | Tier  | Sentence                                                                                                                                                                                                                                     |
+| ---------------------------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `yeastClass = wild` (Brett/wild)                           | **2** | « levure sauvage (Brett) ou fermentation acide : c'est long, imprévisible, et il faut une hygiène irréprochable »                                                                                                                            |
+| `yeastClass = lager` **or** `temperature_max_c` < 14       | **1** | lager → « elle fermente au froid (≈10 °C) puis se garde plusieurs semaines : il te faut de quoi refroidir et de la patience » · cold-fermented ale → « elle fermente au froid : il te faut de quoi refroidir, la marge d'erreur est faible » |
+| `temperature_max_c` > 26 (hot/active ferment, e.g. saison) | **1** | « elle fermente au chaud (>26 °C) et finit très sèche : la fermentation peut caler, il faut savoir la relancer »                                                                                                                             |
+| otherwise (ale, normal temp) or null                       | 0     | —                                                                                                                                                                                                                                            |
 
 The tier already encodes the escalation (wild = Avancé, lager/cold/hot = ≥ Intermédiaire) — there
 is **no separate post-aggregation override** (that would double-count). The sentence keys on the
-**type**, so a cold-fermented *ale* is never told « c'est une lager ».
+**type**, so a cold-fermented _ale_ is never told « c'est une lager ».
 
 ### F2 — Force / densité (gravity)
 
 Use `og_target`; else derive from `abv_estimated`; both null ⇒ tier 0.
 
-| Condition | Tier | Sentence |
-|---|---|---|
-| OG ≤ 1.055 (≈ ABV < 5.5 %) | 0 | — |
-| 1.055 < OG ≤ 1.075 (≈ 5.5–7.5 %) | **1** | « bière assez forte : il y a beaucoup de sucres à transformer, la fermentation demande plus d'attention » |
-| OG > 1.075 (≈ ABV > 7.5 %) | **2** | « grosse bière : il faut BEAUCOUP de levure au départ (un “pied de levure”), sinon la fermentation risque de s'arrêter avant la fin » |
+| Condition                        | Tier  | Sentence                                                                                                                              |
+| -------------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| OG ≤ 1.055 (≈ ABV < 5.5 %)       | 0     | —                                                                                                                                     |
+| 1.055 < OG ≤ 1.075 (≈ 5.5–7.5 %) | **1** | « bière assez forte : il y a beaucoup de sucres à transformer, la fermentation demande plus d'attention »                             |
+| OG > 1.075 (≈ ABV > 7.5 %)       | **2** | « grosse bière : il faut BEAUCOUP de levure au départ (un “pied de levure”), sinon la fermentation risque de s'arrêter avant la fin » |
 
-### F3 — Tolérance aux fautes (« no place to hide »)  *(lager-gated proxy)*
+### F3 — Tolérance aux fautes (« no place to hide ») _(lager-gated proxy)_
 
 Fault-tolerance uses **`yeastClass = lager` as a coarse proxy** for a clean, exacting
 fermentation where nothing masks a flaw. This deliberately **under-penalises clean pale ales**
@@ -71,42 +71,42 @@ fermentation where nothing masks a flaw. This deliberately **under-penalises cle
 
 - **pale** ⇔ `ebc_target` ≤ 10 (true straw-to-gold; null ⇒ not pale).
 
-| Condition | Tier | Sentence |
-|---|---|---|
+| Condition                                             | Tier  | Sentence                                                                                                                         |
+| ----------------------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `yeastClass = lager` **and** pale (`ebc_target` ≤ 10) | **2** | « une lager blonde et nette : ni houblon fort ni malt torréfié pour cacher un défaut — la moindre erreur se voit tout de suite » |
-| otherwise | 0 | — |
+| otherwise                                             | 0     | —                                                                                                                                |
 
 IBU is intentionally **not** used here: on a lager, hop bitterness does **not** mask diagnostic
 faults (DMS, diacetyl…), so a hoppy pale lager (IPL) is **not** easier than a pilsner.
 
-### F4 — Chimie de l'eau  *(a real target, not a single sachet)*
+### F4 — Chimie de l'eau _(a real target, not a single sachet)_
 
 Fires only on a **genuine water-treatment intent**, not the mere presence of a water row (every
 recipe has one for volumes).
 
-| Condition (from `recipe-water`) | Tier | Sentence |
-|---|---|---|
+| Condition (from `recipe-water`)                                                                                | Tier  | Sentence                                                                                                                                     |
+| -------------------------------------------------------------------------------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `ph_target` set, **or** ≥ 2 ion targets set among {`calcium_ppm`,`magnesium_ppm`,`sulfate_ppm`,`chloride_ppm`} | **1** | « l'eau est ajustée avec des sels minéraux pour coller au style : il faut mesurer et calculer, une étape que les débutants sautent souvent » |
-| otherwise (volumes only / a lone addition / null) | 0 | — |
+| otherwise (volumes only / a lone addition / null)                                                              | 0     | —                                                                                                                                            |
 
-### F5 — Empâtage multi-palier  *(DEFERRED in v1 — data gap)*
+### F5 — Empâtage multi-palier _(DEFERRED in v1 — data gap)_
 
 `recipe-step` carries only a phase `type` (mash/boil/…), **no per-rest temperature or duration**,
 so a step / decoction mash cannot be detected from the current model. **F5 is fixed at tier 0 in
 v1** and revisited when the mash model carries rests (§6). (Counting raw rows was rejected: a
 mash-out or a sparge is a row but not a temperature rest.)
 
-### F6 — Complexité de la recette  *(distinct varieties, not timed additions)*
+### F6 — Complexité de la recette _(distinct varieties, not timed additions)_
 
 `complexity = distinctFermentables + distinctHopVarieties + additives`. Counts **varieties**, not
 timed additions — a 4-addition single-hop pale ale is **one** hop variety, so it is not punished.
 
-| Condition | Tier | Sentence |
-|---|---|---|
-| complexity ≤ 7 | 0 | — |
+| Condition      | Tier  | Sentence                                                                                                   |
+| -------------- | ----- | ---------------------------------------------------------------------------------------------------------- |
+| complexity ≤ 7 | 0     | —                                                                                                          |
 | complexity > 7 | **1** | « recette riche : beaucoup d'ingrédients différents à gérer et à minuter, plus d'occasions de se tromper » |
 
-## 2. Aggregation  *(max-dominates + bounded compounding)*
+## 2. Aggregation _(max-dominates + bounded compounding)_
 
 ```
 f1..f6 = per-factor integer tiers    // f5 == 0 in v1
@@ -144,7 +144,7 @@ On `recipe`:
 - `difficulty_computed` : enum(`facile`,`intermediaire`,`avance`), not null, recomputed on
   create/update.
 - `difficulty_override` : enum, nullable.
-- `difficulty_reasons`  : json — `[{ factor, tier, sentence }]` (the computed breakdown, incl. the
+- `difficulty_reasons` : json — `[{ factor, tier, sentence }]` (the computed breakdown, incl. the
   positive Facile reason), so the mobile renders tap-to-explain without recomputing (ADR-0024 D3).
 
 No change to `recipe-yeast` / `recipe-hop` / `recipe-water` / `recipe-step` — all v1 signals
@@ -155,17 +155,17 @@ today (kettle-sour is folded into `wild`); an enum extension is a documented fol
 
 Assumed bills are stated so each number is auditable. F5 = 0 (deferred) throughout.
 
-| Recipe | yeastClass | F1 | F2 | F3 | F4 | F6 | → computed | Why |
-|---|---|---|---|---|---|---|---|---|
-| **Blonde SMaSH** — ale, OG 1.046, EBC 8, IBU 20, no water target, 2 ferm + 1 hop var. | ale | 0 | 0 | 0 | 0 | 0 | **Facile** | nothing fires; matches « Blonde Facile » |
-| **American Pale Ale** — ale, OG 1.052, EBC 12, IBU 38, 4 additions but 2 hop var., 3 ferm | ale | 0 | 0 | 0 | 0 | 0 | **Facile** | complexity = 2+2+0 = 4 ≤ 7; ale so F3 off |
-| **Bohemian Pilsner** — lager, OG 1.050, EBC 6, IBU 35 | lager | 1 | 0 | **2** | 0 | 0 | **Avancé** | pale lager (EBC 6 ≤ 10) → F3; IBU irrelevant |
-| **Italian Pilsner (IPL)** — lager, OG 1.052, EBC 7, IBU 45, dry-hopped | lager | 1 | 0 | **2** | 0 | 0 | **Avancé** | regression lock: a hoppy pale lager is still Avancé |
-| **Saison (Dupont clone)** — ale, OG 1.054, IBU 30, ferment 30 °C | ale | **1** | 0 | 0 | 0 | 0 | **Intermédiaire** | hot/active ferment (F1 >26 °C) — no longer a false Facile |
-| **Amber kit + 1 gypsum sachet** — ale, OG 1.048, no pH/ion target | ale | 0 | 0 | 0 | 0 | 0 | **Facile** | a lone sachet with no target ⇒ F4 = 0 |
-| **Russian Imperial Stout** — ale, OG 1.095, EBC 80, IBU 60, water targets, 6 ferm + 3 hop var. | ale | 0 | **2** | 0 | 1 | 1 | **Avancé** | high gravity (F2); reasons also name water + rich bill |
-| **Decoction Strong Bock** — lager, OG 1.070, EBC 30, water targets, 8 var. bill | lager | 1 | 1 | 0 | 1 | 1 | **Avancé** | base = 1 but 4 factors at tier 1 (≥3) ⇒ compounding +1 |
-| **Brett IPA** — wild culture | wild | **2** | 0 | 0 | 0 | 0 | **Avancé** | wild-culture (F1) |
+| Recipe                                                                                         | yeastClass | F1    | F2    | F3    | F4  | F6  | → computed        | Why                                                       |
+| ---------------------------------------------------------------------------------------------- | ---------- | ----- | ----- | ----- | --- | --- | ----------------- | --------------------------------------------------------- |
+| **Blonde SMaSH** — ale, OG 1.046, EBC 8, IBU 20, no water target, 2 ferm + 1 hop var.          | ale        | 0     | 0     | 0     | 0   | 0   | **Facile**        | nothing fires; matches « Blonde Facile »                  |
+| **American Pale Ale** — ale, OG 1.052, EBC 12, IBU 38, 4 additions but 2 hop var., 3 ferm      | ale        | 0     | 0     | 0     | 0   | 0   | **Facile**        | complexity = 2+2+0 = 4 ≤ 7; ale so F3 off                 |
+| **Bohemian Pilsner** — lager, OG 1.050, EBC 6, IBU 35                                          | lager      | 1     | 0     | **2** | 0   | 0   | **Avancé**        | pale lager (EBC 6 ≤ 10) → F3; IBU irrelevant              |
+| **Italian Pilsner (IPL)** — lager, OG 1.052, EBC 7, IBU 45, dry-hopped                         | lager      | 1     | 0     | **2** | 0   | 0   | **Avancé**        | regression lock: a hoppy pale lager is still Avancé       |
+| **Saison (Dupont clone)** — ale, OG 1.054, IBU 30, ferment 30 °C                               | ale        | **1** | 0     | 0     | 0   | 0   | **Intermédiaire** | hot/active ferment (F1 >26 °C) — no longer a false Facile |
+| **Amber kit + 1 gypsum sachet** — ale, OG 1.048, no pH/ion target                              | ale        | 0     | 0     | 0     | 0   | 0   | **Facile**        | a lone sachet with no target ⇒ F4 = 0                     |
+| **Russian Imperial Stout** — ale, OG 1.095, EBC 80, IBU 60, water targets, 6 ferm + 3 hop var. | ale        | 0     | **2** | 0     | 1   | 1   | **Avancé**        | high gravity (F2); reasons also name water + rich bill    |
+| **Decoction Strong Bock** — lager, OG 1.070, EBC 30, water targets, 8 var. bill                | lager      | 1     | 1     | 0     | 1   | 1   | **Avancé**        | base = 1 but 4 factors at tier 1 (≥3) ⇒ compounding +1    |
+| **Brett IPA** — wild culture                                                                   | wild       | **2** | 0     | 0     | 0   | 0   | **Avancé**        | wild-culture (F1)                                         |
 
 The Decoction Bock vs a salted pale ale (one tier-1 factor → Intermédiaire) shows the compounding
 rule working. The Bock's F3 = 0 because EBC 30 > 10 (not pale).
@@ -183,13 +183,19 @@ rule working. The Bock's F3 = 0 because EBC 30 > 10 (not pale).
 - **Malt-forward big beers** — some high-gravity malt-forward styles (Dubbel, Old Ale) are called
   "easy" by BYO because malt hides flaws; F2 still scores them up. Accepted (max-dominates + author
   override are the escape hatch).
+- **Multi-yeast reduction** — the factors score a _single_ yeast, but a recipe may carry several
+  (e.g. a primary + a Brett secondary). The backend reduces them to the worst-case culture —
+  `wild/brett` > `lager` > `ale`, first row within the winning class — carrying that yeast's
+  `temperature_max_c`. A recipe normally has one yeast; a divergent multi-_ale_ bill (one cold, one
+  hot) resolves to the first ale, and the author override is the escape hatch. (Implemented in the
+  application adapter, not the pure scorer.)
 - **Calibration knobs**: OG bands (F2), EBC ≤ 10 pale cut-off (F3), complexity > 7 (F6),
   compounding threshold (≥ 3). All v1 defaults, expected to move against real recipes.
 
 ## CHANGELOG
 
 - **2026-07-03 — post multi-lens review**: fixed the Bohemian Pilsner contradiction; removed IBU
-  from F3 (was making hoppy lagers *easier*); F3 pale cut-off tightened to EBC ≤ 10; F6 counts hop
+  from F3 (was making hoppy lagers _easier_); F3 pale cut-off tightened to EBC ≤ 10; F6 counts hop
   **varieties** (threshold > 7) instead of timed additions (was over-scoring APAs); added a hot-
   ferment clause to F1 (saison); F4 now needs a real target, not a lone sachet; F5 (mash) deferred
   (no per-rest data); separated `yeastClass` from the integer tiers; removed the no-op override step

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -19,11 +19,16 @@ import { MeasurementOrmEntity } from './entities/measurement.orm.entity';
 import { MeasurementType } from './domain/enums/measurement-type.enum';
 import { ObservationOrmEntity } from './entities/observation.orm.entity';
 import { TastingOrmEntity } from './entities/tasting.orm.entity';
+import { RecipeAdditiveOrmEntity } from '../recipe/entities/recipe-additive.orm.entity';
+import { RecipeDifficultyService } from '../recipe/services/recipe-difficulty.service';
+import { RecipeFermentableOrmEntity } from '../recipe/entities/recipe-fermentable.orm.entity';
 import { RecipeHopOrmEntity } from '../recipe/entities/recipe-hop.orm.entity';
 import { RecipeOrmEntity } from '../recipe/entities/recipe.orm.entity';
 import { RecipeService } from '../recipe/services/recipe.service';
 import { RecipeStepOrmEntity } from '../recipe/entities/recipe-step.orm.entity';
 import { RecipeVisibility } from '../recipe/domain/enums/recipe-visibility.enum';
+import { RecipeWaterOrmEntity } from '../recipe/entities/recipe-water.orm.entity';
+import { RecipeYeastOrmEntity } from '../recipe/entities/recipe-yeast.orm.entity';
 import { Repository } from 'typeorm';
 import { randomUUID } from 'crypto';
 
@@ -50,6 +55,10 @@ describe('BatchService', () => {
             RecipeOrmEntity,
             RecipeStepOrmEntity,
             RecipeHopOrmEntity,
+            RecipeFermentableOrmEntity,
+            RecipeYeastOrmEntity,
+            RecipeAdditiveOrmEntity,
+            RecipeWaterOrmEntity,
             BatchOrmEntity,
             BatchStepOrmEntity,
             BatchReminderOrmEntity,
@@ -64,6 +73,10 @@ describe('BatchService', () => {
           RecipeOrmEntity,
           RecipeStepOrmEntity,
           RecipeHopOrmEntity,
+          RecipeFermentableOrmEntity,
+          RecipeYeastOrmEntity,
+          RecipeAdditiveOrmEntity,
+          RecipeWaterOrmEntity,
           BatchOrmEntity,
           BatchStepOrmEntity,
           BatchReminderOrmEntity,
@@ -72,7 +85,7 @@ describe('BatchService', () => {
           TastingOrmEntity,
         ]),
       ],
-      providers: [RecipeService, BatchService],
+      providers: [RecipeService, RecipeDifficultyService, BatchService],
     }).compile();
 
     batchService = module.get(BatchService);

--- a/packages/api/src/database/migrations/1808000000000-AddRecipeDifficultyColumns.ts
+++ b/packages/api/src/database/migrations/1808000000000-AddRecipeDifficultyColumns.ts
@@ -1,0 +1,44 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Adds the recipe brewing-difficulty columns (ADR-0024, Tranche B).
+ *
+ * - `difficulty_computed`: the backend-computed level, NOT NULL with a
+ *   `'facile'` default so pre-existing rows and any create path that omits it
+ *   stay valid (same pattern as `visibility`). Recomputed by the application
+ *   layer on every recipe/ingredient mutation.
+ * - `difficulty_override`: the optional author override (nullable). Effective
+ *   level = `difficulty_override ?? difficulty_computed`.
+ * - `difficulty_reasons`: the stored per-factor breakdown (JSON text) feeding
+ *   the tap-to-explain. Nullable — no backfill: rows created before this simply
+ *   carry no reasons until their next save recomputes them (same additive model
+ *   as `done_when` / `prep_actions`). The `'facile'` default is a placeholder,
+ *   not an assertion the recipe is easy.
+ */
+export class AddRecipeDifficultyColumns1808000000000 implements MigrationInterface {
+  name = 'AddRecipeDifficultyColumns1808000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "recipes" ADD COLUMN "difficulty_computed" varchar(20) NOT NULL DEFAULT 'facile'`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "recipes" ADD COLUMN "difficulty_override" varchar(20)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "recipes" ADD COLUMN "difficulty_reasons" text`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "recipes" DROP COLUMN "difficulty_reasons"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "recipes" DROP COLUMN "difficulty_override"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "recipes" DROP COLUMN "difficulty_computed"`,
+    );
+  }
+}

--- a/packages/api/src/recipe/domain/enums/recipe-difficulty-level.enum.ts
+++ b/packages/api/src/recipe/domain/enums/recipe-difficulty-level.enum.ts
@@ -1,0 +1,14 @@
+/**
+ * Brewing-difficulty level of a recipe (how hard it is to brew), distinct from
+ * the user's declared skill level. Computed by the backend from objective recipe
+ * signals and optionally overridden by the author. See ADR-0024 and
+ * `docs/architecture/specs/recipe-difficulty-algorithm.md`.
+ */
+export enum RecipeDifficultyLevel {
+  /** Green — accessible to a first-time brewer. */
+  FACILE = 'facile',
+  /** Amber — a step up; reachable after a first brew. */
+  INTERMEDIAIRE = 'intermediaire',
+  /** Red — demanding (cold/wild fermentation, high gravity, exacting styles…). */
+  AVANCE = 'avance',
+}

--- a/packages/api/src/recipe/domain/services/recipe-difficulty.domain.service.spec.ts
+++ b/packages/api/src/recipe/domain/services/recipe-difficulty.domain.service.spec.ts
@@ -161,4 +161,24 @@ describe('RecipeDifficultyDomainService — factor rules & edges', () => {
       RecipeDifficultyLevel.AVANCE,
     );
   });
+
+  it('a cold-fermented ALE fires F1 (Intermédiaire) with a « froid » gloss, not a lager label', () => {
+    const result = compute({
+      yeast: { type: RecipeYeastType.ALE, temperatureMaxC: 10 },
+    });
+    expect(result.computed).toBe(RecipeDifficultyLevel.INTERMEDIAIRE);
+    const f1 = result.reasons.find((r) => r.factor === 'F1');
+    expect(f1?.sentence).toMatch(/froid/);
+    // The sentence keys on the type — a cold ale is never told « c'est une lager ».
+    expect(f1?.sentence).not.toMatch(/lager/i);
+  });
+
+  it('keeps the glossed tap-to-explain strings stable (pedagogy contract, D4)', () => {
+    // The stored sentence is the deepest pedagogy layer (ADR-0024 D4) — it must
+    // gloss the term. Guard a stable substring so a silent edit is caught.
+    const lagerF1 = compute({ yeast: lager }).reasons.find(
+      (r) => r.factor === 'F1',
+    );
+    expect(lagerF1?.sentence).toMatch(/refroidir/);
+  });
 });

--- a/packages/api/src/recipe/domain/services/recipe-difficulty.domain.service.spec.ts
+++ b/packages/api/src/recipe/domain/services/recipe-difficulty.domain.service.spec.ts
@@ -1,0 +1,164 @@
+import { RecipeDifficultyDomainService } from './recipe-difficulty.domain.service';
+import { RecipeDifficultyLevel } from '../enums/recipe-difficulty-level.enum';
+import { RecipeYeastType } from '../enums/recipe-yeast-type.enum';
+
+const compute = (
+  input: Parameters<typeof RecipeDifficultyDomainService.compute>[0],
+) => RecipeDifficultyDomainService.compute(input);
+
+const ale = { type: RecipeYeastType.ALE };
+const lager = { type: RecipeYeastType.LAGER };
+
+describe('RecipeDifficultyDomainService — worked examples (spec §5)', () => {
+  it('Blonde SMaSH → Facile', () => {
+    expect(
+      compute({
+        yeast: ale,
+        ogTarget: 1.046,
+        ebcTarget: 8,
+        distinctFermentables: 2,
+        distinctHopVarieties: 1,
+      }).computed,
+    ).toBe(RecipeDifficultyLevel.FACILE);
+  });
+
+  it('American Pale Ale (hoppy, 2 hop varieties) → Facile', () => {
+    expect(
+      compute({
+        yeast: ale,
+        ogTarget: 1.052,
+        ebcTarget: 12,
+        distinctFermentables: 3,
+        distinctHopVarieties: 2,
+      }).computed,
+    ).toBe(RecipeDifficultyLevel.FACILE);
+  });
+
+  it('Bohemian Pilsner (pale lager) → Avancé', () => {
+    expect(
+      compute({ yeast: lager, ogTarget: 1.05, ebcTarget: 6 }).computed,
+    ).toBe(RecipeDifficultyLevel.AVANCE);
+  });
+
+  it('Italian Pilsner / IPL (hoppy pale lager) → Avancé — hops do not make a lager easier', () => {
+    expect(
+      compute({
+        yeast: lager,
+        ogTarget: 1.052,
+        ebcTarget: 7,
+        distinctHopVarieties: 2,
+      }).computed,
+    ).toBe(RecipeDifficultyLevel.AVANCE);
+  });
+
+  it('Saison (hot ferment 30 °C) → Intermédiaire — no longer a false Facile', () => {
+    expect(
+      compute({
+        yeast: { type: RecipeYeastType.ALE, temperatureMaxC: 30 },
+        ogTarget: 1.054,
+      }).computed,
+    ).toBe(RecipeDifficultyLevel.INTERMEDIAIRE);
+  });
+
+  it('Amber kit + one gypsum sachet (no target) → Facile', () => {
+    expect(
+      compute({
+        yeast: ale,
+        ogTarget: 1.048,
+        water: { calciumPpm: 50 },
+      }).computed,
+    ).toBe(RecipeDifficultyLevel.FACILE);
+  });
+
+  it('Russian Imperial Stout (high gravity) → Avancé', () => {
+    const result = compute({
+      yeast: ale,
+      ogTarget: 1.095,
+      ebcTarget: 80,
+      water: { phTarget: 5.4 },
+      distinctFermentables: 6,
+      distinctHopVarieties: 3,
+    });
+    expect(result.computed).toBe(RecipeDifficultyLevel.AVANCE);
+    // Reasons name the dominant factor first (F2 tier 2), then the tier-1 ones.
+    expect(result.reasons.map((r) => r.factor)).toEqual(['F2', 'F4', 'F6']);
+  });
+
+  it('Decoction Strong Bock → Avancé via bounded compounding (≥3 tier-1 factors)', () => {
+    expect(
+      compute({
+        yeast: lager, // F1 = 1
+        ogTarget: 1.07, // F2 = 1
+        ebcTarget: 30, // F3 = 0 (not pale)
+        water: { phTarget: 5.4 }, // F4 = 1
+        distinctFermentables: 5,
+        distinctHopVarieties: 3, // complexity 8 → F6 = 1
+      }).computed,
+    ).toBe(RecipeDifficultyLevel.AVANCE);
+  });
+
+  it('Brett IPA (wild culture) → Avancé', () => {
+    expect(compute({ yeast: { type: RecipeYeastType.BRETT } }).computed).toBe(
+      RecipeDifficultyLevel.AVANCE,
+    );
+  });
+});
+
+describe('RecipeDifficultyDomainService — factor rules & edges', () => {
+  it('a fully sparse recipe (all null) → Facile, with a stored positive reason', () => {
+    const result = compute({});
+    expect(result.computed).toBe(RecipeDifficultyLevel.FACILE);
+    expect(result.reasons).toHaveLength(1);
+    expect(result.reasons[0].factor).toBe('facile');
+    expect(result.reasons[0].sentence).toMatch(/accessible/i);
+  });
+
+  it('F3 does NOT fire on a pale ALE (fault-tolerance is lager-gated)', () => {
+    expect(
+      compute({ yeast: ale, ogTarget: 1.045, ebcTarget: 5 }).computed,
+    ).toBe(RecipeDifficultyLevel.FACILE);
+  });
+
+  it('F3 does NOT fire on a dark lager (EBC > 10) — only pale lagers', () => {
+    // Dark lager: F1 lager floor = Intermédiaire, F3 off.
+    expect(
+      compute({ yeast: lager, ogTarget: 1.048, ebcTarget: 35 }).computed,
+    ).toBe(RecipeDifficultyLevel.INTERMEDIAIRE);
+  });
+
+  it('F4 fires on a pH target but not on a single ion target', () => {
+    expect(compute({ yeast: ale, water: { phTarget: 5.4 } }).computed).toBe(
+      RecipeDifficultyLevel.INTERMEDIAIRE,
+    );
+    expect(compute({ yeast: ale, water: { sulfatePpm: 200 } }).computed).toBe(
+      RecipeDifficultyLevel.FACILE,
+    );
+    // Two ion targets → fires.
+    expect(
+      compute({ yeast: ale, water: { sulfatePpm: 200, chloridePpm: 50 } })
+        .computed,
+    ).toBe(RecipeDifficultyLevel.INTERMEDIAIRE);
+  });
+
+  it('compounding needs ≥3 tier-1 factors: exactly 2 stays Intermédiaire', () => {
+    // Dark lager (F1=1) + moderate gravity (F2=1) = 2 tier-1, base 1, no bump.
+    expect(
+      compute({ yeast: lager, ogTarget: 1.06, ebcTarget: 40 }).computed,
+    ).toBe(RecipeDifficultyLevel.INTERMEDIAIRE);
+  });
+
+  it('high gravity alone (F2=2) → Avancé without any compounding', () => {
+    expect(compute({ yeast: ale, ogTarget: 1.09 }).computed).toBe(
+      RecipeDifficultyLevel.AVANCE,
+    );
+  });
+
+  it('derives the gravity band from ABV when OG is absent', () => {
+    expect(compute({ yeast: ale, abvEstimated: 4.5 }).computed).toBe(
+      RecipeDifficultyLevel.FACILE,
+    );
+    expect(compute({ yeast: ale, abvEstimated: 9 }).computed).toBe(
+      RecipeDifficultyLevel.AVANCE,
+    );
+  });
+});

--- a/packages/api/src/recipe/domain/services/recipe-difficulty.domain.service.ts
+++ b/packages/api/src/recipe/domain/services/recipe-difficulty.domain.service.ts
@@ -1,48 +1,20 @@
 import { RecipeDifficultyLevel } from '../enums/recipe-difficulty-level.enum';
 import { RecipeYeastType } from '../enums/recipe-yeast-type.enum';
+import {
+  DifficultyInput,
+  DifficultyReason,
+  DifficultyResult,
+} from './recipe-difficulty.types';
 
-/**
- * Framework-agnostic input for the difficulty computation. The caller (the
- * application service) maps the recipe + its sub-entities onto this shape; the
- * domain service stays pure and I/O-free. All fields are optional/nullable — a
- * null signal scores the most permissive tier (never punish a sparse recipe).
- *
- * See `docs/architecture/specs/recipe-difficulty-algorithm.md` (v1) and ADR-0024.
- */
-export interface DifficultyInput {
-  readonly ogTarget?: number | null;
-  readonly abvEstimated?: number | null;
-  readonly ebcTarget?: number | null;
-  readonly yeast?: {
-    readonly type: RecipeYeastType;
-    readonly temperatureMaxC?: number | null;
-  } | null;
-  readonly water?: {
-    readonly phTarget?: number | null;
-    readonly calciumPpm?: number | null;
-    readonly magnesiumPpm?: number | null;
-    readonly sulfatePpm?: number | null;
-    readonly chloridePpm?: number | null;
-  } | null;
-  /** Distinct fermentables (grain/extract) in the bill. */
-  readonly distinctFermentables?: number;
-  /** Distinct hop varieties (not timed additions). */
-  readonly distinctHopVarieties?: number;
-  /** Count of additives/adjuncts. */
-  readonly additives?: number;
-}
-
-/** One stored explanation line — the tap-to-explain pedagogy (ADR-0024 D4). */
-export interface DifficultyReason {
-  readonly factor: string;
-  readonly tier: number;
-  readonly sentence: string;
-}
-
-export interface DifficultyResult {
-  readonly computed: RecipeDifficultyLevel;
-  readonly reasons: DifficultyReason[];
-}
+// Re-exported so existing importers of the domain service keep a single entry
+// point; the shapes themselves live in `recipe-difficulty.types` so the ORM
+// entity / DTO / application service can depend on them without importing a
+// service file.
+export type {
+  DifficultyInput,
+  DifficultyReason,
+  DifficultyResult,
+} from './recipe-difficulty.types';
 
 type YeastClass = 'ale' | 'lager' | 'wild';
 

--- a/packages/api/src/recipe/domain/services/recipe-difficulty.domain.service.ts
+++ b/packages/api/src/recipe/domain/services/recipe-difficulty.domain.service.ts
@@ -1,0 +1,244 @@
+import { RecipeDifficultyLevel } from '../enums/recipe-difficulty-level.enum';
+import { RecipeYeastType } from '../enums/recipe-yeast-type.enum';
+
+/**
+ * Framework-agnostic input for the difficulty computation. The caller (the
+ * application service) maps the recipe + its sub-entities onto this shape; the
+ * domain service stays pure and I/O-free. All fields are optional/nullable — a
+ * null signal scores the most permissive tier (never punish a sparse recipe).
+ *
+ * See `docs/architecture/specs/recipe-difficulty-algorithm.md` (v1) and ADR-0024.
+ */
+export interface DifficultyInput {
+  readonly ogTarget?: number | null;
+  readonly abvEstimated?: number | null;
+  readonly ebcTarget?: number | null;
+  readonly yeast?: {
+    readonly type: RecipeYeastType;
+    readonly temperatureMaxC?: number | null;
+  } | null;
+  readonly water?: {
+    readonly phTarget?: number | null;
+    readonly calciumPpm?: number | null;
+    readonly magnesiumPpm?: number | null;
+    readonly sulfatePpm?: number | null;
+    readonly chloridePpm?: number | null;
+  } | null;
+  /** Distinct fermentables (grain/extract) in the bill. */
+  readonly distinctFermentables?: number;
+  /** Distinct hop varieties (not timed additions). */
+  readonly distinctHopVarieties?: number;
+  /** Count of additives/adjuncts. */
+  readonly additives?: number;
+}
+
+/** One stored explanation line — the tap-to-explain pedagogy (ADR-0024 D4). */
+export interface DifficultyReason {
+  readonly factor: string;
+  readonly tier: number;
+  readonly sentence: string;
+}
+
+export interface DifficultyResult {
+  readonly computed: RecipeDifficultyLevel;
+  readonly reasons: DifficultyReason[];
+}
+
+type YeastClass = 'ale' | 'lager' | 'wild';
+
+/** Per-factor score: an integer tier and, when it fires, its explanation. */
+interface FactorScore {
+  readonly id: string;
+  readonly tier: 0 | 1 | 2;
+  readonly sentence?: string;
+}
+
+/** Calibration knobs (v1 defaults — ADR-0024, spec §6). */
+const OG_MODERATE = 1.055;
+const OG_HIGH = 1.075;
+const ABV_MODERATE = 5.5;
+const ABV_HIGH = 7.5;
+const PALE_EBC_MAX = 10;
+const COLD_FERMENT_MAX_C = 14;
+const HOT_FERMENT_MIN_C = 26;
+const COMPLEXITY_MAX = 7;
+const COMPOUNDING_MIN_MODERATE = 3;
+
+const SENTENCES = {
+  wild: 'levure sauvage (Brett) ou fermentation acide : c’est long, imprévisible, et il faut une hygiène irréprochable',
+  lager:
+    'elle fermente au froid (≈10 °C) puis se garde plusieurs semaines : il te faut de quoi refroidir et de la patience',
+  coldAle:
+    'elle fermente au froid : il te faut de quoi refroidir, la marge d’erreur est faible',
+  hot: 'elle fermente au chaud (>26 °C) et finit très sèche : la fermentation peut caler, il faut savoir la relancer',
+  gravityModerate:
+    'bière assez forte : il y a beaucoup de sucres à transformer, la fermentation demande plus d’attention',
+  gravityHigh:
+    'grosse bière : il faut BEAUCOUP de levure au départ (un « pied de levure »), sinon la fermentation risque de s’arrêter avant la fin',
+  faultExposing:
+    'une lager blonde et nette : ni houblon fort ni malt torréfié pour cacher un défaut — la moindre erreur se voit tout de suite',
+  water:
+    'l’eau est ajustée avec des sels minéraux pour coller au style : il faut mesurer et calculer, une étape que les débutants sautent souvent',
+  complexity:
+    'recette riche : beaucoup d’ingrédients différents à gérer et à minuter, plus d’occasions de se tromper',
+  facile:
+    'Recette accessible : fermentation haute, densité modérée, pas de technique avancée — idéale pour un premier brassin.',
+} as const;
+
+const LEVELS: readonly RecipeDifficultyLevel[] = [
+  RecipeDifficultyLevel.FACILE,
+  RecipeDifficultyLevel.INTERMEDIAIRE,
+  RecipeDifficultyLevel.AVANCE,
+];
+
+function classifyYeast(yeast: DifficultyInput['yeast']): YeastClass {
+  if (!yeast) {
+    return 'ale';
+  }
+  if (
+    yeast.type === RecipeYeastType.WILD ||
+    yeast.type === RecipeYeastType.BRETT
+  ) {
+    return 'wild';
+  }
+  if (yeast.type === RecipeYeastType.LAGER) {
+    return 'lager';
+  }
+  return 'ale';
+}
+
+/** F1 — fermentation/yeast. Tier from the signal, sentence from the type. */
+function scoreYeast(
+  yeastClass: YeastClass,
+  temperatureMaxC?: number | null,
+): FactorScore {
+  if (yeastClass === 'wild') {
+    return { id: 'F1', tier: 2, sentence: SENTENCES.wild };
+  }
+  if (yeastClass === 'lager') {
+    return { id: 'F1', tier: 1, sentence: SENTENCES.lager };
+  }
+  if (temperatureMaxC != null && temperatureMaxC < COLD_FERMENT_MAX_C) {
+    return { id: 'F1', tier: 1, sentence: SENTENCES.coldAle };
+  }
+  if (temperatureMaxC != null && temperatureMaxC > HOT_FERMENT_MIN_C) {
+    return { id: 'F1', tier: 1, sentence: SENTENCES.hot };
+  }
+  return { id: 'F1', tier: 0 };
+}
+
+/** F2 — gravity. Prefer OG; else derive the band from ABV. */
+function scoreGravity(
+  ogTarget?: number | null,
+  abvEstimated?: number | null,
+): FactorScore {
+  let tier: 0 | 1 | 2 = 0;
+  if (ogTarget != null) {
+    tier = ogTarget <= OG_MODERATE ? 0 : ogTarget <= OG_HIGH ? 1 : 2;
+  } else if (abvEstimated != null) {
+    tier = abvEstimated < ABV_MODERATE ? 0 : abvEstimated <= ABV_HIGH ? 1 : 2;
+  }
+  if (tier === 0) {
+    return { id: 'F2', tier };
+  }
+  return {
+    id: 'F2',
+    tier,
+    sentence: tier === 2 ? SENTENCES.gravityHigh : SENTENCES.gravityModerate,
+  };
+}
+
+/** F3 — fault-tolerance, lager-gated on a pale colour (IBU intentionally unused). */
+function scoreFaultTolerance(
+  yeastClass: YeastClass,
+  ebcTarget?: number | null,
+): FactorScore {
+  if (
+    yeastClass === 'lager' &&
+    ebcTarget != null &&
+    ebcTarget <= PALE_EBC_MAX
+  ) {
+    return { id: 'F3', tier: 2, sentence: SENTENCES.faultExposing };
+  }
+  return { id: 'F3', tier: 0 };
+}
+
+/** F4 — water chemistry: a real target profile, not a lone sachet. */
+function scoreWater(water: DifficultyInput['water']): FactorScore {
+  if (!water) {
+    return { id: 'F4', tier: 0 };
+  }
+  const ionTargets = [
+    water.calciumPpm,
+    water.magnesiumPpm,
+    water.sulfatePpm,
+    water.chloridePpm,
+  ].filter((v) => v != null).length;
+  if (water.phTarget != null || ionTargets >= 2) {
+    return { id: 'F4', tier: 1, sentence: SENTENCES.water };
+  }
+  return { id: 'F4', tier: 0 };
+}
+
+/** F6 — recipe complexity (distinct varieties, not timed additions). */
+function scoreComplexity(input: DifficultyInput): FactorScore {
+  const complexity =
+    (input.distinctFermentables ?? 0) +
+    (input.distinctHopVarieties ?? 0) +
+    (input.additives ?? 0);
+  if (complexity > COMPLEXITY_MAX) {
+    return { id: 'F6', tier: 1, sentence: SENTENCES.complexity };
+  }
+  return { id: 'F6', tier: 0 };
+}
+
+/**
+ * Deterministic, explainable recipe brewing-difficulty engine (ADR-0024).
+ *
+ * Rule-based, max-dominates with bounded compounding. Pure — a function of the
+ * recipe alone, so it is trivially unit-tested (the spec's worked examples are
+ * the fixtures) and identical across all clients.
+ *
+ * F5 (mash complexity) is deferred in v1: `recipe-step` carries no per-rest
+ * temperature, so a step/decoction mash is not detectable yet (spec §F5/§6).
+ */
+export class RecipeDifficultyDomainService {
+  static compute(input: DifficultyInput): DifficultyResult {
+    const yeastClass = classifyYeast(input.yeast);
+
+    const factors: FactorScore[] = [
+      scoreYeast(yeastClass, input.yeast?.temperatureMaxC),
+      scoreGravity(input.ogTarget, input.abvEstimated),
+      scoreFaultTolerance(yeastClass, input.ebcTarget),
+      scoreWater(input.water),
+      // F5 deferred → always tier 0.
+      { id: 'F5', tier: 0 },
+      scoreComplexity(input),
+    ];
+
+    const base = factors.reduce((max, f) => Math.max(max, f.tier), 0);
+    const moderateCount = factors.filter((f) => f.tier === 1).length;
+    const tier =
+      moderateCount >= COMPOUNDING_MIN_MODERATE ? Math.min(base + 1, 2) : base;
+    const computed = LEVELS[tier];
+
+    if (tier === 0) {
+      return {
+        computed,
+        reasons: [{ factor: 'facile', tier: 0, sentence: SENTENCES.facile }],
+      };
+    }
+
+    const reasons: DifficultyReason[] = factors
+      .filter((f) => f.tier >= 1 && f.sentence != null)
+      // Highest tier first; ties broken by factor id (F1→F6) for a stable order.
+      .sort((a, b) => b.tier - a.tier || a.id.localeCompare(b.id))
+      .map((f) => ({
+        factor: f.id,
+        tier: f.tier,
+        sentence: f.sentence as string,
+      }));
+
+    return { computed, reasons };
+  }
+}

--- a/packages/api/src/recipe/domain/services/recipe-difficulty.types.ts
+++ b/packages/api/src/recipe/domain/services/recipe-difficulty.types.ts
@@ -1,0 +1,45 @@
+import { RecipeDifficultyLevel } from '../enums/recipe-difficulty-level.enum';
+import { RecipeYeastType } from '../enums/recipe-yeast-type.enum';
+
+/**
+ * Framework-agnostic input for the difficulty computation. The caller (the
+ * application service) maps the recipe + its sub-entities onto this shape; the
+ * domain service stays pure and I/O-free. All fields are optional/nullable — a
+ * null signal scores the most permissive tier (never punish a sparse recipe).
+ *
+ * See `docs/architecture/specs/recipe-difficulty-algorithm.md` (v1) and ADR-0024.
+ */
+export interface DifficultyInput {
+  readonly ogTarget?: number | null;
+  readonly abvEstimated?: number | null;
+  readonly ebcTarget?: number | null;
+  readonly yeast?: {
+    readonly type: RecipeYeastType;
+    readonly temperatureMaxC?: number | null;
+  } | null;
+  readonly water?: {
+    readonly phTarget?: number | null;
+    readonly calciumPpm?: number | null;
+    readonly magnesiumPpm?: number | null;
+    readonly sulfatePpm?: number | null;
+    readonly chloridePpm?: number | null;
+  } | null;
+  /** Distinct fermentables (grain/extract) in the bill. */
+  readonly distinctFermentables?: number;
+  /** Distinct hop varieties (not timed additions). */
+  readonly distinctHopVarieties?: number;
+  /** Count of additives/adjuncts. */
+  readonly additives?: number;
+}
+
+/** One stored explanation line — the tap-to-explain pedagogy (ADR-0024 D4). */
+export interface DifficultyReason {
+  readonly factor: string;
+  readonly tier: number;
+  readonly sentence: string;
+}
+
+export interface DifficultyResult {
+  readonly computed: RecipeDifficultyLevel;
+  readonly reasons: DifficultyReason[];
+}

--- a/packages/api/src/recipe/dtos/create-recipe.dto.ts
+++ b/packages/api/src/recipe/dtos/create-recipe.dto.ts
@@ -12,6 +12,7 @@ import {
   Min,
 } from 'class-validator';
 
+import { RecipeDifficultyLevel } from '../domain/enums/recipe-difficulty-level.enum';
 import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
 
 export class CreateRecipeDto {
@@ -97,4 +98,14 @@ export class CreateRecipeDto {
   @Min(30)
   @Max(100)
   efficiency_target?: number;
+
+  // Difficulty is computed by the backend; the author may override it (ADR-0024).
+  @ApiPropertyOptional({
+    enum: RecipeDifficultyLevel,
+    nullable: true,
+    description: 'Optional author override of the computed brewing difficulty.',
+  })
+  @IsOptional()
+  @IsEnum(RecipeDifficultyLevel)
+  difficulty_override?: RecipeDifficultyLevel | null;
 }

--- a/packages/api/src/recipe/dtos/public-recipe.dto.ts
+++ b/packages/api/src/recipe/dtos/public-recipe.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+import { RecipeDifficultyLevel } from '../domain/enums/recipe-difficulty-level.enum';
+import { RecipeDifficultyReasonDto } from './recipe-difficulty-reason.dto';
 import { RecipeDto } from './recipe.dto';
 import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
 import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
@@ -76,6 +78,19 @@ export class PublicRecipeDto implements Omit<RecipeDto, SensitiveFieldName> {
 
   @ApiPropertyOptional({ nullable: true })
   efficiency_target?: number | null;
+
+  // Brewing-difficulty badge (ADR-0024) — surfaced on catalog cards.
+  @ApiProperty({ enum: RecipeDifficultyLevel })
+  difficulty_computed: RecipeDifficultyLevel;
+
+  @ApiPropertyOptional({ enum: RecipeDifficultyLevel, nullable: true })
+  difficulty_override?: RecipeDifficultyLevel | null;
+
+  @ApiProperty({ enum: RecipeDifficultyLevel })
+  difficulty_effective: RecipeDifficultyLevel;
+
+  @ApiProperty({ type: [RecipeDifficultyReasonDto] })
+  difficulty_reasons: RecipeDifficultyReasonDto[];
 
   // Quality fields used by the matching algo + sorting/badging.
   @ApiPropertyOptional({ nullable: true })

--- a/packages/api/src/recipe/dtos/recipe-difficulty-reason.dto.ts
+++ b/packages/api/src/recipe/dtos/recipe-difficulty-reason.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+/**
+ * One stored line of the difficulty tap-to-explain (ADR-0024 D4). Structurally
+ * mirrors the domain `DifficultyReason` — the value the backend persists on the
+ * recipe and the mobile renders as-is, without recomputing anything.
+ */
+export class RecipeDifficultyReasonDto {
+  @ApiProperty({
+    description:
+      'Factor id that fired (e.g. "F1", or "facile" for the easy case).',
+    example: 'F2',
+  })
+  factor: string;
+
+  @ApiProperty({
+    description: 'Factor tier: 0 = facile, 1 = intermediaire, 2 = avance.',
+    example: 1,
+  })
+  tier: number;
+
+  @ApiProperty({
+    description:
+      'Plain-French, glossed explanation shown when the badge is tapped.',
+  })
+  sentence: string;
+}

--- a/packages/api/src/recipe/dtos/recipe.dto.spec.ts
+++ b/packages/api/src/recipe/dtos/recipe.dto.spec.ts
@@ -1,3 +1,4 @@
+import { RecipeDifficultyLevel } from '../domain/enums/recipe-difficulty-level.enum';
 import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
 import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
 import { RecipeDto } from './recipe.dto';
@@ -22,6 +23,9 @@ function buildEntity(
     ibu_target: 40,
     ebc_target: 15,
     efficiency_target: 72,
+    difficulty_computed: RecipeDifficultyLevel.FACILE,
+    difficulty_override: null,
+    difficulty_reasons: null,
     avg_rating: null,
     brew_count: 0,
     last_brewed_at: null,
@@ -111,5 +115,41 @@ describe('RecipeDto.fromEntity — quality fields (Epic #693 part 2)', () => {
       expect(dto.avg_rating).toBeNull();
       expect(dto.last_brewed_at).toBeNull();
     });
+  });
+});
+
+describe('RecipeDto.fromEntity — difficulty (ADR-0024)', () => {
+  it('effective difficulty falls back to computed when no override is set', () => {
+    const dto = RecipeDto.fromEntity(
+      buildEntity({
+        difficulty_computed: RecipeDifficultyLevel.INTERMEDIAIRE,
+        difficulty_override: null,
+        difficulty_reasons: [{ factor: 'F1', tier: 1, sentence: 'x' }],
+      }),
+    );
+
+    expect(dto.difficulty_effective).toBe(RecipeDifficultyLevel.INTERMEDIAIRE);
+    expect(dto.difficulty_override).toBeNull();
+    expect(dto.difficulty_reasons).toEqual([
+      { factor: 'F1', tier: 1, sentence: 'x' },
+    ]);
+  });
+
+  it('effective difficulty is the author override when one is set', () => {
+    const dto = RecipeDto.fromEntity(
+      buildEntity({
+        difficulty_computed: RecipeDifficultyLevel.FACILE,
+        difficulty_override: RecipeDifficultyLevel.AVANCE,
+      }),
+    );
+
+    expect(dto.difficulty_effective).toBe(RecipeDifficultyLevel.AVANCE);
+    expect(dto.difficulty_override).toBe(RecipeDifficultyLevel.AVANCE);
+  });
+
+  it('defaults difficulty_reasons to [] when the row carries none', () => {
+    const dto = RecipeDto.fromEntity(buildEntity({ difficulty_reasons: null }));
+
+    expect(dto.difficulty_reasons).toEqual([]);
   });
 });

--- a/packages/api/src/recipe/dtos/recipe.dto.ts
+++ b/packages/api/src/recipe/dtos/recipe.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+import { RecipeDifficultyLevel } from '../domain/enums/recipe-difficulty-level.enum';
+import { RecipeDifficultyReasonDto } from './recipe-difficulty-reason.dto';
 import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
 import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
 
@@ -52,6 +54,33 @@ export class RecipeDto {
 
   @ApiPropertyOptional({ nullable: true })
   efficiency_target?: number | null;
+
+  // Brewing-difficulty badge (ADR-0024).
+  @ApiProperty({
+    enum: RecipeDifficultyLevel,
+    description: 'Backend-computed brewing difficulty (from recipe signals).',
+  })
+  difficulty_computed: RecipeDifficultyLevel;
+
+  @ApiPropertyOptional({
+    enum: RecipeDifficultyLevel,
+    nullable: true,
+    description: 'Author override of the computed difficulty, if set.',
+  })
+  difficulty_override?: RecipeDifficultyLevel | null;
+
+  @ApiProperty({
+    enum: RecipeDifficultyLevel,
+    description:
+      'Effective difficulty shown in the app: difficulty_override ?? difficulty_computed.',
+  })
+  difficulty_effective: RecipeDifficultyLevel;
+
+  @ApiProperty({
+    type: [RecipeDifficultyReasonDto],
+    description: 'Stored per-factor breakdown feeding the tap-to-explain.',
+  })
+  difficulty_reasons: RecipeDifficultyReasonDto[];
 
   // Quality fields feeding the scan matching algorithm (Epic #693 part 2).
   @ApiPropertyOptional({
@@ -118,6 +147,10 @@ export class RecipeDto {
       ibu_target: e.ibu_target ?? null,
       ebc_target: e.ebc_target ?? null,
       efficiency_target: e.efficiency_target ?? null,
+      difficulty_computed: e.difficulty_computed,
+      difficulty_override: e.difficulty_override ?? null,
+      difficulty_effective: e.difficulty_override ?? e.difficulty_computed,
+      difficulty_reasons: e.difficulty_reasons ?? [],
       avg_rating: e.avg_rating ?? null,
       brew_count: e.brew_count,
       last_brewed_at: e.last_brewed_at ?? null,

--- a/packages/api/src/recipe/dtos/update-recipe.dto.ts
+++ b/packages/api/src/recipe/dtos/update-recipe.dto.ts
@@ -12,6 +12,7 @@ import {
 } from 'class-validator';
 
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { RecipeDifficultyLevel } from '../domain/enums/recipe-difficulty-level.enum';
 import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
 
 export class UpdateRecipeDto {
@@ -101,4 +102,15 @@ export class UpdateRecipeDto {
   @Min(30)
   @Max(100)
   efficiency_target?: number;
+
+  // Author override of the computed difficulty. An explicit `null` clears it
+  // and falls back to the computed value (ADR-0024 D3).
+  @ApiPropertyOptional({
+    enum: RecipeDifficultyLevel,
+    nullable: true,
+    description: 'Optional author override of the computed brewing difficulty.',
+  })
+  @IsOptional()
+  @IsEnum(RecipeDifficultyLevel)
+  difficulty_override?: RecipeDifficultyLevel | null;
 }

--- a/packages/api/src/recipe/entities/recipe.orm.entity.ts
+++ b/packages/api/src/recipe/entities/recipe.orm.entity.ts
@@ -7,6 +7,8 @@ import {
   UpdateDateColumn,
 } from 'typeorm';
 
+import { RecipeDifficultyLevel } from '../domain/enums/recipe-difficulty-level.enum';
+import { DifficultyReason } from '../domain/services/recipe-difficulty.types';
 import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
 
 @Entity('recipes')
@@ -73,6 +75,32 @@ export class RecipeOrmEntity {
 
   @Column({ type: 'real', nullable: true })
   efficiency_target?: number | null;
+
+  // Brewing-difficulty badge (ADR-0024). Backend-computed from the recipe +
+  // its sub-entities on every create/update, plus an optional author override.
+  // The effective level shown in the app is `difficulty_override ?? difficulty_computed`.
+  @Column({
+    type: 'varchar',
+    length: 20,
+    enum: RecipeDifficultyLevel,
+    nullable: false,
+    default: RecipeDifficultyLevel.FACILE,
+  })
+  difficulty_computed: RecipeDifficultyLevel;
+
+  @Column({
+    type: 'varchar',
+    length: 20,
+    enum: RecipeDifficultyLevel,
+    nullable: true,
+  })
+  difficulty_override?: RecipeDifficultyLevel | null;
+
+  // Stored per-factor breakdown feeding the tap-to-explain (read as-is, never
+  // recomputed client-side). Null on rows created before the feature; the
+  // application layer recomputes it on the next save.
+  @Column({ type: 'simple-json', nullable: true })
+  difficulty_reasons?: DifficultyReason[] | null;
 
   // Quality fields feeding the scan matching algorithm (Epic #693 part 2).
   // Denormalized aggregates + flag maintained by the recipe / batch / rating

--- a/packages/api/src/recipe/recipe-catalog.service.spec.ts
+++ b/packages/api/src/recipe/recipe-catalog.service.spec.ts
@@ -5,6 +5,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
+import { RecipeDifficultyService } from './services/recipe-difficulty.service';
 import { RecipeOrmEntity } from './entities/recipe.orm.entity';
 import { RecipeService } from './services/recipe.service';
 import { RecipeVisibility } from './domain/enums/recipe-visibility.enum';
@@ -29,7 +30,7 @@ describe('RecipeService catalog read paths (Issue #779)', () => {
   beforeAll(async () => {
     module = await Test.createTestingModule({
       imports: [...buildRecipeTestingTypeOrm()],
-      providers: [RecipeService],
+      providers: [RecipeService, RecipeDifficultyService],
     }).compile();
 
     service = module.get(RecipeService);

--- a/packages/api/src/recipe/recipe-difficulty.service.spec.ts
+++ b/packages/api/src/recipe/recipe-difficulty.service.spec.ts
@@ -276,6 +276,44 @@ describe('RecipeDifficultyService (integration)', () => {
     );
   });
 
+  // happy: updating a gravity target through updateMine() recomputes the level
+  // (guards the update-path wiring + its transaction wrapper).
+  it('recomputes the stored level when updateMine changes the gravity target', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Was easy',
+      og_target: 1.04,
+    });
+    expect((await reload(recipe.id)).difficulty_computed).toBe(
+      RecipeDifficultyLevel.FACILE,
+    );
+
+    await recipes.updateMine(OWNER, recipe.id, { og_target: 1.09 });
+
+    const saved = await reload(recipe.id);
+    expect(saved.difficulty_computed).toBe(RecipeDifficultyLevel.AVANCE);
+    expect(
+      (saved.difficulty_reasons ?? []).some((r) => r.factor === 'F2'),
+    ).toBe(true);
+  });
+
+  // sad: clearing the override via updateMine falls the effective level back to
+  // the computed value.
+  it('clears the author override when updateMine sends difficulty_override: null', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Override then clear',
+      og_target: 1.04,
+      difficulty_override: RecipeDifficultyLevel.AVANCE,
+    });
+
+    await recipes.updateMine(OWNER, recipe.id, { difficulty_override: null });
+
+    const saved = await reload(recipe.id);
+    expect(saved.difficulty_override).toBeNull();
+    expect(RecipeDto.fromEntity(saved).difficulty_effective).toBe(
+      saved.difficulty_computed,
+    );
+  });
+
   // sad: a missing recipe is a no-op, not a throw.
   it('returns null and no-ops for a missing recipe', async () => {
     await expect(

--- a/packages/api/src/recipe/recipe-difficulty.service.spec.ts
+++ b/packages/api/src/recipe/recipe-difficulty.service.spec.ts
@@ -1,0 +1,285 @@
+jest.setTimeout(20000);
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { RecipeAdditiveOrmEntity } from './entities/recipe-additive.orm.entity';
+import { RecipeAdditiveType } from './domain/enums/recipe-additive-type.enum';
+import { RecipeDifficultyLevel } from './domain/enums/recipe-difficulty-level.enum';
+import { RecipeDifficultyService } from './services/recipe-difficulty.service';
+import { RecipeDto } from './dtos/recipe.dto';
+import { RecipeFermentableOrmEntity } from './entities/recipe-fermentable.orm.entity';
+import { RecipeFermentableType } from './domain/enums/recipe-fermentable-type.enum';
+import { RecipeHopAdditionStage } from './domain/enums/recipe-hop-addition-stage.enum';
+import { RecipeHopOrmEntity } from './entities/recipe-hop.orm.entity';
+import { RecipeHopType } from './domain/enums/recipe-hop-type.enum';
+import { RecipeOrmEntity } from './entities/recipe.orm.entity';
+import { RecipeService } from './services/recipe.service';
+import { RecipeStepType } from './domain/enums/recipe-step-type.enum';
+import { RecipeWaterOrmEntity } from './entities/recipe-water.orm.entity';
+import { RecipeYeastOrmEntity } from './entities/recipe-yeast.orm.entity';
+import { RecipeYeastType } from './domain/enums/recipe-yeast-type.enum';
+import { buildRecipeTestingTypeOrm } from './recipe-testing.module';
+
+/**
+ * Integration coverage for the difficulty application service (Tranche B slice
+ * 2). The pure scoring rules are unit-tested in
+ * `recipe-difficulty.domain.service.spec.ts`; here we exercise the ADAPTER
+ * (recipe + sub-entities -> DifficultyInput), the persistence of the computed
+ * level + reasons, the multi-yeast reduction and distinct-variety counting, and
+ * the author-override preservation — end-to-end against an in-memory SQLite.
+ */
+describe('RecipeDifficultyService (integration)', () => {
+  let module: TestingModule;
+  let difficulty: RecipeDifficultyService;
+  let recipes: RecipeService;
+  let recipeRepo: Repository<RecipeOrmEntity>;
+  let yeastRepo: Repository<RecipeYeastOrmEntity>;
+  let hopRepo: Repository<RecipeHopOrmEntity>;
+  let fermentableRepo: Repository<RecipeFermentableOrmEntity>;
+  let additiveRepo: Repository<RecipeAdditiveOrmEntity>;
+  let waterRepo: Repository<RecipeWaterOrmEntity>;
+
+  const OWNER = 'owner-difficulty';
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [...buildRecipeTestingTypeOrm()],
+      providers: [RecipeService, RecipeDifficultyService],
+    }).compile();
+
+    difficulty = module.get(RecipeDifficultyService);
+    recipes = module.get(RecipeService);
+    recipeRepo = module.get(getRepositoryToken(RecipeOrmEntity));
+    yeastRepo = module.get(getRepositoryToken(RecipeYeastOrmEntity));
+    hopRepo = module.get(getRepositoryToken(RecipeHopOrmEntity));
+    fermentableRepo = module.get(
+      getRepositoryToken(RecipeFermentableOrmEntity),
+    );
+    additiveRepo = module.get(getRepositoryToken(RecipeAdditiveOrmEntity));
+    waterRepo = module.get(getRepositoryToken(RecipeWaterOrmEntity));
+  });
+
+  afterAll(async () => {
+    await module.close();
+  });
+
+  const addYeast = (
+    recipeId: string,
+    type: RecipeYeastType,
+    temperatureMaxC?: number,
+  ) =>
+    yeastRepo.save(
+      yeastRepo.create({
+        recipe_id: recipeId,
+        name: `${type}-strain`,
+        type,
+        amount_g: 11,
+        temperature_max_c: temperatureMaxC ?? null,
+      }),
+    );
+
+  const addHop = (recipeId: string, variety: string) =>
+    hopRepo.save(
+      hopRepo.create({
+        recipe_id: recipeId,
+        variety,
+        type: RecipeHopType.PELLET,
+        weight_g: 20,
+        addition_stage: RecipeHopAdditionStage.BOIL,
+        addition_time_min: 15,
+      }),
+    );
+
+  const addFermentable = (recipeId: string, name: string) =>
+    fermentableRepo.save(
+      fermentableRepo.create({
+        recipe_id: recipeId,
+        name,
+        type: RecipeFermentableType.GRAIN,
+        weight_g: 1000,
+      }),
+    );
+
+  const reload = (id: string) => recipeRepo.findOneByOrFail({ id });
+
+  // happy: create() computes + stores Facile with the positive reason for a
+  // bare, easy recipe (no ingredients yet).
+  it('stores Facile with a positive reason on create for a bare easy recipe', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Blonde SMaSH',
+      og_target: 1.046,
+      ebc_target: 8,
+    });
+
+    const saved = await reload(recipe.id);
+    expect(saved.difficulty_computed).toBe(RecipeDifficultyLevel.FACILE);
+    const reasons = saved.difficulty_reasons ?? [];
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toMatchObject({ factor: 'facile', tier: 0 });
+    expect(typeof reasons[0].sentence).toBe('string');
+  });
+
+  // happy: adding a pale lager yeast recomputes to Avancé (F3 fault-tolerance).
+  it('recomputes to Avancé when a pale lager yeast is added (F3)', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Bohemian Pilsner',
+      og_target: 1.05,
+      ebc_target: 6,
+    });
+    await addYeast(recipe.id, RecipeYeastType.LAGER, 12);
+
+    const result = await difficulty.recomputeForRecipe(recipe.id);
+
+    expect(result?.computed).toBe(RecipeDifficultyLevel.AVANCE);
+    const saved = await reload(recipe.id);
+    expect(saved.difficulty_computed).toBe(RecipeDifficultyLevel.AVANCE);
+    expect(
+      (saved.difficulty_reasons ?? []).some((r) => r.factor === 'F3'),
+    ).toBe(true);
+  });
+
+  // edge: multiple yeasts reduce to the worst-case culture — a Brett secondary
+  // dominates an ale primary → wild → Avancé (F1).
+  it('reduces multiple yeasts to the worst-case culture (wild dominates)', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Brett Saison',
+      og_target: 1.05,
+    });
+    await addYeast(recipe.id, RecipeYeastType.ALE, 22);
+    await addYeast(recipe.id, RecipeYeastType.BRETT, 24);
+
+    const result = await difficulty.recomputeForRecipe(recipe.id);
+
+    expect(result?.computed).toBe(RecipeDifficultyLevel.AVANCE);
+    expect(result?.reasons.some((r) => r.factor === 'F1' && r.tier === 2)).toBe(
+      true,
+    );
+  });
+
+  // edge: many hop rows of the SAME variety count as one (F6 counts distinct
+  // varieties, case-insensitively) — a single-hop bill is not "complex".
+  it('counts distinct hop varieties case-insensitively (F6 not over-counted)', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Single-hop APA',
+      og_target: 1.05,
+    });
+    for (const variety of ['Citra', 'citra', 'CITRA', 'Citra ', 'citra']) {
+      await addHop(recipe.id, variety);
+    }
+
+    const result = await difficulty.recomputeForRecipe(recipe.id);
+
+    expect(result?.computed).toBe(RecipeDifficultyLevel.FACILE);
+    expect(result?.reasons.some((r) => r.factor === 'F6')).toBe(false);
+  });
+
+  // sad/edge: a genuinely kitchen-sink bill (> 7 distinct items) fires F6.
+  it('fires F6 for a bill with more than 7 distinct items', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Kitchen sink',
+      og_target: 1.05,
+    });
+    for (let i = 0; i < 8; i++) {
+      await addFermentable(recipe.id, `Malt ${i}`);
+    }
+
+    const result = await difficulty.recomputeForRecipe(recipe.id);
+
+    expect(result?.reasons.some((r) => r.factor === 'F6')).toBe(true);
+    expect(result?.computed).toBe(RecipeDifficultyLevel.INTERMEDIAIRE);
+  });
+
+  // happy: a real water target (pH) fires F4.
+  it('fires F4 when the water profile carries a pH target', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Watered',
+      og_target: 1.05,
+    });
+    await waterRepo.save(
+      waterRepo.create({
+        recipe_id: recipe.id,
+        mash_volume_l: 15,
+        sparge_volume_l: 10,
+        ph_target: 5.4,
+      }),
+    );
+
+    const result = await difficulty.recomputeForRecipe(recipe.id);
+
+    expect(result?.reasons.some((r) => r.factor === 'F4')).toBe(true);
+  });
+
+  // sad: a lone water row with no treatment target does NOT fire F4.
+  it('does not fire F4 for a volumes-only water row', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Volumes only',
+      og_target: 1.05,
+    });
+    await waterRepo.save(
+      waterRepo.create({
+        recipe_id: recipe.id,
+        mash_volume_l: 15,
+        sparge_volume_l: 10,
+      }),
+    );
+
+    const result = await difficulty.recomputeForRecipe(recipe.id);
+
+    expect(result?.reasons.some((r) => r.factor === 'F4')).toBe(false);
+  });
+
+  // edge: an additive counts toward complexity via its own count.
+  it('counts additives toward the complexity factor', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Spiced',
+      og_target: 1.05,
+    });
+    await additiveRepo.save(
+      additiveRepo.create({
+        recipe_id: recipe.id,
+        name: 'Coriander',
+        type: RecipeAdditiveType.SPICE,
+        amount_g: 10,
+        addition_step: RecipeStepType.BOIL,
+      }),
+    );
+
+    // One additive alone is not enough to fire F6 (≤ 7) — the recipe stays Facile.
+    const result = await difficulty.recomputeForRecipe(recipe.id);
+    expect(result?.computed).toBe(RecipeDifficultyLevel.FACILE);
+  });
+
+  // sad: recompute never overwrites the author override; the effective level in
+  // the DTO reflects the override while the computed value keeps updating.
+  it('preserves the author override while recomputing the computed value', async () => {
+    const recipe = await recipes.create(OWNER, {
+      name: 'Overridden',
+      og_target: 1.05,
+      difficulty_override: RecipeDifficultyLevel.AVANCE,
+    });
+
+    // Sanity: create() kept the override and computed Facile (no ingredients).
+    let saved = await reload(recipe.id);
+    expect(saved.difficulty_override).toBe(RecipeDifficultyLevel.AVANCE);
+    expect(saved.difficulty_computed).toBe(RecipeDifficultyLevel.FACILE);
+
+    // A recompute must not touch the override.
+    await difficulty.recomputeForRecipe(recipe.id);
+    saved = await reload(recipe.id);
+    expect(saved.difficulty_override).toBe(RecipeDifficultyLevel.AVANCE);
+
+    // The DTO exposes the override as the effective level.
+    expect(RecipeDto.fromEntity(saved).difficulty_effective).toBe(
+      RecipeDifficultyLevel.AVANCE,
+    );
+  });
+
+  // sad: a missing recipe is a no-op, not a throw.
+  it('returns null and no-ops for a missing recipe', async () => {
+    await expect(
+      difficulty.recomputeForRecipe('does-not-exist'),
+    ).resolves.toBeNull();
+  });
+});

--- a/packages/api/src/recipe/recipe-import.service.spec.ts
+++ b/packages/api/src/recipe/recipe-import.service.spec.ts
@@ -10,6 +10,7 @@ import { RecipeFermentableOrmEntity } from './entities/recipe-fermentable.orm.en
 import { RecipeHopAdditionStage } from './domain/enums/recipe-hop-addition-stage.enum';
 import { RecipeHopOrmEntity } from './entities/recipe-hop.orm.entity';
 import { RecipeHopType } from './domain/enums/recipe-hop-type.enum';
+import { RecipeDifficultyService } from './services/recipe-difficulty.service';
 import { RecipeOrmEntity } from './entities/recipe.orm.entity';
 import { RecipeService } from './services/recipe.service';
 import { RecipeStepOrmEntity } from './entities/recipe-step.orm.entity';
@@ -54,7 +55,7 @@ describe('RecipeService.importFromCommunity (Issue #601)', () => {
           RecipeWaterOrmEntity,
         ]),
       ],
-      providers: [RecipeService],
+      providers: [RecipeService, RecipeDifficultyService],
     }).compile();
 
     service = module.get(RecipeService);

--- a/packages/api/src/recipe/recipe-import.service.spec.ts
+++ b/packages/api/src/recipe/recipe-import.service.spec.ts
@@ -10,6 +10,7 @@ import { RecipeFermentableOrmEntity } from './entities/recipe-fermentable.orm.en
 import { RecipeHopAdditionStage } from './domain/enums/recipe-hop-addition-stage.enum';
 import { RecipeHopOrmEntity } from './entities/recipe-hop.orm.entity';
 import { RecipeHopType } from './domain/enums/recipe-hop-type.enum';
+import { RecipeDifficultyLevel } from './domain/enums/recipe-difficulty-level.enum';
 import { RecipeDifficultyService } from './services/recipe-difficulty.service';
 import { RecipeOrmEntity } from './entities/recipe.orm.entity';
 import { RecipeService } from './services/recipe.service';
@@ -18,6 +19,7 @@ import { RecipeStepType } from './domain/enums/recipe-step-type.enum';
 import { RecipeVisibility } from './domain/enums/recipe-visibility.enum';
 import { RecipeWaterOrmEntity } from './entities/recipe-water.orm.entity';
 import { RecipeYeastOrmEntity } from './entities/recipe-yeast.orm.entity';
+import { RecipeYeastType } from './domain/enums/recipe-yeast-type.enum';
 
 describe('RecipeService.importFromCommunity (Issue #601)', () => {
   let module: TestingModule;
@@ -318,6 +320,58 @@ describe('RecipeService.importFromCommunity (Issue #601)', () => {
 
       expect(steps).toHaveLength(0);
       expect(hops).toHaveLength(0);
+    });
+  });
+
+  describe('difficulty (ADR-0024)', () => {
+    it('recomputes the imported copy from its satellites, not the create-time Facile placeholder', async () => {
+      // A pale lager source (EBC ≤ 10 + lager yeast) scores Avancé (F3). After
+      // the import copies its satellites, the copy must be recomputed to Avancé,
+      // not left at the Facile placeholder the fresh copy is created with.
+      const source = recipeRepo.create({
+        id: 'pale-lager-source',
+        owner_id: SOURCE_OWNER,
+        name: 'Pilsner Source',
+        description: null,
+        visibility: RecipeVisibility.PUBLIC,
+        version: 1,
+        root_recipe_id: 'pale-lager-source',
+        parent_recipe_id: null,
+        batch_size_l: 20,
+        boil_time_min: 60,
+        og_target: 1.05,
+        fg_target: 1.01,
+        abv_estimated: 5,
+        ibu_target: 35,
+        ebc_target: 6,
+        efficiency_target: 75,
+        avg_rating: null,
+        brew_count: 0,
+        last_brewed_at: null,
+        is_official: false,
+      });
+      await recipeRepo.save(source);
+
+      const yeastRepo = module.get<Repository<RecipeYeastOrmEntity>>(
+        getRepositoryToken(RecipeYeastOrmEntity),
+      );
+      await yeastRepo.save(
+        yeastRepo.create({
+          recipe_id: source.id,
+          name: 'W-34/70',
+          type: RecipeYeastType.LAGER,
+          amount_g: 11,
+          temperature_max_c: 12,
+        }),
+      );
+
+      const imported = await service.importFromCommunity(
+        IMPORTING_USER,
+        source.id,
+      );
+
+      const saved = await recipeRepo.findOneByOrFail({ id: imported.id });
+      expect(saved.difficulty_computed).toBe(RecipeDifficultyLevel.AVANCE);
     });
   });
 });

--- a/packages/api/src/recipe/recipe-ingredients.service.spec.ts
+++ b/packages/api/src/recipe/recipe-ingredients.service.spec.ts
@@ -12,6 +12,7 @@ import { RecipeHopAdditionStage } from './domain/enums/recipe-hop-addition-stage
 import { RecipeHopOrmEntity } from './entities/recipe-hop.orm.entity';
 import { RecipeHopType } from './domain/enums/recipe-hop-type.enum';
 import { RecipeIbuEstimateDto } from './dtos/recipe-ibu-estimate.dto';
+import { RecipeDifficultyService } from './services/recipe-difficulty.service';
 import { RecipeIngredientsService } from './services/recipe-ingredients.service';
 import { RecipeOrmEntity } from './entities/recipe.orm.entity';
 import { RecipeService } from './services/recipe.service';
@@ -60,7 +61,11 @@ describe('RecipeIngredientsService', () => {
           RecipeWaterOrmEntity,
         ]),
       ],
-      providers: [RecipeService, RecipeIngredientsService],
+      providers: [
+        RecipeService,
+        RecipeIngredientsService,
+        RecipeDifficultyService,
+      ],
     }).compile();
 
     service = module.get(RecipeIngredientsService);

--- a/packages/api/src/recipe/recipe-ingredients.service.spec.ts
+++ b/packages/api/src/recipe/recipe-ingredients.service.spec.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 import { NotFoundException } from '@nestjs/common';
 import { RecipeAdditiveOrmEntity } from './entities/recipe-additive.orm.entity';
 import { RecipeAdditiveType } from './domain/enums/recipe-additive-type.enum';
+import { RecipeDifficultyLevel } from './domain/enums/recipe-difficulty-level.enum';
 import { RecipeFermentableOrmEntity } from './entities/recipe-fermentable.orm.entity';
 import { RecipeFermentableType } from './domain/enums/recipe-fermentable-type.enum';
 import { RecipeHopAdditionStage } from './domain/enums/recipe-hop-addition-stage.enum';
@@ -305,6 +306,59 @@ describe('RecipeIngredientsService', () => {
       await expect(service.listYeasts(OTHER, recipe.id)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  // ─── Difficulty recompute wiring (slice 2) ───────────────────────────────────
+
+  describe('Difficulty recompute (slice 2)', () => {
+    it('recomputes UP when a pale lager yeast is added, then DOWN when it is removed', async () => {
+      const recipe = await recipeService.create(OWNER, {
+        name: 'Pilsner',
+        og_target: 1.05,
+        ebc_target: 6,
+      });
+      // Baseline: no ingredients yet → Facile.
+      expect(
+        (await recipeRepo.findOneByOrFail({ id: recipe.id }))
+          .difficulty_computed,
+      ).toBe(RecipeDifficultyLevel.FACILE);
+
+      // Adding a pale lager yeast through the real mutation must recompute UP.
+      const yeast = await service.addYeast(OWNER, recipe.id, {
+        name: 'W-34/70',
+        type: RecipeYeastType.LAGER,
+        amount_g: 11,
+        temperature_max_c: 12,
+      });
+      let saved = await recipeRepo.findOneByOrFail({ id: recipe.id });
+      expect(saved.difficulty_computed).toBe(RecipeDifficultyLevel.AVANCE);
+      expect(
+        (saved.difficulty_reasons ?? []).some((r) => r.factor === 'F3'),
+      ).toBe(true);
+
+      // Removing the last yeast must recompute back DOWN.
+      await service.removeYeast(OWNER, recipe.id, yeast.id);
+      saved = await recipeRepo.findOneByOrFail({ id: recipe.id });
+      expect(saved.difficulty_computed).toBe(RecipeDifficultyLevel.FACILE);
+    });
+
+    it('recomputes when a water treatment target is upserted (F4)', async () => {
+      const recipe = await recipeService.create(OWNER, {
+        name: 'Watered',
+        og_target: 1.05,
+      });
+
+      await service.upsertWater(OWNER, recipe.id, {
+        mash_volume_l: 15,
+        sparge_volume_l: 10,
+        ph_target: 5.4,
+      });
+
+      const saved = await recipeRepo.findOneByOrFail({ id: recipe.id });
+      expect(
+        (saved.difficulty_reasons ?? []).some((r) => r.factor === 'F4'),
+      ).toBe(true);
     });
   });
 

--- a/packages/api/src/recipe/recipe-steps.service.spec.ts
+++ b/packages/api/src/recipe/recipe-steps.service.spec.ts
@@ -5,6 +5,9 @@ import { DataSource, Repository } from 'typeorm';
 import { Test, TestingModule } from '@nestjs/testing';
 import { TypeOrmModule, getRepositoryToken } from '@nestjs/typeorm';
 
+import { RecipeAdditiveOrmEntity } from './entities/recipe-additive.orm.entity';
+import { RecipeDifficultyService } from './services/recipe-difficulty.service';
+import { RecipeFermentableOrmEntity } from './entities/recipe-fermentable.orm.entity';
 import { RecipeHopAdditionStage } from './domain/enums/recipe-hop-addition-stage.enum';
 import { RecipeHopOrmEntity } from './entities/recipe-hop.orm.entity';
 import { RecipeHopType } from './domain/enums/recipe-hop-type.enum';
@@ -13,6 +16,8 @@ import { RecipeService } from './services/recipe.service';
 import { RecipeStepOrmEntity } from './entities/recipe-step.orm.entity';
 import { RecipeStepType } from './domain/enums/recipe-step-type.enum';
 import { RecipeVisibility } from './domain/enums/recipe-visibility.enum';
+import { RecipeWaterOrmEntity } from './entities/recipe-water.orm.entity';
+import { RecipeYeastOrmEntity } from './entities/recipe-yeast.orm.entity';
 import { randomUUID } from 'crypto';
 
 describe('RecipeService (steps)', () => {
@@ -29,7 +34,15 @@ describe('RecipeService (steps)', () => {
         TypeOrmModule.forRoot({
           type: 'sqlite',
           database: ':memory:',
-          entities: [RecipeOrmEntity, RecipeStepOrmEntity, RecipeHopOrmEntity],
+          entities: [
+            RecipeOrmEntity,
+            RecipeStepOrmEntity,
+            RecipeHopOrmEntity,
+            RecipeFermentableOrmEntity,
+            RecipeYeastOrmEntity,
+            RecipeAdditiveOrmEntity,
+            RecipeWaterOrmEntity,
+          ],
           synchronize: true,
           logging: false,
         }),
@@ -37,9 +50,13 @@ describe('RecipeService (steps)', () => {
           RecipeOrmEntity,
           RecipeStepOrmEntity,
           RecipeHopOrmEntity,
+          RecipeFermentableOrmEntity,
+          RecipeYeastOrmEntity,
+          RecipeAdditiveOrmEntity,
+          RecipeWaterOrmEntity,
         ]),
       ],
-      providers: [RecipeService],
+      providers: [RecipeService, RecipeDifficultyService],
     }).compile();
 
     service = module.get(RecipeService);

--- a/packages/api/src/recipe/recipe.module.ts
+++ b/packages/api/src/recipe/recipe.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { RecipeAdditiveOrmEntity } from './entities/recipe-additive.orm.entity';
 import { RecipeController } from './controllers/recipe.controller';
+import { RecipeDifficultyService } from './services/recipe-difficulty.service';
 import { RecipeFermentableOrmEntity } from './entities/recipe-fermentable.orm.entity';
 import { RecipeHopOrmEntity } from './entities/recipe-hop.orm.entity';
 import { RecipeIngredientsController } from './controllers/recipe-ingredients.controller';
@@ -30,7 +31,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
     ]),
   ],
   controllers: [RecipeController, RecipeIngredientsController],
-  providers: [RecipeService, RecipeIngredientsService, RecipeMatchingService],
+  providers: [
+    RecipeService,
+    RecipeDifficultyService,
+    RecipeIngredientsService,
+    RecipeMatchingService,
+  ],
   exports: [RecipeService],
 })
 export class RecipeModule {}

--- a/packages/api/src/recipe/services/recipe-difficulty.service.ts
+++ b/packages/api/src/recipe/services/recipe-difficulty.service.ts
@@ -73,8 +73,11 @@ export class RecipeDifficultyService {
   ): Promise<DifficultyInput> {
     const recipeId = recipe.id;
     const [yeasts, water, fermentables, hops, additives] = await Promise.all([
+      // Ordered so the multi-yeast "first row within a class wins" reduction is
+      // deterministic (a bare find() has no defined row order).
       em.getRepository(RecipeYeastOrmEntity).find({
         where: { recipe_id: recipeId },
+        order: { created_at: 'ASC' },
       }),
       em.getRepository(RecipeWaterOrmEntity).findOne({
         where: { recipe_id: recipeId },

--- a/packages/api/src/recipe/services/recipe-difficulty.service.ts
+++ b/packages/api/src/recipe/services/recipe-difficulty.service.ts
@@ -1,0 +1,153 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+
+import { RecipeDifficultyDomainService } from '../domain/services/recipe-difficulty.domain.service';
+import {
+  DifficultyInput,
+  DifficultyResult,
+} from '../domain/services/recipe-difficulty.types';
+import { RecipeYeastType } from '../domain/enums/recipe-yeast-type.enum';
+import { RecipeAdditiveOrmEntity } from '../entities/recipe-additive.orm.entity';
+import { RecipeFermentableOrmEntity } from '../entities/recipe-fermentable.orm.entity';
+import { RecipeHopOrmEntity } from '../entities/recipe-hop.orm.entity';
+import { RecipeOrmEntity } from '../entities/recipe.orm.entity';
+import { RecipeWaterOrmEntity } from '../entities/recipe-water.orm.entity';
+import { RecipeYeastOrmEntity } from '../entities/recipe-yeast.orm.entity';
+
+/**
+ * Application service that keeps a recipe's stored brewing difficulty in sync
+ * with its data (ADR-0024 D3). It is the only writer of `difficulty_computed` /
+ * `difficulty_reasons`; the author override is written by the recipe update
+ * flow and never touched here. The scoring rules themselves live in the pure
+ * `RecipeDifficultyDomainService` — this service only adapts the persisted
+ * recipe + its sub-entities onto the domain input and persists the result.
+ *
+ * Called after every mutation that can change the score: recipe create/update,
+ * community import, and each ingredient (fermentable / hop / yeast / additive /
+ * water) mutation.
+ */
+@Injectable()
+export class RecipeDifficultyService {
+  constructor(
+    @InjectRepository(RecipeOrmEntity)
+    private readonly recipeRepo: Repository<RecipeOrmEntity>,
+  ) {}
+
+  /**
+   * Recomputes and persists `difficulty_computed` + `difficulty_reasons` for a
+   * recipe. Pass the transaction `manager` when called inside one (create /
+   * import) so the recompute participates in the same transaction; omit it for
+   * the standalone ingredient mutations (their own save already committed —
+   * a recompute is idempotent and self-heals on the next mutation).
+   *
+   * Returns the computed result, or `null` if the recipe no longer exists
+   * (e.g. it was deleted between the mutation and the recompute).
+   */
+  async recomputeForRecipe(
+    recipeId: string,
+    manager?: EntityManager,
+  ): Promise<DifficultyResult | null> {
+    const em = manager ?? this.recipeRepo.manager;
+    const recipeRepo = em.getRepository(RecipeOrmEntity);
+
+    const recipe = await recipeRepo.findOne({ where: { id: recipeId } });
+    if (!recipe) {
+      return null;
+    }
+
+    const input = await this.buildInput(recipe, em);
+    const result = RecipeDifficultyDomainService.compute(input);
+
+    recipe.difficulty_computed = result.computed;
+    recipe.difficulty_reasons = result.reasons;
+    await recipeRepo.save(recipe);
+
+    return result;
+  }
+
+  /** Maps a recipe + its sub-entities onto the pure domain input shape. */
+  private async buildInput(
+    recipe: RecipeOrmEntity,
+    em: EntityManager,
+  ): Promise<DifficultyInput> {
+    const recipeId = recipe.id;
+    const [yeasts, water, fermentables, hops, additives] = await Promise.all([
+      em.getRepository(RecipeYeastOrmEntity).find({
+        where: { recipe_id: recipeId },
+      }),
+      em.getRepository(RecipeWaterOrmEntity).findOne({
+        where: { recipe_id: recipeId },
+      }),
+      em.getRepository(RecipeFermentableOrmEntity).find({
+        where: { recipe_id: recipeId },
+      }),
+      em.getRepository(RecipeHopOrmEntity).find({
+        where: { recipe_id: recipeId },
+      }),
+      em.getRepository(RecipeAdditiveOrmEntity).find({
+        where: { recipe_id: recipeId },
+      }),
+    ]);
+
+    return {
+      ogTarget: recipe.og_target ?? null,
+      abvEstimated: recipe.abv_estimated ?? null,
+      ebcTarget: recipe.ebc_target ?? null,
+      yeast: this.reduceYeast(yeasts),
+      water: water
+        ? {
+            phTarget: water.ph_target ?? null,
+            calciumPpm: water.calcium_ppm ?? null,
+            magnesiumPpm: water.magnesium_ppm ?? null,
+            sulfatePpm: water.sulfate_ppm ?? null,
+            chloridePpm: water.chloride_ppm ?? null,
+          }
+        : null,
+      distinctFermentables: this.distinctCount(fermentables.map((f) => f.name)),
+      distinctHopVarieties: this.distinctCount(hops.map((h) => h.variety)),
+      additives: additives.length,
+    };
+  }
+
+  /**
+   * Reduces a recipe's yeasts (0..*) to the single worst-case yeast the domain
+   * scores. The class priority mirrors the domain's `yeastClass` ranking —
+   * wild/brett > lager > ale — and among a class the first row wins, carrying
+   * its own fermentation temperature. A recipe normally has one yeast; the rare
+   * divergent multi-ale case falls back to the first ale (author override is the
+   * escape hatch). Documented v1 reduction (spec §6).
+   */
+  private reduceYeast(
+    yeasts: RecipeYeastOrmEntity[],
+  ): DifficultyInput['yeast'] {
+    if (yeasts.length === 0) {
+      return null;
+    }
+    const dominant =
+      yeasts.find(
+        (y) =>
+          y.type === RecipeYeastType.WILD || y.type === RecipeYeastType.BRETT,
+      ) ??
+      yeasts.find((y) => y.type === RecipeYeastType.LAGER) ??
+      yeasts[0];
+    return {
+      type: dominant.type,
+      temperatureMaxC: dominant.temperature_max_c ?? null,
+    };
+  }
+
+  /** Counts distinct non-empty values, case-insensitively (F6 varieties). */
+  private distinctCount(
+    values: ReadonlyArray<string | null | undefined>,
+  ): number {
+    const seen = new Set<string>();
+    for (const value of values) {
+      const key = value?.trim().toLowerCase();
+      if (key) {
+        seen.add(key);
+      }
+    }
+    return seen.size;
+  }
+}

--- a/packages/api/src/recipe/services/recipe-ingredients.service.ts
+++ b/packages/api/src/recipe/services/recipe-ingredients.service.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import { Repository } from 'typeorm';
 
 import { RecipeService } from './recipe.service';
+import { RecipeDifficultyService } from './recipe-difficulty.service';
 import { RecipeAdditiveOrmEntity } from '../entities/recipe-additive.orm.entity';
 import { RecipeFermentableOrmEntity } from '../entities/recipe-fermentable.orm.entity';
 import { RecipeHopOrmEntity } from '../entities/recipe-hop.orm.entity';
@@ -33,6 +34,7 @@ import { UpsertRecipeWaterDto } from '../dtos/upsert-recipe-water.dto';
 export class RecipeIngredientsService {
   constructor(
     private readonly recipeService: RecipeService,
+    private readonly difficulty: RecipeDifficultyService,
     @InjectRepository(RecipeFermentableOrmEntity)
     private readonly fermentableRepo: Repository<RecipeFermentableOrmEntity>,
     @InjectRepository(RecipeHopOrmEntity)
@@ -44,6 +46,16 @@ export class RecipeIngredientsService {
     @InjectRepository(RecipeWaterOrmEntity)
     private readonly waterRepo: Repository<RecipeWaterOrmEntity>,
   ) {}
+
+  /**
+   * Recomputes the parent recipe's stored difficulty after an ingredient
+   * mutation (its fermentables/hops/yeast/water feed the score). Runs in its
+   * own connection (the mutation already committed); idempotent, so a failure
+   * here self-heals on the next mutation rather than rolling back the edit.
+   */
+  private async refreshDifficulty(recipeId: string): Promise<void> {
+    await this.difficulty.recomputeForRecipe(recipeId);
+  }
 
   // ─── Fermentables ───────────────────────────────────────────────────────────
 
@@ -73,7 +85,9 @@ export class RecipeIngredientsService {
       potential_gravity: dto.potential_gravity ?? null,
       color_ebc: dto.color_ebc ?? null,
     });
-    return this.fermentableRepo.save(entity);
+    const saved = await this.fermentableRepo.save(entity);
+    await this.refreshDifficulty(recipeId);
+    return saved;
   }
 
   async updateFermentable(
@@ -92,7 +106,9 @@ export class RecipeIngredientsService {
       entity.potential_gravity = dto.potential_gravity ?? null;
     if (dto.color_ebc !== undefined) entity.color_ebc = dto.color_ebc ?? null;
 
-    return this.fermentableRepo.save(entity);
+    const saved = await this.fermentableRepo.save(entity);
+    await this.refreshDifficulty(recipeId);
+    return saved;
   }
 
   async removeFermentable(
@@ -108,6 +124,7 @@ export class RecipeIngredientsService {
     if (!result.affected) {
       throw new NotFoundException('Fermentable not found');
     }
+    await this.refreshDifficulty(recipeId);
     return { deleted: true };
   }
 
@@ -140,7 +157,9 @@ export class RecipeIngredientsService {
       addition_stage: dto.addition_stage,
       addition_time_min: dto.addition_time_min ?? null,
     });
-    return this.hopRepo.save(entity);
+    const saved = await this.hopRepo.save(entity);
+    await this.refreshDifficulty(recipeId);
+    return saved;
   }
 
   async updateHop(
@@ -162,7 +181,9 @@ export class RecipeIngredientsService {
     if (dto.addition_time_min !== undefined)
       entity.addition_time_min = dto.addition_time_min ?? null;
 
-    return this.hopRepo.save(entity);
+    const saved = await this.hopRepo.save(entity);
+    await this.refreshDifficulty(recipeId);
+    return saved;
   }
 
   async removeHop(
@@ -178,6 +199,7 @@ export class RecipeIngredientsService {
     if (!result.affected) {
       throw new NotFoundException('Hop not found');
     }
+    await this.refreshDifficulty(recipeId);
     return { deleted: true };
   }
 
@@ -210,7 +232,9 @@ export class RecipeIngredientsService {
       temperature_min_c: dto.temperature_min_c ?? null,
       temperature_max_c: dto.temperature_max_c ?? null,
     });
-    return this.yeastRepo.save(entity);
+    const saved = await this.yeastRepo.save(entity);
+    await this.refreshDifficulty(recipeId);
+    return saved;
   }
 
   async updateYeast(
@@ -232,7 +256,9 @@ export class RecipeIngredientsService {
     if (dto.temperature_max_c !== undefined)
       entity.temperature_max_c = dto.temperature_max_c ?? null;
 
-    return this.yeastRepo.save(entity);
+    const saved = await this.yeastRepo.save(entity);
+    await this.refreshDifficulty(recipeId);
+    return saved;
   }
 
   async removeYeast(
@@ -248,6 +274,7 @@ export class RecipeIngredientsService {
     if (!result.affected) {
       throw new NotFoundException('Yeast not found');
     }
+    await this.refreshDifficulty(recipeId);
     return { deleted: true };
   }
 
@@ -279,7 +306,9 @@ export class RecipeIngredientsService {
       addition_step: dto.addition_step,
       addition_time_min: dto.addition_time_min ?? null,
     });
-    return this.additiveRepo.save(entity);
+    const saved = await this.additiveRepo.save(entity);
+    await this.refreshDifficulty(recipeId);
+    return saved;
   }
 
   async updateAdditive(
@@ -299,7 +328,9 @@ export class RecipeIngredientsService {
     if (dto.addition_time_min !== undefined)
       entity.addition_time_min = dto.addition_time_min ?? null;
 
-    return this.additiveRepo.save(entity);
+    const saved = await this.additiveRepo.save(entity);
+    await this.refreshDifficulty(recipeId);
+    return saved;
   }
 
   async removeAdditive(
@@ -315,6 +346,7 @@ export class RecipeIngredientsService {
     if (!result.affected) {
       throw new NotFoundException('Additive not found');
     }
+    await this.refreshDifficulty(recipeId);
     return { deleted: true };
   }
 
@@ -349,7 +381,9 @@ export class RecipeIngredientsService {
       existing.sulfate_ppm = dto.sulfate_ppm ?? null;
       existing.chloride_ppm = dto.chloride_ppm ?? null;
       existing.ph_target = dto.ph_target ?? null;
-      return this.waterRepo.save(existing);
+      const saved = await this.waterRepo.save(existing);
+      await this.refreshDifficulty(recipeId);
+      return saved;
     }
 
     const entity = this.waterRepo.create({
@@ -364,7 +398,9 @@ export class RecipeIngredientsService {
       chloride_ppm: dto.chloride_ppm ?? null,
       ph_target: dto.ph_target ?? null,
     });
-    return this.waterRepo.save(entity);
+    const saved = await this.waterRepo.save(entity);
+    await this.refreshDifficulty(recipeId);
+    return saved;
   }
 
   async removeWater(
@@ -376,6 +412,7 @@ export class RecipeIngredientsService {
     if (!result.affected) {
       throw new NotFoundException('Water profile not found');
     }
+    await this.refreshDifficulty(recipeId);
     return { deleted: true };
   }
 

--- a/packages/api/src/recipe/services/recipe-ingredients.service.ts
+++ b/packages/api/src/recipe/services/recipe-ingredients.service.ts
@@ -60,9 +60,9 @@ export class RecipeIngredientsService {
     try {
       await this.difficulty.recomputeForRecipe(recipeId);
     } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
       this.logger.warn(
-        `Difficulty recompute failed for recipe ${recipeId}; it will self-heal on the next save`,
-        error instanceof Error ? error.stack : String(error),
+        `Difficulty recompute failed for recipe ${recipeId} (${reason}); it will self-heal on the next save`,
       );
     }
   }

--- a/packages/api/src/recipe/services/recipe-ingredients.service.ts
+++ b/packages/api/src/recipe/services/recipe-ingredients.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomUUID } from 'crypto';
 import { Repository } from 'typeorm';
@@ -47,14 +47,24 @@ export class RecipeIngredientsService {
     private readonly waterRepo: Repository<RecipeWaterOrmEntity>,
   ) {}
 
+  private readonly logger = new Logger(RecipeIngredientsService.name);
+
   /**
    * Recomputes the parent recipe's stored difficulty after an ingredient
    * mutation (its fermentables/hops/yeast/water feed the score). Runs in its
    * own connection (the mutation already committed); idempotent, so a failure
-   * here self-heals on the next mutation rather than rolling back the edit.
+   * here is swallowed (logged, never rethrown) rather than turning a successful
+   * ingredient edit into a 5xx — the difficulty self-heals on the next mutation.
    */
   private async refreshDifficulty(recipeId: string): Promise<void> {
-    await this.difficulty.recomputeForRecipe(recipeId);
+    try {
+      await this.difficulty.recomputeForRecipe(recipeId);
+    } catch (error) {
+      this.logger.warn(
+        `Difficulty recompute failed for recipe ${recipeId}; it will self-heal on the next save`,
+        error instanceof Error ? error.stack : String(error),
+      );
+    }
   }
 
   // ─── Fermentables ───────────────────────────────────────────────────────────

--- a/packages/api/src/recipe/services/recipe.service.ts
+++ b/packages/api/src/recipe/services/recipe.service.ts
@@ -141,10 +141,11 @@ export class RecipeService {
    * recipes that are not owned by the viewer still surface as
    * NotFound (deny by default, no information leak).
    *
-   * Write operations (`updateMine`, `deleteMine`, the step
-   * write-helpers) intentionally keep using `getMineById` so the
-   * authorisation surface for mutations stays strictly
-   * owner-scoped.
+   * Write operations stay strictly owner-scoped: `deleteMine` and the
+   * step write-helpers use `getMineById`, while `updateMine` performs the
+   * equivalent owner-scoped lookup (`{ id, owner_id }`) inline inside its
+   * own transaction so the field update and the difficulty recompute commit
+   * atomically. None of them use this public/owner reader.
    */
   async getReadableById(
     viewerOwnerId: string,

--- a/packages/api/src/recipe/services/recipe.service.ts
+++ b/packages/api/src/recipe/services/recipe.service.ts
@@ -11,6 +11,7 @@ import { EntityManager, QueryFailedError, Repository } from 'typeorm';
 import { RecipeDomainService } from '../domain/services/recipe-domain.service';
 import { RecipeIbuTinsethDomainService } from '../domain/services/recipe-ibu-tinseth.domain.service';
 import { RecipeWorkflowService } from '../domain/services/recipe-workflow.service';
+import { RecipeDifficultyService } from './recipe-difficulty.service';
 import { RecipeVisibility } from '../domain/enums/recipe-visibility.enum';
 import { RecipeAdditiveOrmEntity } from '../entities/recipe-additive.orm.entity';
 import { RecipeFermentableOrmEntity } from '../entities/recipe-fermentable.orm.entity';
@@ -37,6 +38,7 @@ export class RecipeService {
     private readonly stepRepo: Repository<RecipeStepOrmEntity>,
     @InjectRepository(RecipeHopOrmEntity)
     private readonly hopRepo: Repository<RecipeHopOrmEntity>,
+    private readonly difficulty: RecipeDifficultyService,
   ) {}
 
   async create(
@@ -73,10 +75,22 @@ export class RecipeService {
         ibu_target: dto.ibu_target ?? null,
         ebc_target: dto.ebc_target ?? null,
         efficiency_target: dto.efficiency_target ?? null,
+        difficulty_override: dto.difficulty_override ?? null,
       });
 
       const saved = await recipeRepo.save(entity);
       await this.ensureDefaultSteps(saved.id, manager);
+      // A fresh recipe has no ingredients yet, so this scores Facile — but we
+      // still store it (+ the positive reason) so the badge is never empty and
+      // the value is consistent with the recompute on later ingredient edits.
+      const difficulty = await this.difficulty.recomputeForRecipe(
+        saved.id,
+        manager,
+      );
+      if (difficulty) {
+        saved.difficulty_computed = difficulty.computed;
+        saved.difficulty_reasons = difficulty.reasons;
+      }
       return saved;
     });
   }
@@ -154,26 +168,51 @@ export class RecipeService {
     id: string,
     dto: UpdateRecipeDto,
   ): Promise<RecipeOrmEntity> {
-    const entity = await this.getMineById(ownerId, id);
+    // Wrapped in a transaction so the field update and the difficulty recompute
+    // (gravity/colour targets feed the score) commit atomically (ADR-0024 D3).
+    return this.repo.manager.transaction(async (manager) => {
+      const recipeRepo = manager.getRepository(RecipeOrmEntity);
+      const entity = await recipeRepo.findOne({
+        where: { id, owner_id: ownerId },
+      });
+      if (!entity) {
+        throw new NotFoundException('Recipe not found');
+      }
 
-    if (dto.name !== undefined) entity.name = dto.name;
-    if (dto.description !== undefined) entity.description = dto.description;
-    if (dto.visibility !== undefined) entity.visibility = dto.visibility;
+      if (dto.name !== undefined) entity.name = dto.name;
+      if (dto.description !== undefined) entity.description = dto.description;
+      if (dto.visibility !== undefined) entity.visibility = dto.visibility;
 
-    // Update brewing metrics
-    if (dto.batch_size_l !== undefined) entity.batch_size_l = dto.batch_size_l;
-    if (dto.boil_time_min !== undefined)
-      entity.boil_time_min = dto.boil_time_min;
-    if (dto.og_target !== undefined) entity.og_target = dto.og_target;
-    if (dto.fg_target !== undefined) entity.fg_target = dto.fg_target;
-    if (dto.abv_estimated !== undefined)
-      entity.abv_estimated = dto.abv_estimated;
-    if (dto.ibu_target !== undefined) entity.ibu_target = dto.ibu_target;
-    if (dto.ebc_target !== undefined) entity.ebc_target = dto.ebc_target;
-    if (dto.efficiency_target !== undefined)
-      entity.efficiency_target = dto.efficiency_target;
+      // Update brewing metrics
+      if (dto.batch_size_l !== undefined)
+        entity.batch_size_l = dto.batch_size_l;
+      if (dto.boil_time_min !== undefined)
+        entity.boil_time_min = dto.boil_time_min;
+      if (dto.og_target !== undefined) entity.og_target = dto.og_target;
+      if (dto.fg_target !== undefined) entity.fg_target = dto.fg_target;
+      if (dto.abv_estimated !== undefined)
+        entity.abv_estimated = dto.abv_estimated;
+      if (dto.ibu_target !== undefined) entity.ibu_target = dto.ibu_target;
+      if (dto.ebc_target !== undefined) entity.ebc_target = dto.ebc_target;
+      if (dto.efficiency_target !== undefined)
+        entity.efficiency_target = dto.efficiency_target;
 
-    return this.repo.save(entity);
+      // Author override (nullable — an explicit null clears it).
+      if (dto.difficulty_override !== undefined)
+        entity.difficulty_override = dto.difficulty_override ?? null;
+
+      await recipeRepo.save(entity);
+
+      const difficulty = await this.difficulty.recomputeForRecipe(
+        entity.id,
+        manager,
+      );
+      if (difficulty) {
+        entity.difficulty_computed = difficulty.computed;
+        entity.difficulty_reasons = difficulty.reasons;
+      }
+      return entity;
+    });
   }
 
   async deleteMine(ownerId: string, id: string): Promise<{ deleted: true }> {
@@ -283,6 +322,17 @@ export class RecipeService {
       const saved = await recipeRepo.save(newRecipe);
 
       await this.copyRecipeSatellites(source.id, newId, manager);
+
+      // Satellites are copied — recompute so the imported copy carries the same
+      // difficulty as the source instead of the create-time Facile placeholder.
+      const difficulty = await this.difficulty.recomputeForRecipe(
+        newId,
+        manager,
+      );
+      if (difficulty) {
+        saved.difficulty_computed = difficulty.computed;
+        saved.difficulty_reasons = difficulty.reasons;
+      }
 
       return saved;
     });


### PR DESCRIPTION
## Summary

Backend for the per-recipe **brewing-difficulty badge** (ADR-0024, screen-review Tranche B). A recipe now carries a backend-computed difficulty (`facile`/`intermediaire`/`avance`) plus an optional author override; the effective level is `difficulty_override ?? difficulty_computed`. The mobile stays a pure consumer (slice 3).

**Slice 1 — pure domain scorer** (`RecipeDifficultyDomainService`): rule-based, max-dominates + bounded compounding, per-factor tiers F1 yeast / F2 gravity / F3 fault-tolerance (lager-gated) / F4 water / F5 mash (deferred) / F6 complexity, each firing factor storing a glossed plain-French tap-to-explain sentence. 18 unit tests from the spec's worked examples.

**Slice 2 — wiring + persistence**:
- New `RecipeDifficultyService` adapts a recipe + its sub-entities onto the domain input (worst-case yeast reduction, distinct fermentable/hop-variety counts, water targets) and persists `difficulty_computed` + `difficulty_reasons`. It is the only writer of the computed fields and never touches the override.
- Recompute wired into **every mutation that can change the score**: recipe create/update (in-transaction) + community import (after satellites copied) + all 15 ingredient mutations (fermentable/hop/yeast/additive/water). The ingredient-path recompute is fire-and-forget (logged, never fails a committed edit — the badge is derived and self-heals).
- 3 new `recipes` columns (migration 1808): `difficulty_computed` (not null, `'facile'` default so existing rows + create paths that omit it stay valid), `difficulty_override` (nullable), `difficulty_reasons` (nullable json). No backfill — rows recompute on their next save.
- DTOs: `difficulty_effective` + `difficulty_reasons` exposed on `RecipeDto` and `PublicRecipeDto` (badge on catalog cards); `difficulty_override` accepted + validated on create/update.

## Context

- Conception PR #1334 (ADR-0024 + spec + diagrams). **ADR-0024 stays `Proposed` on purpose** — it is promoted to `Accepted` (+ added to the CLAUDE.md ADR index) with **slice 3** (the mobile badge), when the feature is user-complete.
- Reviewed adversarially before push: a multi-lens workflow (conception / correctness / security / persistence / test-quality, each finding verified by a skeptic) + the local `pr-pre-reviewer`. Findings addressed: the recompute wiring at the 15 ingredient sites + `updateMine` was untested (mutation-testing proved neutralising it kept the suite green) → integration tests through the real methods; a failing ingredient recompute surfaced as a 5xx on an already-committed edit → now swallowed + logged; import/override/effective-fallback coverage added.

## Checklist

- [x] `nest build` green; ESLint + Prettier clean
- [x] Full API suite green (956 tests, +10)
- [x] Migration reversible (up/down), entity + migration schemas agree
- [x] Tests H/S/E for the new units + the wiring
- [x] No `any`, no default export, no raw SQL outside the migration, DTO bounds validated
- [x] Branch rebased on `main`