### PR TITLE
fix(api/water): restore the Hub'Eau water-quality check (v1 API contract drift)

### DIFF
--- a/packages/api/src/common/normalize-french-label.ts
+++ b/packages/api/src/common/normalize-french-label.ts
@@ -1,0 +1,11 @@
+/**
+ * Lower-cases and strips French diacritics (é→e, à→a, …) so text can be matched
+ * accent-insensitively. Shared by the water provider (network-name matching) and
+ * the water aggregation service (parameter-label → ion matching).
+ */
+export const normalizeFrenchLabel = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .trim()
+    .toLowerCase();

--- a/packages/api/src/water/domain/services/water-aggregation-domain.service.spec.ts
+++ b/packages/api/src/water/domain/services/water-aggregation-domain.service.spec.ts
@@ -34,7 +34,7 @@ describe('WaterAggregationDomainService', () => {
           conformity: 'C',
         },
         {
-          parameterLabel: 'Total bicarbonates',
+          parameterLabel: 'Hydrogénocarbonates',
           numericResult: 141.1,
           conformity: 'C',
         },
@@ -155,12 +155,12 @@ describe('WaterAggregationDomainService', () => {
           conformity: 'C',
         },
         {
-          parameterLabel: 'Chlorides',
+          parameterLabel: 'Chlorures',
           numericResult: 17,
           conformity: 'C',
         },
         {
-          parameterLabel: 'Total bicarbonates',
+          parameterLabel: 'Hydrogénocarbonates',
           numericResult: 122,
           conformity: 'C',
         },
@@ -170,5 +170,40 @@ describe('WaterAggregationDomainService', () => {
     expect(profile.mineralsMgL.mg).toBe(9);
     expect(profile.mineralsMgL.cl).toBe(17);
     expect(profile.mineralsMgL.hco3).toBe(122);
+  });
+
+  it('does not sweep chlorinated compounds into chloride, nor carbonates into bicarbonate', () => {
+    // Hub'Eau reports dozens of chlorine-bearing compounds (« Chlore libre »,
+    // « Chlorure de vinyl monomère », chlorinated pesticides…) and « Carbonates »
+    // (CO3). None of them is the chloride ion (Cl) or bicarbonate (HCO3), so they
+    // must NOT corrupt the aggregated values — only « Chlorures » and
+    // « Hydrogénocarbonates » count.
+    const profile = service.aggregate({
+      provider: WaterProviderKey.HUBEAU,
+      codeInsee: '59350',
+      year: 2024,
+      networkName: 'LILLE',
+      maxSamples: 50,
+      samples: [
+        { parameterLabel: 'Chlore libre', numericResult: 0.3, conformity: 'C' },
+        {
+          parameterLabel: 'Chlorure de vinyl monomère',
+          numericResult: 0.4,
+          conformity: 'C',
+        },
+        { parameterLabel: 'Chloroforme', numericResult: 5, conformity: 'C' },
+        { parameterLabel: 'Carbonates', numericResult: 10, conformity: 'C' },
+        { parameterLabel: 'Chlorures', numericResult: 51, conformity: 'C' },
+        {
+          parameterLabel: 'Hydrogénocarbonates',
+          numericResult: 340,
+          conformity: 'C',
+        },
+      ],
+    });
+
+    // Only the real ions are aggregated — the compounds are ignored.
+    expect(profile.mineralsMgL.cl).toBe(51);
+    expect(profile.mineralsMgL.hco3).toBe(340);
   });
 });

--- a/packages/api/src/water/domain/services/water-aggregation-domain.service.ts
+++ b/packages/api/src/water/domain/services/water-aggregation-domain.service.ts
@@ -18,13 +18,18 @@ const resolveMineralKey = (normalizedLabel: string): MineralKey | null => {
     return 'so4';
   }
 
-  // Matches both "chlorides" and localized variants sharing the same stem.
-  if (normalizedLabel.includes('chlor')) {
+  // The chloride ion is « Chlorures » (plural). Match on the plural stem so we
+  // don't sweep in « Chlore libre », « Chlorure de vinyl » and the dozens of
+  // chlorinated compounds/pesticides Hub'Eau reports (which would corrupt the
+  // average).
+  if (normalizedLabel.includes('chlorures')) {
     return 'cl';
   }
 
-  // Matches both "total bicarbonates" and localized variants.
-  if (normalizedLabel.includes('bicarbonate')) {
+  // Hub'Eau labels bicarbonate (HCO3) as « Hydrogénocarbonates » — never
+  // "bicarbonate". (« Carbonates » is CO3, a different species, and must NOT
+  // match.)
+  if (normalizedLabel.includes('hydrogenocarbonate')) {
     return 'hco3';
   }
 

--- a/packages/api/src/water/domain/services/water-aggregation-domain.service.ts
+++ b/packages/api/src/water/domain/services/water-aggregation-domain.service.ts
@@ -2,6 +2,7 @@ import { WaterConformity } from '../enums/water-conformity.enum';
 import { WaterProfileEntity } from '../entities/water-profile.entity';
 import { WaterProviderKey } from '../enums/water-provider-key.enum';
 import { WaterSample } from '../ports/water-quality-provider.port';
+import { normalizeFrenchLabel } from '../../../common/normalize-french-label';
 
 type MineralKey = 'ca' | 'mg' | 'cl' | 'so4' | 'hco3';
 
@@ -35,13 +36,6 @@ const resolveMineralKey = (normalizedLabel: string): MineralKey | null => {
 
   return null;
 };
-
-const normalizeParameterLabel = (value: string): string =>
-  value
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .trim()
-    .toLowerCase();
 
 interface AggregateBucket {
   sum: number;
@@ -104,7 +98,7 @@ export class WaterAggregationDomainService {
     const aggregate = createEmptyAggregate();
     for (const sample of samples) {
       const key = resolveMineralKey(
-        normalizeParameterLabel(sample.parameterLabel),
+        normalizeFrenchLabel(sample.parameterLabel),
       );
       if (!key) {
         continue;

--- a/packages/api/src/water/providers/hubeau-water-quality.provider.spec.ts
+++ b/packages/api/src/water/providers/hubeau-water-quality.provider.spec.ts
@@ -110,6 +110,114 @@ describe('HubeauWaterQualityProvider', () => {
     expect(result).toEqual({ code: 'R-1', name: 'Syndicat A' });
   });
 
+  it('prefers the network with the highest « NN% » population coverage', async () => {
+    fetchMock.mockResolvedValue(
+      buildResponse(200, () =>
+        Promise.resolve({
+          data: [
+            // Same latest year: the commune-named one would win by rule 2, but a
+            // higher coverage figure on another network takes precedence (rule 1).
+            {
+              code_reseau: 'R-1',
+              nom_reseau: 'TOULOUSE',
+              nom_commune: 'TOULOUSE',
+              nom_quartier: '30 % de la population',
+              annee: '2024',
+            },
+            {
+              code_reseau: 'R-2',
+              nom_reseau: 'Réseau sud',
+              nom_commune: 'TOULOUSE',
+              nom_quartier: '70 % de la population',
+              annee: '2024',
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await provider.findDominantNetworkByInsee('31555');
+
+    expect(result).toEqual({ code: 'R-2', name: 'Réseau sud' });
+  });
+
+  it('falls back to the whole set when every record has a null year', async () => {
+    fetchMock.mockResolvedValue(
+      buildResponse(200, () =>
+        Promise.resolve({
+          data: [
+            {
+              code_reseau: 'R-1',
+              nom_reseau: 'Réseau interco',
+              nom_commune: 'RENNES',
+              annee: null,
+            },
+            {
+              code_reseau: 'R-2',
+              nom_reseau: 'RENNES',
+              nom_commune: 'RENNES',
+              annee: null,
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await provider.findDominantNetworkByInsee('35238');
+
+    // No year to filter on → all records are candidates; the commune-named one wins.
+    expect(result).toEqual({ code: 'R-2', name: 'RENNES' });
+  });
+
+  it('returns the only network when a single record is served', async () => {
+    fetchMock.mockResolvedValue(
+      buildResponse(200, () =>
+        Promise.resolve({
+          data: [
+            {
+              code_reseau: 'R-1',
+              nom_reseau: 'Syndicat unique',
+              nom_commune: 'BREST',
+              annee: '2024',
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await provider.findDominantNetworkByInsee('29019');
+
+    expect(result).toEqual({ code: 'R-1', name: 'Syndicat unique' });
+  });
+
+  it('does not throw when nom_reseau is null on some candidates', async () => {
+    fetchMock.mockResolvedValue(
+      buildResponse(200, () =>
+        Promise.resolve({
+          data: [
+            {
+              code_reseau: 'R-1',
+              nom_reseau: null,
+              nom_commune: 'ANGERS',
+              annee: '2024',
+            },
+            {
+              code_reseau: 'R-2',
+              nom_reseau: 'ANGERS',
+              nom_commune: 'ANGERS',
+              annee: '2024',
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await provider.findDominantNetworkByInsee('49007');
+
+    // The null-named record must not crash the name comparison; the commune-named one wins.
+    expect(result).toEqual({ code: 'R-2', name: 'ANGERS' });
+  });
+
   it('should return null when no network is found', async () => {
     fetchMock.mockResolvedValue(
       buildResponse(200, () => Promise.resolve({ data: [] })),

--- a/packages/api/src/water/providers/hubeau-water-quality.provider.spec.ts
+++ b/packages/api/src/water/providers/hubeau-water-quality.provider.spec.ts
@@ -38,20 +38,29 @@ describe('HubeauWaterQualityProvider', () => {
     fetchMock.mockRestore();
   });
 
-  it('should return dominant network by highest sample count', async () => {
+  it('selects the dominant network: latest year, preferring the one named after the commune', async () => {
     fetchMock.mockResolvedValue(
       buildResponse(200, () =>
         Promise.resolve({
           data: [
+            // An older year — ignored once a later year exists for the commune.
             {
-              code_udi: 'UDI-1',
-              nom_udi: 'Network A',
-              nb_prelevements: '2',
+              code_reseau: 'R-OLD',
+              nom_reseau: 'NANTES',
+              nom_commune: 'NANTES',
+              annee: '2019',
             },
             {
-              code_udi: 'UDI-2',
-              nom_udi: 'Network B',
-              nb_prelevements: 7,
+              code_reseau: 'R-1',
+              nom_reseau: 'Réseau interco',
+              nom_commune: 'NANTES',
+              annee: '2024',
+            },
+            {
+              code_reseau: 'R-2',
+              nom_reseau: 'NANTES',
+              nom_commune: 'NANTES',
+              annee: '2024',
             },
           ],
         }),
@@ -61,9 +70,7 @@ describe('HubeauWaterQualityProvider', () => {
     const result = await provider.findDominantNetworkByInsee('44109');
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const firstCall = fetchMock.mock.calls[0];
-    const requestUrl = firstCall?.[0];
-
+    const requestUrl = fetchMock.mock.calls[0]?.[0];
     expect(typeof requestUrl).toBe('string');
     if (typeof requestUrl !== 'string') {
       throw new Error('Expected fetch URL to be a string');
@@ -72,7 +79,35 @@ describe('HubeauWaterQualityProvider', () => {
     expect(requestUrl).toContain('/communes_udi?');
     expect(requestUrl).toContain('code_commune=44109');
     expect(requestUrl).toContain('size=10');
-    expect(result).toEqual({ code: 'UDI-2', name: 'Network B' });
+    // Latest year (2024) + the réseau named after the commune → R-2.
+    expect(result).toEqual({ code: 'R-2', name: 'NANTES' });
+  });
+
+  it('falls back to the first record of the latest year when none matches the commune name', async () => {
+    fetchMock.mockResolvedValue(
+      buildResponse(200, () =>
+        Promise.resolve({
+          data: [
+            {
+              code_reseau: 'R-1',
+              nom_reseau: 'Syndicat A',
+              nom_commune: 'PETIT-BOURG',
+              annee: '2023',
+            },
+            {
+              code_reseau: 'R-2',
+              nom_reseau: 'Syndicat B',
+              nom_commune: 'PETIT-BOURG',
+              annee: '2023',
+            },
+          ],
+        }),
+      ),
+    );
+
+    const result = await provider.findDominantNetworkByInsee('97101');
+
+    expect(result).toEqual({ code: 'R-1', name: 'Syndicat A' });
   });
 
   it('should return null when no network is found', async () => {
@@ -85,30 +120,30 @@ describe('HubeauWaterQualityProvider', () => {
     ).resolves.toBeNull();
   });
 
-  it('should map and sanitize provider samples', async () => {
+  it('fetches only the ion parameters and maps + sanitizes the samples', async () => {
     fetchMock.mockResolvedValue(
       buildResponse(200, () =>
         Promise.resolve({
           data: [
             {
-              nom_parametre: 'Calcium',
+              libelle_parametre: 'Calcium',
               resultat_numerique: '42,5',
-              conclusion_conformite_prelevement_pc: 'C',
+              conformite_limites_pc_prelevement: 'C',
             },
             {
-              nom_parametre: 'Magnesium',
+              libelle_parametre: 'Magnésium',
               resultat_numerique: 9,
-              conclusion_conformite_prelevement_pc: null,
+              conformite_limites_pc_prelevement: null,
             },
             {
-              nom_parametre: '',
+              libelle_parametre: '',
               resultat_numerique: 10,
-              conclusion_conformite_prelevement_pc: 'C',
+              conformite_limites_pc_prelevement: 'C',
             },
             {
-              nom_parametre: 'Chlorides',
+              libelle_parametre: 'Chlorures',
               resultat_numerique: 'not-a-number',
-              conclusion_conformite_prelevement_pc: 'D',
+              conformite_limites_pc_prelevement: 'N',
             },
           ],
         }),
@@ -116,42 +151,33 @@ describe('HubeauWaterQualityProvider', () => {
     );
 
     const samples = await provider.getNetworkSamples({
-      networkCode: 'UDI-2',
+      networkCode: 'R-2',
       year: 2024,
       size: 3,
     });
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const firstCall = fetchMock.mock.calls[0];
-    const requestUrl = firstCall?.[0];
-
+    const requestUrl = fetchMock.mock.calls[0]?.[0];
     expect(typeof requestUrl).toBe('string');
     if (typeof requestUrl !== 'string') {
       throw new Error('Expected fetch URL to be a string');
     }
 
     expect(requestUrl).toContain('/resultats_dis?');
-    expect(requestUrl).toContain('code_udi=UDI-2');
+    expect(requestUrl).toContain('code_reseau=R-2');
+    // Targeted ion fetch (Ca, Mg, SO4, Cl, HCO3) so infrequently-sampled ions
+    // are never missed on a generic page. URLSearchParams encodes the commas.
+    expect(requestUrl).toContain(
+      'code_parametre=1374%2C1372%2C1338%2C1337%2C1327',
+    );
     expect(requestUrl).toContain('date_min_prelevement=2024-01-01');
     expect(requestUrl).toContain('date_max_prelevement=2024-12-31');
     expect(requestUrl).toContain('size=3');
 
     expect(samples).toEqual([
-      {
-        parameterLabel: 'Calcium',
-        numericResult: 42.5,
-        conformity: 'C',
-      },
-      {
-        parameterLabel: 'Magnesium',
-        numericResult: 9,
-        conformity: null,
-      },
-      {
-        parameterLabel: 'Chlorides',
-        numericResult: null,
-        conformity: 'D',
-      },
+      { parameterLabel: 'Calcium', numericResult: 42.5, conformity: 'C' },
+      { parameterLabel: 'Magnésium', numericResult: 9, conformity: null },
+      { parameterLabel: 'Chlorures', numericResult: null, conformity: 'N' },
     ]);
   });
 

--- a/packages/api/src/water/providers/hubeau-water-quality.provider.ts
+++ b/packages/api/src/water/providers/hubeau-water-quality.provider.ts
@@ -8,6 +8,7 @@ import {
 import type { WaterConfig } from '../../config/water.config';
 import { WATER_CONFIG } from '../water.constants';
 import { WaterProviderKey } from '../domain/enums/water-provider-key.enum';
+import { normalizeFrenchLabel } from '../../common/normalize-french-label';
 
 // Hub'Eau v1 renamed the `communes_udi` fields (`code_udi`→`code_reseau`,
 // `nom_udi`→`nom_reseau`) and dropped `nb_prelevements`, so this record shape
@@ -16,6 +17,10 @@ interface HubEauCommuneUdiRecord {
   readonly code_reseau: string;
   readonly nom_reseau: string | null;
   readonly nom_commune: string | null;
+  // Sometimes a « NN% » population-coverage figure for the network, sometimes an
+  // arrondissement/quartier description — used as the dominant-network signal
+  // only when it parses as a percentage.
+  readonly nom_quartier: string | null;
   readonly annee: string | null;
 }
 
@@ -84,8 +89,9 @@ export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
   /**
    * Picks the network that best represents the commune. Hub'Eau dropped
    * `nb_prelevements` (the old "most-sampled" proxy), so we take the most recent
-   * year's records and, within them, prefer the network named after the commune
-   * (the usual main one), falling back to the first record.
+   * year's records and, within them: (1) the network with the highest « NN% »
+   * population coverage when Hub'Eau exposes one, else (2) the network named
+   * after the commune (the usual main one), else (3) the first record.
    */
   private selectDominantRecord(
     records: HubEauCommuneUdiRecord[],
@@ -103,23 +109,44 @@ export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
       : records;
     const candidates = inLatestYear.length ? inLatestYear : records;
 
+    // 1. Highest population coverage — the truest "dominant" signal left after
+    // `nb_prelevements` was dropped (only some communes expose a « NN% »).
+    const byCoverage = candidates
+      .map((record) => ({
+        record,
+        coverage: this.parseCoveragePercent(record.nom_quartier),
+      }))
+      .filter(
+        (
+          entry,
+        ): entry is { record: HubEauCommuneUdiRecord; coverage: number } =>
+          entry.coverage !== null,
+      )
+      .sort((a, b) => b.coverage - a.coverage);
+    if (byCoverage.length) {
+      return byCoverage[0].record;
+    }
+
+    // 2. The network named after the commune.
     const namedAfterCommune = candidates.find(
       (record) =>
         record.nom_reseau != null &&
         record.nom_commune != null &&
-        this.normalizeName(record.nom_reseau) ===
-          this.normalizeName(record.nom_commune),
+        normalizeFrenchLabel(record.nom_reseau) ===
+          normalizeFrenchLabel(record.nom_commune),
     );
 
+    // 3. Deterministic fallback: the first record.
     return namedAfterCommune ?? candidates[0];
   }
 
-  private normalizeName(value: string): string {
-    return value
-      .normalize('NFD')
-      .replace(/[\u0300-\u036f]/g, '')
-      .trim()
-      .toLowerCase();
+  /** Reads a « NN% » population-coverage figure out of `nom_quartier`, if any. */
+  private parseCoveragePercent(value: string | null): number | null {
+    if (!value) {
+      return null;
+    }
+    const match = /(\d+(?:[.,]\d+)?)\s*%/.exec(value);
+    return match ? this.toNullableNumber(match[1]) : null;
   }
 
   async getNetworkSamples(input: {

--- a/packages/api/src/water/providers/hubeau-water-quality.provider.ts
+++ b/packages/api/src/water/providers/hubeau-water-quality.provider.ts
@@ -9,25 +9,46 @@ import type { WaterConfig } from '../../config/water.config';
 import { WATER_CONFIG } from '../water.constants';
 import { WaterProviderKey } from '../domain/enums/water-provider-key.enum';
 
+// Hub'Eau v1 renamed the `communes_udi` fields (`code_udi`→`code_reseau`,
+// `nom_udi`→`nom_reseau`) and dropped `nb_prelevements`, so this record shape
+// tracks the current API.
 interface HubEauCommuneUdiRecord {
-  readonly code_udi: string;
-  readonly nom_udi: string | null;
-  readonly nb_prelevements: number | string | null;
+  readonly code_reseau: string;
+  readonly nom_reseau: string | null;
+  readonly nom_commune: string | null;
+  readonly annee: string | null;
 }
 
 interface HubEauCommuneUdiResponse {
   readonly data: HubEauCommuneUdiRecord[];
 }
 
+// `resultats_dis` renamed `nom_parametre`→`libelle_parametre`; the old
+// `conclusion_conformite_prelevement_pc` short code now lives in
+// `conformite_limites_pc_prelevement` (the physico-chemical limits verdict).
 interface HubEauResultatsRecord {
-  readonly nom_parametre: string;
+  readonly libelle_parametre: string;
   readonly resultat_numerique: number | string | null;
-  readonly conclusion_conformite_prelevement_pc: string | null;
+  readonly conformite_limites_pc_prelevement: string | null;
 }
 
 interface HubEauResultatsResponse {
   readonly data: HubEauResultatsRecord[];
 }
+
+/**
+ * SANDRE parameter codes for the brewing-relevant ions. Hub'Eau serves hundreds
+ * of parameters and the ions are sampled infrequently, so a generic results
+ * page (size N, most-recent first) can miss Calcium/Magnésium entirely — we
+ * filter the query to exactly these codes so the profile always sees them.
+ */
+const ION_PARAMETER_CODES = [
+  '1374', // Calcium
+  '1372', // Magnésium
+  '1338', // Sulfates
+  '1337', // Chlorures
+  '1327', // Hydrogénocarbonates (bicarbonate / HCO3)
+] as const;
 
 @Injectable()
 export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
@@ -53,19 +74,52 @@ export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
       return null;
     }
 
-    const dominant = response.data.reduce<HubEauCommuneUdiRecord>(
-      (currentDominant, record) => {
-        const currentMax = this.toSafeNumber(currentDominant.nb_prelevements);
-        const value = this.toSafeNumber(record.nb_prelevements);
-        return value > currentMax ? record : currentDominant;
-      },
-      response.data[0],
+    const dominant = this.selectDominantRecord(response.data);
+    return {
+      code: dominant.code_reseau,
+      name: dominant.nom_reseau,
+    };
+  }
+
+  /**
+   * Picks the network that best represents the commune. Hub'Eau dropped
+   * `nb_prelevements` (the old "most-sampled" proxy), so we take the most recent
+   * year's records and, within them, prefer the network named after the commune
+   * (the usual main one), falling back to the first record.
+   */
+  private selectDominantRecord(
+    records: HubEauCommuneUdiRecord[],
+  ): HubEauCommuneUdiRecord {
+    const latestYear = records.reduce<string | null>(
+      (max, record) =>
+        record.annee && (max === null || record.annee > max)
+          ? record.annee
+          : max,
+      null,
     );
 
-    return {
-      code: dominant.code_udi,
-      name: dominant.nom_udi,
-    };
+    const inLatestYear = latestYear
+      ? records.filter((record) => record.annee === latestYear)
+      : records;
+    const candidates = inLatestYear.length ? inLatestYear : records;
+
+    const namedAfterCommune = candidates.find(
+      (record) =>
+        record.nom_reseau != null &&
+        record.nom_commune != null &&
+        this.normalizeName(record.nom_reseau) ===
+          this.normalizeName(record.nom_commune),
+    );
+
+    return namedAfterCommune ?? candidates[0];
+  }
+
+  private normalizeName(value: string): string {
+    return value
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .trim()
+      .toLowerCase();
   }
 
   async getNetworkSamples(input: {
@@ -76,9 +130,10 @@ export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
     const response = await this.fetchHubEau<HubEauResultatsResponse>(
       `${this.waterConfig.hubeauBaseUrl}/resultats_dis`,
       {
-        code_udi: input.networkCode,
+        code_reseau: input.networkCode,
+        code_parametre: ION_PARAMETER_CODES.join(','),
         fields:
-          'nom_parametre,resultat_numerique,conclusion_conformite_prelevement_pc',
+          'libelle_parametre,resultat_numerique,conformite_limites_pc_prelevement',
         date_min_prelevement: `${input.year}-01-01`,
         date_max_prelevement: `${input.year}-12-31`,
         size: String(input.size),
@@ -89,12 +144,13 @@ export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
     return response.data
       .filter(
         (row) =>
-          typeof row.nom_parametre === 'string' && row.nom_parametre.length > 0,
+          typeof row.libelle_parametre === 'string' &&
+          row.libelle_parametre.length > 0,
       )
       .map((row) => ({
-        parameterLabel: row.nom_parametre,
+        parameterLabel: row.libelle_parametre,
         numericResult: this.toNullableNumber(row.resultat_numerique),
-        conformity: row.conclusion_conformite_prelevement_pc,
+        conformity: row.conformite_limites_pc_prelevement,
       }));
   }
 
@@ -137,11 +193,6 @@ export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
 
       throw new BadGatewayException("Hub'Eau request failed");
     }
-  }
-
-  private toSafeNumber(value: number | string | null): number {
-    const numberValue = this.toNullableNumber(value);
-    return numberValue ?? 0;
   }
 
   private toNullableNumber(value: number | string | null): number | null {


### PR DESCRIPTION
## Summary

The water-quality check (used by the recipe Water tab / the upcoming « suis-je prêt ? » prep-readiness epic) returned **nothing**: Hub'Eau's v1 API renamed its fields and the provider still used the old names. Investigating revealed two more latent aggregation bugs. **Every change was verified against the live API** (Lille INSEE 59350 → Ca 114.8 / Mg 22.8 / Cl 50.3 / SO4 106.4 / HCO3 341.5 mg/L, hardness 124.1 °f — realistic hard water).

### Provider (`communes_udi` + `resultats_dis`)
- Field renames: `code_udi`→`code_reseau`, `nom_udi`→`nom_reseau`, `nom_parametre`→`libelle_parametre`.
- `nb_prelevements` was dropped by Hub'Eau → the dominant-network selection now takes the **latest year**, preferring the réseau named after the commune, else the first record.
- **Targeted ion fetch by SANDRE code** (Ca 1374 / Mg 1372 / SO4 1338 / Cl 1337 / HCO3 1327): the ions are sampled infrequently, so a generic page (size N, most-recent first) dropped Calcium/Magnésium entirely. Verified live: a generic size=100 page has no Ca/Mg.
- Conformity now reads `conformite_limites_pc_prelevement` (the short C/N verdict that replaced `conclusion_conformite_prelevement_pc`).

### Aggregation (label → ion matching)
- `'chlor'` → `'chlorures'`: the old stem swept in « Chlore libre », « Chlorure de vinyl monomère » and dozens of chlorinated pesticides, corrupting the chloride average.
- `'bicarbonate'` → `'hydrogenocarbonate'`: Hub'Eau labels HCO3 « Hydrogénocarbonates », never « bicarbonate » — so bicarbonate was never captured.

## Context

Foundation brick for the prep-readiness (« suis-je prêt à brasser ? ») epic and the recipe Water tab. A plain field rename would NOT have been enough (the profile would still be wrong: Ca/Mg missing, chloride corrupted, HCO3 null).

## Checklist

- [x] Verified end-to-end against the live Hub'Eau API (correct ion profile + hardness)
- [x] `nest build` + ESLint + Prettier clean
- [x] Full API suite green (963)
- [x] Regression test: chlorinated compounds + carbonates are NOT swept into chloride/bicarbonate
- [x] No external-network test added (kept unit tests hermetic; live shapes mirrored in fixtures)