### PR TITLE
feat(mobile/recipes): local water profile by postal code (water-profile slice 1)

### DIFF
--- a/docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md
+++ b/docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md
@@ -176,9 +176,14 @@ the user's own location). **C** front-loads analytics screens the feature doesn'
 - **Freshness** = honest **year + conformity** for now ("Analyses <année> — eau conforme, source
   ARS via Hub'Eau"); the exact **dated** freshness pastille arrives with slice-2 (when the DTO
   carries `max(date_prelevement)`). **Never** show a fetch-date as if it were the data currency.
-- **Compatibility** = **reuse the existing global 0–100 score** (`recipe-details.utils`) fed by
-  the live profile instead of a preset. Per-ion %, mineral-water %, and the salt engine stay in
-  later epic slices. **Do not touch** the client-side salts helper
+- **Compatibility** = **deferred to a follow-up slice** (revised at build time). The intent was
+  to reuse the existing global 0–100 score (`recipe-details.utils`), but that function iterates
+  all **6** ions **including sodium** and coerces `null → 0` (`Math.abs(actual − recommended)`);
+  fed the live profile (no Na + nullable ions) it would produce a **confidently-wrong** score —
+  the exact silent-wrong trap this ADR forbids. Slice-1 therefore renders the **raw local
+  profile only**; the score returns once it is adapted to nullable / 5-ion profiles (this also
+  defers `UC3` "compare to the recipe target" to that slice). Per-ion %, mineral-water %, and the
+  salt engine stay in later epic slices. **Do not touch** the client-side salts helper
   (`helpers/water-mineral-salts.ts`) — it contradicts "water-math = backend".
 - **Missing/partial data** = an explicit "donnée partielle / ion non mesuré" state, **distinct**
   from "non conforme" and from "conforme", so blanks never read as either.

--- a/docs/architecture/diagrams/water-profile/01-use-case.md
+++ b/docs/architecture/diagrams/water-profile/01-use-case.md
@@ -25,9 +25,9 @@ flowchart LR
     subgraph Eau ["Domaine Eau"]
       UC1(("Consulter le profil d'eau<br/>de ma commune"))
       UC2(("Choisir la commune<br/>(si code postal ambigu)"))
-      UC3(("Comparer mon eau au<br/>profil cible de la recette"))
     end
     subgraph Differe ["Différé (hors slice 1)"]
+      UC3(("Comparer mon eau au<br/>profil cible de la recette"))
       D1(("Explorer via la carte<br/>de France"))
       D2(("Retenir mon eau<br/>(persistée, consentie)"))
       D3(("Corriger mon eau<br/>(sels correcteurs)"))
@@ -35,17 +35,17 @@ flowchart LR
   end
 
   Brewer --> UC1
-  Brewer --> UC3
   UC2 -.->|"«extend» [CP → plusieurs communes]"| UC1
   GeoApi --- UC1
   HubEau --- UC1
 
+  Brewer --> UC3
   Brewer --> D1
   Brewer --> D2
   Brewer --> D3
 
   classDef deferred fill:#eee,stroke:#bbb,stroke-dasharray:4 3,color:#888
-  class D1,D2,D3 deferred
+  class UC3,D1,D2,D3 deferred
 ```
 
 ## Notes
@@ -59,8 +59,9 @@ flowchart LR
 - **`UC2` is an «extend»** with a real guard `[CP → plusieurs communes]`: disambiguation only
   fires when one postal code maps to several communes (verified live: `01400` → 10). Arrondissement
   input resolves to the parent commune.
-- **`UC3` is a standalone goal** (compare my water to the recipe target), realized by reusing the
-  existing global 0–100 compatibility score — not a conditional fragment of `UC1`.
-- The three **deferred** goals (map, remember-my-water, corrective salts) are solid associations
-  greyed via `classDef` so the slice-1 boundary is unambiguous; each is its own later slice/epic
-  per ADR-0025.
+- **`UC3` (compare my water to the recipe target) is deferred with the compatibility score**
+  (ADR-0025 § Compatibility): the existing global 0–100 score coerces missing/nullable ions to 0,
+  so it is unsafe for the live 5-ion profile (no Na); slice-1 renders the **raw** profile only.
+- The **deferred** goals (compare-to-target, map, remember-my-water, corrective salts) are solid
+  associations greyed via `classDef` so the slice-1 boundary is unambiguous; each is its own later
+  slice/epic per ADR-0025.

--- a/packages/mobile-app/src/features/recipes/application/__tests__/water-profile.use-cases.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/water-profile.use-cases.test.ts
@@ -1,3 +1,4 @@
+import { HttpError } from "@/core/http/http-error";
 import {
   getCommunesByPostalCode,
   getLiveWaterProfile,
@@ -7,6 +8,7 @@ import {
   loadWaterProfile,
   resolveCommunes,
 } from "@/features/recipes/application/water-profile.use-cases";
+import type { LiveWaterProfile } from "@/features/recipes/domain/water-profile.types";
 
 jest.mock("@/features/recipes/data/water-profile.api", () => ({
   getCommunesByPostalCode: jest.fn(),
@@ -19,6 +21,16 @@ const mockGetCommunes = getCommunesByPostalCode as jest.MockedFunction<
 const mockGetProfile = getLiveWaterProfile as jest.MockedFunction<
   typeof getLiveWaterProfile
 >;
+
+const profile: LiveWaterProfile = {
+  codeInsee: "59350",
+  year: 2025,
+  networkName: "LILLE",
+  sampleCount: 100,
+  conformity: "C",
+  mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
+  hardnessFrench: 125.4,
+};
 
 describe("water-profile.use-cases", () => {
   afterEach(() => jest.clearAllMocks());
@@ -50,24 +62,41 @@ describe("water-profile.use-cases", () => {
       expect(mockGetCommunes).toHaveBeenCalledWith("59000", undefined);
       expect(result).toHaveLength(1);
     });
+
+    it("passes an empty result through unchanged (unknown postal code)", async () => {
+      mockGetCommunes.mockResolvedValue([]);
+      expect(await resolveCommunes("00000")).toEqual([]);
+    });
   });
 
   describe("loadWaterProfile", () => {
-    it("delegates to the data layer with the commune code and year", async () => {
-      mockGetProfile.mockResolvedValue({
-        codeInsee: "59350",
-        year: 2024,
-        networkName: "LILLE",
-        sampleCount: 100,
-        conformity: "C",
-        mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
-        hardnessFrench: 125.4,
-      });
+    it("returns the current-year profile when it exists", async () => {
+      mockGetProfile.mockResolvedValue(profile);
 
-      const result = await loadWaterProfile("59350", 2024);
+      const result = await loadWaterProfile("59350");
 
-      expect(mockGetProfile).toHaveBeenCalledWith("59350", 2024, undefined);
+      expect(mockGetProfile).toHaveBeenCalledTimes(1);
       expect(result.codeInsee).toBe("59350");
+    });
+
+    it("falls back to the previous year on a 404", async () => {
+      mockGetProfile
+        .mockRejectedValueOnce(new HttpError(404, ""))
+        .mockResolvedValueOnce(profile);
+
+      const result = await loadWaterProfile("59350");
+
+      expect(mockGetProfile).toHaveBeenCalledTimes(2);
+      const [first, second] = mockGetProfile.mock.calls;
+      expect(second[1]).toBe(first[1] - 1);
+      expect(result.codeInsee).toBe("59350");
+    });
+
+    it("rethrows a non-404 error without a year fallback", async () => {
+      mockGetProfile.mockRejectedValue(new HttpError(500, "boom"));
+
+      await expect(loadWaterProfile("59350")).rejects.toBeInstanceOf(HttpError);
+      expect(mockGetProfile).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/mobile-app/src/features/recipes/application/__tests__/water-profile.use-cases.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/water-profile.use-cases.test.ts
@@ -1,0 +1,73 @@
+import {
+  getCommunesByPostalCode,
+  getLiveWaterProfile,
+} from "@/features/recipes/data/water-profile.api";
+import {
+  isValidPostalCode,
+  loadWaterProfile,
+  resolveCommunes,
+} from "@/features/recipes/application/water-profile.use-cases";
+
+jest.mock("@/features/recipes/data/water-profile.api", () => ({
+  getCommunesByPostalCode: jest.fn(),
+  getLiveWaterProfile: jest.fn(),
+}));
+
+const mockGetCommunes = getCommunesByPostalCode as jest.MockedFunction<
+  typeof getCommunesByPostalCode
+>;
+const mockGetProfile = getLiveWaterProfile as jest.MockedFunction<
+  typeof getLiveWaterProfile
+>;
+
+describe("water-profile.use-cases", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("isValidPostalCode", () => {
+    it.each(["59000", "75056", "97400", " 59000 "])(
+      "accepts the 5-digit code %s",
+      (value) => {
+        expect(isValidPostalCode(value)).toBe(true);
+      },
+    );
+
+    it.each(["5900", "590000", "abcde", "", "59 00"])(
+      "rejects the malformed code %s",
+      (value) => {
+        expect(isValidPostalCode(value)).toBe(false);
+      },
+    );
+  });
+
+  describe("resolveCommunes", () => {
+    it("trims the postal code and delegates to the data layer", async () => {
+      mockGetCommunes.mockResolvedValue([
+        { codeInsee: "59350", nom: "Lille", codesPostaux: ["59000"] },
+      ]);
+
+      const result = await resolveCommunes(" 59000 ");
+
+      expect(mockGetCommunes).toHaveBeenCalledWith("59000", undefined);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe("loadWaterProfile", () => {
+    it("delegates to the data layer with the commune code and year", async () => {
+      mockGetProfile.mockResolvedValue({
+        codeInsee: "59350",
+        year: 2024,
+        networkName: "LILLE",
+        sampleCount: 100,
+        conformity: "C",
+        mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
+        hardnessFrench: 125.4,
+      });
+
+      const result = await loadWaterProfile("59350", 2024);
+
+      expect(mockGetProfile).toHaveBeenCalledWith("59350", 2024, undefined);
+      expect(result.codeInsee).toBe("59350");
+    });
+  });
+});

--- a/packages/mobile-app/src/features/recipes/application/water-profile.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/water-profile.use-cases.ts
@@ -1,3 +1,4 @@
+import { HttpError } from "@/core/http/http-error";
 import {
   getCommunesByPostalCode,
   getLiveWaterProfile,
@@ -26,14 +27,23 @@ export async function resolveCommunes(
 }
 
 /**
- * Loads the local water profile for a resolved commune. `year` defaults to the
- * current calendar year (most communes publish within it); an empty year yields
- * a backend not-found the UI renders as "no data".
+ * Loads the local water profile for a resolved commune, trying the current year
+ * first and falling back to the previous one on a not-found. Hub'Eau lags
+ * ~6 weeks, so the in-progress year is often empty (a 404) even where fresh
+ * prior-year data exists — the fallback keeps the freshest *available* year
+ * instead of dead-ending on "no data". A genuine miss (both years 404) rethrows.
  */
 export async function loadWaterProfile(
   codeInsee: string,
-  year: number,
   signal?: AbortSignal,
 ): Promise<LiveWaterProfile> {
-  return getLiveWaterProfile(codeInsee, year, signal);
+  const currentYear = new Date().getFullYear();
+  try {
+    return await getLiveWaterProfile(codeInsee, currentYear, signal);
+  } catch (error) {
+    if (error instanceof HttpError && error.status === 404) {
+      return getLiveWaterProfile(codeInsee, currentYear - 1, signal);
+    }
+    throw error;
+  }
 }

--- a/packages/mobile-app/src/features/recipes/application/water-profile.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/water-profile.use-cases.ts
@@ -1,0 +1,39 @@
+import {
+  getCommunesByPostalCode,
+  getLiveWaterProfile,
+} from "@/features/recipes/data/water-profile.api";
+
+import type {
+  Commune,
+  LiveWaterProfile,
+} from "@/features/recipes/domain/water-profile.types";
+
+/** French metropolitan + DROM postal codes are 5 digits. */
+export function isValidPostalCode(postalCode: string): boolean {
+  return /^\d{5}$/.test(postalCode.trim());
+}
+
+/**
+ * Resolves a postal code to its candidate communes. Returns `[]` for an unknown
+ * postal code (the UI surfaces an "unknown postal code" state); the caller
+ * disambiguates when more than one commune is returned.
+ */
+export async function resolveCommunes(
+  postalCode: string,
+  signal?: AbortSignal,
+): Promise<Commune[]> {
+  return getCommunesByPostalCode(postalCode.trim(), signal);
+}
+
+/**
+ * Loads the local water profile for a resolved commune. `year` defaults to the
+ * current calendar year (most communes publish within it); an empty year yields
+ * a backend not-found the UI renders as "no data".
+ */
+export async function loadWaterProfile(
+  codeInsee: string,
+  year: number,
+  signal?: AbortSignal,
+): Promise<LiveWaterProfile> {
+  return getLiveWaterProfile(codeInsee, year, signal);
+}

--- a/packages/mobile-app/src/features/recipes/data/__tests__/water-profile.api.test.ts
+++ b/packages/mobile-app/src/features/recipes/data/__tests__/water-profile.api.test.ts
@@ -105,15 +105,19 @@ describe("water-profile.api", () => {
       mockRequest.mockResolvedValue([
         { code: "59350", nom: "Lille", codesPostaux: ["59000"] },
       ]);
+      const controller = new AbortController();
 
-      const result = await getCommunesByPostalCode("59000");
+      const result = await getCommunesByPostalCode("59000", controller.signal);
 
       expect(mockRequest).toHaveBeenCalledTimes(1);
       const [path, options] = mockRequest.mock.calls[0];
-      expect(path).toContain("/communes?codePostal=59000");
+      expect(path).toBe(
+        "/communes?codePostal=59000&fields=nom,code,codesPostaux",
+      );
       expect(options).toMatchObject({
         auth: false,
         baseUrl: "https://geo.api.gouv.fr",
+        signal: controller.signal,
       });
       expect(result).toEqual([
         { codeInsee: "59350", nom: "Lille", codesPostaux: ["59000"] },
@@ -133,10 +137,16 @@ describe("water-profile.api", () => {
         hardnessFrench: 125.4,
       });
 
-      const result = await getLiveWaterProfile("59350", 2024);
+      const controller = new AbortController();
+      const result = await getLiveWaterProfile(
+        "59350",
+        2024,
+        controller.signal,
+      );
 
-      const [path] = mockRequest.mock.calls[0];
+      const [path, options] = mockRequest.mock.calls[0];
       expect(path).toBe("/water?codeInsee=59350&year=2024");
+      expect(options).toMatchObject({ signal: controller.signal });
       expect(result.networkName).toBe("LILLE");
       expect(result.conformity).toBe("C");
       expect(result.mineralsMgL.ca).toBe(116.7);

--- a/packages/mobile-app/src/features/recipes/data/__tests__/water-profile.api.test.ts
+++ b/packages/mobile-app/src/features/recipes/data/__tests__/water-profile.api.test.ts
@@ -1,0 +1,145 @@
+import { request } from "@/core/http/http-client";
+import {
+  getCommunesByPostalCode,
+  getLiveWaterProfile,
+  mapConformity,
+  mapGeoCommune,
+  mapWaterProfile,
+} from "@/features/recipes/data/water-profile.api";
+
+jest.mock("@/core/http/http-client", () => ({
+  request: jest.fn(),
+}));
+
+const mockRequest = request as jest.MockedFunction<typeof request>;
+
+describe("water-profile.api", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("mapGeoCommune", () => {
+    it("maps `code` to `codeInsee` and keeps postal codes", () => {
+      expect(
+        mapGeoCommune({
+          code: "59350",
+          nom: "Lille",
+          codesPostaux: ["59000", "59160"],
+        }),
+      ).toEqual({
+        codeInsee: "59350",
+        nom: "Lille",
+        codesPostaux: ["59000", "59160"],
+      });
+    });
+
+    it("defaults missing postal codes to an empty array", () => {
+      expect(
+        mapGeoCommune({ code: "75056", nom: "Paris" }).codesPostaux,
+      ).toEqual([]);
+    });
+  });
+
+  describe("mapConformity", () => {
+    it.each(["C", "N", "D", "S", "UNKNOWN"] as const)(
+      "keeps the known enum value %s",
+      (value) => {
+        expect(mapConformity(value)).toBe(value);
+      },
+    );
+
+    it.each(["", "X", "conforme"])(
+      "falls back to UNKNOWN for the unknown value %s",
+      (value) => {
+        expect(mapConformity(value)).toBe("UNKNOWN");
+      },
+    );
+  });
+
+  describe("mapWaterProfile", () => {
+    it("maps a full DTO to the domain profile", () => {
+      const profile = mapWaterProfile({
+        codeInsee: "59350",
+        year: 2024,
+        networkName: "LILLE",
+        sampleCount: 100,
+        conformity: "N",
+        mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
+        hardnessFrench: 125.4,
+      });
+
+      expect(profile).toEqual({
+        codeInsee: "59350",
+        year: 2024,
+        networkName: "LILLE",
+        sampleCount: 100,
+        conformity: "N",
+        mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
+        hardnessFrench: 125.4,
+      });
+    });
+
+    it("tolerates a null minerals block and null values (partial data)", () => {
+      const profile = mapWaterProfile({
+        codeInsee: "67482",
+        year: 2024,
+        networkName: null,
+        sampleCount: 0,
+        conformity: "zz",
+        mineralsMgL: null,
+        hardnessFrench: null,
+      });
+
+      expect(profile.conformity).toBe("UNKNOWN");
+      expect(profile.mineralsMgL).toEqual({
+        ca: null,
+        mg: null,
+        cl: null,
+        so4: null,
+        hco3: null,
+      });
+      expect(profile.hardnessFrench).toBeNull();
+    });
+  });
+
+  describe("getCommunesByPostalCode", () => {
+    it("calls the sovereign geo API unauthenticated and maps the result", async () => {
+      mockRequest.mockResolvedValue([
+        { code: "59350", nom: "Lille", codesPostaux: ["59000"] },
+      ]);
+
+      const result = await getCommunesByPostalCode("59000");
+
+      expect(mockRequest).toHaveBeenCalledTimes(1);
+      const [path, options] = mockRequest.mock.calls[0];
+      expect(path).toContain("/communes?codePostal=59000");
+      expect(options).toMatchObject({
+        auth: false,
+        baseUrl: "https://geo.api.gouv.fr",
+      });
+      expect(result).toEqual([
+        { codeInsee: "59350", nom: "Lille", codesPostaux: ["59000"] },
+      ]);
+    });
+  });
+
+  describe("getLiveWaterProfile", () => {
+    it("calls the backend /water with codeInsee + year and maps the DTO", async () => {
+      mockRequest.mockResolvedValue({
+        codeInsee: "59350",
+        year: 2024,
+        networkName: "LILLE",
+        sampleCount: 100,
+        conformity: "C",
+        mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
+        hardnessFrench: 125.4,
+      });
+
+      const result = await getLiveWaterProfile("59350", 2024);
+
+      const [path] = mockRequest.mock.calls[0];
+      expect(path).toBe("/water?codeInsee=59350&year=2024");
+      expect(result.networkName).toBe("LILLE");
+      expect(result.conformity).toBe("C");
+      expect(result.mineralsMgL.ca).toBe(116.7);
+    });
+  });
+});

--- a/packages/mobile-app/src/features/recipes/data/water-profile.api.ts
+++ b/packages/mobile-app/src/features/recipes/data/water-profile.api.ts
@@ -1,0 +1,113 @@
+import { request } from "@/core/http/http-client";
+
+import type {
+  Commune,
+  LiveWaterProfile,
+  WaterConformity,
+} from "@/features/recipes/domain/water-profile.types";
+
+/**
+ * Sovereign French state geo API (DINUM/INSEE) — public, keyless. Fixed
+ * national host (not environment-specific), so it is a constant rather than an
+ * env var. See ADR-0025 § Where INSEE resolution lives.
+ */
+const GEO_API_BASE_URL = "https://geo.api.gouv.fr";
+
+interface GeoCommuneDto {
+  readonly code: string;
+  readonly nom: string;
+  readonly codesPostaux?: readonly string[];
+}
+
+/** Maps a geo.api.gouv.fr commune to the domain shape (`code` → `codeInsee`). */
+export function mapGeoCommune(dto: GeoCommuneDto): Commune {
+  return {
+    codeInsee: dto.code,
+    nom: dto.nom,
+    codesPostaux: dto.codesPostaux ?? [],
+  };
+}
+
+/**
+ * Resolves a postal code to its candidate communes (each with its INSEE code).
+ * One postal code can map to several communes — the caller must disambiguate.
+ */
+export async function getCommunesByPostalCode(
+  postalCode: string,
+  signal?: AbortSignal,
+): Promise<Commune[]> {
+  const rows = await request<GeoCommuneDto[]>(
+    `/communes?codePostal=${encodeURIComponent(postalCode)}&fields=nom,code,codesPostaux`,
+    { auth: false, baseUrl: GEO_API_BASE_URL, signal },
+  );
+  return rows.map(mapGeoCommune);
+}
+
+interface WaterMineralsMgLDto {
+  readonly ca: number | null;
+  readonly mg: number | null;
+  readonly cl: number | null;
+  readonly so4: number | null;
+  readonly hco3: number | null;
+}
+
+interface WaterProfileDto {
+  readonly codeInsee: string;
+  readonly year: number;
+  readonly networkName: string | null;
+  readonly sampleCount: number;
+  readonly conformity: string;
+  readonly mineralsMgL: WaterMineralsMgLDto | null;
+  readonly hardnessFrench: number | null;
+}
+
+const CONFORMITY_VALUES: readonly WaterConformity[] = [
+  "C",
+  "N",
+  "D",
+  "S",
+  "UNKNOWN",
+];
+
+/** Narrows the backend conformity string to the known enum, else `UNKNOWN`. */
+export function mapConformity(raw: string): WaterConformity {
+  return (CONFORMITY_VALUES as readonly string[]).includes(raw)
+    ? (raw as WaterConformity)
+    : "UNKNOWN";
+}
+
+/** Maps the backend `/water` DTO to the domain profile (already camelCase). */
+export function mapWaterProfile(dto: WaterProfileDto): LiveWaterProfile {
+  const minerals = dto.mineralsMgL;
+  return {
+    codeInsee: dto.codeInsee,
+    year: dto.year,
+    networkName: dto.networkName,
+    sampleCount: dto.sampleCount,
+    conformity: mapConformity(dto.conformity),
+    mineralsMgL: {
+      ca: minerals?.ca ?? null,
+      mg: minerals?.mg ?? null,
+      cl: minerals?.cl ?? null,
+      so4: minerals?.so4 ?? null,
+      hco3: minerals?.hco3 ?? null,
+    },
+    hardnessFrench: dto.hardnessFrench,
+  };
+}
+
+/**
+ * Fetches the aggregated local water profile for a commune from the existing
+ * backend `GET /water` (JWT-guarded — the default `auth: true` applies).
+ */
+export async function getLiveWaterProfile(
+  codeInsee: string,
+  year: number,
+  signal?: AbortSignal,
+): Promise<LiveWaterProfile> {
+  const dto = await request<WaterProfileDto>(
+    `/water?codeInsee=${encodeURIComponent(codeInsee)}&year=${year}`,
+    { signal },
+  );
+  return mapWaterProfile(dto);
+}

--- a/packages/mobile-app/src/features/recipes/data/water-profile.api.ts
+++ b/packages/mobile-app/src/features/recipes/data/water-profile.api.ts
@@ -51,6 +51,10 @@ interface WaterMineralsMgLDto {
   readonly hco3: number | null;
 }
 
+// Mirrors the backend `WaterProfileDto` (already camelCase). `mineralsMgL` is
+// typed nullable here as a defensive client guard only — the server always
+// populates the block (individual ions may be null); do NOT design partial-data
+// UX around a null block, which never arrives from the API.
 interface WaterProfileDto {
   readonly codeInsee: string;
   readonly year: number;

--- a/packages/mobile-app/src/features/recipes/domain/water-profile.types.ts
+++ b/packages/mobile-app/src/features/recipes/domain/water-profile.types.ts
@@ -1,0 +1,40 @@
+/**
+ * Types for the local tap-water lookup (water-profile epic, slice 1 — ADR-0025).
+ * `Commune` comes from the sovereign geo.api.gouv.fr resolver; `LiveWaterProfile`
+ * from the existing backend `GET /water`. The backend returns 5 ions (no sodium)
+ * with nullable values, so every mineral is `number | null`.
+ */
+
+/** A commune resolved from a postal code (geo.api.gouv.fr). */
+export interface Commune {
+  /** INSEE code (`code`) — the exact key Hub'Eau / the backend `/water` uses. */
+  readonly codeInsee: string;
+  readonly nom: string;
+  readonly codesPostaux: readonly string[];
+}
+
+/**
+ * Hub'Eau sanitary-conformity verdict (ARS). `C` compliant, `N` non-compliant,
+ * `D` regulatory derogation, `S` increased monitoring, `UNKNOWN` undetermined.
+ */
+export type WaterConformity = "C" | "N" | "D" | "S" | "UNKNOWN";
+
+/** The 5 brewing ions the backend measures (mg/L). Sodium is not measured. */
+export interface LiveWaterMinerals {
+  readonly ca: number | null;
+  readonly mg: number | null;
+  readonly cl: number | null;
+  readonly so4: number | null;
+  readonly hco3: number | null;
+}
+
+/** Aggregated local water profile for a commune, from the backend `/water`. */
+export interface LiveWaterProfile {
+  readonly codeInsee: string;
+  readonly year: number;
+  readonly networkName: string | null;
+  readonly sampleCount: number;
+  readonly conformity: WaterConformity;
+  readonly mineralsMgL: LiveWaterMinerals;
+  readonly hardnessFrench: number | null;
+}

--- a/packages/mobile-app/src/features/recipes/presentation/components/LiveWaterProfilePanel.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/LiveWaterProfilePanel.tsx
@@ -1,0 +1,190 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { Badge } from "@/core/ui/Badge";
+import { Card } from "@/core/ui/Card";
+import { colors, radius, spacing, typography } from "@/core/theme";
+
+import type {
+  LiveWaterMinerals,
+  LiveWaterProfile,
+  WaterConformity,
+} from "@/features/recipes/domain/water-profile.types";
+
+type Props = Readonly<{ profile: LiveWaterProfile }>;
+
+type BadgeVariant = "success" | "warning" | "error" | "neutral";
+
+const CONFORMITY_LABEL: Record<WaterConformity, string> = {
+  C: "Conforme",
+  N: "Non conforme",
+  D: "Dérogation",
+  S: "Surveillance renforcée",
+  UNKNOWN: "Conformité inconnue",
+};
+
+const CONFORMITY_VARIANT: Record<WaterConformity, BadgeVariant> = {
+  C: "success",
+  N: "error",
+  D: "warning",
+  S: "warning",
+  UNKNOWN: "neutral",
+};
+
+const ION_LABEL: Record<keyof LiveWaterMinerals, string> = {
+  ca: "Calcium",
+  mg: "Magnésium",
+  cl: "Chlorures",
+  so4: "Sulfates",
+  hco3: "Bicarbonates",
+};
+
+const ION_ORDER: readonly (keyof LiveWaterMinerals)[] = [
+  "ca",
+  "mg",
+  "cl",
+  "so4",
+  "hco3",
+];
+
+/** Plain-language hardness sentence — the app teaches (ADR-0025 § pedagogy). */
+function hardnessSentence(hardnessFrench: number | null): string | null {
+  if (hardnessFrench === null) {
+    return null;
+  }
+  if (hardnessFrench < 15) {
+    return "Eau douce — pauvre en calcaire.";
+  }
+  if (hardnessFrench < 30) {
+    return "Eau moyennement dure.";
+  }
+  return "Eau dure — riche en calcaire.";
+}
+
+function formatMgL(value: number | null): string {
+  return value === null ? "—" : `${value} mg/L`;
+}
+
+export function LiveWaterProfilePanel({ profile }: Props) {
+  const minerals = profile.mineralsMgL;
+  const hasPartialData =
+    ION_ORDER.some((ion) => minerals[ion] === null) ||
+    profile.hardnessFrench === null;
+  const pedagogy = hardnessSentence(profile.hardnessFrench);
+
+  return (
+    <Card variant="subtle" style={styles.card}>
+      <View style={styles.headerRow}>
+        <Text style={styles.network} numberOfLines={2}>
+          {profile.networkName ?? "Réseau d'eau local"}
+        </Text>
+        <Badge
+          label={CONFORMITY_LABEL[profile.conformity]}
+          variant={CONFORMITY_VARIANT[profile.conformity]}
+        />
+      </View>
+
+      <Text style={styles.caveat}>
+        Plusieurs réseaux peuvent desservir la commune — profil du réseau
+        principal.
+      </Text>
+
+      {ION_ORDER.map((ion) => (
+        <View key={ion} style={styles.metricRow}>
+          <Text style={styles.metricLabel}>{ION_LABEL[ion]}</Text>
+          <Text style={styles.metricValue}>{formatMgL(minerals[ion])}</Text>
+        </View>
+      ))}
+
+      <View style={styles.metricRow}>
+        <Text style={styles.metricLabel}>Sodium</Text>
+        <Text style={styles.metricMuted}>non mesuré</Text>
+      </View>
+
+      <View style={styles.metricRow}>
+        <Text style={styles.metricLabel}>Dureté</Text>
+        <Text style={styles.metricValue}>
+          {profile.hardnessFrench === null
+            ? "—"
+            : `${profile.hardnessFrench} °fH`}
+        </Text>
+      </View>
+
+      {pedagogy ? <Text style={styles.pedagogy}>{pedagogy}</Text> : null}
+
+      {hasPartialData ? (
+        <Text style={styles.partial}>
+          Donnée partielle : certaines mesures manquent pour cette commune (ce
+          n'est pas un signe de non-conformité).
+        </Text>
+      ) : null}
+
+      <Text style={styles.source}>
+        Analyses {profile.year} — source ARS via Hub'Eau.
+      </Text>
+    </Card>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: spacing.xs,
+    marginTop: spacing.sm,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.sm,
+  },
+  network: {
+    flex: 1,
+    fontSize: typography.size.body,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+  },
+  caveat: {
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+  },
+  metricRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: spacing.xxs,
+    borderTopWidth: 1,
+    borderTopColor: colors.neutral.border,
+  },
+  metricLabel: {
+    fontSize: typography.size.body,
+    color: colors.neutral.textPrimary,
+  },
+  metricValue: {
+    fontSize: typography.size.body,
+    fontWeight: typography.weight.medium,
+    color: colors.neutral.textPrimary,
+  },
+  metricMuted: {
+    fontSize: typography.size.body,
+    fontStyle: "italic",
+    color: colors.neutral.textSecondary,
+  },
+  pedagogy: {
+    fontSize: typography.size.label,
+    fontWeight: typography.weight.medium,
+    color: colors.brand.secondary,
+    marginTop: spacing.xxs,
+  },
+  partial: {
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+    backgroundColor: colors.state.infoBackground,
+    borderRadius: radius.sm,
+    padding: spacing.xs,
+  },
+  source: {
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+    marginTop: spacing.xxs,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/LiveWaterProfilePanel.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/LiveWaterProfilePanel.tsx
@@ -73,7 +73,7 @@ export function LiveWaterProfilePanel({ profile }: Props) {
   const pedagogy = hardnessSentence(profile.hardnessFrench);
 
   return (
-    <Card variant="subtle" style={styles.card}>
+    <Card variant="subtle" style={styles.card} testID="water-profile-panel">
       <View style={styles.headerRow}>
         <Text style={styles.network} numberOfLines={2}>
           {profile.networkName ?? "Réseau d'eau local"}
@@ -81,6 +81,7 @@ export function LiveWaterProfilePanel({ profile }: Props) {
         <Badge
           label={CONFORMITY_LABEL[profile.conformity]}
           variant={CONFORMITY_VARIANT[profile.conformity]}
+          accessibilityLabel={`Conformité : ${CONFORMITY_LABEL[profile.conformity]}`}
         />
       </View>
 

--- a/packages/mobile-app/src/features/recipes/presentation/components/LocalWaterByPostalCode.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/LocalWaterByPostalCode.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -11,7 +11,7 @@ import { useQuery } from "@tanstack/react-query";
 
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { colors, radius, spacing, typography } from "@/core/theme";
-import { getErrorMessage } from "@/core/http/http-error";
+import { HttpError, getErrorMessage } from "@/core/http/http-error";
 
 import {
   isValidPostalCode,
@@ -21,13 +21,16 @@ import {
 import type { Commune } from "@/features/recipes/domain/water-profile.types";
 import { LiveWaterProfilePanel } from "@/features/recipes/presentation/components/LiveWaterProfilePanel";
 
+function isNotFound(error: unknown): boolean {
+  return error instanceof HttpError && error.status === 404;
+}
+
 /**
  * Self-contained local-water lookup (ADR-0025 slice 1): postal code → resolve
  * communes via geo.api.gouv.fr → disambiguate if several → fetch the live
  * `/water` profile → render it. Location is ephemeral (nothing is persisted).
  */
 export function LocalWaterByPostalCode() {
-  const year = new Date().getFullYear();
   const [postalCode, setPostalCode] = useState("");
   const [submittedPostalCode, setSubmittedPostalCode] = useState("");
   const [selectedCommune, setSelectedCommune] = useState<Commune | null>(null);
@@ -36,22 +39,21 @@ export function LocalWaterByPostalCode() {
     queryKey: ["geo-communes", submittedPostalCode],
     queryFn: ({ signal }) => resolveCommunes(submittedPostalCode, signal),
     enabled: isValidPostalCode(submittedPostalCode),
+    retry: false,
   });
 
   const communes = communesQuery.data;
-
-  // Auto-select when exactly one commune matches the postal code.
-  useEffect(() => {
-    if (communes && communes.length === 1 && !selectedCommune) {
-      setSelectedCommune(communes[0]);
-    }
-  }, [communes, selectedCommune]);
+  // Derived, not an effect: one commune auto-selects; the user's explicit pick
+  // wins. Recomputes cleanly whenever a new postal code changes the query key.
+  const effectiveCommune =
+    selectedCommune ?? (communes?.length === 1 ? communes[0] : null);
 
   const waterQuery = useQuery({
-    queryKey: ["water", selectedCommune?.codeInsee, year],
+    queryKey: ["water", effectiveCommune?.codeInsee],
     queryFn: ({ signal }) =>
-      loadWaterProfile(selectedCommune?.codeInsee ?? "", year, signal),
-    enabled: !!selectedCommune,
+      loadWaterProfile(effectiveCommune?.codeInsee ?? "", signal),
+    enabled: !!effectiveCommune,
+    retry: false,
   });
 
   const handleResolve = () => {
@@ -61,7 +63,9 @@ export function LocalWaterByPostalCode() {
 
   const showInvalidHint =
     postalCode.trim().length > 0 && !isValidPostalCode(postalCode);
-  const showPicker = !selectedCommune && !!communes && communes.length > 1;
+  // Kept mounted while several communes match, so the user can switch after a
+  // miss without re-typing (highlighting the current pick).
+  const showPicker = !!communes && communes.length > 1;
   const showUnknown =
     !!communes && communes.length === 0 && !communesQuery.isFetching;
 
@@ -89,6 +93,8 @@ export function LocalWaterByPostalCode() {
           label="Trouver mon eau"
           onPress={handleResolve}
           disabled={!isValidPostalCode(postalCode)}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: !isValidPostalCode(postalCode) }}
           style={styles.button}
         />
       </View>
@@ -107,7 +113,9 @@ export function LocalWaterByPostalCode() {
       ) : null}
 
       {communesQuery.isError ? (
-        <Text style={styles.error}>{getErrorMessage(communesQuery.error)}</Text>
+        <Text testID="water-communes-error" style={styles.error}>
+          {getErrorMessage(communesQuery.error)}
+        </Text>
       ) : null}
 
       {showUnknown ? (
@@ -119,37 +127,44 @@ export function LocalWaterByPostalCode() {
           <Text style={styles.pickerTitle}>
             Plusieurs communes partagent ce code postal — laquelle ?
           </Text>
-          {communes?.map((commune) => (
-            <Pressable
-              key={commune.codeInsee}
-              testID={`water-commune-${commune.codeInsee}`}
-              style={styles.pickerOption}
-              onPress={() => setSelectedCommune(commune)}
-              accessibilityRole="button"
-            >
-              <Text style={styles.pickerOptionText}>{commune.nom}</Text>
-            </Pressable>
-          ))}
+          {communes?.map((commune) => {
+            const isSelected =
+              commune.codeInsee === effectiveCommune?.codeInsee;
+            return (
+              <Pressable
+                key={commune.codeInsee}
+                testID={`water-commune-${commune.codeInsee}`}
+                style={[
+                  styles.pickerOption,
+                  isSelected && styles.pickerOptionSelected,
+                ]}
+                onPress={() => setSelectedCommune(commune)}
+                accessibilityRole="button"
+                accessibilityState={{ selected: isSelected }}
+              >
+                <Text style={styles.pickerOptionText}>{commune.nom}</Text>
+              </Pressable>
+            );
+          })}
         </View>
       ) : null}
 
-      {selectedCommune && waterQuery.isLoading ? (
+      {effectiveCommune && waterQuery.isLoading ? (
         <ActivityIndicator
           testID="water-profile-loading"
           color={colors.brand.primary}
         />
       ) : null}
 
-      {selectedCommune && waterQuery.isError ? (
-        <Text style={styles.error}>
-          {getErrorMessage(
-            waterQuery.error,
-            "Pas de données d'eau pour cette commune cette année.",
-          )}
+      {effectiveCommune && waterQuery.isError ? (
+        <Text testID="water-profile-error" style={styles.error}>
+          {isNotFound(waterQuery.error)
+            ? "Pas de données d'eau pour cette commune cette année."
+            : getErrorMessage(waterQuery.error)}
         </Text>
       ) : null}
 
-      {selectedCommune && waterQuery.data ? (
+      {effectiveCommune && waterQuery.data ? (
         <LiveWaterProfilePanel profile={waterQuery.data} />
       ) : null}
     </View>
@@ -211,6 +226,10 @@ const styles = StyleSheet.create({
     borderColor: colors.neutral.border,
     borderRadius: radius.md,
     backgroundColor: colors.neutral.white,
+  },
+  pickerOptionSelected: {
+    borderColor: colors.brand.primary,
+    backgroundColor: colors.state.infoBackground,
   },
   pickerOptionText: {
     fontSize: typography.size.body,

--- a/packages/mobile-app/src/features/recipes/presentation/components/LocalWaterByPostalCode.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/LocalWaterByPostalCode.tsx
@@ -159,7 +159,7 @@ export function LocalWaterByPostalCode() {
       {effectiveCommune && waterQuery.isError ? (
         <Text testID="water-profile-error" style={styles.error}>
           {isNotFound(waterQuery.error)
-            ? "Pas de données d'eau pour cette commune cette année."
+            ? "Pas de données d'eau disponibles pour cette commune."
             : getErrorMessage(waterQuery.error)}
         </Text>
       ) : null}

--- a/packages/mobile-app/src/features/recipes/presentation/components/LocalWaterByPostalCode.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/LocalWaterByPostalCode.tsx
@@ -1,0 +1,219 @@
+import React, { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { useQuery } from "@tanstack/react-query";
+
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { colors, radius, spacing, typography } from "@/core/theme";
+import { getErrorMessage } from "@/core/http/http-error";
+
+import {
+  isValidPostalCode,
+  loadWaterProfile,
+  resolveCommunes,
+} from "@/features/recipes/application/water-profile.use-cases";
+import type { Commune } from "@/features/recipes/domain/water-profile.types";
+import { LiveWaterProfilePanel } from "@/features/recipes/presentation/components/LiveWaterProfilePanel";
+
+/**
+ * Self-contained local-water lookup (ADR-0025 slice 1): postal code → resolve
+ * communes via geo.api.gouv.fr → disambiguate if several → fetch the live
+ * `/water` profile → render it. Location is ephemeral (nothing is persisted).
+ */
+export function LocalWaterByPostalCode() {
+  const year = new Date().getFullYear();
+  const [postalCode, setPostalCode] = useState("");
+  const [submittedPostalCode, setSubmittedPostalCode] = useState("");
+  const [selectedCommune, setSelectedCommune] = useState<Commune | null>(null);
+
+  const communesQuery = useQuery<Commune[]>({
+    queryKey: ["geo-communes", submittedPostalCode],
+    queryFn: ({ signal }) => resolveCommunes(submittedPostalCode, signal),
+    enabled: isValidPostalCode(submittedPostalCode),
+  });
+
+  const communes = communesQuery.data;
+
+  // Auto-select when exactly one commune matches the postal code.
+  useEffect(() => {
+    if (communes && communes.length === 1 && !selectedCommune) {
+      setSelectedCommune(communes[0]);
+    }
+  }, [communes, selectedCommune]);
+
+  const waterQuery = useQuery({
+    queryKey: ["water", selectedCommune?.codeInsee, year],
+    queryFn: ({ signal }) =>
+      loadWaterProfile(selectedCommune?.codeInsee ?? "", year, signal),
+    enabled: !!selectedCommune,
+  });
+
+  const handleResolve = () => {
+    setSelectedCommune(null);
+    setSubmittedPostalCode(postalCode.trim());
+  };
+
+  const showInvalidHint =
+    postalCode.trim().length > 0 && !isValidPostalCode(postalCode);
+  const showPicker = !selectedCommune && !!communes && communes.length > 1;
+  const showUnknown =
+    !!communes && communes.length === 0 && !communesQuery.isFetching;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Mon eau (par code postal)</Text>
+      <Text style={styles.subtitle}>
+        Renseigne ton code postal pour obtenir le profil de l'eau de chez toi.
+      </Text>
+
+      <View style={styles.inputRow}>
+        <TextInput
+          testID="water-postal-input"
+          style={styles.input}
+          value={postalCode}
+          onChangeText={setPostalCode}
+          placeholder="Ex. 59000"
+          placeholderTextColor={colors.neutral.textSecondary}
+          keyboardType="number-pad"
+          maxLength={5}
+          accessibilityLabel="Code postal"
+        />
+        <PrimaryButton
+          testID="water-resolve-button"
+          label="Trouver mon eau"
+          onPress={handleResolve}
+          disabled={!isValidPostalCode(postalCode)}
+          style={styles.button}
+        />
+      </View>
+
+      {showInvalidHint ? (
+        <Text style={styles.hint}>
+          Un code postal français comporte 5 chiffres.
+        </Text>
+      ) : null}
+
+      {communesQuery.isFetching ? (
+        <ActivityIndicator
+          testID="water-communes-loading"
+          color={colors.brand.primary}
+        />
+      ) : null}
+
+      {communesQuery.isError ? (
+        <Text style={styles.error}>{getErrorMessage(communesQuery.error)}</Text>
+      ) : null}
+
+      {showUnknown ? (
+        <Text style={styles.hint}>Code postal inconnu, vérifie ta saisie.</Text>
+      ) : null}
+
+      {showPicker ? (
+        <View style={styles.picker}>
+          <Text style={styles.pickerTitle}>
+            Plusieurs communes partagent ce code postal — laquelle ?
+          </Text>
+          {communes?.map((commune) => (
+            <Pressable
+              key={commune.codeInsee}
+              testID={`water-commune-${commune.codeInsee}`}
+              style={styles.pickerOption}
+              onPress={() => setSelectedCommune(commune)}
+              accessibilityRole="button"
+            >
+              <Text style={styles.pickerOptionText}>{commune.nom}</Text>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+
+      {selectedCommune && waterQuery.isLoading ? (
+        <ActivityIndicator
+          testID="water-profile-loading"
+          color={colors.brand.primary}
+        />
+      ) : null}
+
+      {selectedCommune && waterQuery.isError ? (
+        <Text style={styles.error}>
+          {getErrorMessage(
+            waterQuery.error,
+            "Pas de données d'eau pour cette commune cette année.",
+          )}
+        </Text>
+      ) : null}
+
+      {selectedCommune && waterQuery.data ? (
+        <LiveWaterProfilePanel profile={waterQuery.data} />
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    gap: spacing.xs,
+    marginTop: spacing.md,
+  },
+  title: {
+    fontSize: typography.size.body,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+  },
+  subtitle: {
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+  },
+  inputRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.sm,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    fontSize: typography.size.body,
+    color: colors.neutral.textPrimary,
+    backgroundColor: colors.neutral.white,
+  },
+  button: {
+    flexShrink: 0,
+  },
+  hint: {
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+  },
+  error: {
+    fontSize: typography.size.label,
+    color: colors.semantic.error,
+  },
+  picker: {
+    gap: spacing.xxs,
+  },
+  pickerTitle: {
+    fontSize: typography.size.label,
+    color: colors.neutral.textPrimary,
+  },
+  pickerOption: {
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    borderWidth: 1,
+    borderColor: colors.neutral.border,
+    borderRadius: radius.md,
+    backgroundColor: colors.neutral.white,
+  },
+  pickerOptionText: {
+    fontSize: typography.size.body,
+    color: colors.neutral.textPrimary,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LiveWaterProfilePanel.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LiveWaterProfilePanel.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen } from "@testing-library/react-native";
+
+import { LiveWaterProfilePanel } from "@/features/recipes/presentation/components/LiveWaterProfilePanel";
+import type { LiveWaterProfile } from "@/features/recipes/domain/water-profile.types";
+
+const baseProfile: LiveWaterProfile = {
+  codeInsee: "59350",
+  year: 2024,
+  networkName: "LILLE",
+  sampleCount: 100,
+  conformity: "C",
+  mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
+  hardnessFrench: 125.4,
+};
+
+describe("LiveWaterProfilePanel", () => {
+  it("renders the full profile with the compliant badge and hard-water pedagogy", () => {
+    render(<LiveWaterProfilePanel profile={baseProfile} />);
+
+    expect(screen.getByText("LILLE")).toBeTruthy();
+    expect(screen.getByText("CONFORME")).toBeTruthy();
+    expect(screen.getByText("116.7 mg/L")).toBeTruthy();
+    expect(screen.getByText("322.5 mg/L")).toBeTruthy();
+    expect(screen.getByText("125.4 °fH")).toBeTruthy();
+    expect(screen.getByText("Eau dure — riche en calcaire.")).toBeTruthy();
+    expect(screen.getByText(/Analyses 2024/)).toBeTruthy();
+  });
+
+  it("always labels sodium as non mesuré (never a fabricated 0)", () => {
+    render(<LiveWaterProfilePanel profile={baseProfile} />);
+
+    expect(screen.getByText("Sodium")).toBeTruthy();
+    expect(screen.getByText("non mesuré")).toBeTruthy();
+  });
+
+  it("shows a partial-data notice and dashes for missing ions", () => {
+    render(
+      <LiveWaterProfilePanel
+        profile={{
+          ...baseProfile,
+          mineralsMgL: { ...baseProfile.mineralsMgL, hco3: null },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/Donnée partielle/)).toBeTruthy();
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("renders the non-compliant verdict distinctly", () => {
+    render(
+      <LiveWaterProfilePanel profile={{ ...baseProfile, conformity: "N" }} />,
+    );
+
+    expect(screen.getByText("NON CONFORME")).toBeTruthy();
+  });
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LiveWaterProfilePanel.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LiveWaterProfilePanel.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { render, screen } from "@testing-library/react-native";
 
 import { LiveWaterProfilePanel } from "@/features/recipes/presentation/components/LiveWaterProfilePanel";
-import type { LiveWaterProfile } from "@/features/recipes/domain/water-profile.types";
+import type {
+  LiveWaterProfile,
+  WaterConformity,
+} from "@/features/recipes/domain/water-profile.types";
 
 const baseProfile: LiveWaterProfile = {
   codeInsee: "59350",
@@ -14,17 +17,27 @@ const baseProfile: LiveWaterProfile = {
   hardnessFrench: 125.4,
 };
 
+const withProfile = (patch: Partial<LiveWaterProfile>) => ({
+  ...baseProfile,
+  ...patch,
+});
+
 describe("LiveWaterProfilePanel", () => {
-  it("renders the full profile with the compliant badge and hard-water pedagogy", () => {
+  it("renders the full profile with hard-water pedagogy and no partial notice", () => {
     render(<LiveWaterProfilePanel profile={baseProfile} />);
 
+    expect(screen.getByTestId("water-profile-panel")).toBeTruthy();
     expect(screen.getByText("LILLE")).toBeTruthy();
     expect(screen.getByText("CONFORME")).toBeTruthy();
+    expect(screen.getByLabelText("Conformité : Conforme")).toBeTruthy();
     expect(screen.getByText("116.7 mg/L")).toBeTruthy();
-    expect(screen.getByText("322.5 mg/L")).toBeTruthy();
     expect(screen.getByText("125.4 °fH")).toBeTruthy();
     expect(screen.getByText("Eau dure — riche en calcaire.")).toBeTruthy();
+    expect(
+      screen.getByText(/Plusieurs réseaux peuvent desservir la commune/),
+    ).toBeTruthy();
     expect(screen.getByText(/Analyses 2024/)).toBeTruthy();
+    expect(screen.queryByText(/Donnée partielle/)).toBeNull();
   });
 
   it("always labels sodium as non mesuré (never a fabricated 0)", () => {
@@ -34,13 +47,30 @@ describe("LiveWaterProfilePanel", () => {
     expect(screen.getByText("non mesuré")).toBeTruthy();
   });
 
-  it("shows a partial-data notice and dashes for missing ions", () => {
+  it.each<[number, string]>([
+    [10, "Eau douce — pauvre en calcaire."],
+    [15, "Eau moyennement dure."],
+    [20, "Eau moyennement dure."],
+    [30, "Eau dure — riche en calcaire."],
+    [40, "Eau dure — riche en calcaire."],
+  ])(
+    "maps hardness %d °fH to the right pedagogy sentence",
+    (hardness, text) => {
+      render(
+        <LiveWaterProfilePanel
+          profile={withProfile({ hardnessFrench: hardness })}
+        />,
+      );
+      expect(screen.getByText(text)).toBeTruthy();
+    },
+  );
+
+  it("shows a partial notice + dashes for a missing ion, keeping the verdict", () => {
     render(
       <LiveWaterProfilePanel
-        profile={{
-          ...baseProfile,
+        profile={withProfile({
           mineralsMgL: { ...baseProfile.mineralsMgL, hco3: null },
-        }}
+        })}
       />,
     );
 
@@ -48,11 +78,32 @@ describe("LiveWaterProfilePanel", () => {
     expect(screen.getByText("—")).toBeTruthy();
   });
 
-  it("renders the non-compliant verdict distinctly", () => {
+  it("treats a null hardness as partial (distinct from non-conforme) and drops pedagogy", () => {
     render(
-      <LiveWaterProfilePanel profile={{ ...baseProfile, conformity: "N" }} />,
+      <LiveWaterProfilePanel profile={withProfile({ hardnessFrench: null })} />,
     );
 
-    expect(screen.getByText("NON CONFORME")).toBeTruthy();
+    expect(screen.getByText(/Donnée partielle/)).toBeTruthy();
+    // Partial data is NOT non-conformity — the verdict stays compliant.
+    expect(screen.getByText("CONFORME")).toBeTruthy();
+    expect(screen.queryByText(/Eau (douce|dure|moyennement)/)).toBeNull();
+  });
+
+  it.each<[WaterConformity, string]>([
+    ["C", "CONFORME"],
+    ["N", "NON CONFORME"],
+    ["D", "DÉROGATION"],
+    ["S", "SURVEILLANCE RENFORCÉE"],
+    ["UNKNOWN", "CONFORMITÉ INCONNUE"],
+  ])("renders the %s conformity badge", (conformity, label) => {
+    render(<LiveWaterProfilePanel profile={withProfile({ conformity })} />);
+    expect(screen.getByText(label)).toBeTruthy();
+  });
+
+  it("falls back to a generic network name when none is provided", () => {
+    render(
+      <LiveWaterProfilePanel profile={withProfile({ networkName: null })} />,
+    );
+    expect(screen.getByText("Réseau d'eau local")).toBeTruthy();
   });
 });

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LocalWaterByPostalCode.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LocalWaterByPostalCode.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react-native";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
+import { HttpError } from "@/core/http/http-error";
 import {
   loadWaterProfile,
   resolveCommunes,
@@ -44,7 +45,7 @@ const lomme: Commune = {
 };
 const profile: LiveWaterProfile = {
   codeInsee: "59350",
-  year: 2024,
+  year: 2025,
   networkName: "LILLE",
   sampleCount: 100,
   conformity: "C",
@@ -65,6 +66,11 @@ function renderComponent() {
   );
 }
 
+function submit(postalCode: string) {
+  fireEvent.changeText(screen.getByTestId("water-postal-input"), postalCode);
+  fireEvent.press(screen.getByTestId("water-resolve-button"));
+}
+
 describe("LocalWaterByPostalCode", () => {
   afterEach(() => jest.clearAllMocks());
 
@@ -73,21 +79,19 @@ describe("LocalWaterByPostalCode", () => {
     mockLoad.mockResolvedValue(profile);
     renderComponent();
 
-    fireEvent.changeText(screen.getByTestId("water-postal-input"), "59000");
-    fireEvent.press(screen.getByTestId("water-resolve-button"));
+    submit("59000");
 
-    expect(await screen.findByText("LILLE")).toBeTruthy();
+    expect(await screen.findByTestId("water-profile-panel")).toBeTruthy();
     expect(mockResolve).toHaveBeenCalledWith("59000", expect.anything());
     expect(mockLoad.mock.calls[0][0]).toBe("59350");
   });
 
-  it("forces a commune choice when the postal code maps to several communes", async () => {
+  it("forces a commune choice on several communes and keeps the picker to switch", async () => {
     mockResolve.mockResolvedValue([lille, lomme]);
     mockLoad.mockResolvedValue(profile);
     renderComponent();
 
-    fireEvent.changeText(screen.getByTestId("water-postal-input"), "59000");
-    fireEvent.press(screen.getByTestId("water-resolve-button"));
+    submit("59000");
 
     expect(
       await screen.findByText(/Plusieurs communes partagent ce code postal/),
@@ -98,13 +102,14 @@ describe("LocalWaterByPostalCode", () => {
 
     await waitFor(() => expect(mockLoad).toHaveBeenCalled());
     expect(mockLoad.mock.calls[0][0]).toBe("59352");
+    // The picker stays mounted so the user can switch after a miss.
+    expect(screen.getByTestId("water-commune-59350")).toBeTruthy();
   });
 
   it("does not query on an invalid postal code and shows a hint", () => {
     renderComponent();
 
-    fireEvent.changeText(screen.getByTestId("water-postal-input"), "5900");
-    fireEvent.press(screen.getByTestId("water-resolve-button"));
+    submit("5900");
 
     expect(
       screen.getByText("Un code postal français comporte 5 chiffres."),
@@ -116,8 +121,7 @@ describe("LocalWaterByPostalCode", () => {
     mockResolve.mockResolvedValue([]);
     renderComponent();
 
-    fireEvent.changeText(screen.getByTestId("water-postal-input"), "00000");
-    fireEvent.press(screen.getByTestId("water-resolve-button"));
+    submit("00000");
 
     expect(
       await screen.findByText("Code postal inconnu, vérifie ta saisie."),
@@ -128,9 +132,53 @@ describe("LocalWaterByPostalCode", () => {
     mockResolve.mockRejectedValue(new Error("Service géo indisponible"));
     renderComponent();
 
-    fireEvent.changeText(screen.getByTestId("water-postal-input"), "59000");
-    fireEvent.press(screen.getByTestId("water-resolve-button"));
+    submit("59000");
 
     expect(await screen.findByText("Service géo indisponible")).toBeTruthy();
+  });
+
+  it("shows the French no-data message on a 404 water fetch", async () => {
+    mockResolve.mockResolvedValue([lille]);
+    mockLoad.mockRejectedValue(
+      new HttpError(404, "No data for this city/year"),
+    );
+    renderComponent();
+
+    submit("59000");
+
+    expect(
+      await screen.findByText(
+        "Pas de données d'eau pour cette commune cette année.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("passes through a non-404 water error message", async () => {
+    mockResolve.mockResolvedValue([lille]);
+    mockLoad.mockRejectedValue(new Error("Backend indisponible"));
+    renderComponent();
+
+    submit("59000");
+
+    expect(await screen.findByText("Backend indisponible")).toBeTruthy();
+  });
+
+  it("shows the loading indicator while communes resolve", async () => {
+    mockResolve.mockReturnValue(new Promise<Commune[]>(() => {}));
+    renderComponent();
+
+    submit("59000");
+
+    expect(await screen.findByTestId("water-communes-loading")).toBeTruthy();
+  });
+
+  it("shows the loading indicator while the water profile loads", async () => {
+    mockResolve.mockResolvedValue([lille]);
+    mockLoad.mockReturnValue(new Promise<LiveWaterProfile>(() => {}));
+    renderComponent();
+
+    submit("59000");
+
+    expect(await screen.findByTestId("water-profile-loading")).toBeTruthy();
   });
 });

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LocalWaterByPostalCode.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LocalWaterByPostalCode.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import {
+  loadWaterProfile,
+  resolveCommunes,
+} from "@/features/recipes/application/water-profile.use-cases";
+import { LocalWaterByPostalCode } from "@/features/recipes/presentation/components/LocalWaterByPostalCode";
+import type {
+  Commune,
+  LiveWaterProfile,
+} from "@/features/recipes/domain/water-profile.types";
+
+jest.mock("@/features/recipes/application/water-profile.use-cases", () => ({
+  ...jest.requireActual(
+    "@/features/recipes/application/water-profile.use-cases",
+  ),
+  resolveCommunes: jest.fn(),
+  loadWaterProfile: jest.fn(),
+}));
+
+const mockResolve = resolveCommunes as jest.MockedFunction<
+  typeof resolveCommunes
+>;
+const mockLoad = loadWaterProfile as jest.MockedFunction<
+  typeof loadWaterProfile
+>;
+
+const lille: Commune = {
+  codeInsee: "59350",
+  nom: "Lille",
+  codesPostaux: ["59000"],
+};
+const lomme: Commune = {
+  codeInsee: "59352",
+  nom: "Lomme",
+  codesPostaux: ["59160"],
+};
+const profile: LiveWaterProfile = {
+  codeInsee: "59350",
+  year: 2024,
+  networkName: "LILLE",
+  sampleCount: 100,
+  conformity: "C",
+  mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
+  hardnessFrench: 125.4,
+};
+
+function renderComponent() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Number.POSITIVE_INFINITY },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <LocalWaterByPostalCode />
+    </QueryClientProvider>,
+  );
+}
+
+describe("LocalWaterByPostalCode", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("resolves a single commune and renders its live water profile", async () => {
+    mockResolve.mockResolvedValue([lille]);
+    mockLoad.mockResolvedValue(profile);
+    renderComponent();
+
+    fireEvent.changeText(screen.getByTestId("water-postal-input"), "59000");
+    fireEvent.press(screen.getByTestId("water-resolve-button"));
+
+    expect(await screen.findByText("LILLE")).toBeTruthy();
+    expect(mockResolve).toHaveBeenCalledWith("59000", expect.anything());
+    expect(mockLoad.mock.calls[0][0]).toBe("59350");
+  });
+
+  it("forces a commune choice when the postal code maps to several communes", async () => {
+    mockResolve.mockResolvedValue([lille, lomme]);
+    mockLoad.mockResolvedValue(profile);
+    renderComponent();
+
+    fireEvent.changeText(screen.getByTestId("water-postal-input"), "59000");
+    fireEvent.press(screen.getByTestId("water-resolve-button"));
+
+    expect(
+      await screen.findByText(/Plusieurs communes partagent ce code postal/),
+    ).toBeTruthy();
+    expect(mockLoad).not.toHaveBeenCalled();
+
+    fireEvent.press(screen.getByTestId("water-commune-59352"));
+
+    await waitFor(() => expect(mockLoad).toHaveBeenCalled());
+    expect(mockLoad.mock.calls[0][0]).toBe("59352");
+  });
+
+  it("does not query on an invalid postal code and shows a hint", () => {
+    renderComponent();
+
+    fireEvent.changeText(screen.getByTestId("water-postal-input"), "5900");
+    fireEvent.press(screen.getByTestId("water-resolve-button"));
+
+    expect(
+      screen.getByText("Un code postal français comporte 5 chiffres."),
+    ).toBeTruthy();
+    expect(mockResolve).not.toHaveBeenCalled();
+  });
+
+  it("tells the user when the postal code is unknown", async () => {
+    mockResolve.mockResolvedValue([]);
+    renderComponent();
+
+    fireEvent.changeText(screen.getByTestId("water-postal-input"), "00000");
+    fireEvent.press(screen.getByTestId("water-resolve-button"));
+
+    expect(
+      await screen.findByText("Code postal inconnu, vérifie ta saisie."),
+    ).toBeTruthy();
+  });
+
+  it("surfaces a resolver error message", async () => {
+    mockResolve.mockRejectedValue(new Error("Service géo indisponible"));
+    renderComponent();
+
+    fireEvent.changeText(screen.getByTestId("water-postal-input"), "59000");
+    fireEvent.press(screen.getByTestId("water-resolve-button"));
+
+    expect(await screen.findByText("Service géo indisponible")).toBeTruthy();
+  });
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LocalWaterByPostalCode.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LocalWaterByPostalCode.test.tsx
@@ -148,7 +148,7 @@ describe("LocalWaterByPostalCode", () => {
 
     expect(
       await screen.findByText(
-        "Pas de données d'eau pour cette commune cette année.",
+        "Pas de données d'eau disponibles pour cette commune.",
       ),
     ).toBeTruthy();
   });

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/WaterTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/WaterTab.tsx
@@ -191,6 +191,9 @@ export function WaterTab(props: WaterTabProps) {
               })}
             </View>
 
+            {/* Slice-1 placement: beside the local-water presets, inside the
+                owned-recipe block. Broadening to community recipes is a
+                deliberate follow-up (ADR-0025 leaves the destination open). */}
             <LocalWaterByPostalCode />
 
             <View style={styles.compatibilityCard}>

--- a/packages/mobile-app/src/features/recipes/presentation/tabs/WaterTab.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/tabs/WaterTab.tsx
@@ -9,6 +9,7 @@ import {
   NonPublicWaterPreference,
 } from "@/features/recipes/presentation/recipe-details.constants";
 import { WATER_METRIC_LABELS } from "@/features/recipes/presentation/recipe-details.utils";
+import { LocalWaterByPostalCode } from "@/features/recipes/presentation/components/LocalWaterByPostalCode";
 import {
   WATER_LOCATION_PROFILES,
   WATER_STYLE_PRESETS,
@@ -189,6 +190,8 @@ export function WaterTab(props: WaterTabProps) {
                 );
               })}
             </View>
+
+            <LocalWaterByPostalCode />
 
             <View style={styles.compatibilityCard}>
               <Text style={styles.compatibilityTitle}>


### PR DESCRIPTION
## Summary

**ADR-0025 slice 1** — the recipe Water tab moves from hardcoded city presets to the brewer's **real local tap water** via geolocation. Type a postal code → resolve candidate communes via the sovereign **`geo.api.gouv.fr`** (keyless; disambiguate when >1, picker stays mounted to switch) → fetch the **existing** backend `GET /water` by INSEE → render the live profile: 5 ions (Ca/Mg/Cl/SO4/HCO3) + hardness °fH + conformity badge + dominant-network name with a « plusieurs réseaux » caveat + one plain-language hard/soft sentence.

Mobile is a **pure consumer** — no backend change. Sodium is labelled « non mesuré »; partial data is a first-class state distinct from non-conformity; location is **ephemeral**.

## Context

Builds on the merged conception (#1355, ADR-0025) and the Hub'Eau fix (#1352). New `domain / data / application / presentation` layers + a self-contained `LocalWaterByPostalCode` component slotted into `WaterTab` beside the presets.

**Conception reconciliation** (conception = contract): **compatibility scoring is DEFERRED** — the existing global score iterates 6 ions incl. sodium and coerces `null → 0`, so feeding it the live 5-ion/nullable profile would be silently wrong. ADR-0025 § Compatibility + the use-case diagram (UC3) were updated in this branch.

## Review

Pre-push **3-lens adversarial** review (correctness / test-quality / conformance+a11y). Caught a **real bug**: the `/water` year defaulted to the current calendar year, which 404s for much of the year given Hub'Eau's ~6-week lag → now falls back to the previous year on a 404. Plus: fail-fast on 4xx, persistent commune picker, derived effective-commune (no effect), reliable French no-data message, a11y (roles/labels/testIDs).

## Checklist

- [x] No direct `fetch` (geo call goes through `http-client` with a `baseUrl` override); named exports; no `any`; `StyleSheet.create`; theme tokens.
- [x] H/S/E tests (**52** water: mappers, use-cases incl. year-fallback, panel branches, full lookup flow) + recipes suite **172/172**; tsc / eslint / prettier clean.
- [x] English (code/commits); French UI copy + diagram labels per repo convention.