### PR TITLE
feat(mobile/recipes): render the equipment capacity fit-check (ADR-0026, PR-B)

### DIFF
--- a/packages/mobile-app/src/features/recipes/application/__tests__/equipment-fit.use-cases.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/equipment-fit.use-cases.test.ts
@@ -1,3 +1,4 @@
+import { dataSource } from "@/core/data/data-source";
 import { getEquipmentFit } from "@/features/recipes/data/equipment-fit.api";
 import {
   describeFit,
@@ -36,6 +37,18 @@ describe("loadEquipmentFit", () => {
     await loadEquipmentFit("recipe-1", "profile-9", signal);
 
     expect(mockGet).toHaveBeenCalledWith("recipe-1", "profile-9", signal);
+  });
+
+  it("returns a curated demo fit without hitting the API in demo mode", async () => {
+    dataSource.useDemoData = true;
+    try {
+      const result = await loadEquipmentFit("recipe-1");
+      expect(mockGet).not.toHaveBeenCalled();
+      expect(result.fermenter).toBe("FITS");
+      expect(result.kettle).toBe("OK");
+    } finally {
+      dataSource.useDemoData = false;
+    }
   });
 });
 

--- a/packages/mobile-app/src/features/recipes/application/__tests__/equipment-fit.use-cases.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/equipment-fit.use-cases.test.ts
@@ -1,0 +1,135 @@
+import { getEquipmentFit } from "@/features/recipes/data/equipment-fit.api";
+import {
+  describeFit,
+  loadEquipmentFit,
+} from "@/features/recipes/application/equipment-fit.use-cases";
+import type { CapacityFit } from "@/features/recipes/domain/equipment-fit.types";
+
+jest.mock("@/features/recipes/data/equipment-fit.api", () => ({
+  getEquipmentFit: jest.fn(),
+}));
+
+const mockGet = getEquipmentFit as jest.MockedFunction<typeof getEquipmentFit>;
+
+function fit(overrides: Partial<CapacityFit> = {}): CapacityFit {
+  return {
+    fermenter: "FITS",
+    fermenterReason: null,
+    kettle: "OK",
+    kettleReason: null,
+    fermenterUsableL: 4.5,
+    recipeVolumeL: 4.3,
+    preBoilL: 5,
+    kettleCapacityL: 10,
+    scaleRatio: null,
+    ...overrides,
+  };
+}
+
+describe("loadEquipmentFit", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("delegates to the data layer with the recipe id, profile id and signal", async () => {
+    mockGet.mockResolvedValue(fit());
+    const signal = new AbortController().signal;
+
+    await loadEquipmentFit("recipe-1", "profile-9", signal);
+
+    expect(mockGet).toHaveBeenCalledWith("recipe-1", "profile-9", signal);
+  });
+});
+
+describe("describeFit", () => {
+  it("marks FITS as success with a usable-volume detail", () => {
+    const view = describeFit(fit());
+    expect(view.showProfileCta).toBe(false);
+    expect(view.fermenter.badgeTone).toBe("success");
+    expect(view.fermenter.badgeLabel).toBe("Ça passe");
+    expect(view.fermenter.detail).toBe("4.3 L pour 4.5 L utiles");
+  });
+
+  it("marks TOO_LARGE as error and surfaces the scale ratio in the message", () => {
+    const view = describeFit(
+      fit({ fermenter: "TOO_LARGE", recipeVolumeL: 20, scaleRatio: 4.4 }),
+    );
+    expect(view.fermenter.badgeTone).toBe("error");
+    expect(view.fermenter.badgeLabel).toBe("Trop grand");
+    expect(view.fermenter.message).toContain("~4.4");
+    expect(view.fermenter.message).toContain("20 L");
+  });
+
+  it("marks a kettle WARNING as warning (non-blocking)", () => {
+    const view = describeFit(
+      fit({ kettle: "WARNING", preBoilL: 12, kettleCapacityL: 10 }),
+    );
+    expect(view.kettle.badgeTone).toBe("warning");
+    expect(view.kettle.badgeLabel).toBe("Attention");
+  });
+
+  it("renders a distinct message for a HARD_STOP kettle (not the generic not-evaluated copy)", () => {
+    const view = describeFit(
+      fit({ kettle: "HARD_STOP", preBoilL: 12, kettleCapacityL: 5 }),
+    );
+    expect(view.kettle.badgeTone).toBe("error");
+    expect(view.kettle.badgeLabel).toBe("Impossible");
+    expect(view.kettle.message).not.toBe("Adéquation non vérifiable.");
+  });
+
+  it("falls back to '?' when TOO_LARGE has no scale ratio", () => {
+    const view = describeFit(
+      fit({ fermenter: "TOO_LARGE", recipeVolumeL: 20, scaleRatio: null }),
+    );
+    expect(view.fermenter.badgeTone).toBe("error");
+    expect(view.fermenter.message).toContain("~?");
+  });
+
+  it("shows the declare-equipment CTA when no profile is declared", () => {
+    const view = describeFit(
+      fit({
+        fermenter: "NOT_EVALUATED",
+        fermenterReason: "NO_PROFILE",
+        kettle: "NOT_EVALUATED",
+        kettleReason: "NO_PROFILE",
+      }),
+    );
+    expect(view.showProfileCta).toBe(true);
+  });
+
+  it("does NOT show the whole-screen CTA when only one leg is NO_PROFILE (renders per-leg)", () => {
+    const view = describeFit(
+      fit({ fermenter: "NOT_EVALUATED", fermenterReason: "NO_PROFILE" }),
+    );
+    expect(view.showProfileCta).toBe(false);
+    expect(view.kettle.badgeTone).toBe("success"); // the kettle leg still renders
+  });
+
+  it.each([
+    ["NO_RECIPE_VOLUME", "volume cible"],
+    ["NO_FERMENTER_VOLUME", "fermenteur exploitable"],
+  ] as const)(
+    "renders the %s fermenter reason as a neutral 'à vérifier' advisory",
+    (reason, needle) => {
+      const view = describeFit(
+        fit({ fermenter: "NOT_EVALUATED", fermenterReason: reason }),
+      );
+      expect(view.showProfileCta).toBe(false);
+      expect(view.fermenter.badgeTone).toBe("neutral");
+      expect(view.fermenter.badgeLabel).toBe("À vérifier");
+      expect(view.fermenter.message).toContain(needle);
+    },
+  );
+
+  it.each([
+    ["NO_RECIPE_WATER", "volumes d'eau"],
+    ["NO_KETTLE_VOLUME", "bouilloire exploitable"],
+  ] as const)(
+    "renders the %s kettle reason as a neutral advisory",
+    (reason, needle) => {
+      const view = describeFit(
+        fit({ kettle: "NOT_EVALUATED", kettleReason: reason }),
+      );
+      expect(view.kettle.badgeTone).toBe("neutral");
+      expect(view.kettle.message).toContain(needle);
+    },
+  );
+});

--- a/packages/mobile-app/src/features/recipes/application/equipment-fit.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/equipment-fit.use-cases.ts
@@ -1,3 +1,4 @@
+import { dataSource } from "@/core/data/data-source";
 import { getEquipmentFit } from "@/features/recipes/data/equipment-fit.api";
 import type {
   CapacityFit,
@@ -5,12 +6,32 @@ import type {
   KettleReason,
 } from "@/features/recipes/domain/equipment-fit.types";
 
+/**
+ * Curated demo fit — a positive FITS/OK verdict. In demo mode the whole brew-prep
+ * flow is served locally, so we never call the live JWT-guarded endpoint (which
+ * the demo session cannot reach).
+ */
+const DEMO_FIT: CapacityFit = {
+  fermenter: "FITS",
+  fermenterReason: null,
+  kettle: "OK",
+  kettleReason: null,
+  fermenterUsableL: 4.5,
+  recipeVolumeL: 4.3,
+  preBoilL: 5,
+  kettleCapacityL: 10,
+  scaleRatio: null,
+};
+
 /** Load the advisory capacity fit-check for a recipe (ADR-0026). */
 export function loadEquipmentFit(
   recipeId: string,
   profileId?: string,
   signal?: AbortSignal,
 ): Promise<CapacityFit> {
+  if (dataSource.useDemoData) {
+    return Promise.resolve(DEMO_FIT);
+  }
   return getEquipmentFit(recipeId, profileId, signal);
 }
 

--- a/packages/mobile-app/src/features/recipes/application/equipment-fit.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/equipment-fit.use-cases.ts
@@ -1,0 +1,140 @@
+import { getEquipmentFit } from "@/features/recipes/data/equipment-fit.api";
+import type {
+  CapacityFit,
+  FermenterReason,
+  KettleReason,
+} from "@/features/recipes/domain/equipment-fit.types";
+
+/** Load the advisory capacity fit-check for a recipe (ADR-0026). */
+export function loadEquipmentFit(
+  recipeId: string,
+  profileId?: string,
+  signal?: AbortSignal,
+): Promise<CapacityFit> {
+  return getEquipmentFit(recipeId, profileId, signal);
+}
+
+/** Badge tone for a leg, mapped 1:1 to the UI `Badge` variants. */
+export type FitTone = "success" | "warning" | "error" | "neutral";
+
+/** Display model for one leg (fermenter or kettle). */
+export interface LegDisplay {
+  title: string;
+  badgeLabel: string;
+  badgeTone: FitTone;
+  message: string;
+  detail: string | null;
+}
+
+/** Display model for the whole panel. */
+export interface FitDisplay {
+  /** True when no equipment is declared → show the "declare equipment" CTA. */
+  showProfileCta: boolean;
+  fermenter: LegDisplay;
+  kettle: LegDisplay;
+}
+
+function litres(value: number | null): string {
+  return value === null ? "? L" : `${value} L`;
+}
+
+function describeFermenter(fit: CapacityFit): LegDisplay {
+  const base = { title: "Fermenteur" } as const;
+  switch (fit.fermenter) {
+    case "FITS":
+      return {
+        ...base,
+        badgeLabel: "Ça passe",
+        badgeTone: "success",
+        message: "Ton fermenteur est adapté au volume de cette recette.",
+        detail: `${litres(fit.recipeVolumeL)} pour ${litres(fit.fermenterUsableL)} utiles`,
+      };
+    case "TOO_LARGE":
+      return {
+        ...base,
+        badgeLabel: "Trop grand",
+        badgeTone: "error",
+        message: `Cette recette vise ${litres(fit.recipeVolumeL)} mais ton fermenteur ne tient que ~${litres(fit.fermenterUsableL)} utiles. Réduis l'échelle d'un facteur ~${fit.scaleRatio ?? "?"}.`,
+        detail: null,
+      };
+    default:
+      return describeNotEvaluated(base.title, fit.fermenterReason);
+  }
+}
+
+function describeKettle(fit: CapacityFit): LegDisplay {
+  const base = { title: "Bouilloire" } as const;
+  switch (fit.kettle) {
+    case "OK":
+      return {
+        ...base,
+        badgeLabel: "Ça passe",
+        badgeTone: "success",
+        message: "Ta bouilloire peut contenir le volume de pré-ébullition.",
+        detail: `~${litres(fit.preBoilL)} pour ${litres(fit.kettleCapacityL)}`,
+      };
+    case "WARNING":
+      return {
+        ...base,
+        badgeLabel: "Attention",
+        badgeTone: "warning",
+        message: `Ton volume de pré-ébullition (~${litres(fit.preBoilL)}) dépasse ta bouilloire (${litres(fit.kettleCapacityL)}). Vérifie ta méthode ou réduis le volume.`,
+        detail: null,
+      };
+    case "HARD_STOP":
+      // Modelled but not emitted by the backend in v1 (ADR-0026 / ADR-0020 D2);
+      // handled here so it never falls through to the generic not-evaluated copy.
+      return {
+        ...base,
+        badgeLabel: "Impossible",
+        badgeTone: "error",
+        message: `Ta bouilloire (${litres(fit.kettleCapacityL)}) ne peut pas contenir le volume de pré-ébullition (~${litres(fit.preBoilL)}).`,
+        detail: null,
+      };
+    default:
+      return describeNotEvaluated(base.title, fit.kettleReason);
+  }
+}
+
+const NOT_EVALUATED_MESSAGES: Record<FermenterReason | KettleReason, string> = {
+  NO_PROFILE: "Déclare ton matériel pour vérifier l'adéquation.",
+  NO_RECIPE_VOLUME: "Cette recette n'indique pas de volume cible.",
+  NO_FERMENTER_VOLUME:
+    "Ton profil n'indique pas de volume de fermenteur exploitable.",
+  NO_RECIPE_WATER:
+    "Cette recette ne détaille pas ses volumes d'eau — bouilloire non vérifiée.",
+  NO_KETTLE_VOLUME:
+    "Ton profil n'indique pas de volume de bouilloire exploitable.",
+};
+
+function describeNotEvaluated(
+  title: string,
+  reason: FermenterReason | KettleReason | null,
+): LegDisplay {
+  return {
+    title,
+    badgeLabel: "À vérifier",
+    badgeTone: "neutral",
+    message: reason
+      ? NOT_EVALUATED_MESSAGES[reason]
+      : "Adéquation non vérifiable.",
+    detail: null,
+  };
+}
+
+/**
+ * Map a `CapacityFit` to a display model (ADR-0026). Pure — the panel renders
+ * this verbatim. When no profile is declared, both legs read `NO_PROFILE` and
+ * `showProfileCta` is set so the panel surfaces the "declare equipment" action.
+ */
+export function describeFit(fit: CapacityFit): FitDisplay {
+  return {
+    // Only the whole-screen "declare equipment" CTA when BOTH legs are
+    // NO_PROFILE (the backend always sets them together); a hypothetical
+    // single-leg NO_PROFILE still renders per-leg guidance instead of hiding it.
+    showProfileCta:
+      fit.fermenterReason === "NO_PROFILE" && fit.kettleReason === "NO_PROFILE",
+    fermenter: describeFermenter(fit),
+    kettle: describeKettle(fit),
+  };
+}

--- a/packages/mobile-app/src/features/recipes/data/__tests__/equipment-fit.api.test.ts
+++ b/packages/mobile-app/src/features/recipes/data/__tests__/equipment-fit.api.test.ts
@@ -1,0 +1,107 @@
+import { request } from "@/core/http/http-client";
+import {
+  getEquipmentFit,
+  mapCapacityFit,
+} from "@/features/recipes/data/equipment-fit.api";
+
+jest.mock("@/core/http/http-client", () => ({
+  request: jest.fn(),
+}));
+
+const mockRequest = request as jest.MockedFunction<typeof request>;
+
+const fullDto = {
+  fermenter: "TOO_LARGE",
+  fermenterReason: null,
+  kettle: "WARNING",
+  kettleReason: null,
+  fermenterUsableL: 4.5,
+  recipeVolumeL: 20,
+  preBoilL: 6,
+  kettleCapacityL: 5,
+  scaleRatio: 4.44,
+};
+
+describe("equipment-fit.api", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  describe("mapCapacityFit", () => {
+    it("maps a full DTO verbatim", () => {
+      expect(mapCapacityFit(fullDto)).toEqual({
+        fermenter: "TOO_LARGE",
+        fermenterReason: null,
+        kettle: "WARNING",
+        kettleReason: null,
+        fermenterUsableL: 4.5,
+        recipeVolumeL: 20,
+        preBoilL: 6,
+        kettleCapacityL: 5,
+        scaleRatio: 4.44,
+      });
+    });
+
+    it("falls back to NOT_EVALUATED for an unknown verdict and keeps a valid reason", () => {
+      const fit = mapCapacityFit({
+        fermenter: "WAT",
+        fermenterReason: "NO_FERMENTER_VOLUME",
+        kettle: null,
+        kettleReason: "NO_RECIPE_WATER",
+      });
+      expect(fit.fermenter).toBe("NOT_EVALUATED");
+      expect(fit.fermenterReason).toBe("NO_FERMENTER_VOLUME");
+      expect(fit.kettle).toBe("NOT_EVALUATED");
+      expect(fit.kettleReason).toBe("NO_RECIPE_WATER");
+    });
+
+    it("drops a reason on an evaluated verdict (never FITS-with-a-reason)", () => {
+      const fit = mapCapacityFit({
+        fermenter: "FITS",
+        fermenterReason: "NO_PROFILE",
+        kettle: "OK",
+        kettleReason: "NO_PROFILE",
+      });
+      expect(fit.fermenterReason).toBeNull();
+      expect(fit.kettleReason).toBeNull();
+    });
+
+    it("nulls an unknown reason and non-finite numbers", () => {
+      const fit = mapCapacityFit({
+        fermenter: "FITS",
+        fermenterReason: "BOGUS",
+        fermenterUsableL: Number.NaN,
+        recipeVolumeL: null,
+      });
+      expect(fit.fermenterReason).toBeNull();
+      expect(fit.fermenterUsableL).toBeNull();
+      expect(fit.recipeVolumeL).toBeNull();
+    });
+  });
+
+  describe("getEquipmentFit", () => {
+    it("calls the recipe-scoped route without a profileId and maps the DTO", async () => {
+      mockRequest.mockResolvedValue(fullDto);
+      const controller = new AbortController();
+
+      const fit = await getEquipmentFit(
+        "recipe-1",
+        undefined,
+        controller.signal,
+      );
+
+      const [path, options] = mockRequest.mock.calls[0];
+      expect(path).toBe("/recipes/recipe-1/equipment-fit");
+      expect(options).toMatchObject({ signal: controller.signal });
+      expect(fit.fermenter).toBe("TOO_LARGE");
+    });
+
+    it("appends an explicit profileId to the query", async () => {
+      mockRequest.mockResolvedValue(fullDto);
+
+      await getEquipmentFit("recipe-1", "profile-9");
+
+      expect(mockRequest.mock.calls[0][0]).toBe(
+        "/recipes/recipe-1/equipment-fit?profileId=profile-9",
+      );
+    });
+  });
+});

--- a/packages/mobile-app/src/features/recipes/data/equipment-fit.api.ts
+++ b/packages/mobile-app/src/features/recipes/data/equipment-fit.api.ts
@@ -1,0 +1,105 @@
+import { request } from "@/core/http/http-client";
+import type {
+  CapacityFit,
+  FermenterReason,
+  FermenterVerdict,
+  KettleReason,
+  KettleVerdict,
+} from "@/features/recipes/domain/equipment-fit.types";
+
+/** Raw `CapacityFitDto` as returned by `GET /recipes/:id/equipment-fit`. */
+interface CapacityFitApiDto {
+  fermenter?: string | null;
+  fermenterReason?: string | null;
+  kettle?: string | null;
+  kettleReason?: string | null;
+  fermenterUsableL?: number | null;
+  recipeVolumeL?: number | null;
+  preBoilL?: number | null;
+  kettleCapacityL?: number | null;
+  scaleRatio?: number | null;
+}
+
+const FERMENTER_VERDICTS: readonly FermenterVerdict[] = [
+  "FITS",
+  "TOO_LARGE",
+  "NOT_EVALUATED",
+];
+const KETTLE_VERDICTS: readonly KettleVerdict[] = [
+  "OK",
+  "WARNING",
+  "HARD_STOP",
+  "NOT_EVALUATED",
+];
+const FERMENTER_REASONS: readonly FermenterReason[] = [
+  "NO_PROFILE",
+  "NO_RECIPE_VOLUME",
+  "NO_FERMENTER_VOLUME",
+];
+const KETTLE_REASONS: readonly KettleReason[] = [
+  "NO_PROFILE",
+  "NO_RECIPE_WATER",
+  "NO_KETTLE_VOLUME",
+];
+
+function oneOf<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return allowed.includes(value as T) ? (value as T) : fallback;
+}
+
+function reason<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+): T | null {
+  return allowed.includes(value as T) ? (value as T) : null;
+}
+
+function num(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/** Defensively map the raw DTO to the domain profile (unknown enums → safe defaults). */
+export function mapCapacityFit(dto: CapacityFitApiDto): CapacityFit {
+  const fermenter = oneOf(dto.fermenter, FERMENTER_VERDICTS, "NOT_EVALUATED");
+  const kettle = oneOf(dto.kettle, KETTLE_VERDICTS, "NOT_EVALUATED");
+  // Invariant: a `reason` is meaningful only for a NOT_EVALUATED leg, so it is
+  // dropped on any evaluated verdict (never a FITS-with-NO_PROFILE state).
+  return {
+    fermenter,
+    fermenterReason:
+      fermenter === "NOT_EVALUATED"
+        ? reason(dto.fermenterReason, FERMENTER_REASONS)
+        : null,
+    kettle,
+    kettleReason:
+      kettle === "NOT_EVALUATED"
+        ? reason(dto.kettleReason, KETTLE_REASONS)
+        : null,
+    fermenterUsableL: num(dto.fermenterUsableL),
+    recipeVolumeL: num(dto.recipeVolumeL),
+    preBoilL: num(dto.preBoilL),
+    kettleCapacityL: num(dto.kettleCapacityL),
+    scaleRatio: num(dto.scaleRatio),
+  };
+}
+
+/**
+ * Fetch the advisory capacity fit-check for a recipe against the caller's
+ * equipment (JWT-authenticated). `profileId` is optional — the backend resolves
+ * the default profile when omitted (ADR-0026).
+ */
+export async function getEquipmentFit(
+  recipeId: string,
+  profileId?: string,
+  signal?: AbortSignal,
+): Promise<CapacityFit> {
+  const query = profileId ? `?profileId=${encodeURIComponent(profileId)}` : "";
+  const dto = await request<CapacityFitApiDto>(
+    `/recipes/${encodeURIComponent(recipeId)}/equipment-fit${query}`,
+    { signal },
+  );
+  return mapCapacityFit(dto);
+}

--- a/packages/mobile-app/src/features/recipes/domain/equipment-fit.types.ts
+++ b/packages/mobile-app/src/features/recipes/domain/equipment-fit.types.ts
@@ -1,0 +1,31 @@
+/**
+ * Advisory equipment capacity fit-check (ADR-0026) — mobile domain types,
+ * mirroring the backend `CapacityFitDto` from `GET /recipes/:id/equipment-fit`.
+ * Numeric fields are null when the corresponding leg is `NOT_EVALUATED`.
+ */
+
+export type FermenterVerdict = "FITS" | "TOO_LARGE" | "NOT_EVALUATED";
+
+export type KettleVerdict = "OK" | "WARNING" | "HARD_STOP" | "NOT_EVALUATED";
+
+export type FermenterReason =
+  | "NO_PROFILE"
+  | "NO_RECIPE_VOLUME"
+  | "NO_FERMENTER_VOLUME";
+
+export type KettleReason =
+  | "NO_PROFILE"
+  | "NO_RECIPE_WATER"
+  | "NO_KETTLE_VOLUME";
+
+export interface CapacityFit {
+  fermenter: FermenterVerdict;
+  fermenterReason: FermenterReason | null;
+  kettle: KettleVerdict;
+  kettleReason: KettleReason | null;
+  fermenterUsableL: number | null;
+  recipeVolumeL: number | null;
+  preBoilL: number | null;
+  kettleCapacityL: number | null;
+  scaleRatio: number | null;
+}

--- a/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
@@ -10,6 +10,7 @@ import { useConfirm } from "@/core/ui/confirm-provider";
 import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
 import { ChecklistRow } from "@/core/ui/ChecklistRow";
+import { CapacityFitPanel } from "@/features/recipes/presentation/components/CapacityFitPanel";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
@@ -275,6 +276,9 @@ export function BrewPrepScreen({ recipeId }: Props) {
             title="Préparer mon brassin"
             subtitle="Mise en place : coche ce que tu as. Le brassage se lance une fois la liste complète."
           />
+
+          {/* Capacity fit-check first (ADR-0026): advisory, never blocks the launch. */}
+          <CapacityFitPanel recipeId={recipeId} />
 
           {hasItems ? (
             <Card style={styles.listCard}>

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
@@ -40,6 +40,15 @@ jest.mock("@/features/batches/application/batches.use-cases", () => ({
   updateBatchPrepChecklist: jest.fn(),
 }));
 
+// The capacity fit-check panel self-fetches; mock its use-case so the screen
+// tests never fire a real HTTP call (test isolation).
+jest.mock("@/features/recipes/application/equipment-fit.use-cases", () => ({
+  ...jest.requireActual(
+    "@/features/recipes/application/equipment-fit.use-cases",
+  ),
+  loadEquipmentFit: jest.fn().mockResolvedValue(null),
+}));
+
 jest.mock("expo-router", () => {
   const actual = jest.requireActual("expo-router");
   return {

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/BrewPrepScreen.test.tsx
@@ -40,14 +40,19 @@ jest.mock("@/features/batches/application/batches.use-cases", () => ({
   updateBatchPrepChecklist: jest.fn(),
 }));
 
-// The capacity fit-check panel self-fetches; mock its use-case so the screen
-// tests never fire a real HTTP call (test isolation).
-jest.mock("@/features/recipes/application/equipment-fit.use-cases", () => ({
-  ...jest.requireActual(
-    "@/features/recipes/application/equipment-fit.use-cases",
-  ),
-  loadEquipmentFit: jest.fn().mockResolvedValue(null),
-}));
+// The capacity fit-check panel is a self-fetching collaborator with its own
+// unit test; mock it to a marker so the screen test stays isolated (no async
+// query settling after assertions) while still proving the panel is composed in.
+jest.mock("@/features/recipes/presentation/components/CapacityFitPanel", () => {
+  const ReactActual = jest.requireActual("react");
+  const { View } = jest.requireActual("react-native");
+  return {
+    CapacityFitPanel: ({ recipeId }: { recipeId: string }) =>
+      ReactActual.createElement(View, {
+        testID: `capacity-fit-panel-mock-${recipeId}`,
+      }),
+  };
+});
 
 jest.mock("expo-router", () => {
   const actual = jest.requireActual("expo-router");
@@ -178,6 +183,8 @@ describe("BrewPrepScreen — pre-launch gate on the draft batch", () => {
     expect(screen.getByTestId(CASCADE_ROW)).toBeTruthy();
     expect(screen.getByTestId(PILSNER_MISSING)).toBeTruthy();
     expect(screen.getByTestId(CASCADE_MISSING)).toBeTruthy();
+    // The advisory capacity fit-check panel is composed into the screen (ADR-0026).
+    expect(screen.getByTestId("capacity-fit-panel-mock-r1")).toBeTruthy();
 
     // Gate closed: pressing the disabled CTA must not open the dialog.
     fireEvent.press(screen.getByText("Lancer le brassage"));

--- a/packages/mobile-app/src/features/recipes/presentation/components/CapacityFitPanel.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/CapacityFitPanel.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
-import { useRouter } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
 import type { Href } from "expo-router";
 import { useQuery } from "@tanstack/react-query";
 
@@ -50,12 +50,21 @@ export function CapacityFitPanel({ recipeId }: Props) {
     isLoading,
     isError,
     error,
+    refetch,
   } = useQuery({
     queryKey: ["equipment-fit", recipeId],
     queryFn: ({ signal }) => loadEquipmentFit(recipeId, undefined, signal),
     enabled: recipeId.trim().length > 0,
     retry: false,
   });
+
+  // Re-check on focus so a fit computed while "no equipment" is refreshed after
+  // the user declares their equipment via the CTA and returns (ADR-0026).
+  useFocusEffect(
+    useCallback(() => {
+      void refetch();
+    }, [refetch]),
+  );
 
   return (
     <Card testID="capacity-fit-panel" style={styles.card}>

--- a/packages/mobile-app/src/features/recipes/presentation/components/CapacityFitPanel.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/CapacityFitPanel.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
+import { useRouter } from "expo-router";
+import type { Href } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+
+import { Badge } from "@/core/ui/Badge";
+import { Card } from "@/core/ui/Card";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { colors, spacing, typography } from "@/core/theme";
+import { getErrorMessage } from "@/core/http/http-error";
+
+import {
+  describeFit,
+  loadEquipmentFit,
+  type LegDisplay,
+} from "@/features/recipes/application/equipment-fit.use-cases";
+
+type Props = Readonly<{ recipeId: string }>;
+
+const EQUIPMENT_ROUTE = "/equipment" as Href;
+
+function Leg({ leg, testID }: { leg: LegDisplay; testID: string }) {
+  return (
+    <View style={styles.leg} testID={testID}>
+      <View style={styles.legHeader}>
+        <Text style={styles.legTitle}>{leg.title}</Text>
+        <Badge
+          variant={leg.badgeTone}
+          label={leg.badgeLabel}
+          accessibilityLabel={`${leg.title} : ${leg.badgeLabel}`}
+        />
+      </View>
+      <Text style={styles.legMessage}>{leg.message}</Text>
+      {leg.detail ? <Text style={styles.legDetail}>{leg.detail}</Text> : null}
+    </View>
+  );
+}
+
+/**
+ * Advisory equipment capacity fit-check panel (ADR-0026) — placed first on the
+ * brew-prep screen. Fetches the fit for the recipe against the caller's
+ * equipment and renders a per-leg advisory; it never blocks the launch. When no
+ * equipment is declared, it shows a just-in-time "declare your equipment" CTA.
+ */
+export function CapacityFitPanel({ recipeId }: Props) {
+  const router = useRouter();
+  const {
+    data: fit,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["equipment-fit", recipeId],
+    queryFn: ({ signal }) => loadEquipmentFit(recipeId, undefined, signal),
+    enabled: recipeId.trim().length > 0,
+    retry: false,
+  });
+
+  return (
+    <Card testID="capacity-fit-panel" style={styles.card}>
+      <Text style={styles.title}>Mon matériel est-il adapté ?</Text>
+
+      {isLoading ? (
+        <ActivityIndicator
+          testID="capacity-fit-loading"
+          color={colors.brand.primary}
+        />
+      ) : null}
+
+      {isError ? (
+        <Text testID="capacity-fit-error" style={styles.error}>
+          {getErrorMessage(error, "Vérification du matériel indisponible.")}
+        </Text>
+      ) : null}
+
+      {fit ? renderBody() : null}
+    </Card>
+  );
+
+  function renderBody() {
+    if (!fit) {
+      return null;
+    }
+    const view = describeFit(fit);
+    if (view.showProfileCta) {
+      return (
+        <View style={styles.ctaBlock}>
+          <Text style={styles.legMessage}>
+            Déclare ton matériel pour vérifier que ta cuve et ta marmite suivent
+            cette recette.
+          </Text>
+          <PrimaryButton
+            testID="capacity-fit-cta"
+            label="Déclarer mon matériel"
+            onPress={() => router.push(EQUIPMENT_ROUTE)}
+            accessibilityRole="button"
+          />
+        </View>
+      );
+    }
+    return (
+      <>
+        <Leg leg={view.fermenter} testID="capacity-fit-fermenter" />
+        <Leg leg={view.kettle} testID="capacity-fit-kettle" />
+      </>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  card: {
+    gap: spacing.sm,
+  },
+  title: {
+    fontSize: typography.size.body,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+  },
+  ctaBlock: {
+    gap: spacing.sm,
+  },
+  leg: {
+    gap: spacing.xxs,
+  },
+  legHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.sm,
+  },
+  legTitle: {
+    fontSize: typography.size.label,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+  },
+  legMessage: {
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+  },
+  legDetail: {
+    fontSize: typography.size.caption,
+    color: colors.neutral.textSecondary,
+    fontWeight: typography.weight.bold,
+  },
+  error: {
+    fontSize: typography.size.label,
+    color: colors.semantic.error,
+  },
+});

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/CapacityFitPanel.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/CapacityFitPanel.test.tsx
@@ -14,6 +14,7 @@ import type { CapacityFit } from "@/features/recipes/domain/equipment-fit.types"
 const mockPush = jest.fn();
 jest.mock("expo-router", () => ({
   useRouter: () => ({ push: mockPush }),
+  useFocusEffect: jest.fn(),
 }));
 
 jest.mock("@/features/recipes/application/equipment-fit.use-cases", () => ({

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/CapacityFitPanel.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/CapacityFitPanel.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { loadEquipmentFit } from "@/features/recipes/application/equipment-fit.use-cases";
+import { CapacityFitPanel } from "@/features/recipes/presentation/components/CapacityFitPanel";
+import type { CapacityFit } from "@/features/recipes/domain/equipment-fit.types";
+
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/features/recipes/application/equipment-fit.use-cases", () => ({
+  ...jest.requireActual(
+    "@/features/recipes/application/equipment-fit.use-cases",
+  ),
+  loadEquipmentFit: jest.fn(),
+}));
+
+const mockLoad = loadEquipmentFit as jest.MockedFunction<
+  typeof loadEquipmentFit
+>;
+
+function fit(overrides: Partial<CapacityFit> = {}): CapacityFit {
+  return {
+    fermenter: "FITS",
+    fermenterReason: null,
+    kettle: "OK",
+    kettleReason: null,
+    fermenterUsableL: 4.5,
+    recipeVolumeL: 4.3,
+    preBoilL: 5,
+    kettleCapacityL: 10,
+    scaleRatio: null,
+    ...overrides,
+  };
+}
+
+function renderPanel() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Number.POSITIVE_INFINITY },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <CapacityFitPanel recipeId="recipe-1" />
+    </QueryClientProvider>,
+  );
+}
+
+describe("CapacityFitPanel", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("shows a loading indicator while the fit loads", async () => {
+    mockLoad.mockReturnValue(new Promise<CapacityFit>(() => {}));
+    renderPanel();
+    expect(await screen.findByTestId("capacity-fit-loading")).toBeTruthy();
+  });
+
+  it("renders both legs with their verdicts on a successful fit", async () => {
+    mockLoad.mockResolvedValue(fit());
+    renderPanel();
+
+    expect(await screen.findByTestId("capacity-fit-fermenter")).toBeTruthy();
+    expect(screen.getByTestId("capacity-fit-kettle")).toBeTruthy();
+    expect(screen.getByText("Fermenteur")).toBeTruthy();
+    expect(screen.getByText("Bouilloire")).toBeTruthy();
+    // Badge force-uppercases its label.
+    expect(screen.getAllByText("ÇA PASSE").length).toBeGreaterThan(0);
+  });
+
+  it("surfaces an error message when the fetch fails", async () => {
+    mockLoad.mockRejectedValue(new Error("Backend indisponible"));
+    renderPanel();
+    expect(await screen.findByText("Backend indisponible")).toBeTruthy();
+  });
+
+  it("shows the declare-equipment CTA and navigates when no profile is declared", async () => {
+    mockLoad.mockResolvedValue(
+      fit({
+        fermenter: "NOT_EVALUATED",
+        fermenterReason: "NO_PROFILE",
+        kettle: "NOT_EVALUATED",
+        kettleReason: "NO_PROFILE",
+      }),
+    );
+    renderPanel();
+
+    const cta = await screen.findByTestId("capacity-fit-cta");
+    expect(screen.queryByTestId("capacity-fit-fermenter")).toBeNull();
+
+    fireEvent.press(cta);
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/equipment"));
+  });
+});


### PR DESCRIPTION
## Summary

Mobile (PR-B) of the brew-prep equipment leg, on top of the merged backend ([#1362](https://github.com/benoit-bremaud/brasse-bouillon/pull/1362)). Implements the render side of **[ADR-0026](docs/architecture/decisions/0026-equipment-capacity-fit-check.md)**.

- **domain** `equipment-fit.types.ts` — `CapacityFit` + verdict/reason unions, mirroring the backend DTO.
- **data** `getEquipmentFit()` → `GET /recipes/:id/equipment-fit` (through `http-client`, JWT); defensive mapper (unknown enum → `NOT_EVALUATED`, non-finite → null).
- **application** `describeFit()` — pure verdict/reason → display model (French copy, badge tone, `showProfileCta`), incl. an explicit `HARD_STOP` case (modelled but not emitted in v1); + thin `loadEquipmentFit()`.
- **presentation** `CapacityFitPanel` — self-fetching (react-query, `retry:false`), renders per-leg verdicts (fermenter + kettle) or a **JIT "declare your equipment" CTA** to `/equipment` when no profile is declared. Placed **first** on `BrewPrepScreen` (before the ingredient checklist). **Never blocks the launch** — the gate stays ingredient-only (unchanged).

## Context

Second half of the fit-check's visible value. The live visual test (emulator/APK against the deployed backend) comes later, like water slice-1; everything is covered by unit tests here.

## Checklist

- [x] ADR-0026: advisory-only, launch gate unchanged, capacity block first, per-leg verdict+reason, NO_PROFILE → JIT CTA
- [x] Mobile rules: no `any`, named exports, egress via `http-client`, theme tokens, `StyleSheet.create`, `type` unions / `interface` shapes
- [x] 20 unit tests (mapper/route, `describeFit` all verdicts × reasons incl. HARD_STOP + null-scaleRatio, panel loading/error/legs/CTA-navigation); recipes suite green
- [x] Pre-push review (local): 0 Must, 3 Should addressed (BrewPrepScreen test mock, HARD_STOP case, edge tests)

Refs #1247, #1248