### PR TITLE
docs(water-profile/architecture): ADR-0025 + UML deliverables for local water geolocation

### DIFF
--- a/docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md
+++ b/docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md
@@ -1,0 +1,256 @@
+# ADR-0025 — Local water profile: postal-code geolocation, live proxy first, append-only cache second
+
+**Status**  Proposed
+**Date**  2026-07-06
+**Owners**  @benoit-bremaud
+
+---
+
+## Context
+
+A brewer needs the **tap-water profile where they live** to judge whether their water suits a
+recipe (and, later, how to correct it). Today the recipe **Water tab** runs entirely on 8
+hardcoded predefined-city presets (`features/tools/data/water-profiles.data.ts`: Paris, Munich,
+Dortmund, Burton, Dublin, London, Edinburgh, Pilsen) and **never calls the backend** — no
+grep hit for `/water`, `getWaterProfile`, `codeInsee`, or `hubeau` anywhere in
+`packages/mobile-app/src`.
+
+The backend already exposes the data: `GET /water?codeInsee=&year=` (JWT-guarded,
+`packages/api/src/water/controllers/water.controller.ts`), fixed on `main` in #1352 (`6595786`)
+after the Hub'Eau v1 contract drift. It returns **5 brewing ions** (Ca, Mg, Cl, SO4, HCO3) +
+`networkName` + `sampleCount` + a `conformity` enum + `hardnessFrench`. It does **not** return
+sodium (Na), a per-sample `date_prelevement`, or pH.
+
+This ADR governs the **bridge** from "where I live" to that live profile, and how we treat the
+Hub'Eau data locally. It is the first buildable increment of the broader
+**water-profile epic** ([[project_water_profile_epic]]) — whose full vision (recommended vs
+local profile, per-ion compatibility %, mineral-water compatibility %, corrective-salt
+suggestions) stays deferred and out of scope here.
+
+**Locked before this ADR** (requirements debrief, 2026-07-06):
+
+- **Functional core first, fancy map later.** The founder's idea of an interactive
+  France **drill-down map** (région → département → commune, progressive zoom + back) is a
+  genuine but **separate UX epic**; slice-1 delivers "get the water where I live" without it.
+- **"My water" is a user-level notion**, but slice-1 keeps the location **ephemeral**
+  (re-entered each time); persisting it ("remember my water") is a later, consented slice.
+- **Visible feature first, cache second.** The live `/water` proxy already works (deployed,
+  live-verified across Lille/Strasbourg/Rennes/Bordeaux). Ship the user-facing bridge on it,
+  then add a backend cache + history.
+
+### Documented study (why we are not guessing)
+
+A five-angle research pass (French geo data, GeoJSON/map rendering weight, RN/Expo map options,
+Hub'Eau freshness/multi-network semantics, existing-conception state) grounded the options, and
+every external fact below was **verified live** against the two public APIs.
+
+- **`geo.api.gouv.fr`** (DINUM, INSEE data — "API Découpage administratif") is a **sovereign,
+  keyless, open** French state API: 50 req/s/IP, Licence Ouverte. It covers
+  région → département → commune **and** postal→commune resolution. Every commune object exposes
+  its INSEE `code` — **exactly the key Hub'Eau uses** — plus a `codesPostaux` array.
+- **Postal ↔ INSEE is many-to-many in both directions** (verified live): one postal code →
+  several communes (`01400` → 10 communes), one commune → several postal codes (Lille INSEE
+  `59350` → 5 postal codes). A picker **must** force a commune choice when >1 candidate before
+  calling `/water`. INSEE code ≠ postal code; codes are **strings** (Corsica `2A`/`2B`, DROM
+  3-digit) — never parsed as integers.
+- **Arrondissements**: the data lives on the **parent ("chapeau") commune code** — Paris
+  `75056` (635 819 records) and Lyon `69123` have data; arrondissement codes (`75101`, `69383`)
+  return **0**. Resolve to the parent commune INSEE.
+- **Hub'Eau** refreshes ~monthly with a ~6-week sampling-to-publication lag. The honest
+  freshness signal is `max(date_prelevement)` — **absent from our current DTO** (year only).
+  A commune's supply is often a **blend of networks** (`reseaux[]`); the per-network `debit` %
+  is documented in swagger but **absent from live JSON**, and the "NN%" seen in `nom_quartier`
+  is free text (sometimes a %, sometimes a district, sometimes `-`). The dominant network is
+  genuinely an **approximation**. `conclusion_conformite_prelevement` repeats per parameter row
+  (a dedupe-by-`code_prelevement` concern for the **slice-2** cache, not the live path), and
+  Hub'Eau caps query depth at 20 000 records.
+- **The existing live `/water` path** (what slice 1 consumes, unchanged): it resolves the
+  dominant network (`communes_udi` → `code_reseau`), queries `resultats_dis` by that
+  `code_reseau` + the 5 ion SANDRE codes (Ca `1374`, Mg `1372`, SO4 `1338`, Cl `1337`, HCO3
+  `1327`) + a one-year window (`size=100`), then **averages** the matching rows (cap 50) — **no**
+  `code_prelevement` dedupe today. It already has an **in-memory per-request TTL cache**
+  (`WaterService`, 3600 s, 500 entries); slice-2's append-only DB cache is a **separate durable
+  layer**, not the first cache.
+- **A clickable commune-level map is a real build, not a widget.** ~35 000 commune polygons
+  crash / single-digit-FPS on `react-native-maps <Polygon>`; the only fully Expo-Go-compatible,
+  offline, tile-free path is `react-native-svg` drawing simplified GeoJSON (region+dept contours
+  are sub-MB; the national commune layer is 18 MB simplified → per-department lazy fetch).
+  MapLibre looks best but forces a dev build (leaves Expo Go). This is why the map is deferred.
+- **The whole chain is FR/EU-sovereign** with no US dependency: Hub'Eau (OFB/BRGM, SANDRE
+  codes, ARS data) + geo.api.gouv.fr (DINUM/INSEE) + IGN geo data (Licence Ouverte).
+
+Repo constraints: ADR-0001 (build for today), ADR-0002 (centralized backend), ADR-0003 (consent
+as single source of truth — gates the deferred user-location persistence), ADR-0004 (data
+locality hybrid), ADR-0015 (ingestion staging — the analogue for the cache), ADR-0020 (heavy
+math server-side).
+
+## Decision
+
+Deliver the local-water bridge in **two slices**, and defer the map and the epic's richer
+pillars.
+
+- **Slice 1 (mobile, on the existing live proxy)** — a **postal-code** entry on the recipe
+  Water tab → resolve via **live `geo.api.gouv.fr`** → **force a commune pick** when the postal
+  code maps to several communes → call the **existing `GET /water`** with the resolved 5-digit
+  INSEE → render the live profile. Location stays **ephemeral**.
+- **Slice 2 (backend, after slice 1)** — an **append-only cache** of Hub'Eau measurements in our
+  own DB, refreshed by a **conditional sync** (cheap date-check → full fetch only when Hub'Eau is
+  newer than ours), serving from the DB with a **fallback** when Hub'Eau is unreachable, and
+  finally exposing the **freshness date**.
+
+### Geo input model for slice-1 (weighted decision matrix)
+
+EU-sovereign data source is a **pass/fail prerequisite** (all options below use
+geo.api.gouv.fr / IGN — all pass), not a scored criterion. Weights reflect a novice-facing,
+KISS-first, ship-visible-value goal.
+
+| Criterion (weight) | **A. Postal-code entry** | B. Région→dépt→commune list | C. Clickable France map |
+| --- | --- | --- | --- |
+| Shortest path to the INSEE the backend needs (30%) | **5** | 3 | 2 |
+| Matches how a novice thinks ("mon code postal") (25%) | **5** | 3 | 3 |
+| Build cost / risk in Expo (managed) (25%) | **5** | 4 | 1 |
+| Forces the many-to-many disambiguation cleanly (20%) | **5** | 4 | 3 |
+| **Weighted score** | **5.00** | **3.45** | **2.20** |
+
+**Chosen: A (postal-code entry).** It is the shortest route to a 5-digit INSEE, matches the
+novice's mental model, carries the least Expo build risk, and makes the unavoidable
+`01400 → 10 communes` disambiguation a first-class step. **B** (a browse path) is the natural
+post-slice-1 enrichment; **C** (the map) is the deferred UX epic — it adds real cost (SVG path
+simplification, per-department lazy GeoJSON, a gesture/onPress conflict, an unvalidated Expo
+SDK-54 `Path.onPress` Android regression) for **zero extra business value** over a postal-code
+box for "get the water where I live".
+
+### Where INSEE resolution lives (weighted decision matrix)
+
+| Criterion (weight) | **A. Live geo.api.gouv.fr** | B. New backend resolver | C. Bundled offline table |
+| --- | --- | --- | --- |
+| Slice-1 build cost (30%) | **5** | 2 | 3 |
+| No added surface (endpoint/DTO/ADR) (25%) | **5** | 2 | 4 |
+| Freshness vs INSEE COG yearly changes (20%) | **5** | 4 | 2 |
+| Bundle weight (20%) | **5** | 5 | 3 |
+| Offline capability (5%) | 2 | 3 | **5** |
+| **Weighted score** | **4.85** | **3.05** | **3.15** |
+
+**Chosen: A (live geo.api.gouv.fr).** The user is already online to hit `/water`; the state API
+is keyless, sovereign, always current, and adds zero bundle weight. **C** (a ~432 KB-gzipped
+offline commune dump) is only justified once the offline drill-down map exists; **B** (a backend
+resolver) is more surface for a lookup the free state API already does — revisit only if we later
+want to cache/normalise it or feed the deferred salt engine.
+
+### Data locality — live proxy now, cache later (weighted decision matrix)
+
+| Criterion (weight) | A. Live proxy only | **B. Proxy now + append-only cache next** | C. Cache + history + analytics now |
+| --- | --- | --- | --- |
+| Time to visible user value (30%) | **5** | **5** (slice-1 unchanged) | 2 |
+| Resilience if Hub'Eau is down (20%) | 1 | **5** | 5 |
+| Enables freshness date + history (20%) | 1 | **5** | 5 |
+| Slice size / KISS (15%) | **5** | 3 | 1 |
+| Avoids speculative build (YAGNI) (15%) | **5** | 4 | 1 |
+| **Weighted score** | **3.40** | **4.55** | **2.90** |
+
+**Chosen: B.** Slice-1 ships on the live proxy (top score on time-to-value, unchanged); slice-2
+adds the **append-only cache** (history accrues for free, keyed `commune + parameter +
+date_prelevement + code_prelevement`) with a **conditional sync** and a **DB fallback**. This is
+RGPD-safe — the cached data is **public** ARS/Hub'Eau reference data, **not PII** (distinct from
+the user's own location). **C** front-loads analytics screens the feature doesn't need yet
+(YAGNI); the append-only schema keeps those analyses **possible later at no extra cost today**.
+
+## Locked slice-1 parameters
+
+- **Input** = a postal-code field on the recipe Water tab. On submit → `GET
+  https://geo.api.gouv.fr/communes?codePostal=<cp>&fields=nom,code,codesPostaux` (live).
+- **Disambiguation** = if the result has **>1 commune**, show a plain-language commune picker
+  ("Plusieurs communes partagent ce code postal — laquelle ?") and resolve to one INSEE;
+  resolve arrondissement inputs to their **parent commune** code.
+- **Backend call** = the **existing** `GET /water?codeInsee=<insee>&year=<latest>` via a new
+  mobile use-case + the shared `http-client` (**never** a direct `fetch`).
+- **Output** = the live profile: **5 ions** (Ca/Mg/Cl/SO4/HCO3) + `hardnessFrench` (°fH) +
+  `conformity` + **dominant network name with an honest "plusieurs réseaux desservent la
+  commune" caveat** (expandable, depth-on-demand). **Never** render a fabricated per-network %.
+- **Pedagogy** = **one** plain-language sentence (e.g. "Eau dure, riche en calcaire") — the app
+  teaches; ppm alone don't speak to a novice.
+- **Sodium (Na)** = **dropped and labelled** "non mesuré" (the backend returns 5 ions, not 6).
+  Feeding a null/0 Na into compatibility or a future NaCl salt suggestion would be silently
+  wrong.
+- **Freshness** = honest **year + conformity** for now ("Analyses <année> — eau conforme, source
+  ARS via Hub'Eau"); the exact **dated** freshness pastille arrives with slice-2 (when the DTO
+  carries `max(date_prelevement)`). **Never** show a fetch-date as if it were the data currency.
+- **Compatibility** = **reuse the existing global 0–100 score** (`recipe-details.utils`) fed by
+  the live profile instead of a preset. Per-ion %, mineral-water %, and the salt engine stay in
+  later epic slices. **Do not touch** the client-side salts helper
+  (`helpers/water-mineral-salts.ts`) — it contradicts "water-math = backend".
+- **Missing/partial data** = an explicit "donnée partielle / ion non mesuré" state, **distinct**
+  from "non conforme" and from "conforme", so blanks never read as either.
+- **Persistence** = **none** (ephemeral, like today). No new consent surface opened.
+
+## Slice-2 design (cache + history)
+
+- **Consistency with slice-1** = slice-2 keeps the existing **dominant-network** resolution
+  (`communes_udi` → `code_reseau`) so the aggregation semantics are **unchanged**; the Hub'Eau
+  calls below key on `code_reseau` (**not** `code_commune`, which would blend all networks and
+  shift the average), and slice-2 additionally requests `code_prelevement` in the `fields` (the
+  live path does not) to key the append-only rows.
+- **Storage** = an **append-only** table of measurements, unique key
+  `(code_reseau, code_parametre, date_prelevement, code_prelevement)`; never overwrite → history
+  accumulates. The commune → dominant-network link is resolved at read time (as today).
+- **Conditional sync** = on a lookup, a **cheap** call
+  `resultats_dis?code_reseau=X&size=1&sort=desc&fields=date_prelevement` gives Hub'Eau's
+  `max(date_prelevement)`; if it is newer than our stored max, run a **full fetch +
+  upsert-ignore** (network + year + ion codes; dedupe by `code_prelevement`).
+- **Serve + fallback** = read the profile from our DB; if Hub'Eau is unreachable during a sync,
+  **serve the last known** data (resilience) and surface its date.
+- **DTO evolution** = slice-2 **additively** extends the `/water` DTO with the freshness date
+  (`max(date_prelevement)`); the endpoint contract, the 5 ions/hardness/conformity/network, and
+  the mobile call site are otherwise **unchanged** — the mobile only upgrades its year-granular
+  freshness line to a dated pastille.
+- **Borrowed from ADR-0015, minus the gate** = the append-only shape reuses ADR-0015's staging
+  *mechanism* (immutable, keyed, history-accreting) but **not** its human-gate (D4):
+  Hub'Eau/ARS is authoritative **public reference** data, served directly with **no** promotion
+  step — the trust boundary ADR-0015 protects does not exist here.
+- **RGPD** = the cache holds **public** commune water data — **not PII**. The user's own
+  location persistence remains out of scope (ADR-0003 territory).
+
+## Deferred (explicitly out of scope here)
+
+- The **clickable France drill-down map** (its own UML-first UX epic).
+- **Analytics** on water-quality evolution by commune/département (the append-only schema keeps
+  them possible; the screens/queries are YAGNI now).
+- **"Remember my water"** = persisting the user's location (coarse PII → ADR-0003 consent + a
+  retention decision) — its own consented slice.
+- Epic pillars: **per-ion %**, **mineral-water compatibility %**, **corrective salts** (backend
+  engine), and **sodium** ingestion (SANDRE `1367`).
+
+## Consequences
+
+- **Positive**: a real "get the water where I live" feature ships fast on code that already runs;
+  a sovereign, keyless geo resolver; a clean two-slice path; the cache buys resilience,
+  freshness, and free history without front-loading analytics.
+- **Compliance (ADR-0004)**: the water lookup is a **cloud-first** journey — it is **not** in the
+  active-brew critical path and carries **no offline guarantee**; slice-2's cache is an
+  HTTP-style resilience layer, **not** a local-first sync engine. This is the explicit
+  locality-world classification ADR-0004 § Compliance requires.
+- **Negative / accepted**: two live external dependencies at input time (geo.api.gouv.fr + the
+  Hub'Eau-backed `/water`) in slice-1 (mitigated by slice-2's cache/fallback); the dominant
+  network stays an approximation (surfaced honestly); slice-1 shows year-granular freshness until
+  slice-2 lands the dated signal.
+- **Open (settle in build)**: the picker's **destination** (recipe Water tab vs the "Calculateur
+  Eau" tool vs the prep-readiness water check — recommend the recipe Water tab first, one
+  reusable entry point later) and the exact input widget (a single "nom-ou-code-postal" search
+  field vs a postal-only field).
+
+## Roadmap
+
+1. **Slice 1** — mobile postal→disambiguation→INSEE→`/water` bridge + honest render. UML:
+   `01-use-case`, `02-sequence-slice1-lookup`, `04-component`, `05-data-flow`.
+2. **Slice 2** — backend append-only cache + conditional sync + DB fallback + `date_prelevement`
+   in the DTO. UML: `03-sequence-slice2-cache-sync`.
+3. **Later epic** — drill-down map (UX epic), reuse-persistence (consented), per-ion %,
+   mineral-water %, corrective salts, Na, analytics.
+
+## References
+
+- Epic + debrief decisions: [[project_water_profile_epic]].
+- Hub'Eau fix that unblocked this: #1352 (`6595786`), [[project_water_quality_hubeau_refresh]].
+- `geo.api.gouv.fr` — API Découpage administratif (DINUM/INSEE), Licence Ouverte.
+- Hub'Eau `qualite_eau_potable` v1 (OFB/BRGM, SANDRE, ARS data).
+- Related ADRs: 0001, 0002, 0003, 0004, 0015, 0020.

--- a/docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md
+++ b/docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md
@@ -11,9 +11,10 @@
 A brewer needs the **tap-water profile where they live** to judge whether their water suits a
 recipe (and, later, how to correct it). Today the recipe **Water tab** runs entirely on 8
 hardcoded predefined-city presets (`features/tools/data/water-profiles.data.ts`: Paris, Munich,
-Dortmund, Burton, Dublin, London, Edinburgh, Pilsen) and **never calls the backend** — no
-grep hit for `/water`, `getWaterProfile`, `codeInsee`, or `hubeau` anywhere in
-`packages/mobile-app/src`.
+Dortmund, Burton, Dublin, London, Edinburgh, Pilsen) and **never calls the backend `/water`
+endpoint** — there is no HTTP call to it (`getWaterProfile`, `codeInsee`, and `hubeau` return
+nothing in `packages/mobile-app/src`; the `/water` substring appears only inside unrelated import
+paths like `water-profiles` / `water-mineral-salts`).
 
 The backend already exposes the data: `GET /water?codeInsee=&year=` (JWT-guarded,
 `packages/api/src/water/controllers/water.controller.ts`), fixed on `main` in #1352 (`6595786`)
@@ -68,9 +69,9 @@ every external fact below was **verified live** against the two public APIs.
   dominant network (`communes_udi` → `code_reseau`), queries `resultats_dis` by that
   `code_reseau` + the 5 ion SANDRE codes (Ca `1374`, Mg `1372`, SO4 `1338`, Cl `1337`, HCO3
   `1327`) + a one-year window (`size=100`), then **averages** the matching rows (cap 50) — **no**
-  `code_prelevement` dedupe today. It already has an **in-memory per-request TTL cache**
-  (`WaterService`, 3600 s, 500 entries); slice-2's append-only DB cache is a **separate durable
-  layer**, not the first cache.
+  `code_prelevement` dedupe today. It already has a **process-level in-memory TTL cache** (a `Map`
+  on the singleton `WaterService`, shared across requests, 3600 s, 500 entries); slice-2's
+  append-only DB cache is a **separate durable layer**, not the first cache.
 - **A clickable commune-level map is a real build, not a widget.** ~35 000 commune polygons
   crash / single-digit-FPS on `react-native-maps <Polygon>`; the only fully Expo-Go-compatible,
   offline, tile-free path is `react-native-svg` drawing simplified GeoJSON (region+dept contours
@@ -149,7 +150,7 @@ want to cache/normalise it or feed the deferred salt engine.
 | **Weighted score** | **3.40** | **4.55** | **2.90** |
 
 **Chosen: B.** Slice-1 ships on the live proxy (top score on time-to-value, unchanged); slice-2
-adds the **append-only cache** (history accrues for free, keyed `commune + parameter +
+adds the **append-only cache** (history accrues for free, keyed `code_reseau + parameter +
 date_prelevement + code_prelevement`) with a **conditional sync** and a **DB fallback**. This is
 RGPD-safe — the cached data is **public** ARS/Hub'Eau reference data, **not PII** (distinct from
 the user's own location). **C** front-loads analytics screens the feature doesn't need yet

--- a/docs/architecture/diagrams/water-profile/01-use-case.md
+++ b/docs/architecture/diagrams/water-profile/01-use-case.md
@@ -1,0 +1,66 @@
+# Use-case diagram — water-profile — local tap-water lookup (slice 1)
+
+> **Feature**: water-profile epic — local tap water by geolocation ([[project_water_profile_epic]])
+> **Related ADRs**: ADR-0025 (postal-code geolocation, live proxy first, cache second)
+> **Decisions captured**: slice-1 = postal-code → INSEE → live `/water`; map + salts + reuse deferred
+
+## Context
+
+`uc — Domaine Eau : consultation du profil d'eau local (slice 1)`. Actor goals of the **water
+domain** for slice 1: the brewer consults the tap-water profile of their commune and compares it
+with the recipe's target. External state APIs (`geo.api.gouv.fr`, Hub'Eau) are **supporting
+actors** (undirected associations), not use cases. The freshness sync and the drill-down map are
+**not** use cases here: the sync is a system-internal mechanism (shown in the sequence diagrams),
+the map is a deferred UX epic. Deferred actor goals are shown greyed to make scope explicit.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brasseur amateur<br/>(novice, persona cible)"))
+  GeoApi(("API Géo<br/>geo.api.gouv.fr"))
+  HubEau(("Hub'Eau<br/>eau potable"))
+
+  subgraph SYSTEM ["Brasse-Bouillon"]
+    subgraph Eau ["Domaine Eau"]
+      UC1(("Consulter le profil d'eau<br/>de ma commune"))
+      UC2(("Choisir la commune<br/>(si code postal ambigu)"))
+      UC3(("Comparer mon eau au<br/>profil cible de la recette"))
+    end
+    subgraph Differe ["Différé (hors slice 1)"]
+      D1(("Explorer via la carte<br/>de France"))
+      D2(("Retenir mon eau<br/>(persistée, consentie)"))
+      D3(("Corriger mon eau<br/>(sels correcteurs)"))
+    end
+  end
+
+  Brewer --> UC1
+  Brewer --> UC3
+  UC2 -.->|"«extend» [CP → plusieurs communes]"| UC1
+  GeoApi --- UC1
+  HubEau --- UC1
+
+  Brewer --> D1
+  Brewer --> D2
+  Brewer --> D3
+
+  classDef deferred fill:#eee,stroke:#bbb,stroke-dasharray:4 3,color:#888
+  class D1,D2,D3 deferred
+```
+
+## Notes
+
+- **UML orthodoxy**: use cases are actor-initiated goals (verb phrases). `UC1` and `UC3` are
+  goals the brewer initiates; the **freshness cache sync** (slice 2) is a system mechanism, not a
+  use case — realized in `03-sequence-slice2-cache-sync`, triggered by `UC1`, never an actor goal.
+- **Supporting actors**: `geo.api.gouv.fr` and Hub'Eau are external systems `UC1` relies on,
+  drawn with **undirected** associations (`---`) on the right. The call direction (who invokes
+  whom) belongs to `04-component`, not here.
+- **`UC2` is an «extend»** with a real guard `[CP → plusieurs communes]`: disambiguation only
+  fires when one postal code maps to several communes (verified live: `01400` → 10). Arrondissement
+  input resolves to the parent commune.
+- **`UC3` is a standalone goal** (compare my water to the recipe target), realized by reusing the
+  existing global 0–100 compatibility score — not a conditional fragment of `UC1`.
+- The three **deferred** goals (map, remember-my-water, corrective salts) are solid associations
+  greyed via `classDef` so the slice-1 boundary is unambiguous; each is its own later slice/epic
+  per ADR-0025.

--- a/docs/architecture/diagrams/water-profile/02-sequence-slice1-lookup.md
+++ b/docs/architecture/diagrams/water-profile/02-sequence-slice1-lookup.md
@@ -1,0 +1,78 @@
+# Sequence diagram — water-profile — slice 1: postal code → INSEE → live profile
+
+> **Feature**: water-profile epic — slice 1 ([[project_water_profile_epic]])
+> **Related ADRs**: ADR-0025 (§ Geo input model, § Where INSEE resolution lives)
+> **Decisions captured**: live `geo.api.gouv.fr` resolve, forced disambiguation, existing `/water`
+
+## Context
+
+`sd — UC1 Consulter le profil d'eau de ma commune (slice 1, live proxy)`. Realizes the
+postal-code → disambiguation → INSEE → `GET /water` flow on the **existing** backend proxy.
+Covers the many-to-many branch (one postal code → several communes), the empty-input branch
+(invalid postal code), the **no-fallback** external-error branch (slice 1 has no cache), and the
+partial-data branch. The mobile calls go through the shared `http-client` (never a direct
+`fetch`).
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor U as Brasseur
+  participant M as Mobile — onglet Eau
+  participant G as geo.api.gouv.fr
+  participant A as API — /water (existant)
+  participant H as Hub'Eau
+
+  U->>M: Saisir le code postal (ex. 59000)
+  M->>G: GET /communes?codePostal=59000&fields=nom,code,codesPostaux
+
+  alt geo.api.gouv.fr indisponible
+    G-->>M: erreur / timeout
+    M->>U: « Service indisponible, réessayez » (pas de fallback en slice 1)
+  else Réponse reçue
+    G-->>M: liste de communes
+    alt Aucune commune (CP invalide)
+      M->>U: « Code postal inconnu, vérifiez la saisie »
+    else Plusieurs communes (ex. 01400 → 10)
+      M->>U: Afficher le sélecteur « laquelle ? »
+      U->>M: Choisir une commune
+    else Une seule commune
+      M->>M: Sélection automatique
+    end
+    note over M: Arrondissement → code commune parent (Paris 75056)
+
+    M->>A: GET /water?codeInsee=59350&year=(récente) (JWT, http-client)
+    alt /water indisponible (5xx / timeout)
+      A-->>M: erreur
+      M->>U: « Service indisponible, réessayez » (pas de fallback en slice 1)
+    else Profil renvoyé
+      A->>H: communes_udi → réseau dominant (règle 3 paliers)
+      A->>H: resultats_dis?code_reseau=…&code_parametre=1374,1372,1338,1337,1327
+      H-->>A: mesures ions (moyenne, cap 50 — pas de dédupe en slice 1)
+      A-->>M: profil : 5 ions + dureté °fH + conformité + réseau
+      alt Profil complet
+        M->>U: Afficher profil + 1 phrase (dure/douce) + caveat « plusieurs réseaux »
+      else Donnée partielle / absente
+        M->>U: État « donnée partielle / ion non mesuré » (≠ non conforme)
+      end
+    end
+  end
+```
+
+## Notes
+
+- **Disambiguation is mandatory** (many-to-many, verified live): the app must never assume one
+  postal code → one INSEE. The picker resolves to a **single 5-digit INSEE** before `/water`.
+- **No fallback in slice 1**: both external calls (geo + `/water`) surface an error to the user on
+  failure — slice 1 has no cache. The DB fallback arrives with slice 2
+  (`03-sequence-slice2-cache-sync`).
+- The `/water` internals (dominant-network selection + ion fetch by SANDRE code, **plain average**
+  over ≤ 50 rows, **no** `code_prelevement` dedupe) are the **existing** backend (`6595786`);
+  slice 1 adds **no** backend change — the mobile is a pure consumer via a new use-case +
+  `http-client`.
+- **SANDRE ion codes** (existing #1352 mapping): Ca `1374`, Mg `1372`, SO4 `1338`, Cl `1337`,
+  HCO3 `1327`. **Na (`1367`) is absent by design** → shown "non mesuré", never null/0-fed into any
+  score.
+- **Freshness** here is year-granular (the DTO has no `date_prelevement` yet); the dated pastille
+  arrives with slice 2.
+- The partial/empty branch is a **first-class state** — blanks must not read as "non conforme".

--- a/docs/architecture/diagrams/water-profile/03-sequence-slice2-cache-sync.md
+++ b/docs/architecture/diagrams/water-profile/03-sequence-slice2-cache-sync.md
@@ -1,0 +1,69 @@
+# Sequence diagram — water-profile — slice 2: append-only cache + conditional sync
+
+> **Feature**: water-profile epic — slice 2 ([[project_water_profile_epic]])
+> **Related ADRs**: ADR-0025 (§ Data locality, § Slice-2 design), ADR-0004, ADR-0015
+> **Decisions captured**: cheap date-check → conditional full sync → append-only → DB fallback
+
+## Context
+
+`sd — Rafraîchir & servir le profil d'eau depuis notre cache (slice 2)`. Slice 2 makes `/water`
+**cache-backed**: it serves from our DB, refreshes only when Hub'Eau is genuinely newer (a cheap
+date-check gate), appends measurements (never overwrites → history), and falls back to the last
+known data when Hub'Eau is unreachable. It keeps the **existing `code_reseau` keying** (dominant
+network) so the aggregation is identical to slice 1 — **not** a `code_commune` fetch, which would
+blend all networks and shift the average. This finally exposes the **dated freshness** the DTO
+lacks today.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  participant M as Mobile
+  participant A as API — WaterService (cache-backed)
+  participant DB as DB — mesures eau (append-only)
+  participant H as Hub'Eau
+
+  M->>A: GET /water?codeInsee=59350&year=(récente)
+  A->>A: Résoudre le réseau dominant (cache commune→réseau, sinon communes_udi)
+  A->>DB: max(date_prelevement) connu pour ce réseau ?
+  DB-->>A: date locale (ou vide)
+
+  A->>H: resultats_dis?code_reseau=…&size=1&sort=desc&fields=date_prelevement
+  alt Hub'Eau joignable
+    H-->>A: date Hub'Eau la plus récente
+    alt Hub'Eau plus récent que notre DB
+      A->>H: Full fetch (réseau + année + codes ions, fields inc. code_prelevement)
+      H-->>A: mesures
+      A->>DB: INSERT append-only (clé réseau+paramètre+date+code_prelevement, ignore doublons)
+    else Notre cache est à jour
+      A->>A: Pas de sync (économie d'appels)
+    end
+  else Hub'Eau indisponible
+    A->>A: Fallback : servir le dernier connu (DB)
+  end
+
+  A->>DB: Lire le profil courant (agrégation réseau dominant)
+  DB-->>A: profil + date de fraîcheur
+  A-->>M: profil : 5 ions + dureté + conformité + réseau + « données au JJ/MM/AAAA »
+  M->>M: Pastille de fraîcheur datée (vert < 6 mois / orange / gris)
+```
+
+## Notes
+
+- **Same key as slice 1**: slice 2 keeps `code_reseau` (the dominant network), so the aggregation
+  semantics are unchanged; it only **adds** `code_prelevement` to the fetched `fields` (the live
+  path does not request it) to key the append-only rows.
+- **Two-step sync is deliberate**: the size=1 date-check is cheap and gates the expensive full
+  fetch — most lookups do **no** heavy call. Reduces Hub'Eau load and our latency.
+- **Append-only** (unique key `réseau + paramètre + date_prelevement + code_prelevement`) means
+  the full fetch is **idempotent** (`INSERT … ON CONFLICT DO NOTHING`) and history accrues for
+  free — the basis for later evolution analytics (deferred, ADR-0025).
+- **DTO evolution is additive**: slice 2 adds the freshness date to the DTO; the endpoint
+  contract and the 5 ions/hardness/conformity/network are unchanged, and the mobile only upgrades
+  its year-granular line to a dated pastille.
+- **Fallback** on Hub'Eau outage serves stale-but-honest data with its date — resilience the
+  live-proxy slice-1 lacks.
+- **RGPD**: this cache is **public** ARS/Hub'Eau data, not PII. The user's location is not stored
+  here (that is the deferred, consented "remember my water" slice — ADR-0003).
+- **Freshness pastille**: `max(date_prelevement)` is the honest currency (Hub'Eau lags ~6 weeks);
+  never present the fetch date as the data date.

--- a/docs/architecture/diagrams/water-profile/04-component.md
+++ b/docs/architecture/diagrams/water-profile/04-component.md
@@ -1,0 +1,71 @@
+# Component diagram — water-profile — mobile ↔ API ↔ sovereign external APIs
+
+> **Feature**: water-profile epic — slices 1 & 2 ([[project_water_profile_epic]])
+> **Related ADRs**: ADR-0025, ADR-0002 (centralized backend), ADR-0004 (data locality)
+> **Decisions captured**: egress via `http-client` (mobile) + `HubeauProvider` (API); cache = slice 2
+
+## Context
+
+Structural view. Answers "where does each responsibility live and what are the egress points",
+not "who wants what" (that is `01-use-case`). Makes the **two external egresses** explicit —
+the mobile `http-client` (no direct `fetch`) and the backend `HubeauWaterQualityProvider` — and
+marks which components are **slice 2** (the durable cache).
+
+## Diagram
+
+```mermaid
+flowchart TB
+  subgraph Mobile ["packages/mobile-app"]
+    Tab["WaterTab (écran recette)"]
+    UcGeo["use-case: résoudre commune"]
+    UcWater["use-case: profil d'eau"]
+    HTTP["core/http/http-client (egress unique)"]
+    Tab --> UcGeo
+    Tab --> UcWater
+    UcGeo --> HTTP
+    UcWater --> HTTP
+  end
+
+  subgraph API ["packages/api — water module"]
+    Ctrl["WaterController (GET /water, JWT)"]
+    Svc["WaterService (orchestration + cache TTL mémoire)"]
+    Agg["WaterAggregationDomainService (agrégation)"]
+    Prov["HubeauWaterQualityProvider (egress)"]
+    Repo["WaterMeasurementRepository (slice 2)"]
+    DB[("DB mesures eau — append-only (slice 2)")]
+    Ctrl --> Svc
+    Svc --> Agg
+    Svc --> Prov
+    Svc -.->|slice 2| Repo
+    Repo -.->|slice 2| DB
+  end
+
+  GeoApi["geo.api.gouv.fr (DINUM/INSEE)"]
+  HubEau["Hub'Eau qualite_eau_potable (OFB/BRGM/ARS)"]
+
+  HTTP -->|"GET /communes?codePostal="| GeoApi
+  HTTP -->|"GET /water?codeInsee=&year="| Ctrl
+  Prov -->|"communes_udi + resultats_dis"| HubEau
+
+  classDef slice2 stroke-dasharray:4 3,stroke:#a67,color:#a67
+  class Repo,DB slice2
+```
+
+## Notes
+
+- **Two egress points, both explicit**: mobile leaves only through `http-client` (the project
+  forbids a direct `fetch` elsewhere); the backend leaves only through
+  `HubeauWaterQualityProvider`. The geo resolution is a mobile-side call to the sovereign state
+  API **through `http-client`** — not a new backend endpoint (ADR-0025 § INSEE resolution = A).
+- **Aggregation** lives in `WaterAggregationDomainService` (a domain service `WaterService`
+  orchestrates), not in `WaterService` itself.
+- **Caching**: `WaterService` already holds an **in-memory per-request TTL cache** on the live
+  path (slice 1). `WaterMeasurementRepository` + the append-only DB are the **slice-2** *durable /
+  history* layer — a different, additional cache, not the first one.
+- **Slice boundary**: the **endpoint contract and the mobile call site are unchanged** when slice
+  2 lands; slice 2 **additively** extends the `/water` DTO with the freshness date (the mobile
+  upgrades its year-granular line to a dated pastille). Same `GET /water`, same 5
+  ions/hardness/conformity/network.
+- This is **not** the use-case grouping: `geo.api.gouv.fr` and Hub'Eau appear here as
+  infrastructure dependencies, consistent with `01-use-case` where they are supporting actors.
+- No US vendor anywhere — the whole egress is FR/EU-sovereign (ADR-0025 § study).

--- a/docs/architecture/diagrams/water-profile/04-component.md
+++ b/docs/architecture/diagrams/water-profile/04-component.md
@@ -59,9 +59,10 @@ flowchart TB
   API **through `http-client`** — not a new backend endpoint (ADR-0025 § INSEE resolution = A).
 - **Aggregation** lives in `WaterAggregationDomainService` (a domain service `WaterService`
   orchestrates), not in `WaterService` itself.
-- **Caching**: `WaterService` already holds an **in-memory per-request TTL cache** on the live
-  path (slice 1). `WaterMeasurementRepository` + the append-only DB are the **slice-2** *durable /
-  history* layer — a different, additional cache, not the first one.
+- **Caching**: `WaterService` already holds a **process-level in-memory TTL cache** (a `Map` on
+  the singleton, shared across requests) on the live path (slice 1). `WaterMeasurementRepository`
+  + the append-only DB are the **slice-2** *durable / history* layer — a different, additional
+  cache, not the first one.
 - **Slice boundary**: the **endpoint contract and the mobile call site are unchanged** when slice
   2 lands; slice 2 **additively** extends the `/water` DTO with the freshness date (the mobile
   upgrades its year-granular line to a dated pastille). Same `GET /water`, same 5

--- a/docs/architecture/diagrams/water-profile/05-data-flow.md
+++ b/docs/architecture/diagrams/water-profile/05-data-flow.md
@@ -1,0 +1,54 @@
+# Data-flow diagram — water-profile — what flows where, and what is PII
+
+> **Feature**: water-profile epic — slices 1 & 2 ([[project_water_profile_epic]])
+> **Related ADRs**: ADR-0025, ADR-0003 (consent single source of truth), ADR-0004
+> **Decisions captured**: location = coarse PII kept ephemeral in slice 1; water data = public
+
+## Context
+
+Traces the data and flags the **privacy boundary** that drives ADR-0025: the user's
+**location** (postal code / chosen commune) is coarse PII, whereas the **water measurements**
+are public ARS/Hub'Eau reference data. Slice 1 keeps the location **ephemeral** (never
+persisted → no consent surface); the slice-2 cache stores **only public water data**. Persisting
+the location is a **deferred, consented** flow (dashed), not part of these slices.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  Brewer(("Brasseur"))
+  Mobile["Mobile — onglet Eau"]
+  GeoApi["geo.api.gouv.fr"]
+  API["API /water"]
+  HubEau["Hub'Eau"]
+  Cache[("Cache mesures eau (slice 2)")]
+  UserStore[("Profil utilisateur (différé)")]
+
+  Brewer -->|"code postal — PII: localisation (grossière), éphémère"| Mobile
+  Mobile -->|"code postal — PII: localisation, transit vers tiers (éphémère)"| GeoApi
+  GeoApi -->|"communes + INSEE (public)"| Mobile
+  Mobile -->|"code INSEE (localisation résolue, éphémère — non persistée)"| API
+  API -->|"code commune → réseau + année"| HubEau
+  HubEau -->|"mesures ions (public)"| API
+  API -.->|"mesures (public, NON-PII)"| Cache
+  API -->|"profil eau (public)"| Mobile
+  Mobile -->|"profil affiché"| Brewer
+
+  Brewer -.->|"« retenir mon eau » — PII: commune stockée (consentement ADR-0003)"| UserStore
+
+  classDef deferred stroke-dasharray:4 3,stroke:#a67,color:#a67
+  class UserStore,Cache deferred
+```
+
+## Notes
+
+- **The privacy line**: only the **location** edges carry PII. The postal code / commune is
+  coarse location; in slice 1 it is **transient** (used to resolve INSEE, then dropped) — no
+  storage, **no consent surface opened**.
+- **Public data ≠ PII**: the slice-2 cache holds commune water measurements (ARS/Hub'Eau public
+  data). Storing it triggers **no** RGPD obligation — this is what makes the cache safe to build.
+- **Deferred consented flow** (dashed `UserStore`): "remember my water" would persist the chosen
+  commune (stored PII) → falls under **ADR-0003** consent + a retention decision. Explicitly out
+  of ADR-0025's slices.
+- **Minimisation**: we send Hub'Eau only a commune code + year; we send geo.api.gouv.fr only a
+  postal code. No name, no address, no precise geolocation (lat/lon) is ever collected.


### PR DESCRIPTION
## Summary

Conception (UML-first, per the project method) for the **water-profile epic**'s first buildable increment: bring the recipe Water tab from hardcoded city presets to the brewer's **real local tap water** via geolocation.

- **ADR-0025** — postal-code geolocation (live `geo.api.gouv.fr`, sovereign/keyless), **live `/water` proxy first, append-only cache + conditional sync second**. Three **weighted decision matrices** (geo input model, INSEE resolution, data locality), explicit deferred scope, a 2-slice roadmap.
- **5 UML diagrams** (`docs/architecture/diagrams/water-profile/`): use-case, sequence slice-1 (postal → disambiguation → INSEE → `/water`), sequence slice-2 (date-check → conditional full sync → append-only → DB fallback), component (egress points), data-flow (PII boundary: coarse location vs public water data).

## Context

Builds on the Hub'Eau fix (#1352, `6595786`). Slice-1 consumes the **existing** `/water` (no backend change); slice-2 adds the cache. Map drill-down, per-ion %, mineral-water %, corrective salts, sodium, analytics, and location persistence are **explicitly deferred**.

## Checklist

- [x] Docs-only; renders clean (mermaid-cli), no stray EOF fence.
- [x] UML 2.5 orthodoxy (actor goals, use-case != component, domain grouping).
- [x] 4-lens adversarial review (UML, ADR/matrix arithmetic, tech-accuracy vs live APIs + code, decision fidelity) — all findings applied.
- [x] English only.