### PR TITLE
docs(brew-prep/architecture): ADR-0026 equipment capacity fit-check + brew-prep UML refresh

### DIFF
--- a/docs/architecture/decisions/0026-equipment-capacity-fit-check.md
+++ b/docs/architecture/decisions/0026-equipment-capacity-fit-check.md
@@ -1,0 +1,189 @@
+# ADR-0026 — Equipment capacity fit-check: advisory pre-batch readiness, backend-computed
+
+**Status**  Proposed
+**Date**  2026-07-07
+**Owners**  @benoit-bremaud
+
+---
+
+## Context
+
+The pre-batch **readiness journey** (brew-prep conception, PR #1248) already ships an
+**ingredient checklist** and a **launch gate** (`BrewReadiness.readyToLaunch`), reached from a
+recipe's "Préparer mon brassin" CTA. The conception (UC5, `01-use-case`; `04-class`) also modelled
+an **equipment checklist** — a `ReadinessChecklist` of `Kind = EQUIPMENT` with have/required
+`ChecklistItem`s — as the second leg of the gate (`ingredient.isComplete() && equipment.isComplete()`).
+
+Reconciling that conception against the **shipped code** (audit 2026-07-07) surfaces a mismatch that
+this ADR resolves:
+
+- **The equipment model is capacity-based, not an item list.** The stored `equipment_profiles` ORM
+  entity carries three **volumes** (`mash_tun_volume_l`, `boil_kettle_volume_l`,
+  `fermenter_volume_l`) plus three **loss** fields (`trub_loss_l`, `dead_space_loss_l`,
+  `transfer_loss_l`). There is **no discrete-equipment inventory** and no recipe field expressing a
+  "required equipment items" list. A have/required item checklist (UC5 as drawn) therefore has **no
+  data source**.
+- **ADR-0020's volume cascade is not built.** `VolumePlanner`, the `VolumePlan` value object, the
+  boil-off / grain-absorption constants, and the **method** decision (full-volume BIAB vs
+  dunk-sparge, ADR-0020 D2) are **conception-only**. No service computes a pre-boil volume today.
+- **The equipment profile is declared but consumed nowhere.** It is stored and editable, but no
+  batch/recipe logic reads it — so a novice's declared capacities currently mean nothing.
+- **The recipe carries its own target volume** in the **nullable** column `batch_size_l`
+  (`recipe.orm.entity.ts`; the mobile layer surfaces it as `RecipeStats.volumeLiters`, aliased in
+  `recipes.api.ts`). The mash/sparge water volumes (`mash_volume_l` / `sparge_volume_l`) do **not**
+  live on the recipe — they are on the **optional** `recipe_water` 1:1 entity (written only via
+  `upsertWater`; `getWater` returns `null` when absent), and the **seeded/demo public recipes carry
+  no `recipe_water` row** (all `batch_size_l: 20`). Both inputs are therefore routinely **missing**.
+- **No rescale/scale path exists** anywhere in the code.
+
+The concrete novice failure this leaves invisible: importing a **20 L** recipe while brewing in a
+**5 L** demijohn. Nothing warns the novice; the app lets them walk into a batch their gear cannot
+hold — a silent dead-end that contradicts the "never dead-end mid-brew" north-star.
+
+### Documented study (why we are not guessing)
+
+- **Fermenter sizing is a fit question, headspace ≠ losses.** Homebrew practice sizes the fermenter
+  **~20–25 % above** the batch volume to absorb krausen and allow a blow-off — critical on a
+  narrow-neck demijohn. That **headspace** decides whether the wort *physically fits*; the stored
+  `trub_/dead_space_/transfer_loss_l` fields reduce *final yield*, not fit. The two must not be
+  conflated. No `headspace` value exists on the profile today, so v1 introduces it as a **constant**.
+- **The kettle "physically impossible" test is method-dependent.** Whether a kettle can hold the
+  pre-boil volume depends on the method (full-volume BIAB holds all the water at mash-in; a
+  dunk-sparge / 3-vessel build raises volume gradually), and that method logic (ADR-0020 D2) is
+  **not built**. Using `mash_volume_l + sparge_volume_l` as the pre-boil volume is an
+  **approximation** (ignores grain absorption ~1 L/kg and the method split). A **hard block** on an
+  approximate number would risk **false-blocking** a novice whose real method would pass.
+- **The volume math belongs in the backend** (ADR-0020 D3): a single source of truth for the
+  headspace/loss constants, testable, and the natural home of the future `VolumePlanner`.
+
+## Decision
+
+Ship the equipment leg of the readiness journey as an **advisory capacity fit-check**, computed in
+the **backend**, reusing the **real** equipment fields — **not** the conceived item checklist.
+
+- **Fermenter (primary check).** `fermenterUsableL = fermenter_volume_l × (1 − HEADSPACE_RATIO)`
+  compared to the recipe's **`batch_size_l`**. Verdicts: **`FITS`** or **`TOO_LARGE`**. `TOO_LARGE`
+  is **advisory**: it surfaces the **scale ratio** `scaleRatio = batch_size_l / fermenterUsableL`
+  ("cette recette vise 20 L, ton fermenteur tient ~4 L utiles → divise par ~5") as a manual escape
+  hatch — computed **only when `fermenterUsableL > 0`** (never a raw division). **No auto-rescale in
+  v1** (guided rescale is the next slice; the recipe-scaling code does not exist yet). The fermenter
+  verdict is **`NOT_EVALUATED`** (**never `FITS`**, never a division) whenever **either input is
+  missing/degenerate**: `batch_size_l` **null, non-finite, or ≤ 0** (a common case — user recipes
+  omit it → "cette recette n'indique pas de volume cible"), **or** `fermenter_volume_l` **null,
+  non-finite, or ≤ 0** (`@Min(0)` lets a `0` through → "ton profil n'indique pas de volume de
+  fermenteur exploitable"). This mirrors the existing guard in `batch.service.ts`
+  (`volumeL == null || !Number.isFinite(volumeL) || volumeL <= 0`).
+- **Kettle (secondary check).** `boil_kettle_volume_l` compared to an **approximate pre-boil volume**
+  (`mash_volume_l + sparge_volume_l`, both on the optional `recipe_water`). Verdicts: **`OK`** or
+  **`WARNING`**. The kettle verdict is a **non-blocking warning in v1** — a `HARD_STOP` verdict is
+  kept in the model but stays **inactive** until the method decision (ADR-0020 D2) makes "physically
+  impossible" reliable. The kettle verdict is **`NOT_EVALUATED`** (never a computed `NaN`) when
+  **no `recipe_water` row exists** (the demo-recipe case → pre-boil undefined) **or**
+  `boil_kettle_volume_l` is **null, non-finite, or ≤ 0**; only the fermenter check then runs.
+- **No profile → `NOT_EVALUATED`.** When the user has declared no equipment, the check renders a
+  **just-in-time call-to-action** ("déclare ton matériel pour vérifier l'adéquation", linking to the
+  Equipment screen) and does **not** block the launch. v1 uses the user's **default / only** profile;
+  multi-profile selection is deferred.
+- **One response shape for `NOT_EVALUATED`, tagged with a `reason`.** Every non-evaluable case
+  returns the **same `CapacityFit`** object with the affected per-verdict enum(s) set to
+  `NOT_EVALUATED`, the numeric fields absent (optional — `number?` on the class), and a **per-verdict
+  `reason`** so the mobile picks the right message without inferring intent from absent numbers (a
+  no-profile payload and a valid-profile-but-volume-less payload are otherwise byte-identical):
+  `NO_PROFILE` → the whole-screen JIT CTA "déclare ton matériel"; `NO_RECIPE_VOLUME` → "cette recette
+  n'indique pas de volume cible"; `NO_FERMENTER_VOLUME` → "ton profil n'indique pas de volume de
+  fermenteur exploitable"; `NO_RECIPE_WATER` / `NO_KETTLE_VOLUME` → the kettle leg is simply omitted.
+  It stays **one payload TYPE**, just self-describing — for the `GET /recipes/:id/equipment-fit`
+  response.
+- **The launch gate is unchanged in v1.** `readyToLaunch = ingredientChecklist.isComplete()`. The
+  capacity fit-check is **advisory only** — it never disables "Démarrer" in v1. Placement on the
+  screen puts the **capacity block first** (most fundamental), then the ingredient checklist.
+- **`HEADSPACE_RATIO` is a calibratable constant** (defaulted **0.20**), in the spirit of ADR-0020
+  D4 — a backend constant in v1, promotable to a per-profile `fermenterHeadspaceRatio` field later.
+
+This is the **first consumer** of the equipment profile and a **partial, honest realization** of
+ADR-0020: it reuses ADR-0020's model and constants for the two comparisons it can make reliably
+today, and explicitly defers the full cascade, the method decision, the active hard-stop, and the
+guided rescale.
+
+### Readiness power of the capacity check (weighted decision matrix)
+
+Weights reflect a novice-facing, KISS-first goal that must not create a silent dead-end **nor**
+false-block a viable brew.
+
+| Criterion (weight) | A. Strict gate | **B. Advisory + physical hard-stop** | C. Pure informative |
+| --- | --- | --- | --- |
+| Prevents the novice dead-end (20 L on 5 L) (30%) | 5 | **4** | 3 |
+| Avoids false-blocking on approximate / method-less math (25%) | 1 | **4** | 5 |
+| Novice safety — stops the physically impossible (20%) | 5 | **4** | 2 |
+| KISS / build cost v1 (15%) | 3 | **4** | 5 |
+| Preserves novice autonomy / escape hatch (10%) | 1 | **4** | 5 |
+| **Weighted score** | **3.30** | **4.00** | **3.80** |
+
+**Chosen: B (advisory + physical hard-stop) — as the durable MODEL, with C's behaviour in v1.**
+The scores above rate the **target model** (B warns without dead-ending and blocks only the truly
+impossible). **Honest caveat:** the "stops the physically impossible" row (20 %) credits B a `4`,
+and that credit is what carries B's 4.00 over C's 3.80 — but v1 ships **no active hard-stop** (the
+kettle is a non-blocking warning; `HARD_STOP` is modelled-but-inactive until ADR-0020 D2). On the
+capability **actually shipped in v1**, B's safety row collapses to C's (`2`), making B ≈ C
+(≈ 3.60 vs 3.80). **B is therefore chosen for its durable model/roadmap value, not a v1 safety
+advantage** — v1 deliberately behaves like C (advisory-only), and the hard-stop activates when the
+method logic lands. **A** (strict gate) is rejected: blocking on an approximate volume punishes the
+novice for the app's missing method math.
+
+### Where the verdict is computed (weighted decision matrix)
+
+| Criterion (weight) | A. Mobile arithmetic | **B. Backend service** | C. Hybrid |
+| --- | --- | --- | --- |
+| Single source of truth for constants / losses (30%) | 2 | **5** | 4 |
+| Consistency with ADR-0020 D3 (volume-math = backend) (25%) | 1 | **5** | 3 |
+| Testability (20%) | 3 | **5** | 3 |
+| Build cost v1 (15%) | 5 | **3** | 3 |
+| Offline / latency (10%) | 5 | **2** | 3 |
+| **Weighted score** | **2.70** | **4.40** | **3.30** |
+
+**Chosen: B (backend service).** The headspace/loss constants live once, the verdict is testable,
+and it sits where the future `VolumePlanner` will live. The user is already online for the rest of
+the prep flow, so the latency cost is marginal.
+
+### "Too large" behaviour (weighted decision matrix)
+
+| Criterion (weight) | A. Auto-rescale (ADR-0020 D1) | **B. Advisory + explicit ratio** | C. Bare warning |
+| --- | --- | --- | --- |
+| Avoids a soft dead-end / gives a path (35%) | 5 | **4** | 2 |
+| Build cost v1 (30%) | 1 | **5** | 5 |
+| Does not surprise the novice (numbers changing) (20%) | 2 | **5** | 5 |
+| Reuses existing code (15%) | 1 | **5** | 5 |
+| **Weighted score** | **2.60** | **4.65** | **3.95** |
+
+**Chosen: B (advisory + explicit ratio).** Giving the concrete scale ratio is a real manual escape
+without building the (non-existent) rescale engine or silently changing the novice's numbers.
+**A** (auto-rescale) is the natural **next slice** once the cascade + a guided-rescale UX exist.
+
+## Consequences
+
+- The equipment profile becomes **consumed for the first time**, giving the declared capacities
+  meaning inside the readiness journey.
+- A new **backend fit-check** (a focused service + `GET /recipes/:id/equipment-fit?profileId=`, or
+  the equivalent folded onto the pre-batch draft) is introduced; the mobile only renders verdicts.
+- **Introduced now, deferred deliberately:** the active kettle `HARD_STOP` (needs ADR-0020 D2
+  method logic), the **guided rescale** (needs a scaling engine), the full **`VolumePlanner`
+  cascade**, multi-profile selection, and a per-profile `fermenterHeadspaceRatio`.
+- **Underfill is out of scope for v1 — a known, accepted limitation.** v1 only guards the overflow
+  direction (recipe > fermenter). The opposite failure — a tiny recipe in a large fermenter (recipe
+  ≪ `fermenterUsableL` → excessive headspace → oxidation risk) — is a real novice hazard, but the v1
+  `FermenterVerdict` enum has **no underfill member**, so **in v1 it is reported as `FITS`** (the
+  accepted limitation). A dedicated `UNDERFILL` `FermenterVerdict` lands in a later slice so it is no
+  longer conflated with a good fit — it is flagged here so the gap is explicit, not silent.
+- The `04-class` `ReadinessChecklist` of `Kind = EQUIPMENT` is **replaced** by a `CapacityFit`
+  value object; the launch gate stays ingredient-only in v1 (`05-state-readiness` updated).
+- `HEADSPACE_RATIO = 0.20` is a documented, calibratable constant, distinct from the stored losses.
+
+## Relation to other ADRs
+
+- **ADR-0020 (equipment-driven volume planning)** — this ADR is its **first partial realization**:
+  it reuses ADR-0020's model (fermenter caps the batch, D1) and backend-math principle (D3) for the
+  two reliable comparisons, and defers the cascade + method (D2) + calibratable constants (D4).
+- **ADR-0002 (centralized NestJS backend)** — the verdict is computed backend; the mobile egress
+  stays through `core/http/http-client` only.
+- **brew-prep conception** (`docs/architecture/diagrams/brew-prep/`) — `01`, `03`, `04`, `05` are
+  updated and `02b-sequence-capacity-fit` is added to realize this decision.

--- a/docs/architecture/decisions/0026-equipment-capacity-fit-check.md
+++ b/docs/architecture/decisions/0026-equipment-capacity-fit-check.md
@@ -42,9 +42,13 @@ hold — a silent dead-end that contradicts the "never dead-end mid-brew" north-
 
 ### Documented study (why we are not guessing)
 
-- **Fermenter sizing is a fit question, headspace ≠ losses.** Homebrew practice sizes the fermenter
-  **~20–25 % above** the batch volume to absorb krausen and allow a blow-off — critical on a
-  narrow-neck demijohn. That **headspace** decides whether the wort *physically fits*; the stored
+- **Fermenter sizing is a fit question, headspace ≠ losses.** The general krausen-safe norm sizes the
+  fermenter **~20–25 % above** the batch volume (blow-off room), but the project's **own canonical
+  first brew deliberately runs tight** — `Blonde Facile (premier brassin)` seeds `batch_size_l: 4.3`
+  into a **5 L demijohn** (`public-recipes.seed.ts`), i.e. ~14 % headspace. So **v1 defaults
+  `HEADSPACE_RATIO = 0.10`** (usable = `5 × 0.90 = 4.5 L ≥ 4.3` → the flagship reads `FITS` with
+  margin, never `TOO_LARGE`); the 20–25 % norm is the **deferred per-style refinement**. That
+  **headspace** decides whether the wort *physically fits*; the stored
   `trub_/dead_space_/transfer_loss_l` fields reduce *final yield*, not fit. The two must not be
   conflated. No `headspace` value exists on the profile today, so v1 introduces it as a **constant**.
 - **The kettle "physically impossible" test is method-dependent.** Whether a kettle can hold the
@@ -62,10 +66,12 @@ Ship the equipment leg of the readiness journey as an **advisory capacity fit-ch
 the **backend**, reusing the **real** equipment fields — **not** the conceived item checklist.
 
 - **Fermenter (primary check).** `fermenterUsableL = fermenter_volume_l × (1 − HEADSPACE_RATIO)`
-  compared to the recipe's **`batch_size_l`**. Verdicts: **`FITS`** or **`TOO_LARGE`**. `TOO_LARGE`
-  is **advisory**: it surfaces the **scale ratio** `scaleRatio = batch_size_l / fermenterUsableL`
-  ("cette recette vise 20 L, ton fermenteur tient ~4 L utiles → divise par ~5") as a manual escape
-  hatch — computed **only when `fermenterUsableL > 0`** (never a raw division). **No auto-rescale in
+  compared to the recipe's **`batch_size_l`**. Verdicts: **`FITS`** (`batch_size_l ≤ fermenterUsableL`)
+  or **`TOO_LARGE`** (`batch_size_l > fermenterUsableL`, **strict `>`** so a boundary-equal recipe
+  reads `FITS`). `TOO_LARGE` is **advisory**: it surfaces the **scale ratio**
+  `scaleRatio = batch_size_l / fermenterUsableL` ("cette recette vise 20 L, ton fermenteur ne tient
+  que ~4,5 L utiles → réduis d'un facteur ~4–5") as a manual escape hatch — computed **only when
+  `fermenterUsableL > 0`** (never a raw division). **No auto-rescale in
   v1** (guided rescale is the next slice; the recipe-scaling code does not exist yet). The fermenter
   verdict is **`NOT_EVALUATED`** (**never `FITS`**, never a division) whenever **either input is
   missing/degenerate**: `batch_size_l` **null, non-finite, or ≤ 0** (a common case — user recipes
@@ -82,8 +88,12 @@ the **backend**, reusing the **real** equipment fields — **not** the conceived
   `boil_kettle_volume_l` is **null, non-finite, or ≤ 0**; only the fermenter check then runs.
 - **No profile → `NOT_EVALUATED`.** When the user has declared no equipment, the check renders a
   **just-in-time call-to-action** ("déclare ton matériel pour vérifier l'adéquation", linking to the
-  Equipment screen) and does **not** block the launch. v1 uses the user's **default / only** profile;
-  multi-profile selection is deferred.
+  Equipment screen) and does **not** block the launch. There is **no persisted default marker** on
+  `equipment_profiles` today, so v1 uses the user's **single profile** when there is one, and — for a
+  user with several — the **most-recently-created** one (the existing `EquipmentProfileService.listMine`
+  `created_at DESC` order), documented as the de-facto default. An explicit `profileId` selection / a
+  real default marker is a **deferred** slice; until then the endpoint accepts an optional
+  `profileId` and falls back to that most-recent profile.
 - **One response shape for `NOT_EVALUATED`, tagged with a `reason`.** Every non-evaluable case
   returns the **same `CapacityFit`** object with the affected per-verdict enum(s) set to
   `NOT_EVALUATED`, the numeric fields absent (optional — `number?` on the class), and a **per-verdict
@@ -97,7 +107,8 @@ the **backend**, reusing the **real** equipment fields — **not** the conceived
 - **The launch gate is unchanged in v1.** `readyToLaunch = ingredientChecklist.isComplete()`. The
   capacity fit-check is **advisory only** — it never disables "Démarrer" in v1. Placement on the
   screen puts the **capacity block first** (most fundamental), then the ingredient checklist.
-- **`HEADSPACE_RATIO` is a calibratable constant** (defaulted **0.20**), in the spirit of ADR-0020
+- **`HEADSPACE_RATIO` is a calibratable constant** (defaulted **0.10**, calibrated so the shipped
+  guided first brew — `batch_size_l 4.3` in a 5 L demijohn — reads `FITS`), in the spirit of ADR-0020
   D4 — a backend constant in v1, promotable to a per-profile `fermenterHeadspaceRatio` field later.
 
 This is the **first consumer** of the equipment profile and a **partial, honest realization** of
@@ -176,7 +187,8 @@ without building the (non-existent) rescale engine or silently changing the novi
   longer conflated with a good fit — it is flagged here so the gap is explicit, not silent.
 - The `04-class` `ReadinessChecklist` of `Kind = EQUIPMENT` is **replaced** by a `CapacityFit`
   value object; the launch gate stays ingredient-only in v1 (`05-state-readiness` updated).
-- `HEADSPACE_RATIO = 0.20` is a documented, calibratable constant, distinct from the stored losses.
+- `HEADSPACE_RATIO = 0.10` is a documented, calibratable constant (calibrated so the shipped guided
+  first brew reads `FITS`), distinct from the stored losses.
 
 ## Relation to other ADRs
 

--- a/docs/architecture/diagrams/brew-prep/01-use-case.md
+++ b/docs/architecture/diagrams/brew-prep/01-use-case.md
@@ -1,7 +1,7 @@
 # Use case diagram — brew-prep — Prepare a brew (novice, pre-batch)
 
 > **Feature**: first real-world brew — the reversible pre-batch readiness journey.
-> **Related ADRs**: ADR-0020 (equipment-driven volume planning), ADR-0002.
+> **Related ADRs**: ADR-0026 (advisory capacity fit-check), ADR-0020 (equipment-driven volume planning), ADR-0002.
 > **Recipe**: [`../../../real-world-test/blonde-ale-5l-first-brew.md`](../../../real-world-test/blonde-ale-5l-first-brew.md).
 
 ## Context
@@ -23,7 +23,7 @@ flowchart LR
       UC2(("Review recipe & volume plan"))
       UC3(("Declare my equipment & capacities"))
       UC4(("Check ingredient readiness"))
-      UC5(("Check equipment readiness"))
+      UC5(("Check equipment capacity fit"))
       UC6(("Confirm ready to brew"))
     end
   end
@@ -37,16 +37,26 @@ flowchart LR
 
 ## Notes
 
-- **Relationships (real UML, not navigation):** UC2 **«include»** UC3 — the volume
-  plan is *derived from* the declared equipment (ADR-0020 D1/D2), so reviewing the
-  plan presumes equipment is known. UC6 **«include»** UC4 + UC5 — "ready" requires
-  both checklists complete.
+- **Relationships (real UML, not navigation):** UC2 **«include»** UC3 — **once the
+  ADR-0020 volume plan lands**, the plan is *derived from* the declared equipment
+  (D1/D2), so reviewing it will presume equipment is known. **In v1** equipment is
+  **optional** (no profile → `NOT_EVALUATED`, ADR-0026), so UC2 does **not yet**
+  unconditionally include UC3. UC6 **«include»** UC4 only — in v1 "ready" requires the
+  **ingredient** checklist complete. UC5 is an **advisory** the brewer consults
+  (ADR-0026): it warns about capacity but **does not gate** the launch, so it is
+  *not* an «include» of UC6.
+- **UC5 reframed (ADR-0026):** the equipment model is **capacity-based** (three
+  volumes), not a have/required item list, so UC5 is a **capacity fit-check**
+  (fermenter usable vs recipe volume; kettle vs pre-boil) — advisory, computed in
+  the backend, non-blocking in v1. A strict equipment **gate** returns only once the
+  ADR-0020 D2 method logic makes "physically impossible" reliable.
 - **Proportionality:** UC1 (browse/choose) and the recipe-stats part of UC2 are
-  simple reads → stay at the textual spec level. The non-trivial flow (equipment
-  → backend volume plan → checklists → gate) is in the sequence (02).
+  simple reads → stay at the textual spec level. The non-trivial flows (equipment
+  → backend volume plan → checklist → gate; and the capacity fit-check) are in the
+  sequences (02, 02b).
 - **Cockburn (brief) — UC6 *Confirm ready to brew*:** precondition = a recipe
-  imported + equipment declared; success guarantee = "Start the batch" is enabled
-  **only** when the ingredient and equipment checklists are both satisfied; the
-  confirmation hands off to the irreversible batch start.
+  imported; success guarantee = "Start the batch" is enabled **only** when the
+  ingredient checklist is satisfied; the capacity fit-check (UC5) is surfaced
+  alongside as advice; the confirmation hands off to the irreversible batch start.
 - **Out of scope:** starting the batch + the brew day (brewing-session epic).
   **Skipped diagram types:** data-flow (no PII in this journey).

--- a/docs/architecture/diagrams/brew-prep/02-sequence-plan-and-confirm.md
+++ b/docs/architecture/diagrams/brew-prep/02-sequence-plan-and-confirm.md
@@ -1,9 +1,17 @@
 # Sequence diagram — brew-prep — Plan volumes from equipment & confirm readiness
 
 > **Feature**: first real-world brew — pre-batch volume planning + readiness gate.
-> **Related ADRs**: ADR-0020 (backend-computed plan, fermenter caps batch), ADR-0002.
+> **Related ADRs**: ADR-0020 (backend-computed plan, fermenter caps batch), ADR-0002, ADR-0026 (supersedes the v1 gate — see banner).
 
 ## Context
+
+> **DEFERRED / future-state flow.** This sequence depicts the full ADR-0020 cascade
+> (equipment → volume plan) **and the original two-checklist gate**, which return
+> once the `VolumePlanner` + method logic are built. **In v1 (ADR-0026)** the launch
+> gate is **ingredient-only** and the equipment leg is an **advisory capacity
+> fit-check** (no "required equipment" item list) — see `02b-sequence-capacity-fit`,
+> `04-class`, and `05-state-readiness`. Read the gate steps below as the target, not
+> as v1 behaviour.
 
 The one non-trivial pre-batch flow: the app derives the **volume plan** from the
 recipe targets + the brewer's equipment **in the backend** (ADR-0020 D3), shows

--- a/docs/architecture/diagrams/brew-prep/02b-sequence-capacity-fit.md
+++ b/docs/architecture/diagrams/brew-prep/02b-sequence-capacity-fit.md
@@ -22,8 +22,8 @@ sequenceDiagram
   participant R as Recipe store
   participant RW as recipe_water store
 
-  B->>M: Open Preparer mon brassin
-  M->>API: GET /recipes/:id/equipment-fit with default profileId
+  B->>M: Open Préparer mon brassin
+  M->>API: GET /recipes/:id/equipment-fit with optional profileId, else backend resolves my default
   API->>FS: computeFit recipeId profileId
   FS->>EP: load default equipment profile
   FS->>R: load recipe batch_size_l
@@ -32,7 +32,7 @@ sequenceDiagram
     EP-->>FS: none
     FS-->>API: CapacityFit both NOT_EVALUATED, both reason NO_PROFILE
     API-->>M: 200 CapacityFit
-    M-->>B: reason NO_PROFILE drives the JIT CTA declare ton materiel
+    M-->>B: reason NO_PROFILE drives the JIT CTA déclare ton matériel
   else Profile exists
     EP-->>FS: capacities fermenter and kettle
     alt batch_size_l missing or not positive

--- a/docs/architecture/diagrams/brew-prep/02b-sequence-capacity-fit.md
+++ b/docs/architecture/diagrams/brew-prep/02b-sequence-capacity-fit.md
@@ -1,0 +1,79 @@
+# Sequence diagram — brew-prep — the equipment capacity fit-check (advisory)
+
+> **Feature**: first real-world brew — the pre-batch capacity fit-check.
+> **Related ADRs**: ADR-0026 (advisory capacity fit-check), ADR-0020 (equipment model), ADR-0002.
+
+## Context
+
+Realizes **UC5 (Check equipment capacity fit)** per ADR-0026: when the brewer opens the pre-batch
+screen, the mobile asks the backend for a capacity verdict, which the backend derives from the
+recipe volume + the user's default equipment profile. It is **advisory** — it informs, it never
+gates the launch in v1. Covers the no-profile branch (a just-in-time call-to-action).
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor B as Novice brewer
+  participant M as Mobile Brew-prep screen
+  participant API as Equipment-fit controller
+  participant FS as CapacityFitService
+  participant EP as EquipmentProfile store
+  participant R as Recipe store
+  participant RW as recipe_water store
+
+  B->>M: Open Preparer mon brassin
+  M->>API: GET /recipes/:id/equipment-fit with default profileId
+  API->>FS: computeFit recipeId profileId
+  FS->>EP: load default equipment profile
+  FS->>R: load recipe batch_size_l
+  FS->>RW: load recipe_water mash_volume_l and sparge_volume_l (optional)
+  alt No equipment profile declared
+    EP-->>FS: none
+    FS-->>API: CapacityFit both NOT_EVALUATED, both reason NO_PROFILE
+    API-->>M: 200 CapacityFit
+    M-->>B: reason NO_PROFILE drives the JIT CTA declare ton materiel
+  else Profile exists
+    EP-->>FS: capacities fermenter and kettle
+    alt batch_size_l missing or not positive
+      FS->>FS: fermenter = NOT_EVALUATED, reason NO_RECIPE_VOLUME
+    else fermenter_volume_l missing or not positive
+      FS->>FS: fermenter = NOT_EVALUATED, reason NO_FERMENTER_VOLUME
+    else both present and positive
+      FS->>FS: fermenterUsable = fermenter minus headspace ratio
+      FS->>FS: fermenter = FITS or TOO_LARGE plus scaleRatio (fermenterUsable above zero)
+    end
+    alt no recipe_water row
+      FS->>FS: kettle = NOT_EVALUATED, reason NO_RECIPE_WATER
+    else boil_kettle_volume_l missing or not positive
+      FS->>FS: kettle = NOT_EVALUATED, reason NO_KETTLE_VOLUME
+    else pre-boil and kettle available
+      FS->>FS: kettle = OK or WARNING vs approximate pre-boil
+    end
+    FS-->>API: CapacityFit per leg (verdict plus reason when NOT_EVALUATED)
+    API-->>M: 200 CapacityFit
+    M-->>B: Render each leg by its verdict, and NOT_EVALUATED legs by their reason message
+  end
+  Note over M: Advisory only — the launch gate stays ingredient-only in v1 per ADR-0026
+```
+
+## Notes
+
+- **The verdict is backend-computed** (ADR-0026, ADR-0020 D3): the headspace/loss constants and the
+  comparison live once in `CapacityFitService`; the mobile only renders. No duplicated math.
+- **Two data sources, both optional.** The fermenter leg reads the recipe's **nullable**
+  `batch_size_l`; the kettle leg reads `mash_volume_l` / `sparge_volume_l` from the **optional**
+  `recipe_water` 1:1 (absent on the demo recipes). Each missing input yields `NOT_EVALUATED` for its
+  own verdict — never a `NaN` comparison or a fabricated `FITS`.
+- **Approximate pre-boil**: `mash_volume_l + sparge_volume_l` is a method-agnostic approximation
+  (the ADR-0020 D2 full-volume-vs-dunk-sparge logic is not built), so the kettle verdict is a
+  **non-blocking warning** — `HARD_STOP` stays modelled but inactive until the cascade lands.
+- **`TOO_LARGE` carries `scaleRatio`** as a manual escape hatch (no auto-rescale in v1); guided
+  rescale is the next slice.
+- **One payload shape, self-describing via `reason`**: every non-evaluable case returns the same
+  `CapacityFit` with the affected verdict(s) = `NOT_EVALUATED`, numeric fields absent, and a
+  per-verdict `reason` (`NO_PROFILE` / `NO_RECIPE_VOLUME` / `NO_FERMENTER_VOLUME` / `NO_RECIPE_WATER`
+  / `NO_KETTLE_VOLUME`) that drives the message — so a no-profile payload and a valid-profile-but-
+  volume-less payload, otherwise identical, render differently (04-class enums). Never a bare
+  top-level status. The launch gate is the ingredient checklist only, so the brewer can always start
+  the batch.

--- a/docs/architecture/diagrams/brew-prep/03-component.md
+++ b/docs/architecture/diagrams/brew-prep/03-component.md
@@ -1,7 +1,7 @@
 # Component diagram — brew-prep — where the brew-prep logic runs
 
 > **Feature**: first real-world brew — pre-batch structural view.
-> **Related ADRs**: ADR-0020 (backend volume planning), ADR-0002 (NestJS egress).
+> **Related ADRs**: ADR-0026 (CapacityFitService), ADR-0020 (backend volume planning), ADR-0002 (NestJS egress).
 
 ## Context
 
@@ -15,7 +15,7 @@ egress through the http-client (ADR-0002).
 flowchart LR
   subgraph Mobile ["packages/mobile-app"]
     Screen["Brew-prep screen"]
-    UCm["use-cases (display + checklists)"]
+    UCm["use-cases (display + ingredient checklist + render fit verdicts)"]
     HTTP["core/http/http-client"]
     Screen --> UCm
     UCm --> HTTP
@@ -23,24 +23,35 @@ flowchart LR
   subgraph API ["packages/api (NestJS)"]
     RecipeC["Recipe controller"]
     EquipC["Equipment controller"]
-    PlanC["Volume-plan controller (GET /recipes/:id/volume-plan)"]
-    Planner["VolumePlanner (domain service)"]
+    FitC["Equipment-fit controller (GET /recipes/:id/equipment-fit)"]
+    FitService["CapacityFitService (domain service, ADR-0026)"]
+    PlanC["Volume-plan controller (GET /recipes/:id/volume-plan) — future"]
+    Planner["VolumePlanner (domain service) — future"]
     BatchC["Batch controller (start → snapshot plan)"]
+    FitC --> FitService
     PlanC --> Planner
     BatchC --> Planner
   end
   HTTP --> RecipeC
   HTTP --> EquipC
-  HTTP --> PlanC
+  HTTP --> FitC
   HTTP --> BatchC
 ```
 
 ## Notes
 
-- The **`VolumePlanner` domain service** is the single source of truth for the
-  cascade (ADR-0020 D3); both the pre-batch preview (`PlanC`) and batch start
-  (`BatchC`, which snapshots it) call it — no duplicate math.
+- The **`CapacityFitService`** (ADR-0026) is the **v1** backend consumer of the
+  equipment profile: it computes the fermenter/kettle verdicts from the recipe's
+  `batch_size_l` (+ the optional `recipe_water` mash/sparge for the kettle) + the
+  profile capacities + the `HEADSPACE_RATIO` constant, and returns them for the
+  mobile to render. It owns the headspace/loss constants as a single source of truth
+  (ADR-0020 D3 principle) so the mobile never duplicates the math.
+- The **`VolumePlanner`** + `PlanC` (the full ADR-0020 cascade) are **future** — not
+  built in v1; `CapacityFitService` is the first, partial realization. When the
+  cascade lands, `VolumePlanner` becomes the SSOT and the fit-check reuses its
+  derived pre-boil volume instead of the `mash+sparge` approximation.
 - **No direct `fetch` in the mobile** — egress only through
   `core/http/http-client` (ADR-0002, repo forbidden-pattern rule).
 - The equipment profile (capacities) lives in the API (reuses the existing
-  `equipment-profiles`); the mobile reads/edits it.
+  `equipment-profiles`); the mobile reads/edits it. The fit-check uses the user's
+  default/only profile in v1 (multi-profile selection deferred).

--- a/docs/architecture/diagrams/brew-prep/04-class.md
+++ b/docs/architecture/diagrams/brew-prep/04-class.md
@@ -1,7 +1,7 @@
 # Class diagram — brew-prep — volume planning & readiness model
 
 > **Feature**: first real-world brew — the pre-batch domain model.
-> **Related ADRs**: ADR-0020 (equipment-driven, backend-computed).
+> **Related ADRs**: ADR-0026 (CapacityFit replaces the equipment checklist), ADR-0020 (equipment-driven, backend-computed).
 
 ## Context
 
@@ -51,6 +51,23 @@ classDiagram
     +ChecklistItem[] items
     +isComplete() boolean
   }
+  class RecipeWater {
+    <<optional 1:1>>
+    +number mash_volume_l
+    +number sparge_volume_l
+  }
+  class CapacityFit {
+    <<value object>>
+    +FermenterVerdict fermenter
+    +KettleVerdict kettle
+    +FermenterReason? fermenterReason
+    +KettleReason? kettleReason
+    +number? fermenterUsableL
+    +number? recipeVolumeL
+    +number? preBoilL
+    +number? kettleCapacityL
+    +number? scaleRatio
+  }
   class BrewReadiness {
     +boolean readyToLaunch
   }
@@ -61,8 +78,12 @@ classDiagram
   }
   Recipe "1" ..> "1" VolumePlan : targets feed
   EquipmentProfile "1" ..> "1" VolumePlan : caps & method (D1/D2)
+  Recipe "1" ..> "1" CapacityFit : batch_size_l
+  RecipeWater "0..1" ..> "1" CapacityFit : mash + sparge (pre-boil)
+  EquipmentProfile "1" ..> "1" CapacityFit : fermenter + kettle (ADR-0026)
   BrewReadiness "1" o-- "1" VolumePlan
-  BrewReadiness "1" o-- "2" ReadinessChecklist
+  BrewReadiness "1" o-- "1" ReadinessChecklist : ingredient (gates v1)
+  BrewReadiness "1" o-- "1" CapacityFit : equipment (advisory, v1)
   ReadinessChecklist "1" *-- "1..*" ChecklistItem
   Batch "1" *-- "1" VolumePlan : snapshot at launch (Memento)
   Batch "1" ..> "1" ReadinessChecklist : carries the coches (draft, F14)
@@ -83,7 +104,36 @@ classDiagram
   shown as a stub only: it is owned by the **brewing-session epic (phase B)**,
   out of this conception's scope — it appears here solely to anchor the snapshot
   (Memento) target and make the persistence contract explicit.
-- `BrewReadiness.readyToLaunch = ingredientChecklist.isComplete() && equipmentChecklist.isComplete()` (UC6).
+- **`BrewReadiness.readyToLaunch = ingredientChecklist.isComplete()` in v1** (UC6). The
+  `CapacityFit` (equipment leg) is **advisory** and does **not** gate the launch — see
+  **ADR-0026**. The full gate `ingredient.isComplete() && !capacityFit.isHardStop()` returns once
+  the ADR-0020 D2 method logic makes the kettle `HARD_STOP` reliable.
+- **`CapacityFit` (ADR-0026)** replaces the conceived equipment `ReadinessChecklist`: the equipment
+  profile is **capacity-based** (three volumes), not an item list, so the equipment leg is a
+  backend-computed fit — `fermenterUsableL = fermenterCapacityL × (1 − HEADSPACE_RATIO)` (default
+  `0.20`, distinct from the yield-only trub/dead-space/transfer losses) vs `recipeVolumeL`, and
+  `kettleCapacityL` vs an **approximate** `preBoilL = mash_volume_l + sparge_volume_l`. `scaleRatio`
+  is surfaced on `TOO_LARGE` as a manual escape hatch (no auto-rescale in v1).
+- **Source mapping (backend, ADR-0026):** the value-object fields alias the shipped columns —
+  `recipeVolumeL` ← the recipe's **nullable** `batch_size_l`; `fermenterUsableL` ← the profile's
+  `fermenter_volume_l`; `kettleCapacityL` ← `boil_kettle_volume_l`; `preBoilL` ← `mash_volume_l +
+  sparge_volume_l` on the **optional `RecipeWater`**. (The mobile surfaces `batch_size_l` as
+  `RecipeStats.volumeLiters`; do not use that mobile name for the backend fetch.)
+- **`NOT_EVALUATED` is per-verdict, carries a `reason`, and the numeric fields are populated only
+  when that verdict is evaluated** — shown as **`number?`** (optional `[0..1]`) on the class body;
+  absent otherwise. Every non-evaluable case returns the **same `CapacityFit`** shape (never a bare
+  status, never a fabricated `FITS`/`NaN`/`Infinity`), tagged with a **per-verdict `reason`** so the
+  mobile picks the right advisory without inferring intent from absent numbers:
+  - no equipment profile → both verdicts `NOT_EVALUATED`, both reasons `NO_PROFILE` (→ whole-screen
+    JIT CTA « déclare ton matériel »);
+  - `batch_size_l` null/non-finite/≤ 0 → `fermenter = NOT_EVALUATED`, reason `NO_RECIPE_VOLUME`
+    (→ « cette recette n'indique pas de volume cible »); `fermenter_volume_l` null/non-finite/≤ 0 →
+    reason `NO_FERMENTER_VOLUME` (→ « ton profil n'indique pas de volume de fermenteur exploitable »);
+    `scaleRatio` is computed only when `fermenterUsableL > 0`;
+  - no `RecipeWater` row (the demo-recipe case) → `kettle = NOT_EVALUATED`, reason `NO_RECIPE_WATER`;
+    `boil_kettle_volume_l` null/non-finite/≤ 0 → reason `NO_KETTLE_VOLUME`.
+  Underfill (recipe ≪ fermenter) has no v1 verdict, so **v1 reports it as `FITS`** (a known, accepted
+  limitation); a future `UNDERFILL` `FermenterVerdict` will distinguish it (ADR-0026 Consequences).
 - **Checklist state lives on the draft `Batch` (F14/F15 amendment, brew-day/07b).**
   "Préparer" creates (or resumes) an « en préparation » draft batch that carries
   the ticks as `prepCheckedIds` — only the CHECKED item ids are persisted; the
@@ -93,7 +143,19 @@ classDiagram
   naturally on each new brew — the original "client state pre-batch" note in
   `02` is superseded. Ids from a recipe edited mid-prep simply stop matching
   (benign; drafts are short-lived).
-- Enums: `Method` = {FULL_VOLUME, DUNK_SPARGE}; `Kind` = {INGREDIENT, EQUIPMENT}.
+- Enums: `Method` = {FULL_VOLUME, DUNK_SPARGE}; `Kind` = {INGREDIENT} (the `EQUIPMENT` kind is
+  dropped — the equipment leg is now `CapacityFit`, ADR-0026);
+  `FermenterVerdict` = {FITS, TOO_LARGE, NOT_EVALUATED};
+  `KettleVerdict` = {OK, WARNING, HARD_STOP, NOT_EVALUATED} — `HARD_STOP` modelled but **inactive**
+  in v1 (surfaced as `WARNING` until ADR-0020 D2 method logic lands);
+  `FermenterReason` = {NO_PROFILE, NO_RECIPE_VOLUME, NO_FERMENTER_VOLUME};
+  `KettleReason` = {NO_PROFILE, NO_RECIPE_WATER, NO_KETTLE_VOLUME} — each `Reason` is set **only**
+  when its matching verdict is `NOT_EVALUATED`, and drives which advisory the mobile shows.
+- **`EquipmentProfile.fermenterHeadspaceRatio` is the ADR-0020 *target* field, deferred in v1**
+  (ADR-0026 § Consequences): the v1 `CapacityFit` uses the backend `HEADSPACE_RATIO` **constant**
+  (`0.20`, line derivation above), **not** this per-profile field — which only the ADR-0020 cascade
+  (`intoFermenterL`, line 93) reads. Like the dropped `EQUIPMENT` `Kind` and the inactive
+  `HARD_STOP`, it is modelled-but-not-v1.
 - **Design patterns (named, see ADR-0020 § Design patterns):** `VolumePlan` is a
   **Value Object** (immutable, identity-less — the `«value object»` stereotype);
   the derivation `Recipe + EquipmentProfile → VolumePlan` is owned by the

--- a/docs/architecture/diagrams/brew-prep/04-class.md
+++ b/docs/architecture/diagrams/brew-prep/04-class.md
@@ -80,7 +80,7 @@ classDiagram
   EquipmentProfile "1" ..> "1" VolumePlan : caps & method (D1/D2)
   Recipe "1" ..> "1" CapacityFit : batch_size_l
   RecipeWater "0..1" ..> "1" CapacityFit : mash + sparge (pre-boil)
-  EquipmentProfile "1" ..> "1" CapacityFit : fermenter + kettle (ADR-0026)
+  EquipmentProfile "0..1" ..> "1" CapacityFit : fermenter + kettle (ADR-0026)
   BrewReadiness "1" o-- "1" VolumePlan
   BrewReadiness "1" o-- "1" ReadinessChecklist : ingredient (gates v1)
   BrewReadiness "1" o-- "1" CapacityFit : equipment (advisory, v1)
@@ -111,14 +111,15 @@ classDiagram
 - **`CapacityFit` (ADR-0026)** replaces the conceived equipment `ReadinessChecklist`: the equipment
   profile is **capacity-based** (three volumes), not an item list, so the equipment leg is a
   backend-computed fit — `fermenterUsableL = fermenterCapacityL × (1 − HEADSPACE_RATIO)` (default
-  `0.20`, distinct from the yield-only trub/dead-space/transfer losses) vs `recipeVolumeL`, and
+  `0.10`, distinct from the yield-only trub/dead-space/transfer losses) vs `recipeVolumeL`, and
   `kettleCapacityL` vs an **approximate** `preBoilL = mash_volume_l + sparge_volume_l`. `scaleRatio`
   is surfaced on `TOO_LARGE` as a manual escape hatch (no auto-rescale in v1).
-- **Source mapping (backend, ADR-0026):** the value-object fields alias the shipped columns —
-  `recipeVolumeL` ← the recipe's **nullable** `batch_size_l`; `fermenterUsableL` ← the profile's
-  `fermenter_volume_l`; `kettleCapacityL` ← `boil_kettle_volume_l`; `preBoilL` ← `mash_volume_l +
-  sparge_volume_l` on the **optional `RecipeWater`**. (The mobile surfaces `batch_size_l` as
-  `RecipeStats.volumeLiters`; do not use that mobile name for the backend fetch.)
+- **Source mapping (backend, ADR-0026):** `recipeVolumeL` ← the recipe's **nullable** `batch_size_l`;
+  `kettleCapacityL` ← the profile's `boil_kettle_volume_l` (direct alias); `preBoilL` ← `mash_volume_l
+  + sparge_volume_l` on the **optional `RecipeWater`**. **`fermenterUsableL` is DERIVED, not a raw
+  alias** — `fermenter_volume_l × (1 − HEADSPACE_RATIO)` — so the mobile must display the
+  headspace-adjusted usable volume, never the raw `fermenter_volume_l`. (The mobile surfaces
+  `batch_size_l` as `RecipeStats.volumeLiters`; do not use that mobile name for the backend fetch.)
 - **`NOT_EVALUATED` is per-verdict, carries a `reason`, and the numeric fields are populated only
   when that verdict is evaluated** — shown as **`number?`** (optional `[0..1]`) on the class body;
   absent otherwise. Every non-evaluable case returns the **same `CapacityFit`** shape (never a bare
@@ -153,7 +154,7 @@ classDiagram
   when its matching verdict is `NOT_EVALUATED`, and drives which advisory the mobile shows.
 - **`EquipmentProfile.fermenterHeadspaceRatio` is the ADR-0020 *target* field, deferred in v1**
   (ADR-0026 § Consequences): the v1 `CapacityFit` uses the backend `HEADSPACE_RATIO` **constant**
-  (`0.20`, line derivation above), **not** this per-profile field — which only the ADR-0020 cascade
+  (`0.10`, line derivation above), **not** this per-profile field — which only the ADR-0020 cascade
   (`intoFermenterL`, line 93) reads. Like the dropped `EQUIPMENT` `Kind` and the inactive
   `HARD_STOP`, it is modelled-but-not-v1.
 - **Design patterns (named, see ADR-0020 § Design patterns):** `VolumePlan` is a

--- a/docs/architecture/diagrams/brew-prep/05-state-readiness.md
+++ b/docs/architecture/diagrams/brew-prep/05-state-readiness.md
@@ -1,7 +1,7 @@
 # State diagram — brew-prep — the pre-batch readiness gate
 
 > **Feature**: first real-world brew — the pre-batch lifecycle.
-> **Related ADRs**: ADR-0020.
+> **Related ADRs**: ADR-0026 (ingredient-only v1 gate), ADR-0020.
 
 ## Context
 
@@ -14,23 +14,28 @@ batch start. Everything before `BatchStarted` is reversible/editable;
 ```mermaid
 stateDiagram-v2
   [*] --> RecipeChosen: import a recipe
-  RecipeChosen --> Planned: declare equipment → backend computes the volume plan
-  Planned --> Checking: show ingredient + equipment checklists
+  RecipeChosen --> Checking: show ingredient checklist + capacity-fit advice
   Checking --> Checking: tick / untick an item
-  Checking --> Ready: both checklists complete
+  Checking --> Checking: capacity fit-check (advisory, non-gating)
+  Checking --> Ready: ingredient checklist complete
   Ready --> Checking: an item becomes missing
-  Ready --> BatchStarted: confirm "Start the batch" (snapshot the plan)
+  Ready --> BatchStarted: confirm "Start the batch"
   BatchStarted --> [*]
 ```
 
 ## Notes
 
-- `Planned` **requires equipment** (ADR-0020 D1/D2): no equipment → no plan, no
-  meaningful volumes.
-- `Ready ⇄ Checking` keeps the gate honest — unchecking an item disables the
+- **v1 gate is ingredient-only (ADR-0026):** `Ready` requires the **ingredient**
+  checklist complete; the capacity fit-check is **advisory** and never blocks the
+  transition to `Ready` (the self-transition on `Checking` reflects that it only
+  informs). The equipment-driven `Planned` state (declare equipment → backend
+  volume plan, ADR-0020 D1/D2) returns once that cascade is built; until then
+  equipment is **optional** (no profile → `NOT_EVALUATED`, a JIT call-to-action).
+- `Ready ⇄ Checking` keeps the gate honest — unchecking an ingredient disables the
   launch again (UC6).
 - `BatchStarted` is **irreversible**: the brew then runs against the snapshotted
   plan (ADR-0020 D3), and the brewing-session epic owns everything after.
-- The `Ready → BatchStarted (snapshot the plan)` transition is a **Memento**: the
+- The `Ready → BatchStarted` transition is a **Memento** (design target): the
   `VolumePlan` Value Object is captured and frozen onto the batch, so a started
   batch keeps the exact numbers it was brewed with (ADR-0020 § Design patterns).
+  The snapshot lands with the ADR-0020 cascade; v1 has no plan to freeze yet.


### PR DESCRIPTION
## Summary

Conception-refresh for the **brew-prep readiness journey's equipment leg (UC5)** — docs only, no code.

Reconciling the existing brew-prep conception against the shipped code surfaced a mismatch: the stored equipment profile is **capacity-based** (3 volumes), not a have/required item list, and the ADR-0020 volume cascade is **not built**. So the conceived equipment *checklist* (UC5) is reframed as an **advisory capacity fit-check**, computed in the backend.

**ADR-0026 (Proposed)** with three weighted decision matrices (readiness power; compute location; too-large behaviour). Key decisions:
- **Fermenter**: usable = `fermenter_volume_l × (1 − HEADSPACE_RATIO 0.20)` vs recipe `batch_size_l` → `FITS` / `TOO_LARGE` (+ `scaleRatio` manual escape; no auto-rescale in v1).
- **Kettle**: vs approximate pre-boil (`recipe_water` mash+sparge) → non-blocking `WARNING`; `HARD_STOP` modelled but inactive until ADR-0020 D2 method logic.
- Every non-evaluable input (no profile; null/degenerate volume or capacity; no `recipe_water` row) returns **one `CapacityFit` shape tagged with a per-verdict `reason`** so each advisory message is reachable.
- **v1 launch gate stays ingredient-only** — the fit-check never blocks.

**Diagrams** `docs/architecture/diagrams/brew-prep/`: 01-use-case, 02-sequence (DEFERRED banner), 02b-sequence-capacity-fit (new), 03-component, 04-class, 05-state-readiness — all Mermaid-render-verified.

## Context

Prevents a silent novice dead-end: importing a 20 L recipe on a 5 L demijohn is currently invisible. The build (backend `CapacityFitService` + `GET /recipes/:id/equipment-fit` + mobile render) is a **follow-up PR** after this conception is validated.

## Checklist

- [x] UML-first; conception is the contract the code will satisfy
- [x] ADR follows MADR; matrices arithmetic-checked
- [x] Diagrams render clean (mmdc); no trailing fences; sequence messages unquoted
- [x] Reviewed via 3 adversarial multi-agent rounds + independent verification (field-name accuracy, edge-case guards, model↔prose sync, discriminator completeness)
- [x] English; no code touched

Refs #1247, #1248