### PR TITLE
feat(mobile/recipes): brewing-difficulty badge + tap-to-explain (Tranche B slice 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ Currently accepted ADRs (see each file for the `Status` line and full rationale)
 - [ADR-0018 — Admin/moderation surface: in-app CREATOR moderation, secured at the NestJS API](docs/architecture/decisions/0018-admin-moderation-surface.md)
 - [ADR-0020 — Equipment-driven batch sizing & volume planning (computed in the backend)](docs/architecture/decisions/0020-equipment-driven-volume-planning.md)
 - [ADR-0022 — Public FAQ chatbot: Mistral LLM + self-hosted ALTCHA, EU-sovereign](docs/architecture/decisions/0022-public-faq-chatbot-llm.md)
+- [ADR-0024 — Recipe brewing-difficulty badge: rule-based, max-dominates, backend-computed](docs/architecture/decisions/0024-recipe-difficulty-scoring.md)
 
 When a new ADR is accepted, add its file link here (no dates, no per-ADR summaries — open the file for the live status and content). When reviewing a PR, flag any diff that violates these ADRs and cite the ADR number and clause in the review comment.
 

--- a/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
+++ b/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
@@ -1,15 +1,15 @@
 # ADR-0024 — Recipe brewing-difficulty badge: rule-based, max-dominates, backend-computed
 
-**Status**  Proposed
-**Date**    2026-07-03
-**Owners**  @benoit-bremaud
+**Status** Proposed
+**Date** 2026-07-03
+**Owners** @benoit-bremaud
 
 ---
 
 ## Context
 
 The screen-by-screen UX review (2026-07-03) activated a **per-recipe brewing-difficulty
-badge**: a novice must see, at a glance, *how hard a recipe is to brew* so they can pick one
+badge**: a novice must see, at a glance, _how hard a recipe is to brew_ so they can pick one
 at their level. This is a property of the **recipe** (how hard it is to brew), distinct from
 the **user's declared level** (ADR-0021 D5). It surfaces on the recipe « Vue » tab / hero and on
 the recipe cards (« Mes recettes » / catalog), with a tap-to-explain sentence (the app **teaches
@@ -18,8 +18,8 @@ and the difficulty-badge decisions in `bb-recipe-hallmark`.
 
 **Locked before this ADR** (requirements workshop, 2026-07-03):
 
-- **3 levels**: Facile / Intermédiaire / Avancé, colour-coded green / amber / red, each with a
-  tap-to-explain sentence.
+- **3 levels**: Facile / Intermédiaire / Avancé, colour-coded as a brand traffic-light
+  (olive-green / amber / terracotta — see D4), each with a tap-to-explain sentence.
 - **Determination = BOTH**: a **backend-computed** default from objective recipe signals,
   **overridable by the recipe author**.
 - **Factors** the founder retained: base (step/ingredient count) + **techniques**,
@@ -32,12 +32,12 @@ and the difficulty-badge decisions in `bb-recipe-hallmark`.
 ### Documented study (why we are not guessing)
 
 A four-angle web study (homebrew apps, beginner-vs-advanced styles, brewing techniques,
-scoring rubrics) was run to ground the model. Load-bearing sources: **John Palmer, *How to
-Brew*** (progression ladder); the **American Homebrewers Association** (beginner recipe design,
+scoring rubrics) was run to ground the model. Load-bearing sources: **John Palmer, _How to
+Brew_** (progression ladder); the **American Homebrewers Association** (beginner recipe design,
 SMaSH first-brew); **Brew Your Own — "10 easiest / 10 hardest styles"**; **Brulosophy**
 (blind exBEERiments); **Grainfather** (lager control); and — for the aggregation principle —
-**Kusu et al. 2017, *Calculating Cooking Recipe's Difficulty based on Cooking Activities*** (a
-peer-reviewed method that scores a recipe from the difficulty of the *operations* it requires).
+**Kusu et al. 2017, _Calculating Cooking Recipe's Difficulty based on Cooking Activities_** (a
+peer-reviewed method that scores a recipe from the difficulty of the _operations_ it requires).
 
 Three findings shaped the decision:
 
@@ -48,7 +48,7 @@ Three findings shaped the decision:
    side (Homebrew Emporium literally has a 3-tier taxonomy), which are editorial, not a formula
    — useful only as corroboration of the 3-tier boundaries.
 2. **No formal published point-rubric exists** for homebrew difficulty. Sources instead
-   enumerate the *attributes* that make a brew hard, all derivable from our structured recipe
+   enumerate the _attributes_ that make a brew hard, all derivable from our structured recipe
    fields.
 3. **The hardest single factor should set the tier** (max-dominates), not an average: a recipe
    trivial on seven axes but soured, or a light lager, is still hard — averaging would hide it.
@@ -82,14 +82,14 @@ over-engineering per ADR-0001).
 
 ### D2 — Factors (all derivable from existing fields; **all-grain baseline**)
 
-| Factor | Signal (existing field) | Escalates because |
-|---|---|---|
-| **Fermentation / levure** | `recipe-yeast.type` (`{wild, brett}` / `lager` / `ale`) + `temperature_max_c` | wild culture = Avancé; lager **or** cold ferment (<14 °C) **or** hot/active ferment (>26 °C, e.g. saison) = ≥ Intermédiaire |
-| **Force / densité** | `og_target`, `abv_estimated` | high-gravity stresses the yeast, needs a starter |
-| **Tolérance aux fautes** | `ebc_target` (pale ≤ 10) **gated on `lager`** | a pale *lager* = "no place to hide" → Avancé; a pale *ale* stays Facile (keeps « Blonde Facile »). IBU is **not** used — hops don't mask lager faults |
-| **Chimie de l'eau** | `recipe-water` ion/pH **targets** | a real target profile (pH or ≥2 ion targets), not a lone pre-measured sachet |
-| **Base (complexité)** | count of fermentables + hop **varieties** + additives (> 7) | "kitchen-sink" bill multiplies error surface; counts varieties, not timed additions |
-| ~~Empâtage multi-palier~~ | `recipe-step` | **deferred v1** — steps carry no per-rest temperature, so a step/decoction mash is not detectable yet |
+| Factor                    | Signal (existing field)                                                       | Escalates because                                                                                                                                     |
+| ------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Fermentation / levure** | `recipe-yeast.type` (`{wild, brett}` / `lager` / `ale`) + `temperature_max_c` | wild culture = Avancé; lager **or** cold ferment (<14 °C) **or** hot/active ferment (>26 °C, e.g. saison) = ≥ Intermédiaire                           |
+| **Force / densité**       | `og_target`, `abv_estimated`                                                  | high-gravity stresses the yeast, needs a starter                                                                                                      |
+| **Tolérance aux fautes**  | `ebc_target` (pale ≤ 10) **gated on `lager`**                                 | a pale _lager_ = "no place to hide" → Avancé; a pale _ale_ stays Facile (keeps « Blonde Facile »). IBU is **not** used — hops don't mask lager faults |
+| **Chimie de l'eau**       | `recipe-water` ion/pH **targets**                                             | a real target profile (pH or ≥2 ion targets), not a lone pre-measured sachet                                                                          |
+| **Base (complexité)**     | count of fermentables + hop **varieties** + additives (> 7)                   | "kitchen-sink" bill multiplies error surface; counts varieties, not timed additions                                                                   |
+| ~~Empâtage multi-palier~~ | `recipe-step`                                                                 | **deferred v1** — steps carry no per-rest temperature, so a step/decoction mash is not detectable yet                                                 |
 
 Exact thresholds and the explanation strings live in the spec
 (`docs/architecture/specs/recipe-difficulty-algorithm.md`) — they are **v1 defaults, meant to
@@ -110,10 +110,15 @@ deliberately omitted (all-grain baseline, D-context above).
 
 ### D4 — 3 levels, explainable, novice-first
 
-`facile` (green) / `intermediaire` (amber) / `avance` (red). An internal integer score MAY back
+`facile` / `intermediaire` / `avance`, colour-coded as a **brand traffic-light** — the app's warm
+charte, not literal RGB. The mobile maps each level onto the existing design-system semantic tokens
+(`facile` → olive-green `success`, `intermediaire` → amber `warning`, `avance` → terracotta `error`),
+so the badge stays on-palette (decided 2026-07-04, slice 3): a novice reads green→amber→red at a
+glance while every pill respects the earthy charte and WCAG AA legibility (label text darkened off
+the decorative amber). An internal integer score MAY back
 the tiering for calibration, but **only 3 levels are ever exposed** (no false precision). Every
 badge is **tap-to-explain**, and each stored sentence is written in **glossed plain French** (the
-sentence is the deepest layer — nothing behind it — so it must introduce *and* explain each term),
+sentence is the deepest layer — nothing behind it — so it must introduce _and_ explain each term),
 e.g. « Avancé car : une lager blonde et nette — ni houblon fort ni malt torréfié pour cacher un
 défaut, la moindre erreur se voit ». Pedagogy is the point (`feedback_educational_vocation`); the
 spec holds the exact strings and they must stay at this clarity bar.
@@ -137,12 +142,12 @@ de la recette » as the default**, and **move « Phases de brassage » into the 
 
 Criteria weighted for a **novice-first, explainable, no-dataset** app (5 = best).
 
-| Approach | Explainable to novice (×3) | Faithful to sources (×2) | Effort / YAGNI (×2) | Calibratable (×1) | **Score** |
-|---|---|---|---|---|---|
-| **Rule-based + max-dominates (chosen)** | 5 | 5 | 4 | 4 | **41** |
-| Weighted numeric score + thresholds | 2 | 4 | 3 | 5 | 29 |
-| Style → tier lookup table | 3 | 1 | 5 | 2 | 23 |
-| ML / learned model | 1 | 3 | 1 | 3 | 14 |
+| Approach                                | Explainable to novice (×3) | Faithful to sources (×2) | Effort / YAGNI (×2) | Calibratable (×1) | **Score** |
+| --------------------------------------- | -------------------------- | ------------------------ | ------------------- | ----------------- | --------- |
+| **Rule-based + max-dominates (chosen)** | 5                          | 5                        | 4                   | 4                 | **41**    |
+| Weighted numeric score + thresholds     | 2                          | 4                        | 3                   | 5                 | 29        |
+| Style → tier lookup table               | 3                          | 1                        | 5                   | 2                 | 23        |
+| ML / learned model                      | 1                          | 3                        | 1                   | 3                 | 14        |
 
 Rule-based + max-dominates wins on the two heaviest criteria (explainability, source fidelity):
 every tier decision traces to a named factor with a novice sentence, and "hardest factor sets
@@ -161,7 +166,7 @@ omitted extraction axis; backend-owned (ADR-0002) so all clients agree.
 **Negative / risks** — thresholds are **judgement calls**; v1 defaults will need calibration
 against real recipes (mitigation: thresholds isolated in the spec + the author override as an
 escape hatch). Documented v1 limitations (spec §6): (a) **fault-tolerance uses `lager` as a coarse
-proxy** and deliberately under-penalises clean pale *ales* (Kölsch, Cream Ale, Bitter…) to keep
+proxy** and deliberately under-penalises clean pale _ales_ (Kölsch, Cream Ale, Bitter…) to keep
 the flagship « Blonde Facile » at Facile; (b) **F5 mash complexity is deferred** — `recipe-step`
 carries no per-rest temperature, so step/decoction mashes are invisible until the mash model
 gains rests; (c) the yeast enum has **no `sour`/`mixed`** value, so a kettle-sour is folded into

--- a/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
+++ b/docs/architecture/decisions/0024-recipe-difficulty-scoring.md
@@ -1,7 +1,7 @@
 # ADR-0024 — Recipe brewing-difficulty badge: rule-based, max-dominates, backend-computed
 
-**Status** Proposed
-**Date** 2026-07-03
+**Status** Accepted
+**Date** 2026-07-03 (accepted 2026-07-04, on the Tranche B build landing: backend #1342 + mobile badge)
 **Owners** @benoit-bremaud
 
 ---

--- a/docs/architecture/specs/recipe-difficulty-algorithm.md
+++ b/docs/architecture/specs/recipe-difficulty-algorithm.md
@@ -19,7 +19,10 @@ DifficultyLevel = "facile" | "intermediaire" | "avance"   // tiers 0 / 1 / 2
 effectiveDifficulty = difficultyOverride ?? difficultyComputed
 ```
 
-Badge colour: facile = green, intermediaire = amber, avance = red.
+Badge colour: a **brand traffic-light** in the app's warm charte (not literal RGB) — facile =
+olive-green, intermediaire = amber, avance = terracotta. The mobile maps each level onto the
+design-system semantic tokens (`success` / `warning` / `error`); label text is darkened off the
+decorative amber so every pill clears WCAG AA (ADR-0024 D4, slice 3 decision 2026-07-04).
 
 `yeastClass` is derived **once** from `RecipeYeastType` (`ale | lager | wild | brett`) and used by
 several factors, so a factor never doubles as a category (kept separate from the integer tiers):

--- a/packages/mobile-app/src/core/ui/Badge.tsx
+++ b/packages/mobile-app/src/core/ui/Badge.tsx
@@ -47,7 +47,11 @@ const variantStyles: Record<Variant, { container: object; text: object }> = {
       backgroundColor: colors.state.warningBackground,
       borderColor: colors.semantic.warning,
     },
-    text: { color: colors.semantic.warning },
+    // `semantic.warning` (#d9b364) is a decorative amber — used for the border
+    // only. The label needs a darker token to stay legible on the pale amber
+    // background (brand.secondary ≈ 5.3:1 vs the 1.8:1 of amber-on-amber), while
+    // reading distinct from the `error` variant's darker brown.
+    text: { color: colors.brand.secondary },
   },
   error: {
     container: {

--- a/packages/mobile-app/src/core/ui/Badge.tsx
+++ b/packages/mobile-app/src/core/ui/Badge.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Text, TextProps } from "react-native";
 
 import React from "react";
 
-type Variant = "neutral" | "info" | "success";
+type Variant = "neutral" | "info" | "success" | "warning" | "error";
 type Placement = "inline" | "corner";
 
 type Props = TextProps & {
@@ -41,6 +41,20 @@ const variantStyles: Record<Variant, { container: object; text: object }> = {
       borderColor: colors.semantic.success,
     },
     text: { color: colors.semantic.success },
+  },
+  warning: {
+    container: {
+      backgroundColor: colors.state.warningBackground,
+      borderColor: colors.semantic.warning,
+    },
+    text: { color: colors.semantic.warning },
+  },
+  error: {
+    container: {
+      backgroundColor: colors.state.errorBackground,
+      borderColor: colors.semantic.error,
+    },
+    text: { color: colors.semantic.error },
   },
 };
 

--- a/packages/mobile-app/src/features/recipes/data/__tests__/recipes.api.test.ts
+++ b/packages/mobile-app/src/features/recipes/data/__tests__/recipes.api.test.ts
@@ -46,6 +46,12 @@ type DtoLike = {
   abv_estimated?: number | null;
   ibu_target?: number | null;
   ebc_target?: number | null;
+  difficulty_computed?: "facile" | "intermediaire" | "avance" | null;
+  difficulty_override?: "facile" | "intermediaire" | "avance" | null;
+  difficulty_effective?: "facile" | "intermediaire" | "avance" | null;
+  difficulty_reasons?:
+    | { factor: string; tier: number; sentence: string }[]
+    | null;
   created_at: string;
   updated_at: string;
 };
@@ -130,6 +136,52 @@ describe("mapRecipe (Issue #779 — catalog API mapper coverage)", () => {
     expect(recipe.ownerId).toBeUndefined();
     expect(recipe.id).toBe("r-1");
     expect(recipe.name).toBe("Recipe");
+  });
+});
+
+describe("mapRecipe — difficulty (ADR-0024)", () => {
+  it("happy: maps the snake_case difficulty fields to camelCase", () => {
+    const recipe = mapRecipe(
+      buildDto({
+        difficulty_computed: "intermediaire",
+        difficulty_override: null,
+        difficulty_effective: "intermediaire",
+        difficulty_reasons: [
+          { factor: "F2", tier: 1, sentence: "bière assez forte" },
+        ],
+      }),
+    );
+
+    expect(recipe.difficultyComputed).toBe("intermediaire");
+    expect(recipe.difficultyOverride).toBeNull();
+    expect(recipe.difficultyEffective).toBe("intermediaire");
+    expect(recipe.difficultyReasons).toEqual([
+      { factor: "F2", tier: 1, sentence: "bière assez forte" },
+    ]);
+  });
+
+  it("edge: carries an author override through (effective = override)", () => {
+    const recipe = mapRecipe(
+      buildDto({
+        difficulty_computed: "intermediaire",
+        difficulty_override: "avance",
+        difficulty_effective: "avance",
+        difficulty_reasons: [],
+      }),
+    );
+
+    expect(recipe.difficultyOverride).toBe("avance");
+    expect(recipe.difficultyEffective).toBe("avance");
+  });
+
+  it("sad: a DTO without difficulty (pre-feature recipe) yields undefined fields", () => {
+    const recipe = mapRecipe(buildDto({}));
+
+    expect(recipe.difficultyComputed).toBeUndefined();
+    expect(recipe.difficultyEffective).toBeUndefined();
+    expect(recipe.difficultyReasons).toBeUndefined();
+    // Override defaults to null (the mapper normalises absent → null).
+    expect(recipe.difficultyOverride).toBeNull();
   });
 });
 

--- a/packages/mobile-app/src/features/recipes/data/recipes.api.ts
+++ b/packages/mobile-app/src/features/recipes/data/recipes.api.ts
@@ -1,6 +1,11 @@
 import { request } from "@/core/http/http-client";
 
-import { Recipe, RecipeStep } from "../domain/recipe.types";
+import {
+  Recipe,
+  RecipeDifficultyLevel,
+  RecipeDifficultyReason,
+  RecipeStep,
+} from "../domain/recipe.types";
 
 type RecipeDto = {
   id: string;
@@ -24,6 +29,13 @@ type RecipeDto = {
   abv_estimated?: number | null;
   ibu_target?: number | null;
   ebc_target?: number | null;
+  // Brewing-difficulty badge (ADR-0024). Backend-computed; the effective level
+  // = `difficulty_override ?? difficulty_computed`. `difficulty_reasons` feeds
+  // the tap-to-explain (rendered as-is, never recomputed client-side).
+  difficulty_computed?: RecipeDifficultyLevel | null;
+  difficulty_override?: RecipeDifficultyLevel | null;
+  difficulty_effective?: RecipeDifficultyLevel | null;
+  difficulty_reasons?: RecipeDifficultyReason[] | null;
   created_at: string;
   updated_at: string;
 };
@@ -51,6 +63,10 @@ export function mapRecipe(dto: RecipeDto): Recipe {
     rootRecipeId: dto.root_recipe_id,
     parentRecipeId: dto.parent_recipe_id ?? null,
     stats: mapRecipeStats(dto),
+    difficultyComputed: dto.difficulty_computed ?? undefined,
+    difficultyOverride: dto.difficulty_override ?? null,
+    difficultyEffective: dto.difficulty_effective ?? undefined,
+    difficultyReasons: dto.difficulty_reasons ?? undefined,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
   };

--- a/packages/mobile-app/src/features/recipes/domain/recipe.types.ts
+++ b/packages/mobile-app/src/features/recipes/domain/recipe.types.ts
@@ -1,5 +1,15 @@
 export type RecipeVisibility = "private" | "unlisted" | "public";
 
+/** Brewing-difficulty level of a recipe (how hard it is to brew). ADR-0024. */
+export type RecipeDifficultyLevel = "facile" | "intermediaire" | "avance";
+
+/** One stored tap-to-explain line for the difficulty badge (ADR-0024 D4). */
+export type RecipeDifficultyReason = {
+  factor: string;
+  tier: number;
+  sentence: string;
+};
+
 export type RecipeStats = {
   ibu: number;
   abv: number;
@@ -43,6 +53,13 @@ export type Recipe = {
   version: number;
   rootRecipeId: string;
   parentRecipeId?: string | null;
+  // Brewing-difficulty badge (ADR-0024). Optional — absent on recipes fetched
+  // before the feature, and the mobile is a pure consumer (never computes it).
+  // The badge shows `difficultyEffective` (= override ?? computed).
+  difficultyComputed?: RecipeDifficultyLevel;
+  difficultyOverride?: RecipeDifficultyLevel | null;
+  difficultyEffective?: RecipeDifficultyLevel;
+  difficultyReasons?: RecipeDifficultyReason[];
   createdAt: string;
   updatedAt: string;
 };

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
@@ -3,6 +3,7 @@ import { colors, radius, spacing, typography } from "@/core/theme";
 
 import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
+import { DifficultyBadge } from "@/features/recipes/presentation/components/DifficultyBadge";
 import { Ionicons } from "@expo/vector-icons";
 import React from "react";
 import { Recipe } from "@/features/recipes/domain/recipe.types";
@@ -89,6 +90,12 @@ export function RecipeCard({ recipe, badgeLabel, onPress }: Props) {
                 <Text style={styles.statItem}>{stats.volumeLiters}L</Text>
               </View>
             )}
+            {recipe.difficultyEffective ? (
+              <DifficultyBadge
+                level={recipe.difficultyEffective}
+                style={styles.difficultyBadge}
+              />
+            ) : null}
           </View>
           <Ionicons
             name="chevron-forward"
@@ -131,6 +138,9 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     marginTop: spacing.xxs,
+  },
+  difficultyBadge: {
+    marginTop: spacing.xs,
   },
   statItem: {
     fontSize: typography.size.label,

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
@@ -90,7 +90,7 @@ export function RecipeCard({ recipe, badgeLabel, onPress }: Props) {
                 <Text style={styles.statItem}>{stats.volumeLiters}L</Text>
               </View>
             )}
-            {recipe.difficultyEffective ? (
+            {recipe.difficultyEffective && recipe.difficultyReasons?.length ? (
               <DifficultyBadge
                 level={recipe.difficultyEffective}
                 style={styles.difficultyBadge}

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeCard.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeCard.test.tsx
@@ -19,6 +19,7 @@ const baseRecipe: Recipe = {
     colorEbc: 11,
   },
   difficultyEffective: "intermediaire",
+  difficultyReasons: [{ factor: "F2", tier: 1, sentence: "bière assez forte" }],
   createdAt: "2026-01-01T00:00:00.000Z",
   updatedAt: "2026-01-01T00:00:00.000Z",
 };
@@ -36,7 +37,11 @@ describe("RecipeCard — difficulty badge", () => {
   it("edge: renders no badge for a recipe without difficulty (pre-feature)", () => {
     render(
       <RecipeCard
-        recipe={{ ...baseRecipe, difficultyEffective: undefined }}
+        recipe={{
+          ...baseRecipe,
+          difficultyEffective: undefined,
+          difficultyReasons: undefined,
+        }}
         onPress={() => {}}
       />,
     );
@@ -44,5 +49,22 @@ describe("RecipeCard — difficulty badge", () => {
     expect(screen.queryByText("INTERMÉDIAIRE")).toBeNull();
     expect(screen.queryByText("FACILE")).toBeNull();
     expect(screen.queryByText("AVANCÉ")).toBeNull();
+  });
+
+  it("edge: renders no badge for a backend placeholder (level set, empty reasons)", () => {
+    // The migration defaults un-recomputed rows to `facile` with empty reasons —
+    // the card must NOT show a misleading badge until a real recompute lands.
+    render(
+      <RecipeCard
+        recipe={{
+          ...baseRecipe,
+          difficultyEffective: "facile",
+          difficultyReasons: [],
+        }}
+        onPress={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText("FACILE")).toBeNull();
   });
 });

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeCard.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeCard.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+
+import { RecipeCard } from "@/features/recipes/presentation/RecipeCard";
+import type { Recipe } from "@/features/recipes/domain/recipe.types";
+
+const baseRecipe: Recipe = {
+  id: "r-1",
+  name: "Session IPA",
+  visibility: "private",
+  version: 1,
+  rootRecipeId: "r-1",
+  stats: {
+    ibu: 42,
+    abv: 5.1,
+    og: 1.048,
+    fg: 1.01,
+    volumeLiters: 20,
+    colorEbc: 11,
+  },
+  difficultyEffective: "intermediaire",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("RecipeCard — difficulty badge", () => {
+  it("happy: shows the difficulty badge display-only (the card owns the tap)", () => {
+    render(<RecipeCard recipe={baseRecipe} onPress={() => {}} />);
+
+    expect(screen.getByText("INTERMÉDIAIRE")).toBeTruthy();
+    // Display-only: the badge must NOT nest a tap-to-explain button inside the
+    // card's own Pressable (RN nested-touchable anti-pattern).
+    expect(screen.queryByLabelText("Difficulté : Intermédiaire")).toBeNull();
+  });
+
+  it("edge: renders no badge for a recipe without difficulty (pre-feature)", () => {
+    render(
+      <RecipeCard
+        recipe={{ ...baseRecipe, difficultyEffective: undefined }}
+        onPress={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText("INTERMÉDIAIRE")).toBeNull();
+    expect(screen.queryByText("FACILE")).toBeNull();
+    expect(screen.queryByText("AVANCÉ")).toBeNull();
+  });
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/DifficultyBadge.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/DifficultyBadge.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from "react";
+import {
+  Pressable,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from "react-native";
+
+import { Badge } from "@/core/ui/Badge";
+import {
+  RecipeDifficultyLevel,
+  RecipeDifficultyReason,
+} from "@/features/recipes/domain/recipe.types";
+import { DIFFICULTY_LABELS, DIFFICULTY_VARIANTS } from "./difficulty.constants";
+import { DifficultyExplainModal } from "./DifficultyExplainModal";
+
+export type DifficultyBadgeProps = Readonly<{
+  level: RecipeDifficultyLevel;
+  /** Computed level — surfaced as the « calculé : … » hint when overridden. */
+  computed?: RecipeDifficultyLevel | null;
+  reasons?: RecipeDifficultyReason[];
+  /** When true, the badge is tappable and opens the tap-to-explain modal. */
+  interactive?: boolean;
+  style?: StyleProp<ViewStyle>;
+}>;
+
+/**
+ * Brewing-difficulty badge (green / amber / red) — a pure consumer of the
+ * backend-computed level (ADR-0024, the mobile never computes it). On the recipe
+ * detail it is `interactive`: tapping it opens the stored tap-to-explain. On list
+ * cards it is display-only (the card itself is the touch target, so the badge
+ * must not nest a second touchable).
+ */
+export function DifficultyBadge({
+  level,
+  computed,
+  reasons,
+  interactive = false,
+  style,
+}: DifficultyBadgeProps) {
+  const [explaining, setExplaining] = useState(false);
+  const label = DIFFICULTY_LABELS[level];
+  const badge = <Badge label={label} variant={DIFFICULTY_VARIANTS[level]} />;
+
+  if (!interactive) {
+    return <View style={[styles.wrap, style]}>{badge}</View>;
+  }
+
+  return (
+    <View style={[styles.wrap, style]}>
+      <Pressable
+        onPress={() => setExplaining(true)}
+        accessibilityRole="button"
+        accessibilityLabel={`Difficulté : ${label}`}
+        accessibilityHint="Appuie pour comprendre pourquoi"
+      >
+        {badge}
+      </Pressable>
+      <DifficultyExplainModal
+        visible={explaining}
+        level={level}
+        computed={computed}
+        reasons={reasons ?? []}
+        onClose={() => setExplaining(false)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    alignSelf: "flex-start",
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/DifficultyExplainModal.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/DifficultyExplainModal.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import {
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import { colors, radius, shadows, spacing, typography } from "@/core/theme";
+import {
+  RecipeDifficultyLevel,
+  RecipeDifficultyReason,
+} from "@/features/recipes/domain/recipe.types";
+import { DIFFICULTY_LABELS } from "./difficulty.constants";
+
+export type DifficultyExplainModalProps = Readonly<{
+  visible: boolean;
+  level: RecipeDifficultyLevel;
+  /** The computed level — shown as a hint when the author overrode it. */
+  computed?: RecipeDifficultyLevel | null;
+  reasons: RecipeDifficultyReason[];
+  onClose: () => void;
+}>;
+
+/**
+ * Read-only tap-to-explain popup for the difficulty badge (ADR-0024 D4). Renders
+ * the stored `reasons` as-is — the app TEACHES why a recipe sits at its level —
+ * and never recomputes anything (the backend owns the math). Mirrors the branded
+ * `ConfirmDialog` look (scrim + white rounded card) with a single close action.
+ */
+export function DifficultyExplainModal({
+  visible,
+  level,
+  computed,
+  reasons,
+  onClose,
+}: DifficultyExplainModalProps) {
+  const showComputedHint = computed != null && computed !== level;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+    >
+      <Pressable
+        style={styles.backdrop}
+        onPress={onClose}
+        accessibilityRole="button"
+        accessibilityLabel="Fermer"
+      >
+        <View style={styles.card} onStartShouldSetResponder={() => true}>
+          <Text
+            style={styles.title}
+          >{`Difficulté : ${DIFFICULTY_LABELS[level]}`}</Text>
+
+          {showComputedHint ? (
+            <Text style={styles.hint}>
+              {`Niveau choisi par l'auteur — calculé : ${DIFFICULTY_LABELS[computed]}.`}
+            </Text>
+          ) : null}
+
+          <Text style={styles.subheading}>Pourquoi ce niveau ?</Text>
+
+          {reasons.length > 0 ? (
+            <ScrollView style={styles.reasons}>
+              {reasons.map((reason, index) => (
+                <View
+                  key={`${reason.factor}-${index}`}
+                  style={styles.reasonRow}
+                >
+                  <Text style={styles.bullet}>•</Text>
+                  <Text style={styles.reasonText}>{reason.sentence}</Text>
+                </View>
+              ))}
+            </ScrollView>
+          ) : (
+            <Text style={styles.emptyText}>
+              Aucune explication disponible pour cette recette.
+            </Text>
+          )}
+
+          <Pressable
+            style={styles.closeButton}
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="J'ai compris"
+          >
+            <Text style={styles.closeText}>J'ai compris</Text>
+          </Pressable>
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: colors.overlay.scrim,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: spacing.lg,
+  },
+  card: {
+    backgroundColor: colors.neutral.white,
+    borderRadius: radius.md,
+    padding: spacing.md,
+    width: "100%",
+    maxWidth: 420,
+    ...shadows.sm,
+  },
+  title: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+  },
+  hint: {
+    marginTop: spacing.xs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    fontStyle: "italic",
+  },
+  subheading: {
+    marginTop: spacing.md,
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+  },
+  reasons: {
+    marginTop: spacing.xs,
+    maxHeight: 260,
+  },
+  reasonRow: {
+    flexDirection: "row",
+    marginTop: spacing.xs,
+  },
+  bullet: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    marginRight: spacing.xs,
+  },
+  reasonText: {
+    flex: 1,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+  },
+  emptyText: {
+    marginTop: spacing.xs,
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+  },
+  closeButton: {
+    marginTop: spacing.lg,
+    alignSelf: "flex-end",
+    backgroundColor: colors.brand.primary,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: radius.md,
+  },
+  closeText: {
+    color: colors.neutral.white,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.bold,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/DifficultyBadge.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/DifficultyBadge.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { DifficultyBadge } from "../DifficultyBadge";
+
+describe("DifficultyBadge", () => {
+  it("happy: renders the French uppercase label (display-only, not a button)", () => {
+    render(<DifficultyBadge level="intermediaire" />);
+
+    expect(screen.getByText("INTERMÉDIAIRE")).toBeTruthy();
+    // A display-only badge exposes no button — the card owns the tap.
+    expect(screen.queryByLabelText("Difficulté : Intermédiaire")).toBeNull();
+  });
+
+  it("happy: interactive badge opens the tap-to-explain with the stored reason", () => {
+    render(
+      <DifficultyBadge
+        level="avance"
+        computed="avance"
+        reasons={[
+          { factor: "F2", tier: 2, sentence: "grosse bière : starter requis" },
+        ]}
+        interactive
+      />,
+    );
+
+    expect(screen.queryByText("grosse bière : starter requis")).toBeNull();
+
+    fireEvent.press(screen.getByLabelText("Difficulté : Avancé"));
+    expect(screen.getByText("grosse bière : starter requis")).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText("J'ai compris"));
+    expect(screen.queryByText("grosse bière : starter requis")).toBeNull();
+  });
+
+  it("edge: an override surfaces the « calculé : … » hint and an empty reasons list", () => {
+    render(
+      <DifficultyBadge
+        level="avance"
+        computed="intermediaire"
+        reasons={[]}
+        interactive
+      />,
+    );
+
+    fireEvent.press(screen.getByLabelText("Difficulté : Avancé"));
+    expect(screen.getByText(/calculé : Intermédiaire/)).toBeTruthy();
+    expect(screen.getByText(/Aucune explication disponible/)).toBeTruthy();
+  });
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/DifficultyExplainModal.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/DifficultyExplainModal.test.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+
+import { DifficultyExplainModal } from "../DifficultyExplainModal";
+
+describe("DifficultyExplainModal", () => {
+  it("happy: shows the level title + reasons, no override hint when computed matches", () => {
+    render(
+      <DifficultyExplainModal
+        visible
+        level="facile"
+        computed="facile"
+        reasons={[
+          { factor: "facile", tier: 0, sentence: "Recette accessible" },
+        ]}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText("Difficulté : Facile")).toBeTruthy();
+    expect(screen.getByText("Recette accessible")).toBeTruthy();
+    expect(screen.queryByText(/calculé :/)).toBeNull();
+  });
+
+  it("sad: renders nothing when hidden", () => {
+    render(
+      <DifficultyExplainModal
+        visible={false}
+        level="facile"
+        reasons={[
+          { factor: "facile", tier: 0, sentence: "Recette accessible" },
+        ]}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText("Recette accessible")).toBeNull();
+  });
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/difficulty.constants.ts
+++ b/packages/mobile-app/src/features/recipes/presentation/components/difficulty.constants.ts
@@ -1,0 +1,18 @@
+import { RecipeDifficultyLevel } from "@/features/recipes/domain/recipe.types";
+
+/** French UI labels for each difficulty level (UI stays French). */
+export const DIFFICULTY_LABELS: Record<RecipeDifficultyLevel, string> = {
+  facile: "Facile",
+  intermediaire: "Intermédiaire",
+  avance: "Avancé",
+};
+
+/** Maps a difficulty level onto a `Badge` variant (green / amber / red). */
+export const DIFFICULTY_VARIANTS: Record<
+  RecipeDifficultyLevel,
+  "success" | "warning" | "error"
+> = {
+  facile: "success",
+  intermediaire: "warning",
+  avance: "error",
+};

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/OverviewTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/OverviewTab.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, Text, View } from "react-native";
 import { BeerHero } from "@/features/scan/presentation/components/BeerHero";
 import { Card } from "@/core/ui/Card";
 import { colors, radius, spacing, typography } from "@/core/theme";
+import { DifficultyBadge } from "@/features/recipes/presentation/components/DifficultyBadge";
 import { RecipeProvenanceBadge } from "@/features/recipes/presentation/components/RecipeProvenanceBadge";
 import type {
   Recipe,
@@ -55,6 +56,16 @@ export function OverviewTab({
         style={styleLabel}
         colorEbc={colorEbc}
       />
+
+      {recipe.difficultyEffective ? (
+        <DifficultyBadge
+          level={recipe.difficultyEffective}
+          computed={recipe.difficultyComputed}
+          reasons={recipe.difficultyReasons}
+          interactive
+          style={styles.difficultyBadge}
+        />
+      ) : null}
 
       {stats ? (
         <Card style={styles.statsCard}>
@@ -159,6 +170,9 @@ const styles = StyleSheet.create({
   container: {
     paddingHorizontal: spacing.md,
     paddingTop: spacing.md,
+  },
+  difficultyBadge: {
+    marginTop: spacing.md,
   },
   statsCard: {
     padding: spacing.md,

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/OverviewTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/OverviewTab.tsx
@@ -57,7 +57,11 @@ export function OverviewTab({
         colorEbc={colorEbc}
       />
 
-      {recipe.difficultyEffective ? (
+      {/* Gate on `reasons`, not just `difficultyEffective`: the backend defaults
+          pre-feature rows to `facile` with empty reasons (migration, no backfill),
+          so a genuinely-computed recipe always carries ≥1 reason while an
+          un-recomputed placeholder carries none — no misleading badge for it. */}
+      {recipe.difficultyEffective && recipe.difficultyReasons?.length ? (
         <DifficultyBadge
           level={recipe.difficultyEffective}
           computed={recipe.difficultyComputed}

--- a/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/__tests__/BeerInfoCardScreen.test.tsx
@@ -556,10 +556,16 @@ describe("BeerInfoCardScreen", () => {
       await confirmImportInDialog(); // fires the (pending) import
 
       await waitFor(() => expect(mockedImport).toHaveBeenCalledTimes(1));
-      // Flush the pending-state re-render so the handlers observe isPending=true.
-      await act(async () => {
-        await Promise.resolve();
-      });
+      // Wait for the pending-state re-render to LAND before retrying — a single
+      // micro-task flush was racy under CI (the handler could still observe the
+      // stale isPending=false and fire a 2nd import). The row surfaces its busy
+      // state via accessibilityState.disabled, so poll on that: deterministic.
+      await waitFor(() =>
+        expect(
+          screen.getByLabelText(/Importer Session IPA Citra/).props
+            .accessibilityState?.disabled,
+        ).toBe(true),
+      );
 
       // Second attempt while the first is still pending. Whether the top-of-
       // handler guard blocks the dialog or the post-confirm `!isPending` re-check

--- a/packages/mobile-app/src/mocks/__tests__/demo-data.difficulty.test.ts
+++ b/packages/mobile-app/src/mocks/__tests__/demo-data.difficulty.test.ts
@@ -16,6 +16,16 @@ describe("demoRecipes — difficulty (ADR-0024)", () => {
     expect(overridden?.difficultyEffective).toBe("avance");
   });
 
+  it("edge: a recipe outside the curated set carries no difficulty (badge degrades away)", () => {
+    // r-demo-4 is intentionally absent from DEMO_DIFFICULTY — it stands in for a
+    // recipe created before the feature, so the badge must not render for it.
+    const bare = demoRecipes.find((r) => r.id === "r-demo-4");
+
+    expect(bare).toBeDefined();
+    expect(bare?.difficultyEffective).toBeUndefined();
+    expect(bare?.difficultyReasons).toBeUndefined();
+  });
+
   it("covers all three levels across the demo set (badge is demoable)", () => {
     const levels = new Set(
       demoRecipes

--- a/packages/mobile-app/src/mocks/__tests__/demo-data.difficulty.test.ts
+++ b/packages/mobile-app/src/mocks/__tests__/demo-data.difficulty.test.ts
@@ -1,0 +1,28 @@
+import { demoRecipes } from "@/mocks/demo-data";
+
+describe("demoRecipes — difficulty (ADR-0024)", () => {
+  it("attaches a pre-computed difficulty to the community recipe", () => {
+    const community = demoRecipes.find((r) => r.id === "r-demo-community-1");
+
+    expect(community?.difficultyEffective).toBe("facile");
+    expect(community?.difficultyReasons?.length).toBeGreaterThan(0);
+  });
+
+  it("models an author override (effective = override, computed kept for the hint)", () => {
+    const overridden = demoRecipes.find((r) => r.id === "r-demo-8");
+
+    expect(overridden?.difficultyComputed).toBe("intermediaire");
+    expect(overridden?.difficultyOverride).toBe("avance");
+    expect(overridden?.difficultyEffective).toBe("avance");
+  });
+
+  it("covers all three levels across the demo set (badge is demoable)", () => {
+    const levels = new Set(
+      demoRecipes
+        .map((r) => r.difficultyEffective)
+        .filter((level): level is NonNullable<typeof level> => level != null),
+    );
+
+    expect(levels).toEqual(new Set(["facile", "intermediaire", "avance"]));
+  });
+});

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -3,7 +3,12 @@ import {
   BatchStep,
   BatchSummary,
 } from "@/features/batches/domain/batch.types";
-import { Recipe, RecipeStep } from "@/features/recipes/domain/recipe.types";
+import {
+  Recipe,
+  RecipeDifficultyLevel,
+  RecipeDifficultyReason,
+  RecipeStep,
+} from "@/features/recipes/domain/recipe.types";
 
 import { User } from "@/features/auth/domain/auth.types";
 import { HopProduct } from "@/features/ingredients/domain/hop.types";
@@ -1271,7 +1276,7 @@ export const demoRecipeSteps: RecipeStep[] = [
   },
 ];
 
-export const demoRecipes: Recipe[] = [
+const demoRecipesSeed: Recipe[] = [
   {
     id: "r-demo-1",
     ownerId: demoUsers[0].id,
@@ -2357,6 +2362,91 @@ export const demoRecipes: Recipe[] = [
     updatedAt: "2026-05-01T10:00:00.000Z",
   },
 ];
+
+// Pre-computed difficulty for a representative subset of the demo recipes, as
+// the backend would store it (the mobile never computes difficulty — ADR-0024).
+// Covers the three levels + one author override, so the badge + tap-to-explain
+// are demonstrable in demo mode. Recipes not listed here intentionally carry no
+// badge (they stand in for recipes created before the feature).
+const FACILE_REASONS: RecipeDifficultyReason[] = [
+  {
+    factor: "facile",
+    tier: 0,
+    sentence:
+      "Recette accessible : fermentation haute, densité modérée, pas de technique avancée — idéale pour un premier brassin.",
+  },
+];
+const GRAVITY_MODERATE_REASONS: RecipeDifficultyReason[] = [
+  {
+    factor: "F2",
+    tier: 1,
+    sentence:
+      "bière assez forte : il y a beaucoup de sucres à transformer, la fermentation demande plus d'attention",
+  },
+];
+const LAGER_REASONS: RecipeDifficultyReason[] = [
+  {
+    factor: "F1",
+    tier: 1,
+    sentence:
+      "elle fermente au froid (≈10 °C) puis se garde plusieurs semaines : il te faut de quoi refroidir et de la patience",
+  },
+];
+const PALE_LAGER_REASONS: RecipeDifficultyReason[] = [
+  {
+    factor: "F3",
+    tier: 2,
+    sentence:
+      "une lager blonde et nette : ni houblon fort ni malt torréfié pour cacher un défaut — la moindre erreur se voit tout de suite",
+  },
+  ...LAGER_REASONS,
+];
+const BIG_BEER_REASONS: RecipeDifficultyReason[] = [
+  {
+    factor: "F2",
+    tier: 2,
+    sentence:
+      "grosse bière : il faut BEAUCOUP de levure au départ (un « pied de levure »), sinon la fermentation risque de s'arrêter avant la fin",
+  },
+];
+
+const DEMO_DIFFICULTY: Record<
+  string,
+  {
+    computed: RecipeDifficultyLevel;
+    override?: RecipeDifficultyLevel;
+    reasons: RecipeDifficultyReason[];
+  }
+> = {
+  "r-demo-community-1": { computed: "facile", reasons: FACILE_REASONS },
+  "r-demo-1": { computed: "intermediaire", reasons: GRAVITY_MODERATE_REASONS },
+  "r-demo-2": { computed: "avance", reasons: BIG_BEER_REASONS },
+  "r-demo-3": { computed: "facile", reasons: FACILE_REASONS },
+  "r-demo-5": { computed: "intermediaire", reasons: LAGER_REASONS },
+  // Author override: computed Intermédiaire, the author bumped it to Avancé —
+  // the modal shows « calculé : Intermédiaire ».
+  "r-demo-8": {
+    computed: "intermediaire",
+    override: "avance",
+    reasons: GRAVITY_MODERATE_REASONS,
+  },
+  "r-demo-11": { computed: "facile", reasons: FACILE_REASONS },
+  "r-demo-brewdog-diy-dog": { computed: "avance", reasons: PALE_LAGER_REASONS },
+};
+
+export const demoRecipes: Recipe[] = demoRecipesSeed.map((recipe) => {
+  const difficulty = DEMO_DIFFICULTY[recipe.id];
+  if (!difficulty) {
+    return recipe;
+  }
+  return {
+    ...recipe,
+    difficultyComputed: difficulty.computed,
+    difficultyOverride: difficulty.override ?? null,
+    difficultyEffective: difficulty.override ?? difficulty.computed,
+    difficultyReasons: difficulty.reasons,
+  };
+});
 
 /**
  * Steps for the "La Première du dimanche" fil-rouge batches.


### PR DESCRIPTION
## Summary

The **mobile** half of the brewing-difficulty badge (ADR-0024, screen-review Tranche B) — the user-visible completion of the feature whose backend shipped in #1342. The mobile is a **pure consumer**: it renders the backend-computed `difficultyEffective` (= override ?? computed) + the stored `difficultyReasons`, and never scores anything.

- **Badge** (green/amber/red, brand palette): extends the generic `core/ui/Badge` with `warning`/`error` variants; a new `DifficultyBadge` maps level → variant + French label. Display-only on list cards (the card owns the tap — no nested touchables), interactive on the recipe « Vue » where tapping opens a read-only `DifficultyExplainModal` (stored reasons + a « calculé : … » hint when the author overrode the level).
- **Placement**: OverviewTab (below the hero) + RecipeCard (below the stats row).
- **Data**: `Recipe` type + `mapRecipe` gain the 4 difficulty fields (snake_case DTO → camelCase domain), all optional — pre-feature/public recipes render no badge.
- **Demo**: a pre-computed difficulty attached to a representative subset (3 levels + one author override) so the badge is demoable.

## Context

- Completes Tranche B → **ADR-0024 promoted Proposed → Accepted** + added to the CLAUDE.md ADR index (per the plan recorded when the conception PR #1334 merged).
- Reviewed adversarially (multi-lens workflow + `pr-pre-reviewer`). **MUST fixed**: the amber `warning` badge text was illegible on the amber background (1.8:1, fails WCAG AA) → label darkened to `brand.secondary` (~5.3:1), border stays amber; verified legible live on the emulator. **Palette reconciled**: the badge is the brand's warm traffic-light (olive-green / amber / terracotta), not literal RGB — ADR-0024 D4 + the spec updated to match the code (conception = contract). Tests added (RecipeCard integration + demo edge).
- **Verified live on an Android emulator** (demo mode): badge on « Vue » + tap-to-explain, list cards across all 3 levels, the override recipe reads « Avancé », and a recipe outside the curated demo set degrades to no badge.

## Checklist

- [x] `tsc --noEmit` + ESLint + Prettier clean
- [x] Full mobile suite green (1217 tests, +21 for this feature)
- [x] Theme tokens only, StyleSheet.create only, named exports, no `any`
- [x] Mobile is a pure consumer (no client-side scoring)
- [x] Live-verified on the emulator
- [x] Branch up to date with `main`