### PR TITLE
docs(adr): promote ADR-0026 to Accepted + CLAUDE.md index

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Currently accepted ADRs (see each file for the `Status` line and full rationale)
 - [ADR-0020 — Equipment-driven batch sizing & volume planning (computed in the backend)](docs/architecture/decisions/0020-equipment-driven-volume-planning.md)
 - [ADR-0022 — Public FAQ chatbot: Mistral LLM + self-hosted ALTCHA, EU-sovereign](docs/architecture/decisions/0022-public-faq-chatbot-llm.md)
 - [ADR-0024 — Recipe brewing-difficulty badge: rule-based, max-dominates, backend-computed](docs/architecture/decisions/0024-recipe-difficulty-scoring.md)
+- [ADR-0026 — Equipment capacity fit-check: advisory pre-batch readiness, backend-computed](docs/architecture/decisions/0026-equipment-capacity-fit-check.md)
 
 When a new ADR is accepted, add its file link here (no dates, no per-ADR summaries — open the file for the live status and content). When reviewing a PR, flag any diff that violates these ADRs and cite the ADR number and clause in the review comment.
 

--- a/docs/architecture/decisions/0022-public-faq-chatbot-llm.md
+++ b/docs/architecture/decisions/0022-public-faq-chatbot-llm.md
@@ -1,7 +1,7 @@
 # ADR-0022 — Public project FAQ chatbot on the website, backed by Mistral (EU/RGPD)
 
-**Status**  Proposed
-**Date**    2026-07-01
+**Status**  Accepted
+**Date**    2026-07-01 (accepted 2026-07-09; decision adopted and shipped in #1293)
 **Owners**  @benoit-bremaud
 
 ---

--- a/docs/architecture/decisions/0026-equipment-capacity-fit-check.md
+++ b/docs/architecture/decisions/0026-equipment-capacity-fit-check.md
@@ -1,8 +1,8 @@
 # ADR-0026 — Equipment capacity fit-check: advisory pre-batch readiness, backend-computed
 
-**Status**  Proposed
-**Date**  2026-07-07
-**Owners**  @benoit-bremaud
+**Status** Accepted
+**Date** 2026-07-07 (accepted 2026-07-09, on the equipment fit-check leg landing: backend #1362 + mobile #1364)
+**Owners** @benoit-bremaud
 
 ---
 

--- a/docs/architecture/decisions/0026-equipment-capacity-fit-check.md
+++ b/docs/architecture/decisions/0026-equipment-capacity-fit-check.md
@@ -1,8 +1,8 @@
 # ADR-0026 — Equipment capacity fit-check: advisory pre-batch readiness, backend-computed
 
-**Status** Accepted
-**Date** 2026-07-07 (accepted 2026-07-09, on the equipment fit-check leg landing: backend #1362 + mobile #1364)
-**Owners** @benoit-bremaud
+**Status**  Accepted
+**Date**    2026-07-07 (accepted 2026-07-09, on the equipment fit-check leg landing: backend #1362 + mobile #1364)
+**Owners**  @benoit-bremaud
 
 ---
 


### PR DESCRIPTION
## Summary

The equipment capacity fit-check leg is now built end-to-end — backend [#1362](https://github.com/benoit-bremaud/brasse-bouillon/pull/1362) (`73feaa0`) and mobile [#1364](https://github.com/benoit-bremaud/brasse-bouillon/pull/1364) (`df42a92`) — so [ADR-0026](docs/architecture/decisions/0026-equipment-capacity-fit-check.md) moves from **Proposed** to **Accepted**.

- Status line → `Accepted`, with a Date annotation recording the acceptance (2026-07-09) and the two build PRs.
- Added ADR-0026 to the root [CLAUDE.md](CLAUDE.md) accepted-ADR index that every reviewer must read before reviewing a PR.

No code change; conception now matches the shipped reality (conception = contract).

## Checklist

- [x] ADR body carries no other stale `Proposed` reference (grep-verified)
- [x] No stale `ADR-0026 (Proposed)` cross-reference elsewhere in `docs/`
- [x] Index entry follows the existing format (link only, no date/summary)