### PR TITLE
fix(mobile/ui): demo/live nav parity — drop the demo-only « Communauté » tab

### DIFF
--- a/packages/mobile-app/src/core/ui/NavigationFooter.tsx
+++ b/packages/mobile-app/src/core/ui/NavigationFooter.tsx
@@ -9,7 +9,6 @@ import Animated, {
 import { colors, spacing } from "@/core/theme";
 
 import { Ionicons } from "@expo/vector-icons";
-import { dataSource } from "@/core/data/data-source";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 export function useNavigationFooterOffset() {
@@ -73,31 +72,6 @@ const BASE_NAV_ITEMS: NavItem[] = [
   },
 ];
 
-// Demo-mode-only "Communauté" slot, inserted between Académie and Profil.
-// Surfaces the SocialFeedScreen mockup behind the same dock as the rest
-// of the app so the soutenance live demo can navigate to it without
-// typing a URL. Hidden in live mode so production users never see the
-// community placeholder (the real social feature is deferred to v0.2).
-const COMMUNITY_NAV_ITEM: NavItem = {
-  label: "Communauté",
-  icon: "people-outline",
-  href: "/social",
-  routePrefix: "/social",
-};
-
-function buildNavItems(useDemoData: boolean): NavItem[] {
-  if (!useDemoData) {
-    return BASE_NAV_ITEMS;
-  }
-  // Insert Communauté just before the last slot (Profil) so the
-  // persona-anchor stays at the far right of the dock.
-  const profileSlot = BASE_NAV_ITEMS.at(-1);
-  if (!profileSlot) {
-    return BASE_NAV_ITEMS;
-  }
-  return [...BASE_NAV_ITEMS.slice(0, -1), COMMUNITY_NAV_ITEM, profileSlot];
-}
-
 function isFooterItemActive(pathname: string, routePrefix: string): boolean {
   return pathname === routePrefix || pathname.startsWith(`${routePrefix}/`);
 }
@@ -129,10 +103,8 @@ export function NavigationFooter() {
   const pathname = usePathname();
   const insets = useSafeAreaInsets();
 
-  // Read the demo flag on each render. It only flips at login (demo
-  // trigger credentials) and logout, both of which remount the app
-  // shell — so a non-reactive read is sufficient here.
-  const navItems = buildNavItems(dataSource.useDemoData);
+  // Same dock in demo and live — the nav must not diverge between modes.
+  const navItems = BASE_NAV_ITEMS;
 
   const activeIndex = findActiveNavIndex(pathname, navItems);
   const hasActiveItem = activeIndex >= 0;

--- a/packages/mobile-app/src/core/ui/__tests__/NavigationFooter.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/NavigationFooter.test.tsx
@@ -113,6 +113,25 @@ describe("NavigationFooter", () => {
     expect(screen.queryByLabelText("Outils")).toBeNull();
   });
 
+  // Demo/live parity: the dock is identical in both modes. The old
+  // demo-only "Communauté" placeholder (a soutenance-era teaser) is gone —
+  // the real social feature is deferred to v0.2 for both modes.
+  it("shows the same six items with no demo-only Communauté tab", () => {
+    render(<NavigationFooter />);
+
+    expect(screen.queryByLabelText("Communauté")).toBeNull();
+    for (const label of [
+      "Accueil",
+      "Brassins",
+      "Recettes",
+      "Scan",
+      "Académie",
+      "Profil",
+    ]) {
+      expect(screen.getByLabelText(label)).toBeTruthy();
+    }
+  });
+
   // Issue #613 — Scan is a new permanent tab pointing at the
   // existing /dashboard/scan route. Tapping it must replace into
   // that path.


### PR DESCRIPTION
## Summary

The bottom navigation diverged between demo and live: in demo mode the footer inserted a « Communauté » tab (a soutenance-era teaser for the social feature deferred to v0.2), absent in live/prod. Spotted by the founder testing the demo APK — the demo should represent the real app, not carry extra placeholder tabs.

The nav is now **identical in demo and live** — the same six items (Accueil · Brassins · Recettes · Scan · Académie · Profil). Removed the demo-only branch + `COMMUNITY_NAV_ITEM`; the footer no longer reads the demo flag. Regression guard added. When the social feature actually ships (v0.2) it will be added to **both** modes.

## Context

- The « Communauté » tab was gated to demo for a school defense ("soutenance") demo; the project is now personal, so the rationale is obsolete.
- The `/social` route (`app/(app)/social.tsx`) is now unreferenced (was reachable only via this tab) — flagged as dead code to clean up separately.
- Verified live on an Android emulator: the demo footer now shows the six live items, no Communauté.

## Checklist

- [x] `tsc --noEmit` + ESLint + Prettier clean
- [x] Full mobile suite green (1219)
- [x] Regression guard (footer shows the six items, no Communauté)
- [x] Live-verified on the emulator