### PR TITLE
fix(website): serve a real 404 page for unknown routes

### DIFF
--- a/packages/website/404.html
+++ b/packages/website/404.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page introuvable (404) — Brasse-Bouillon</title>
+  <meta name="description" content="La page demandée est introuvable. Revenez à l’accueil de Brasse-Bouillon.">
+  <!-- Cloudflare Pages serves this file with a real HTTP 404 for any
+       unmatched route. noindex keeps it out of the index if it is ever
+       reached at 200; no canonical because the requested URL varies. -->
+  <meta name="robots" content="noindex,follow">
+
+  <link rel="icon" href="favicon.ico" sizes="any">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+
+  <link rel="stylesheet" href="site.css?v=20260526-3">
+
+  <!-- Page-specific layout only; all colours/typography come from the
+       site.css design tokens (no hardcoded values). -->
+  <style>
+    .error-page {
+      min-height: 82vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 48px 20px;
+      text-align: center;
+    }
+    .error-card { max-width: 34rem; }
+    .error-logo { width: 96px; height: auto; margin: 0 auto 24px; display: block; }
+    .error-code {
+      font-family: var(--font-display);
+      font-size: clamp(4rem, 18vw, 7rem);
+      font-weight: 900;
+      line-height: 1;
+      color: var(--copper);
+      margin: 0;
+    }
+    .error-title {
+      font-family: var(--font-display);
+      font-size: clamp(1.4rem, 5vw, 2rem);
+      color: var(--ink);
+      margin: 8px 0 12px;
+    }
+    .error-text {
+      color: var(--muted);
+      font-size: 1.05rem;
+      line-height: 1.6;
+      margin: 0 auto 28px;
+      max-width: 28rem;
+    }
+    .error-home {
+      display: inline-block;
+      background: var(--copper-deep);
+      color: var(--foam);
+      font-family: var(--font-body);
+      font-weight: 700;
+      text-decoration: none;
+      padding: 14px 28px;
+      border-radius: var(--radius-md);
+      box-shadow: var(--shadow-md);
+      transition: transform 0.2s var(--ease-out-soft), background 0.2s;
+    }
+    .error-home:hover { background: var(--ink-soft); transform: translateY(-2px); }
+    .error-home:focus-visible { outline: 3px solid var(--color-focus); outline-offset: 3px; }
+    .error-sub { margin: 20px 0 0; color: var(--muted); font-size: 0.9rem; }
+    .error-sub a { color: var(--copper-deep); }
+    .error-foot { margin-top: 40px; color: var(--muted); font-size: 0.9rem; }
+    @media (prefers-reduced-motion: reduce) {
+      .error-home { transition: none; }
+      .error-home:hover { transform: none; }
+    }
+  </style>
+</head>
+<body>
+  <main class="error-page">
+    <div class="error-card">
+      <img class="error-logo" src="logo-hero.webp" width="96" height="96" alt="Mascotte Brasse-Bouillon">
+      <p class="error-code">404</p>
+      <h1 class="error-title">Cette page est introuvable</h1>
+      <p class="error-text">
+        Le lien est peut-être cassé, ou la page a été déplacée.
+        Rien de perdu : revenons à l’accueil pour reprendre le fil.
+      </p>
+      <a class="error-home" href="/">Retour à l’accueil</a>
+      <p class="error-sub" lang="en">Page not found. <a href="/">Back to the home page</a>.</p>
+      <p class="error-foot">Brasse-Bouillon — l’application des brasseurs amateurs.</p>
+    </div>
+  </main>
+</body>
+</html>

--- a/packages/website/404.html
+++ b/packages/website/404.html
@@ -10,13 +10,16 @@
        reached at 200; no canonical because the requested URL varies. -->
   <meta name="robots" content="noindex,follow">
 
-  <link rel="icon" href="favicon.ico" sizes="any">
+  <link rel="icon" href="/favicon.ico" sizes="any">
 
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,500;9..144,700;9..144,900&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 
-  <link rel="stylesheet" href="site.css?v=20260526-3">
+  <!-- Root-absolute asset URLs: this page is served for ANY unmatched
+       route (e.g. /foo/bar/), so relative URLs would resolve against the
+       requested path and 404. Assets must be pinned to the site root. -->
+  <link rel="stylesheet" href="/site.css?v=20260526-3">
 
   <!-- Page-specific layout only; all colours/typography come from the
        site.css design tokens (no hardcoded values). -->
@@ -78,7 +81,7 @@
 <body>
   <main class="error-page">
     <div class="error-card">
-      <img class="error-logo" src="logo-hero.webp" width="96" height="96" alt="Mascotte Brasse-Bouillon">
+      <img class="error-logo" src="/logo-hero.webp" width="96" height="96" alt="Mascotte Brasse-Bouillon">
       <p class="error-code">404</p>
       <h1 class="error-title">Cette page est introuvable</h1>
       <p class="error-text">

--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -18,6 +18,7 @@ HOMEPAGE_URL = "https://brasse-bouillon.com/"
 REQUIRED_FILES = [
     "index.html",
     "index-en.html",
+    "404.html",
     "legal.html",
     "legal-en.html",
     "privacy.html",
@@ -101,6 +102,19 @@ HTML_RULES = {
             r"<link\s+rel=\"canonical\"\s+href=\""
             r"https://brasse-bouillon\.com/\"",
             "canonical EN vers https://brasse-bouillon.com/ manquante",
+        ),
+    ],
+    # The catch-all error page (Cloudflare Pages serves it with a real HTTP
+    # 404 for unmatched routes). It is a single locale-agnostic file — no
+    # `-en.html` twin — so only the structural invariants are enforced: it
+    # must stay noindex and never be indexed as home-page duplicate content.
+    "404.html": [
+        (r"<!DOCTYPE html>", "doctype HTML5 manquant"),
+        (r"<html\s+lang=\"fr\"", 'balise <html lang="fr"> manquante'),
+        (r"<title>.+</title>", "balise <title> manquante"),
+        (
+            r"<meta\s+name=\"robots\"\s+content=\"noindex",
+            "meta robots noindex manquant dans 404.html",
         ),
     ],
 }

--- a/packages/website/tests/test_quality_gate.py
+++ b/packages/website/tests/test_quality_gate.py
@@ -89,6 +89,20 @@ def _create_valid_fixture(base: Path) -> None:
 
     _write_file(
         base,
+        "404.html",
+        """<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <title>404</title>
+  <meta name="robots" content="noindex,follow">
+</head>
+<body></body>
+</html>
+""",
+    )
+
+    _write_file(
+        base,
         "sitemap.xml",
         """<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -141,6 +155,24 @@ class QualityGateTests(unittest.TestCase):
 
             errors = quality_gate.collect_errors(root)
             self.assertTrue(any("meta robots noindex,follow" in err for err in errors))
+
+    def test_detects_404_missing_noindex(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            not_found_path = root / "404.html"
+            not_found_path.write_text(
+                not_found_path.read_text(encoding="utf-8").replace(
+                    '<meta name="robots" content="noindex,follow">',
+                    "",
+                ),
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.collect_errors(root)
+            self.assertTrue(
+                any("meta robots noindex manquant dans 404.html" in err for err in errors)
+            )
 
     def test_detects_disallowed_software_application_schema(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Add `packages/website/404.html` so Cloudflare Pages returns a real **HTTP 404** for unmatched routes, replacing the current **soft-404** (HTTP 200 + a byte-identical copy of the home page) surfaced by the 2026-07-09 security/SEO audit. The soft-404 let arbitrary/mistyped URLs be indexed as home-page duplicates and wasted crawl budget.

## Context

- Cloudflare Pages serves a root `404.html` with a genuine 404 status for any unmatched path (ADR-0014 hosting) — no client redirect, no config file needed beyond the file itself.
- The page is a **single locale-agnostic file**: Cloudflare serves one root `404.html` for every route, so an `-en.html` twin would be dead code. Instead it carries a discreet English line so it serves both audiences.
- SEO hygiene: `noindex,follow`, **no** `rel=canonical` (the requested URL varies), links back to `/`.
- Design: reuses `site.css` design tokens (no hardcoded colours), honours `prefers-reduced-motion`, `width`/`height` on the logo to avoid CLS.
- Guardrail: `scripts/quality_gate.py` now **requires** `404.html` and enforces its structural invariants (doctype, `lang`, `title`, `noindex`), with a covering test.

## Checklist

- [x] Quality gate passes locally (`python scripts/quality_gate.py`)
- [x] Unit tests pass (`python -m unittest discover -s tests`, 11/11)
- [x] Renders correctly (FR + EN line, mascot, AA button contrast) — verified via local static server
- [x] No forbidden patterns (tokens only, no inline `style=` attributes, semantic HTML, meaningful alt text)
- [x] Pre-push review run (pr-pre-reviewer: 0 Must Have)
- [x] Deploy workflow already stages the page via the `*.html` glob

🤖 Generated with [Claude Code](https://claude.com/claude-code)