### PR TITLE
feat(api/equipment-fit): advisory capacity fit-check endpoint (ADR-0026)

### DIFF
--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { BeerContributionModule } from './beer-contribution/beer-contribution.mo
 import { CatalogModule } from './catalog/catalog.module';
 import { ConfigModule } from '@nestjs/config';
 import { DatabaseModule } from './database/database.module';
+import { EquipmentFitModule } from './equipment-fit/equipment-fit.module';
 import { EquipmentModule } from './equipment/equipment.module';
 import { FaqBotModule } from './faq-bot/faq-bot.module';
 import { FeedbackModule } from './feedback/feedback.module';
@@ -90,6 +91,8 @@ const bootstrapEnvironment = buildBootstrapEnvironmentConfig();
     RecipeModule,
     BatchModule,
     WaterModule,
+    // Advisory equipment capacity fit-check (ADR-0026)
+    EquipmentFitModule,
     LabelModule,
     ScanModule,
 

--- a/packages/api/src/equipment-fit/controllers/equipment-fit.controller.spec.ts
+++ b/packages/api/src/equipment-fit/controllers/equipment-fit.controller.spec.ts
@@ -1,0 +1,61 @@
+import { JwtAuthGuard } from '../../auth/guards/jwt.guard';
+import { User } from '../../user/entities/user.entity';
+import { CapacityFit } from '../domain/capacity-fit';
+import {
+  FermenterVerdict,
+  KettleVerdict,
+} from '../domain/enums/capacity-verdict.enum';
+import { GetEquipmentFitQueryDto } from '../dtos/get-equipment-fit-query.dto';
+import { EquipmentFitService } from '../services/equipment-fit.service';
+import { EquipmentFitController } from './equipment-fit.controller';
+
+const domainFit: CapacityFit = {
+  fermenter: FermenterVerdict.FITS,
+  fermenterReason: null,
+  kettle: KettleVerdict.OK,
+  kettleReason: null,
+  fermenterUsableL: 4.5,
+  recipeVolumeL: 4.3,
+  preBoilL: 5,
+  kettleCapacityL: 10,
+  scaleRatio: null,
+};
+
+describe('EquipmentFitController', () => {
+  const getFit = jest.fn();
+  const service = { getFit } as unknown as EquipmentFitService;
+  const controller = new EquipmentFitController(service);
+  const user = { id: 'user-1' } as User;
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('is protected by the JWT auth guard', () => {
+    const guards = Reflect.getMetadata(
+      '__guards__',
+      EquipmentFitController,
+    ) as unknown[];
+    expect(guards).toContain(JwtAuthGuard);
+  });
+
+  it('delegates to the service with the caller id, recipe id, and profileId, and maps the DTO', async () => {
+    getFit.mockResolvedValue(domainFit);
+    const query: GetEquipmentFitQueryDto = { profileId: 'profile-9' };
+
+    const dto = await controller.getEquipmentFit(user, 'recipe-1', query);
+
+    expect(getFit).toHaveBeenCalledWith('user-1', 'recipe-1', 'profile-9');
+    expect(dto.fermenter).toBe(FermenterVerdict.FITS);
+    expect(dto.kettle).toBe(KettleVerdict.OK);
+    expect(dto.fermenterUsableL).toBe(4.5);
+    expect(dto.recipeVolumeL).toBe(4.3);
+    expect(dto.scaleRatio).toBeNull();
+  });
+
+  it('passes an undefined profileId through when the query omits it', async () => {
+    getFit.mockResolvedValue(domainFit);
+
+    await controller.getEquipmentFit(user, 'recipe-1', {});
+
+    expect(getFit).toHaveBeenCalledWith('user-1', 'recipe-1', undefined);
+  });
+});

--- a/packages/api/src/equipment-fit/controllers/equipment-fit.controller.ts
+++ b/packages/api/src/equipment-fit/controllers/equipment-fit.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiTags,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../../auth/guards/jwt.guard';
+import { User } from '../../user/entities/user.entity';
+import { CapacityFitDto } from '../dtos/capacity-fit.dto';
+import { GetEquipmentFitQueryDto } from '../dtos/get-equipment-fit-query.dto';
+import { EquipmentFitService } from '../services/equipment-fit.service';
+
+@ApiTags('Equipment fit')
+@ApiBearerAuth('JWT-auth')
+@UseGuards(JwtAuthGuard)
+@Controller('recipes/:id/equipment-fit')
+export class EquipmentFitController {
+  constructor(private readonly equipmentFitService: EquipmentFitService) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'Advisory capacity fit-check of a recipe against my equipment',
+  })
+  @ApiOkResponse({ type: CapacityFitDto })
+  @ApiUnauthorizedResponse({ description: 'Missing or invalid JWT' })
+  @ApiNotFoundResponse({
+    description: 'Recipe not readable, or the given profileId is not mine',
+  })
+  async getEquipmentFit(
+    @CurrentUser() user: User,
+    @Param('id', new ParseUUIDPipe()) recipeId: string,
+    @Query() query: GetEquipmentFitQueryDto,
+  ): Promise<CapacityFitDto> {
+    const fit = await this.equipmentFitService.getFit(
+      user.id,
+      recipeId,
+      query.profileId,
+    );
+    return CapacityFitDto.fromDomain(fit);
+  }
+}

--- a/packages/api/src/equipment-fit/domain/capacity-fit.spec.ts
+++ b/packages/api/src/equipment-fit/domain/capacity-fit.spec.ts
@@ -1,0 +1,168 @@
+import { CapacityFitInput, computeCapacityFit } from './capacity-fit';
+import {
+  FermenterReason,
+  FermenterVerdict,
+  KettleReason,
+  KettleVerdict,
+} from './enums/capacity-verdict.enum';
+
+const HS = 0.1;
+
+function input(overrides: Partial<CapacityFitInput> = {}): CapacityFitInput {
+  return {
+    batchSizeL: 4.3,
+    recipeWater: { mashVolumeL: 3, spargeVolumeL: 2 },
+    profile: { fermenterVolumeL: 5, boilKettleVolumeL: 10 },
+    headspaceRatio: HS,
+    ...overrides,
+  };
+}
+
+describe('computeCapacityFit', () => {
+  describe('no equipment profile', () => {
+    it('returns both legs NOT_EVALUATED with NO_PROFILE and no numbers', () => {
+      const fit = computeCapacityFit(input({ profile: null }));
+
+      expect(fit.fermenter).toBe(FermenterVerdict.NOT_EVALUATED);
+      expect(fit.fermenterReason).toBe(FermenterReason.NO_PROFILE);
+      expect(fit.kettle).toBe(KettleVerdict.NOT_EVALUATED);
+      expect(fit.kettleReason).toBe(KettleReason.NO_PROFILE);
+      expect(fit.fermenterUsableL).toBeNull();
+      expect(fit.recipeVolumeL).toBeNull();
+      expect(fit.preBoilL).toBeNull();
+      expect(fit.kettleCapacityL).toBeNull();
+      expect(fit.scaleRatio).toBeNull();
+    });
+  });
+
+  describe('fermenter leg', () => {
+    it('FITS the canonical guided first brew (4.3 L in a 5 L demijohn, headspace 0.10)', () => {
+      const fit = computeCapacityFit(input({ batchSizeL: 4.3 }));
+
+      expect(fit.fermenter).toBe(FermenterVerdict.FITS);
+      expect(fit.fermenterReason).toBeNull();
+      expect(fit.fermenterUsableL).toBe(4.5);
+      expect(fit.recipeVolumeL).toBe(4.3);
+      expect(fit.scaleRatio).toBeNull();
+    });
+
+    it('treats a recipe exactly at usable volume as FITS (strict >)', () => {
+      const fit = computeCapacityFit(input({ batchSizeL: 4.5 }));
+      expect(fit.fermenter).toBe(FermenterVerdict.FITS);
+      expect(fit.scaleRatio).toBeNull();
+    });
+
+    it('flags TOO_LARGE with a finite scale ratio (20 L in a 5 L fermenter)', () => {
+      const fit = computeCapacityFit(input({ batchSizeL: 20 }));
+
+      expect(fit.fermenter).toBe(FermenterVerdict.TOO_LARGE);
+      expect(fit.fermenterUsableL).toBe(4.5);
+      expect(fit.scaleRatio).toBe(4.44); // 20 / 4.5
+      expect(Number.isFinite(fit.scaleRatio as number)).toBe(true);
+    });
+
+    it.each([null, 0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+      'NOT_EVALUATED (NO_RECIPE_VOLUME) for a degenerate batch_size_l: %p',
+      (batchSizeL) => {
+        const fit = computeCapacityFit(input({ batchSizeL }));
+        expect(fit.fermenter).toBe(FermenterVerdict.NOT_EVALUATED);
+        expect(fit.fermenterReason).toBe(FermenterReason.NO_RECIPE_VOLUME);
+        expect(fit.fermenterUsableL).toBeNull();
+        expect(fit.recipeVolumeL).toBeNull();
+        expect(fit.scaleRatio).toBeNull();
+      },
+    );
+
+    it.each([0, -5, Number.NaN])(
+      'NOT_EVALUATED (NO_FERMENTER_VOLUME) for a degenerate fermenter capacity: %p',
+      (fermenterVolumeL) => {
+        const fit = computeCapacityFit(
+          input({ profile: { fermenterVolumeL, boilKettleVolumeL: 10 } }),
+        );
+        expect(fit.fermenter).toBe(FermenterVerdict.NOT_EVALUATED);
+        expect(fit.fermenterReason).toBe(FermenterReason.NO_FERMENTER_VOLUME);
+        expect(fit.fermenterUsableL).toBeNull();
+      },
+    );
+
+    it.each([1, 1.5, Number.NaN])(
+      'NOT_EVALUATED (no fabricated NaN/Infinity) for a headspaceRatio that yields a non-positive usable volume: %p',
+      (headspaceRatio) => {
+        const fit = computeCapacityFit(input({ headspaceRatio }));
+        expect(fit.fermenter).toBe(FermenterVerdict.NOT_EVALUATED);
+        expect(fit.fermenterReason).toBe(FermenterReason.NO_FERMENTER_VOLUME);
+        expect(fit.fermenterUsableL).toBeNull();
+        expect(fit.scaleRatio).toBeNull();
+      },
+    );
+  });
+
+  describe('kettle leg', () => {
+    it('OK when the pre-boil fits the kettle', () => {
+      const fit = computeCapacityFit(
+        input({ recipeWater: { mashVolumeL: 3, spargeVolumeL: 2 } }),
+      );
+      expect(fit.kettle).toBe(KettleVerdict.OK);
+      expect(fit.kettleReason).toBeNull();
+      expect(fit.preBoilL).toBe(5);
+      expect(fit.kettleCapacityL).toBe(10);
+    });
+
+    it('WARNING (never HARD_STOP in v1) when the pre-boil exceeds the kettle', () => {
+      const fit = computeCapacityFit(
+        input({ recipeWater: { mashVolumeL: 8, spargeVolumeL: 6 } }),
+      );
+      expect(fit.kettle).toBe(KettleVerdict.WARNING);
+      expect(fit.preBoilL).toBe(14);
+    });
+
+    it('NOT_EVALUATED (NO_RECIPE_WATER) when there is no water row', () => {
+      const fit = computeCapacityFit(input({ recipeWater: null }));
+      expect(fit.kettle).toBe(KettleVerdict.NOT_EVALUATED);
+      expect(fit.kettleReason).toBe(KettleReason.NO_RECIPE_WATER);
+      expect(fit.preBoilL).toBeNull();
+      expect(fit.kettleCapacityL).toBeNull();
+    });
+
+    it('NOT_EVALUATED (NO_RECIPE_WATER) when the water row is empty (0 + 0)', () => {
+      const fit = computeCapacityFit(
+        input({ recipeWater: { mashVolumeL: 0, spargeVolumeL: 0 } }),
+      );
+      expect(fit.kettle).toBe(KettleVerdict.NOT_EVALUATED);
+      expect(fit.kettleReason).toBe(KettleReason.NO_RECIPE_WATER);
+    });
+
+    it('NOT_EVALUATED (NO_KETTLE_VOLUME) for a degenerate kettle capacity', () => {
+      const fit = computeCapacityFit(
+        input({ profile: { fermenterVolumeL: 5, boilKettleVolumeL: 0 } }),
+      );
+      expect(fit.kettle).toBe(KettleVerdict.NOT_EVALUATED);
+      expect(fit.kettleReason).toBe(KettleReason.NO_KETTLE_VOLUME);
+      expect(fit.preBoilL).toBeNull();
+    });
+  });
+
+  describe('legs are independent', () => {
+    it('a valid profile with a volume-less, water-less recipe → per-leg NOT_EVALUATED (distinct from NO_PROFILE)', () => {
+      const fit = computeCapacityFit(
+        input({ batchSizeL: null, recipeWater: null }),
+      );
+      expect(fit.fermenterReason).toBe(FermenterReason.NO_RECIPE_VOLUME);
+      expect(fit.kettleReason).toBe(KettleReason.NO_RECIPE_WATER);
+      // Not the no-profile reason — the client must render recipe-side messages.
+      expect(fit.fermenterReason).not.toBe(FermenterReason.NO_PROFILE);
+    });
+
+    it('never emits HARD_STOP in v1 across a large input sweep', () => {
+      for (const preBoil of [1, 5, 14, 50]) {
+        const fit = computeCapacityFit(
+          input({
+            recipeWater: { mashVolumeL: preBoil, spargeVolumeL: 0 },
+            profile: { fermenterVolumeL: 5, boilKettleVolumeL: 10 },
+          }),
+        );
+        expect(fit.kettle).not.toBe(KettleVerdict.HARD_STOP);
+      }
+    });
+  });
+});

--- a/packages/api/src/equipment-fit/domain/capacity-fit.ts
+++ b/packages/api/src/equipment-fit/domain/capacity-fit.ts
@@ -1,0 +1,176 @@
+import {
+  FermenterReason,
+  FermenterVerdict,
+  KettleReason,
+  KettleVerdict,
+} from './enums/capacity-verdict.enum';
+
+/**
+ * Inputs to the capacity fit-check (ADR-0026), already read from the recipe,
+ * its optional `recipe_water` row, and the caller's equipment profile.
+ */
+export interface CapacityFitInput {
+  /** Recipe target volume (`batch_size_l`); nullable — user recipes omit it. */
+  readonly batchSizeL: number | null;
+  /** Mash + sparge water, from the OPTIONAL `recipe_water` 1:1 (null if absent). */
+  readonly recipeWater: {
+    readonly mashVolumeL: number;
+    readonly spargeVolumeL: number;
+  } | null;
+  /** The resolved equipment profile capacities (null when none is declared). */
+  readonly profile: {
+    readonly fermenterVolumeL: number;
+    readonly boilKettleVolumeL: number;
+  } | null;
+  /** Headspace fraction reserved on the fermenter (see `HEADSPACE_RATIO`). */
+  readonly headspaceRatio: number;
+}
+
+/**
+ * The advisory capacity fit result (ADR-0026). Numeric fields are populated
+ * **only** when the corresponding leg's verdict is evaluated — `null` otherwise
+ * (never a fabricated `0`/`NaN`). A `NOT_EVALUATED` verdict carries a `reason`.
+ */
+export interface CapacityFit {
+  readonly fermenter: FermenterVerdict;
+  readonly fermenterReason: FermenterReason | null;
+  readonly kettle: KettleVerdict;
+  readonly kettleReason: KettleReason | null;
+  readonly fermenterUsableL: number | null;
+  readonly recipeVolumeL: number | null;
+  readonly preBoilL: number | null;
+  readonly kettleCapacityL: number | null;
+  readonly scaleRatio: number | null;
+}
+
+/** A finite, strictly-positive number — the only shape every leg can evaluate. */
+function isPositiveFinite(value: number | null | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0;
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+interface FermenterLeg {
+  readonly fermenter: FermenterVerdict;
+  readonly fermenterReason: FermenterReason | null;
+  readonly fermenterUsableL: number | null;
+  readonly recipeVolumeL: number | null;
+  readonly scaleRatio: number | null;
+}
+
+function evaluateFermenter(
+  batchSizeL: number | null,
+  fermenterVolumeL: number,
+  headspaceRatio: number,
+): FermenterLeg {
+  const notEvaluated = (reason: FermenterReason): FermenterLeg => ({
+    fermenter: FermenterVerdict.NOT_EVALUATED,
+    fermenterReason: reason,
+    fermenterUsableL: null,
+    recipeVolumeL: null,
+    scaleRatio: null,
+  });
+
+  if (!isPositiveFinite(batchSizeL)) {
+    return notEvaluated(FermenterReason.NO_RECIPE_VOLUME);
+  }
+  if (!isPositiveFinite(fermenterVolumeL)) {
+    return notEvaluated(FermenterReason.NO_FERMENTER_VOLUME);
+  }
+
+  const usableL = fermenterVolumeL * (1 - headspaceRatio);
+  // Guard the derived usable volume, not just the raw capacity: a degenerate
+  // headspaceRatio (NaN, negative, or >= 1) would make `usableL` NaN/<= 0 and
+  // fabricate a TOO_LARGE with a NaN/Infinity scale ratio. In v1 headspaceRatio
+  // is the fixed 0.10 constant, but this keeps the pure function's "never
+  // fabricates a verdict / never divides by zero" contract caller-agnostic.
+  if (!isPositiveFinite(usableL)) {
+    return notEvaluated(FermenterReason.NO_FERMENTER_VOLUME);
+  }
+  const fits = batchSizeL <= usableL;
+  return {
+    fermenter: fits ? FermenterVerdict.FITS : FermenterVerdict.TOO_LARGE,
+    fermenterReason: null,
+    fermenterUsableL: round2(usableL),
+    recipeVolumeL: round2(batchSizeL),
+    scaleRatio: fits ? null : round2(batchSizeL / usableL),
+  };
+}
+
+interface KettleLeg {
+  readonly kettle: KettleVerdict;
+  readonly kettleReason: KettleReason | null;
+  readonly preBoilL: number | null;
+  readonly kettleCapacityL: number | null;
+}
+
+function evaluateKettle(
+  recipeWater: CapacityFitInput['recipeWater'],
+  boilKettleVolumeL: number,
+): KettleLeg {
+  const notEvaluated = (reason: KettleReason): KettleLeg => ({
+    kettle: KettleVerdict.NOT_EVALUATED,
+    kettleReason: reason,
+    preBoilL: null,
+    kettleCapacityL: null,
+  });
+
+  if (recipeWater === null) {
+    return notEvaluated(KettleReason.NO_RECIPE_WATER);
+  }
+  const preBoilL = recipeWater.mashVolumeL + recipeWater.spargeVolumeL;
+  if (!isPositiveFinite(preBoilL)) {
+    // A present-but-empty water row yields no usable pre-boil.
+    return notEvaluated(KettleReason.NO_RECIPE_WATER);
+  }
+  if (!isPositiveFinite(boilKettleVolumeL)) {
+    return notEvaluated(KettleReason.NO_KETTLE_VOLUME);
+  }
+
+  // Approximate pre-boil (method logic deferred, ADR-0020 D2): a non-blocking
+  // WARNING only — never HARD_STOP in v1.
+  const ok = preBoilL <= boilKettleVolumeL;
+  return {
+    kettle: ok ? KettleVerdict.OK : KettleVerdict.WARNING,
+    kettleReason: null,
+    preBoilL: round2(preBoilL),
+    kettleCapacityL: round2(boilKettleVolumeL),
+  };
+}
+
+/**
+ * Compute the advisory equipment capacity fit (ADR-0026) — a pure function.
+ *
+ * Never throws, never blocks, never fabricates a verdict: any missing or
+ * degenerate input yields `NOT_EVALUATED` for its own leg, tagged with a
+ * `reason`. When no profile is declared, both legs are `NOT_EVALUATED` with
+ * `NO_PROFILE` (the client shows the "declare your equipment" call-to-action).
+ */
+export function computeCapacityFit(input: CapacityFitInput): CapacityFit {
+  const { batchSizeL, recipeWater, profile, headspaceRatio } = input;
+
+  if (profile === null) {
+    return {
+      fermenter: FermenterVerdict.NOT_EVALUATED,
+      fermenterReason: FermenterReason.NO_PROFILE,
+      kettle: KettleVerdict.NOT_EVALUATED,
+      kettleReason: KettleReason.NO_PROFILE,
+      fermenterUsableL: null,
+      recipeVolumeL: null,
+      preBoilL: null,
+      kettleCapacityL: null,
+      scaleRatio: null,
+    };
+  }
+
+  const fermenter = evaluateFermenter(
+    batchSizeL,
+    profile.fermenterVolumeL,
+    headspaceRatio,
+  );
+  const kettle = evaluateKettle(recipeWater, profile.boilKettleVolumeL);
+
+  return { ...fermenter, ...kettle };
+}

--- a/packages/api/src/equipment-fit/domain/enums/capacity-verdict.enum.ts
+++ b/packages/api/src/equipment-fit/domain/enums/capacity-verdict.enum.ts
@@ -1,0 +1,41 @@
+/**
+ * Verdicts and reasons for the equipment capacity fit-check (ADR-0026).
+ *
+ * The fit-check is advisory — it never blocks the launch in v1. Each leg
+ * (fermenter, kettle) carries its own verdict, and a `NOT_EVALUATED` verdict
+ * carries a `reason` so the client renders the right advisory without inferring
+ * intent from absent numbers.
+ */
+
+/** Fermenter leg verdict. `TOO_LARGE` is advisory (surfaces a scale ratio). */
+export enum FermenterVerdict {
+  FITS = 'FITS',
+  TOO_LARGE = 'TOO_LARGE',
+  NOT_EVALUATED = 'NOT_EVALUATED',
+}
+
+/**
+ * Kettle leg verdict. `WARNING` is non-blocking in v1; `HARD_STOP` is modelled
+ * but not emitted until the ADR-0020 D2 method logic makes "physically
+ * impossible" reliable.
+ */
+export enum KettleVerdict {
+  OK = 'OK',
+  WARNING = 'WARNING',
+  HARD_STOP = 'HARD_STOP',
+  NOT_EVALUATED = 'NOT_EVALUATED',
+}
+
+/** Why the fermenter leg could not be evaluated (set only when `NOT_EVALUATED`). */
+export enum FermenterReason {
+  NO_PROFILE = 'NO_PROFILE',
+  NO_RECIPE_VOLUME = 'NO_RECIPE_VOLUME',
+  NO_FERMENTER_VOLUME = 'NO_FERMENTER_VOLUME',
+}
+
+/** Why the kettle leg could not be evaluated (set only when `NOT_EVALUATED`). */
+export enum KettleReason {
+  NO_PROFILE = 'NO_PROFILE',
+  NO_RECIPE_WATER = 'NO_RECIPE_WATER',
+  NO_KETTLE_VOLUME = 'NO_KETTLE_VOLUME',
+}

--- a/packages/api/src/equipment-fit/dtos/capacity-fit.dto.ts
+++ b/packages/api/src/equipment-fit/dtos/capacity-fit.dto.ts
@@ -1,0 +1,68 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { CapacityFit } from '../domain/capacity-fit';
+import {
+  FermenterReason,
+  FermenterVerdict,
+  KettleReason,
+  KettleVerdict,
+} from '../domain/enums/capacity-verdict.enum';
+
+/**
+ * Response of `GET /recipes/:id/equipment-fit` (ADR-0026). One shape for every
+ * case: a `NOT_EVALUATED` leg carries a `reason` and leaves its numbers null.
+ */
+export class CapacityFitDto {
+  @ApiProperty({ enum: FermenterVerdict, example: FermenterVerdict.FITS })
+  fermenter: FermenterVerdict;
+
+  @ApiPropertyOptional({
+    enum: FermenterReason,
+    nullable: true,
+    description: 'Set only when `fermenter` is NOT_EVALUATED.',
+  })
+  fermenterReason: FermenterReason | null;
+
+  @ApiProperty({ enum: KettleVerdict, example: KettleVerdict.OK })
+  kettle: KettleVerdict;
+
+  @ApiPropertyOptional({
+    enum: KettleReason,
+    nullable: true,
+    description: 'Set only when `kettle` is NOT_EVALUATED.',
+  })
+  kettleReason: KettleReason | null;
+
+  @ApiPropertyOptional({ nullable: true, example: 4.5 })
+  fermenterUsableL: number | null;
+
+  @ApiPropertyOptional({ nullable: true, example: 4.3 })
+  recipeVolumeL: number | null;
+
+  @ApiPropertyOptional({ nullable: true, example: 6.2 })
+  preBoilL: number | null;
+
+  @ApiPropertyOptional({ nullable: true, example: 10 })
+  kettleCapacityL: number | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    example: 4.6,
+    description: 'Divide the recipe by this to fit; set only on TOO_LARGE.',
+  })
+  scaleRatio: number | null;
+
+  static fromDomain(fit: CapacityFit): CapacityFitDto {
+    const dto = new CapacityFitDto();
+    dto.fermenter = fit.fermenter;
+    dto.fermenterReason = fit.fermenterReason;
+    dto.kettle = fit.kettle;
+    dto.kettleReason = fit.kettleReason;
+    dto.fermenterUsableL = fit.fermenterUsableL;
+    dto.recipeVolumeL = fit.recipeVolumeL;
+    dto.preBoilL = fit.preBoilL;
+    dto.kettleCapacityL = fit.kettleCapacityL;
+    dto.scaleRatio = fit.scaleRatio;
+    return dto;
+  }
+}

--- a/packages/api/src/equipment-fit/dtos/get-equipment-fit-query.dto.ts
+++ b/packages/api/src/equipment-fit/dtos/get-equipment-fit-query.dto.ts
@@ -1,0 +1,20 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+/**
+ * Query for `GET /recipes/:id/equipment-fit`. `profileId` is optional: when
+ * omitted, the backend resolves the caller's default equipment profile (their
+ * only one, or the most-recently-created — ADR-0026, no persisted default marker
+ * yet).
+ */
+export class GetEquipmentFitQueryDto {
+  @ApiPropertyOptional({
+    description:
+      'Explicit equipment profile id; defaults to the most-recent profile.',
+    maxLength: 36,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(36)
+  profileId?: string;
+}

--- a/packages/api/src/equipment-fit/equipment-fit.constants.ts
+++ b/packages/api/src/equipment-fit/equipment-fit.constants.ts
@@ -1,0 +1,16 @@
+/**
+ * Equipment capacity fit-check constants (ADR-0026).
+ */
+
+/**
+ * Fraction of the fermenter's total volume reserved as headspace (krausen +
+ * blow-off), subtracted before comparing to the recipe's batch volume:
+ * `fermenterUsableL = fermenter_volume_l × (1 − HEADSPACE_RATIO)`.
+ *
+ * Defaulted to **0.10** — deliberately below the 20–25 % krausen norm so the
+ * shipped guided first brew (`Blonde Facile`, `batch_size_l 4.3` in a 5 L
+ * demijohn → usable 4.5 L) reads `FITS`, not `TOO_LARGE`. Per-style headspace is
+ * a deferred refinement (ADR-0026 § Consequences). Calibratable constant, not a
+ * per-profile field yet.
+ */
+export const HEADSPACE_RATIO = 0.1;

--- a/packages/api/src/equipment-fit/equipment-fit.module.ts
+++ b/packages/api/src/equipment-fit/equipment-fit.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { EquipmentModule } from '../equipment/equipment.module';
+import { RecipeWaterOrmEntity } from '../recipe/entities/recipe-water.orm.entity';
+import { RecipeModule } from '../recipe/recipe.module';
+import { EquipmentFitController } from './controllers/equipment-fit.controller';
+import { EquipmentFitService } from './services/equipment-fit.service';
+
+/**
+ * Advisory equipment capacity fit-check (ADR-0026). Reuses `RecipeService`
+ * (readable-recipe access) and `EquipmentProfileService` (profile resolution),
+ * and reads the optional `recipe_water` row directly.
+ */
+@Module({
+  imports: [
+    EquipmentModule,
+    RecipeModule,
+    // Deliberate: the fit-check reads the optional recipe_water row directly
+    // (ADR-0026 / brew-prep 03-component — no WaterService in the picture), so we
+    // register the repository here rather than route through RecipeModule.
+    TypeOrmModule.forFeature([RecipeWaterOrmEntity]),
+  ],
+  controllers: [EquipmentFitController],
+  providers: [EquipmentFitService],
+})
+export class EquipmentFitModule {}

--- a/packages/api/src/equipment-fit/services/equipment-fit.service.spec.ts
+++ b/packages/api/src/equipment-fit/services/equipment-fit.service.spec.ts
@@ -1,0 +1,120 @@
+import { NotFoundException } from '@nestjs/common';
+import { Repository } from 'typeorm';
+
+import { EquipmentProfileService } from '../../equipment/services/equipment-profile.service';
+import { RecipeWaterOrmEntity } from '../../recipe/entities/recipe-water.orm.entity';
+import { RecipeService } from '../../recipe/services/recipe.service';
+import {
+  FermenterReason,
+  FermenterVerdict,
+  KettleReason,
+  KettleVerdict,
+} from '../domain/enums/capacity-verdict.enum';
+import { EquipmentFitService } from './equipment-fit.service';
+
+type RecipeServiceMock = { getReadableById: jest.Mock };
+type EquipmentServiceMock = { getMineById: jest.Mock; listMine: jest.Mock };
+type WaterRepoMock = { findOne: jest.Mock };
+
+const USER = 'user-1';
+const RECIPE = 'recipe-1';
+
+const profile = { fermenter_volume_l: 5, boil_kettle_volume_l: 10 };
+const waterRow = { mash_volume_l: 3, sparge_volume_l: 2 };
+
+function build(): {
+  service: EquipmentFitService;
+  recipe: RecipeServiceMock;
+  equip: EquipmentServiceMock;
+  water: WaterRepoMock;
+} {
+  const recipe: RecipeServiceMock = {
+    getReadableById: jest.fn().mockResolvedValue({ batch_size_l: 4.3 }),
+  };
+  const equip: EquipmentServiceMock = {
+    getMineById: jest.fn().mockResolvedValue(profile),
+    listMine: jest.fn().mockResolvedValue([profile]),
+  };
+  const water: WaterRepoMock = {
+    findOne: jest.fn().mockResolvedValue(waterRow),
+  };
+  const service = new EquipmentFitService(
+    recipe as unknown as RecipeService,
+    equip as unknown as EquipmentProfileService,
+    water as unknown as Repository<RecipeWaterOrmEntity>,
+  );
+  return { service, recipe, equip, water };
+}
+
+describe('EquipmentFitService', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('checks recipe access, resolves the default profile, and returns a FITS verdict', async () => {
+    const { service, recipe, equip, water } = build();
+
+    const fit = await service.getFit(USER, RECIPE);
+
+    expect(recipe.getReadableById).toHaveBeenCalledWith(USER, RECIPE);
+    expect(equip.listMine).toHaveBeenCalledWith(USER);
+    expect(equip.getMineById).not.toHaveBeenCalled();
+    expect(water.findOne).toHaveBeenCalledWith({
+      where: { recipe_id: RECIPE },
+    });
+    expect(fit.fermenter).toBe(FermenterVerdict.FITS);
+    expect(fit.kettle).toBe(KettleVerdict.OK);
+    expect(fit.recipeVolumeL).toBe(4.3);
+  });
+
+  it('uses the explicit profileId (getMineById), not the list', async () => {
+    const { service, equip } = build();
+
+    await service.getFit(USER, RECIPE, 'profile-9');
+
+    expect(equip.getMineById).toHaveBeenCalledWith(USER, 'profile-9');
+    expect(equip.listMine).not.toHaveBeenCalled();
+  });
+
+  it('picks the most-recently-created profile when several exist (listMine[0])', async () => {
+    const { service, equip } = build();
+    equip.listMine.mockResolvedValue([
+      { fermenter_volume_l: 30, boil_kettle_volume_l: 40 }, // most recent
+      profile,
+    ]);
+
+    const fit = await service.getFit(USER, RECIPE);
+
+    // usable = 30 * 0.9 = 27 → still FITS, but usable reflects the first profile.
+    expect(fit.fermenterUsableL).toBe(27);
+  });
+
+  it('returns NO_PROFILE (non-blocking) when the caller has declared none', async () => {
+    const { service, equip } = build();
+    equip.listMine.mockResolvedValue([]);
+
+    const fit = await service.getFit(USER, RECIPE);
+
+    expect(fit.fermenter).toBe(FermenterVerdict.NOT_EVALUATED);
+    expect(fit.fermenterReason).toBe(FermenterReason.NO_PROFILE);
+    expect(fit.kettleReason).toBe(KettleReason.NO_PROFILE);
+  });
+
+  it('maps a missing water row to a NO_RECIPE_WATER kettle verdict', async () => {
+    const { service, water } = build();
+    water.findOne.mockResolvedValue(null);
+
+    const fit = await service.getFit(USER, RECIPE);
+
+    expect(fit.kettle).toBe(KettleVerdict.NOT_EVALUATED);
+    expect(fit.kettleReason).toBe(KettleReason.NO_RECIPE_WATER);
+    expect(fit.fermenter).toBe(FermenterVerdict.FITS); // fermenter still runs
+  });
+
+  it('propagates a NotFound from the recipe access check (unreadable/missing recipe)', async () => {
+    const { service, recipe } = build();
+    recipe.getReadableById.mockRejectedValue(new NotFoundException());
+
+    await expect(service.getFit(USER, RECIPE)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+});

--- a/packages/api/src/equipment-fit/services/equipment-fit.service.ts
+++ b/packages/api/src/equipment-fit/services/equipment-fit.service.ts
@@ -1,0 +1,81 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { EquipmentProfileService } from '../../equipment/services/equipment-profile.service';
+import { RecipeWaterOrmEntity } from '../../recipe/entities/recipe-water.orm.entity';
+import { RecipeService } from '../../recipe/services/recipe.service';
+import { CapacityFit, computeCapacityFit } from '../domain/capacity-fit';
+import { HEADSPACE_RATIO } from '../equipment-fit.constants';
+
+/**
+ * Orchestrates the advisory equipment capacity fit-check (ADR-0026): resolves
+ * the caller's equipment profile, reads the (access-checked) recipe + its
+ * optional water row, and delegates the verdict to the pure domain function.
+ */
+@Injectable()
+export class EquipmentFitService {
+  constructor(
+    private readonly recipeService: RecipeService,
+    private readonly equipmentProfileService: EquipmentProfileService,
+    @InjectRepository(RecipeWaterOrmEntity)
+    private readonly waterRepo: Repository<RecipeWaterOrmEntity>,
+  ) {}
+
+  /**
+   * @param userId  authenticated caller
+   * @param recipeId  recipe to fit (must be readable by the caller — owner or public)
+   * @param profileId  optional explicit equipment profile; defaults to the
+   *                   caller's most-recently-created one (no persisted default
+   *                   marker yet, ADR-0026)
+   */
+  async getFit(
+    userId: string,
+    recipeId: string,
+    profileId?: string,
+  ): Promise<CapacityFit> {
+    // Access control + existence: throws NotFound if the recipe is not readable.
+    const recipe = await this.recipeService.getReadableById(userId, recipeId);
+
+    const profile = await this.resolveProfile(userId, profileId);
+    const water = await this.waterRepo.findOne({
+      where: { recipe_id: recipeId },
+    });
+
+    return computeCapacityFit({
+      batchSizeL: recipe.batch_size_l ?? null,
+      recipeWater: water
+        ? {
+            mashVolumeL: water.mash_volume_l,
+            spargeVolumeL: water.sparge_volume_l,
+          }
+        : null,
+      profile: profile
+        ? {
+            fermenterVolumeL: profile.fermenter_volume_l,
+            boilKettleVolumeL: profile.boil_kettle_volume_l,
+          }
+        : null,
+      headspaceRatio: HEADSPACE_RATIO,
+    });
+  }
+
+  /**
+   * Explicit `profileId` → that profile (404 if it is not the caller's).
+   * Otherwise the most-recently-created profile, or `null` when the caller has
+   * declared none (→ a non-blocking NO_PROFILE advisory).
+   */
+  private async resolveProfile(
+    userId: string,
+    profileId?: string,
+  ): Promise<{
+    fermenter_volume_l: number;
+    boil_kettle_volume_l: number;
+  } | null> {
+    if (profileId) {
+      return this.equipmentProfileService.getMineById(userId, profileId);
+    }
+    const profiles = await this.equipmentProfileService.listMine(userId);
+    return profiles[0] ?? null;
+  }
+}


### PR DESCRIPTION
## Summary

Backend (PR-A) of the brew-prep equipment leg — implements **[ADR-0026](docs/architecture/decisions/0026-equipment-capacity-fit-check.md)** (merged conception). New `packages/api/src/equipment-fit/` module; the mobile render is a **follow-up PR-B**.

- **Pure domain `computeCapacityFit()`** — fermenter usable = `fermenter_volume_l × (1 − HEADSPACE_RATIO 0.10)` vs recipe `batch_size_l` → `FITS` (`≤`) / `TOO_LARGE` (strict `>`, + `scaleRatio`, computed only when usable > 0 → no div-by-zero); kettle vs approximate pre-boil (`recipe_water` mash+sparge) → `OK` / `WARNING` (non-blocking; `HARD_STOP` modelled but **never emitted** in v1). Any missing/degenerate input (incl. degenerate profile capacities) → `NOT_EVALUATED` with a per-verdict `reason` (`NO_PROFILE` / `NO_RECIPE_VOLUME` / `NO_FERMENTER_VOLUME` / `NO_RECIPE_WATER` / `NO_KETTLE_VOLUME`); numeric fields null when not evaluated. Never throws, never fabricates a verdict.
- **`GET /recipes/:id/equipment-fit?profileId=`** (JWT-guarded, `ParseUUIDPipe` on the id) — access-checked recipe read (`RecipeService.getReadableById`, owner-or-public); profile resolved by explicit `profileId` (`getMineById`) or the most-recent (`listMine` DESC), or none → `NO_PROFILE`. Reads the optional `recipe_water` row directly (per brew-prep 03-component).
- **No migration** (no schema change). Launch gate untouched (stays ingredient-only).

## Context

Prevents a silent novice dead-end (20 L recipe on a 5 L demijohn). Headspace 0.10 is calibrated so the shipped guided first brew (`Blonde Facile`, `batch_size_l 4.3` in a 5 L demijohn → usable 4.5 L) reads `FITS`.

## Checklist

- [x] Conforms to ADR-0026 (verdict taxonomy, boundaries, reason discriminator, HARD_STOP inactive)
- [x] Access control: recipe read + equipment profile ownership scoped to the caller
- [x] 28 unit tests H/S/E (domain + service + controller); full api unit suite green (992 passing)
- [x] build + lint + prettier clean; no `any`, named exports only
- [x] Pre-push review (local Claude reviewer): 0 Must, 3 Should addressed

Refs #1247, #1248