### PR TITLE
feat(api/db): one-off difficulty backfill CLI (recompute existing recipes)

### DIFF
--- a/packages/api/src/database/recompute-difficulty-cli.spec.ts
+++ b/packages/api/src/database/recompute-difficulty-cli.spec.ts
@@ -84,4 +84,13 @@ describe('backfillRecipeDifficulty', () => {
 
     expect(result).toEqual({ total: 2, recomputed: 1 });
   });
+
+  it('sad: propagates a recompute failure so the operator gets a non-zero exit', async () => {
+    recompute.mockRejectedValueOnce(new Error('db boom'));
+    const { dataSource } = buildDataSource(true, [{ id: 'r1' }, { id: 'r2' }]);
+
+    await expect(backfillRecipeDifficulty(dataSource)).rejects.toThrow(
+      'db boom',
+    );
+  });
 });

--- a/packages/api/src/database/recompute-difficulty-cli.spec.ts
+++ b/packages/api/src/database/recompute-difficulty-cli.spec.ts
@@ -1,0 +1,87 @@
+import { DataSource } from 'typeorm';
+
+import { RecipeDifficultyService } from '../recipe/services/recipe-difficulty.service';
+import { backfillRecipeDifficulty } from './recompute-difficulty-cli';
+
+jest.mock('../recipe/services/recipe-difficulty.service');
+
+const MockedService = jest.mocked(RecipeDifficultyService);
+
+function buildDataSource(
+  isInitialized: boolean,
+  recipes: { id: string }[],
+): { dataSource: DataSource; initialize: jest.Mock } {
+  const initialize = jest.fn().mockResolvedValue(undefined);
+  const recipeRepo = { find: jest.fn().mockResolvedValue(recipes) };
+  const dataSource = {
+    isInitialized,
+    initialize,
+    getRepository: jest.fn(() => recipeRepo),
+  } as unknown as DataSource;
+  return { dataSource, initialize };
+}
+
+describe('backfillRecipeDifficulty', () => {
+  let recompute: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    recompute = jest
+      .fn()
+      .mockResolvedValue({ computed: 'facile', reasons: [] });
+    MockedService.mockImplementation(
+      () =>
+        ({
+          recomputeForRecipe: recompute,
+        }) as unknown as RecipeDifficultyService,
+    );
+  });
+
+  it('happy: recomputes every recipe and returns the summary', async () => {
+    const { dataSource } = buildDataSource(true, [
+      { id: 'r1' },
+      { id: 'r2' },
+      { id: 'r3' },
+    ]);
+
+    const result = await backfillRecipeDifficulty(dataSource);
+
+    expect(recompute).toHaveBeenCalledTimes(3);
+    expect(recompute).toHaveBeenCalledWith('r1');
+    expect(recompute).toHaveBeenCalledWith('r2');
+    expect(recompute).toHaveBeenCalledWith('r3');
+    expect(result).toEqual({ total: 3, recomputed: 3 });
+  });
+
+  it('edge: initialises the DataSource when it is not yet connected', async () => {
+    const { dataSource, initialize } = buildDataSource(false, [{ id: 'r1' }]);
+
+    await backfillRecipeDifficulty(dataSource);
+
+    expect(initialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('edge: does not re-initialise an already-connected DataSource (and no-ops on an empty catalogue)', async () => {
+    const { dataSource, initialize } = buildDataSource(true, []);
+
+    const result = await backfillRecipeDifficulty(dataSource);
+
+    expect(initialize).not.toHaveBeenCalled();
+    expect(recompute).not.toHaveBeenCalled();
+    expect(result).toEqual({ total: 0, recomputed: 0 });
+  });
+
+  it('sad: counts only recipes still present (a recompute returning null is skipped)', async () => {
+    recompute
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ computed: 'facile', reasons: [] });
+    const { dataSource } = buildDataSource(true, [
+      { id: 'gone' },
+      { id: 'r2' },
+    ]);
+
+    const result = await backfillRecipeDifficulty(dataSource);
+
+    expect(result).toEqual({ total: 2, recomputed: 1 });
+  });
+});

--- a/packages/api/src/database/recompute-difficulty-cli.ts
+++ b/packages/api/src/database/recompute-difficulty-cli.ts
@@ -1,0 +1,88 @@
+import 'reflect-metadata';
+
+import { DataSource } from 'typeorm';
+
+import { RecipeOrmEntity } from '../recipe/entities/recipe.orm.entity';
+import { RecipeDifficultyService } from '../recipe/services/recipe-difficulty.service';
+import { buildTypeOrmOptions } from './typeorm.config';
+
+/**
+ * One-off backfill of the recipe brewing-difficulty (ADR-0024).
+ *
+ * Migration 1808 added the difficulty columns with NO backfill, so every recipe
+ * that existed before the feature carries the `'facile'` placeholder + empty
+ * reasons — and the mobile deliberately hides the badge for those (it gates on
+ * `difficulty_reasons`). New/edited recipes recompute on save, but pre-existing
+ * ones stay placeholders forever until touched. This entrypoint recomputes them
+ * all, so the badge appears on the real catalogue right after a deploy.
+ *
+ * Compiles into `dist/database/recompute-difficulty-cli.js` (ships inside the Fly
+ * image) and runs on the app machine, which has the SQLite volume mounted:
+ *
+ *   fly ssh console --app brasse-bouillon-api \
+ *     -C "node dist/database/recompute-difficulty-cli.js"
+ *
+ * Idempotent: it recomputes from the recipe's current data, so re-running just
+ * converges on the same values. Reuses `RecipeDifficultyService` verbatim (the
+ * single source of the scoring + persistence) — no duplicated logic.
+ */
+
+/** Result of the backfill, for logging / verification. */
+export interface RecipeDifficultyBackfillSummary {
+  /** Recipes found in the catalogue. */
+  total: number;
+  /** Recipes whose difficulty was recomputed (skips any deleted mid-run). */
+  recomputed: number;
+}
+
+/**
+ * Recomputes and persists the difficulty of every recipe. The caller owns the
+ * DataSource lifecycle; this initialises it if needed (which also applies any
+ * pending migrations, `migrationsRun: true`) but never destroys it.
+ */
+export async function backfillRecipeDifficulty(
+  dataSource: DataSource,
+): Promise<RecipeDifficultyBackfillSummary> {
+  if (!dataSource.isInitialized) {
+    await dataSource.initialize();
+  }
+
+  const recipeRepo = dataSource.getRepository(RecipeOrmEntity);
+  const difficulty = new RecipeDifficultyService(recipeRepo);
+
+  const recipes = await recipeRepo.find({ select: { id: true } });
+  let recomputed = 0;
+  for (const { id } of recipes) {
+    const result = await difficulty.recomputeForRecipe(id);
+    if (result) {
+      recomputed += 1;
+    }
+  }
+
+  return { total: recipes.length, recomputed };
+}
+
+/**
+ * CLI bootstrap: build a runtime DataSource, run the backfill, and always
+ * release the connection. Exits non-zero on failure so the operator sees it.
+ */
+async function bootstrap(): Promise<void> {
+  const dataSource = new DataSource(buildTypeOrmOptions());
+  try {
+    const summary = await backfillRecipeDifficulty(dataSource);
+    console.log('Difficulty backfill complete:', JSON.stringify(summary));
+  } finally {
+    if (dataSource.isInitialized) {
+      await dataSource.destroy();
+    }
+  }
+}
+
+// Only auto-run when invoked directly (`node dist/database/recompute-difficulty-cli.js`),
+// not when imported by a test — so `backfillRecipeDifficulty` stays unit-testable.
+if (require.main === module) {
+  bootstrap().catch((err) => {
+    console.error('Difficulty backfill failed:', err);
+    process.exit(1);
+  });
+}

--- a/packages/api/src/database/recompute-difficulty-cli.ts
+++ b/packages/api/src/database/recompute-difficulty-cli.ts
@@ -37,8 +37,10 @@ export interface RecipeDifficultyBackfillSummary {
 
 /**
  * Recomputes and persists the difficulty of every recipe. The caller owns the
- * DataSource lifecycle; this initialises it if needed (which also applies any
- * pending migrations, `migrationsRun: true`) but never destroys it.
+ * DataSource lifecycle: this initialises it if needed but never destroys it.
+ * (Whether `initialize()` also applies pending migrations depends on the
+ * DataSource's own `migrationsRun` option — the CLI's, built by
+ * `buildTypeOrmOptions()`, has it on; see `bootstrap`.)
  */
 export async function backfillRecipeDifficulty(
   dataSource: DataSource,
@@ -63,8 +65,10 @@ export async function backfillRecipeDifficulty(
 }
 
 /**
- * CLI bootstrap: build a runtime DataSource, run the backfill, and always
- * release the connection. Exits non-zero on failure so the operator sees it.
+ * CLI bootstrap: build a runtime DataSource (`migrationsRun: true`, so
+ * `initialize()` applies any pending migrations first), run the backfill, and
+ * always release the connection. Exits non-zero on failure so the operator
+ * sees it.
  */
 async function bootstrap(): Promise<void> {
   const dataSource = new DataSource(buildTypeOrmOptions());


### PR DESCRIPTION
## Summary

Migration 1808 added the recipe difficulty columns with **no backfill**, so recipes that existed before the feature are `'facile'` placeholders with empty reasons — and the mobile deliberately hides the badge for those (it gates on `difficulty_reasons`). New/edited recipes recompute on save; pre-existing ones stay placeholders until touched. So right after deploying the difficulty backend to prod, the badge would appear on **no** existing recipe.

This adds a one-off backfill CLI so the badge shows on the real catalogue immediately after a deploy.

- `recompute-difficulty-cli` mirrors `seed-cli`: compiles to `dist/database/recompute-difficulty-cli.js` (ships in the Fly image), runs on the app machine (SQLite volume mounted) via `fly ssh console --app brasse-bouillon-api -C "node dist/database/recompute-difficulty-cli.js"`.
- Reuses `RecipeDifficultyService` **verbatim** (the single source of scoring + persistence) — no duplicated logic. Idempotent (recomputes from current data).
- Unit-tested (happy / sad / edge), mirroring `seed-cli.spec`.

## Context

Needed for the « prod-representative » live APK: deploy the API (applies migration 1808) → run this backfill → the difficulty badge renders on the seeded/existing recipes, not just newly-edited ones.

## Checklist

- [x] `nest build` green; compiles to `dist/`
- [x] ESLint + Prettier clean
- [x] Unit tests (4) green
- [x] No duplicated scoring logic (reuses the service)