### PR TITLE
feat(mobile/recipes): default the Brassage tab to the recipe's own steps (ADR-0024 D5)

### DIFF
--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -137,8 +137,12 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
   const [targetVolumeLiters, setTargetVolumeLiters] = useState(
     DEFAULT_TARGET_VOLUME_LITRES,
   );
+  // Default to THIS recipe's own steps rather than the generic brewing-phase
+  // glossary (ADR-0024 D5): a novice should land on what to do for the recipe in
+  // front of them. The glossary stays reachable as a non-default mode until it
+  // moves to the Academy (pending the Academy epic #1333).
   const [processDisplayMode, setProcessDisplayMode] =
-    useState<RecipeProcessDisplayMode>("phases");
+    useState<RecipeProcessDisplayMode>("recipe");
 
   const [selectedLocalWaterProfileName, setSelectedLocalWaterProfileName] =
     useState(DEFAULT_LOCAL_WATER_PROFILE_NAME);

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -587,25 +587,31 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
     expect(screen.getByText("Phases de brassage")).toBeTruthy();
     expect(screen.getByText("Étapes de la recette")).toBeTruthy();
     expect(screen.getByText("Condensé")).toBeTruthy();
-    // The default "phases" view shows French brewing-phase titles.
-    expect(screen.getByText("🪣 EMPÂTAGE")).toBeTruthy();
-
-    // The active mode chip exposes its selected state to screen readers
-    // (#1172, Copilot review).
-    expect(
-      screen.getByTestId("recipe-process-filter-phases").props
-        .accessibilityState.selected,
-    ).toBe(true);
-    expect(
-      screen.getByTestId("recipe-process-filter-recipe").props
-        .accessibilityState.selected,
-    ).toBe(false);
-
-    fireEvent.press(screen.getByTestId("recipe-process-filter-recipe"));
+    // The default view is now « Étapes de la recette » (ADR-0024 D5): the
+    // recipe's OWN steps, not the generic brewing-phase glossary.
     expect(screen.getByText("1. Mash")).toBeTruthy();
     expect(screen.getByText("Hold at 67°C")).toBeTruthy();
     // The step-type chip renders the French label, not the raw enum.
     expect(screen.getByText("Empâtage")).toBeTruthy();
+
+    // The active mode chip exposes its selected state to screen readers
+    // (#1172, Copilot review): the recipe view leads by default now.
+    expect(
+      screen.getByTestId("recipe-process-filter-recipe").props
+        .accessibilityState.selected,
+    ).toBe(true);
+    expect(
+      screen.getByTestId("recipe-process-filter-phases").props
+        .accessibilityState.selected,
+    ).toBe(false);
+
+    // The generic brewing-phase glossary stays reachable as a non-default mode.
+    fireEvent.press(screen.getByTestId("recipe-process-filter-phases"));
+    expect(screen.getByText("🪣 EMPÂTAGE")).toBeTruthy();
+    expect(
+      screen.getByTestId("recipe-process-filter-phases").props
+        .accessibilityState.selected,
+    ).toBe(true);
 
     fireEvent.press(screen.getByTestId("recipe-process-filter-compact"));
     expect(screen.getByText("Étapes recette : 1")).toBeTruthy();
@@ -627,7 +633,8 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
 
     await screen.findByTestId("recipe-overview-tab");
     switchToTab("brewing");
-    fireEvent.press(screen.getByTestId("recipe-process-filter-recipe"));
+    // « Étapes de la recette » is the default mode now (ADR-0024 D5), so the
+    // empty-state hint shows without switching modes.
 
     expect(
       screen.getByText("Pas d'étapes renseignées pour cette recette."),
@@ -651,7 +658,7 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
 
     await screen.findByTestId("recipe-overview-tab");
     switchToTab("brewing");
-    fireEvent.press(screen.getByTestId("recipe-process-filter-recipe"));
+    // Recipe steps are the default view now (ADR-0024 D5) — no mode switch.
 
     expect(screen.getByText("1. Empâtage maison")).toBeTruthy();
     expect(screen.getByText("Empâtage")).toBeTruthy();

--- a/packages/mobile-app/src/features/recipes/presentation/recipe-details.constants.ts
+++ b/packages/mobile-app/src/features/recipes/presentation/recipe-details.constants.ts
@@ -22,12 +22,15 @@ export const RECIPE_VOLUME_INPUT_MODES: {
 
 export type RecipeProcessDisplayMode = "phases" | "recipe" | "compact";
 
+// Order matters: the leading chip is the default view (ADR-0024 D5) — the
+// recipe's own steps come first, the generic brewing-phase glossary second
+// (it moves to the Academy later, epic #1333), the compact summary last.
 export const RECIPE_PROCESS_DISPLAY_OPTIONS: {
   id: RecipeProcessDisplayMode;
   label: string;
 }[] = [
-  { id: "phases", label: "Phases de brassage" },
   { id: "recipe", label: "Étapes de la recette" },
+  { id: "phases", label: "Phases de brassage" },
   { id: "compact", label: "Condensé" },
 ];
 


### PR DESCRIPTION
## Summary

ADR-0024 D5 (part a): the recipe detail's **Brassage** tab now defaults to « Étapes de la recette » — the recipe's own steps — instead of the generic « Phases de brassage » glossary. A novice should land on what to do for the recipe in front of them.

- Default process-display mode → `recipe` (was `phases`).
- Toggle chips reordered so the default leads: Étapes de la recette · Phases de brassage · Condensé.
- The glossary stays reachable as a non-default mode; **relocating it to the Academy (D5 part b) is deferred to the Academy epic #1333.**

## Context

- Completes the shippable half of ADR-0024 D5 (the Brassage-tab decision adjacent to the difficulty badge). Verified live on an Android emulator (Brassage now opens on the recipe's steps).
- Reviewed with the local `pr-pre-reviewer` (0 Must / 0 Should; one Nice — a redundant press on the now-default chip — applied). Empty-steps recipes still show the pre-existing empty-state hint.

## Checklist

- [x] `tsc --noEmit` + ESLint + Prettier clean
- [x] Full mobile suite green (1218)
- [x] Theme tokens only, named exports, no `any`
- [x] Live-verified on the emulator
- [x] ADR-0024 D5 part a; part b (glossary → Academy) deferred to #1333