### PR TITLE
fix(academy): polish content navigation and glossary search

### DIFF
--- a/docs/architecture/academy/ux-flows.md
+++ b/docs/architecture/academy/ux-flows.md
@@ -10,6 +10,111 @@
 - Technical depth is progressive: beginner summary first, deeper material later.
 - Controls must be familiar, accessible, and stable.
 
+## Mobile Visual Review Follow-Ups
+
+Observed during local Android emulator review on 2026-07-08 and 2026-07-09.
+These are follow-up items, not immediate implementation scope. Items marked as
+addressed still need one final emulator confirmation before the PR review.
+
+### Must Fix
+
+- Explicit navigation to an Academy page must follow the global app navigation
+  invariant: new page = top of page; back navigation may restore the previous
+  position when useful.
+- Glossary explicit entry and glossary deep links must not reuse a stale middle
+  scroll position.
+- Glossary `termSlug` deep links must open the focused term card reliably.
+- Glossary search ranking must prioritize exact term/title matches before
+  secondary matches in definitions or related metadata. Example observed:
+  searching `ibu` showed `Acide alpha` and `Calcium` before `IBU`.
+- The glossary article should avoid showing duplicate glossary/article content
+  below the interactive glossary section, especially when the keyboard is open.
+
+### Should Improve
+
+- The fixed detail header consumes significant vertical space while reading on a
+  phone. Consider a compact or collapsible header pattern after the first screen.
+- The article hero order should be reviewed when an article has a calculator
+  CTA. In the current visual pass, the calculator CTA appears before the
+  article summary content, which can make the page feel tool-first instead of
+  reference-first.
+- Category chips work horizontally, but partially clipped chips at the viewport
+  edge are not self-explanatory. Consider a subtle horizontal fade or adjusted
+  side padding.
+- Search focus can remain visible after selecting a category chip. Consider
+  dismissing search focus when the user switches category.
+- Inline glossary reference chips work, but their visual treatment is minimal.
+  Consider making them more explicit as tappable vocabulary references without
+  adding heavy UI.
+- Low-density category results can leave a large empty viewport. Consider
+  suggested adjacent articles or a short helper state when a category has only
+  one item.
+- Replace current generic topic icons with a coherent pedagogical iconography or
+  illustration set. Priority subjects: malt, hops, yeast, water, density,
+  color, process, fermentation, glossary, and calculators.
+- Plan a dedicated review of all calculator tools before relying on them as
+  Academy-linked pedagogical references: formulas, units, rounding, edge cases,
+  validation messages, source alignment, and educational wording.
+- Before the calculator review/refactor, create a proper UML design study for
+  calculator tools: use-case diagrams, domain class diagrams, sequence diagrams
+  for calculations and validation, component boundaries, and Clean Architecture
+  dependencies.
+- Academy-to-calculator navigation should provide a clear way back to the
+  originating article or concept when the user arrives from an Academy CTA.
+- Calculator result sections must respect bottom navigation clearance. The
+  fermentescibles calculator result card was partially hidden by the bottom nav
+  during the visual pass.
+- Hub and glossary empty states can later suggest adjacent categories, popular
+  searches, or a one-tap clear action, but this is not a blocker for the current
+  Academy slice.
+
+### Addressed, Pending Visual Confirmation
+
+- Article detail no longer repeats the article title in the fixed header and in
+  the article hero. The fixed header now provides navigation context only.
+- Academy article/detail scroll views now add extra bottom clearance above the
+  bottom navigation.
+- Calculator CTAs now name the target calculator instead of using only the
+  generic "Ouvrir le calculateur" label.
+- The focused glossary card label now uses "Terme sélectionné".
+
+### Next Emulator Checklist
+
+- Open the Academy hub from the bottom navigation and verify the page starts at
+  the top.
+- Open `Malts et fermentescibles`; verify the first viewport has only one
+  primary article title.
+- Scroll to the end of `Malts et fermentescibles`; verify sources and footer
+  navigation stay above the bottom navigation.
+- Tap the calculator CTA; verify the button label is explicit and the calculator
+  route opens.
+- Use Android back from the calculator; verify the user can return to the
+  Academy context.
+- Open `Glossaire brassicole`, search `ibu`, and verify exact term ranking.
+- Open the `IBU` glossary term; verify the focused card appears and starts from
+  the expected top position.
+- Navigate from a related glossary term and from a related article; verify new
+  pages start at the top while back navigation restores context.
+
+### Confirmed Good
+
+- The Academy hub hierarchy is readable on mobile: title, value card, search,
+  category chips, and article cards are understandable.
+- "Malts et fermentescibles" is visible from the first hub viewport, which fits
+  the ingredient-first learning expectation.
+- Focused glossary cards are readable on mobile and show definition, aliases,
+  related terms, and sources in a useful order.
+- Related glossary term navigation works from the focused card.
+- Hub search filters results immediately and has a visible clear action.
+- Hub empty search state is clear and readable.
+- Returning from an article to the hub restores the selected category and
+  horizontal chip position, which is appropriate for back navigation.
+- Article-to-article "Lire aussi" navigation opens the target article at the top,
+  and returning restores the source article near the related-link position.
+- Android system back from article reading returns to the Academy hub with the
+  previous filter context restored.
+- Article-to-glossary reference chips open the focused glossary term correctly.
+
 ## Academy Hub
 
 ### Primary Content
@@ -22,13 +127,13 @@
 
 ### States
 
-| State | Expected behavior |
-| --- | --- |
-| Ready | Search, categories, pilot cards, FAQ links visible. |
-| Empty corpus | Controlled empty state explaining that Academy content is unavailable. |
-| Search empty | Show curated article/category suggestions. |
-| Search no result | Show clear no-result message and category shortcuts. |
-| Invalid link | Show controlled error and return action. |
+| State            | Expected behavior                                                      |
+| ---------------- | ---------------------------------------------------------------------- |
+| Ready            | Search, categories, pilot cards, FAQ links visible.                    |
+| Empty corpus     | Controlled empty state explaining that Academy content is unavailable. |
+| Search empty     | Show curated article/category suggestions.                             |
+| Search no result | Show clear no-result message and category shortcuts.                   |
+| Invalid link     | Show controlled error and return action.                               |
 
 ## Article Reader
 

--- a/docs/design/ux-refonte/04-implementation-backlog.md
+++ b/docs/design/ux-refonte/04-implementation-backlog.md
@@ -76,6 +76,9 @@ then the consolidations. Each step leaves the app shippable.
 - Each R-chunk updates the relevant UML diagram first (per [03](03-uml-refresh-plan.md)).
 - Each R-chunk adds tests (happy/sad/edge) and reconciles its user stories.
 - Harmonisation rules ([02](02-target-ia.md)) become a review checklist.
+- Global scroll invariant: explicit navigation to a new page starts at the top
+  of that page; intentional back navigation may restore the previous scroll
+  position when it helps the user resume context.
 
 ## Out of scope of #1082 (tracked elsewhere)
 

--- a/packages/mobile-app/docs/ANDROID_EMULATOR.md
+++ b/packages/mobile-app/docs/ANDROID_EMULATOR.md
@@ -3,64 +3,148 @@
 Use this when a Codex worktree needs to inspect the Expo mobile app on the
 local Android emulator.
 
-## Required environment
+## Required host terminal environment
 
-The project expects Node 20:
+Run Metro from the user's host terminal, not from the sandboxed Codex session.
+The sandbox can prevent Metro, Gradle, or ADB from opening local network
+listeners. When that happens, run the host-terminal commands manually and let
+Codex continue with repository checks.
+
+The project expects Node 20. From the Academy worktree:
 
 ```bash
 cd /tmp/brasse-bouillon-academy-content
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
 nvm use 20
-```
 
-Expose the Android SDK tools:
-
-```bash
 export ANDROID_HOME="$HOME/Android/Sdk"
 export ANDROID_SDK_ROOT="$ANDROID_HOME"
 export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
 ```
 
-## Important: reuse the host ADB server
-
-In sandboxed Codex sessions, starting a new ADB daemon can fail with
-`Operation not permitted`. If the emulator is already visible from the user's
-terminal, reuse that host ADB server:
+Start Metro from that same host terminal:
 
 ```bash
-export ADB_SERVER_SOCKET=tcp:127.0.0.1:5037
-adb devices
+npm -w packages/mobile-app start -- --android --localhost --clear
 ```
 
-Expected output:
+If Expo reports that port `8081` is already used by another Brasse Bouillon
+worktree, accept the next port, usually `8082`.
+
+## Emulator setup
+
+List the available AVDs:
+
+```bash
+emulator -list-avds
+```
+
+Known local AVDs:
+
+- `bb_pixel`
+- `bb_pixel_academy`
+
+Start the Academy AVD if needed:
+
+```bash
+emulator -avd bb_pixel_academy
+```
+
+For a full reset of the Academy AVD:
+
+```bash
+adb -H 127.0.0.1 -P 5037 emu kill
+emulator -avd bb_pixel_academy -wipe-data -no-snapshot-load -no-snapshot-save
+```
+
+Wait until Android has booted:
+
+```bash
+adb -H 127.0.0.1 -P 5037 wait-for-device
+adb -H 127.0.0.1 -P 5037 shell getprop sys.boot_completed
+```
+
+Expected boot value:
+
+```text
+1
+```
+
+If the emulator was wiped and Expo Go is missing, reinstall it from the local
+Expo cache:
+
+```bash
+adb -H 127.0.0.1 -P 5037 install -r "$HOME/.expo/android-apk-cache/Expo-Go-54.0.8.apk"
+```
+
+## Codex ADB workflow
+
+In sandboxed Codex sessions, starting or connecting to an ADB daemon can fail
+with `Operation not permitted`. Reuse the host ADB server explicitly with `-H`
+and `-P`; this proved more reliable than relying only on `ADB_SERVER_SOCKET`
+when the sandbox allows local socket access.
+
+Check that Codex sees the emulator. If this fails with `Operation not
+permitted`, run the same commands from the host terminal instead:
+
+```bash
+export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
+adb -H 127.0.0.1 -P 5037 devices
+adb -H 127.0.0.1 -P 5037 shell getprop ro.build.version.release
+```
+
+Expected output includes:
 
 ```text
 List of devices attached
 emulator-5554    device
 ```
 
-## Start the Academy worktree app
-
-From the Codex worktree:
+Open the Expo experience from Codex once Metro is running on the host:
 
 ```bash
-cd /tmp/brasse-bouillon-academy-content
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-nvm use 20
-export ANDROID_HOME="$HOME/Android/Sdk"
-export ANDROID_SDK_ROOT="$ANDROID_HOME"
-export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/platform-tools:$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
-export ADB_SERVER_SOCKET=tcp:127.0.0.1:5037
-
-npm -w packages/mobile-app start -- --android
+adb -H 127.0.0.1 -P 5037 shell am start \
+  -a android.intent.action.VIEW \
+  -d exp://10.0.2.2:8082
 ```
 
-If the emulator is not running, the available AVDs can be listed from the
-user's terminal:
+Use `8081` instead of `8082` if Metro kept the default port.
+
+Take a screenshot for visual review:
 
 ```bash
-emulator -list-avds
-emulator -avd bb_pixel_academy
+adb -H 127.0.0.1 -P 5037 exec-out screencap -p > /tmp/bb-academy-current.png
+```
+
+If ADB intermittently returns `Operation not permitted`, run the minimal device
+check first, then retry the failed command as a separate command:
+
+```bash
+adb -H 127.0.0.1 -P 5037 devices
+adb -H 127.0.0.1 -P 5037 shell getprop ro.build.version.release
+```
+
+## Navigation shortcuts
+
+The local Pixel emulator is `1080x2400`. Useful bottom navigation tap targets:
+
+```bash
+# Home
+adb -H 127.0.0.1 -P 5037 shell input tap 170 2185
+
+# Brew session
+adb -H 127.0.0.1 -P 5037 shell input tap 310 2185
+
+# Recipes
+adb -H 127.0.0.1 -P 5037 shell input tap 465 2185
+
+# Scan
+adb -H 127.0.0.1 -P 5037 shell input tap 610 2185
+
+# Academy
+adb -H 127.0.0.1 -P 5037 shell input tap 765 2185
+
+# Account
+adb -H 127.0.0.1 -P 5037 shell input tap 920 2185
 ```

--- a/packages/mobile-app/src/features/academy/application/__tests__/academy.use-cases.test.ts
+++ b/packages/mobile-app/src/features/academy/application/__tests__/academy.use-cases.test.ts
@@ -122,6 +122,13 @@ describe("Academy use cases", () => {
     expect(listAcademyGlossaryTermsUseCase(repository, "unknown")).toEqual([]);
   });
 
+  it("prioritizes exact glossary matches before secondary definition matches", () => {
+    expect(listAcademyGlossaryTermsUseCase(repository, "ibu")).toEqual([
+      ibuTerm,
+      alphaAcidTerm,
+    ]);
+  });
+
   it("searches published articles and glossary entries", () => {
     const results = searchAcademy(repository, "amertume");
 

--- a/packages/mobile-app/src/features/academy/application/academy.use-cases.ts
+++ b/packages/mobile-app/src/features/academy/application/academy.use-cases.ts
@@ -71,7 +71,7 @@ export function listAcademyGlossaryTermsUseCase(
     )
     .slice()
     .sort((left, right) =>
-      left.label.localeCompare(right.label, "fr", { sensitivity: "base" }),
+      compareGlossaryTermsForPresentation(left, right, normalizedQuery),
     );
 }
 
@@ -181,7 +181,67 @@ function doesGlossaryTermMatch(
     term.shortDefinition,
     term.detailedDefinition,
     ...term.aliases,
+    ...term.relatedTerms,
   ].some((value) => normalizeSearchValue(value).includes(normalizedQuery));
+}
+
+function compareGlossaryTermsForPresentation(
+  left: GlossaryTerm,
+  right: GlossaryTerm,
+  normalizedQuery: string,
+): number {
+  if (normalizedQuery) {
+    const leftScore = getGlossaryTermMatchScore(left, normalizedQuery);
+    const rightScore = getGlossaryTermMatchScore(right, normalizedQuery);
+
+    if (leftScore !== rightScore) {
+      return leftScore - rightScore;
+    }
+  }
+
+  return left.label.localeCompare(right.label, "fr", { sensitivity: "base" });
+}
+
+function getGlossaryTermMatchScore(
+  term: GlossaryTerm,
+  normalizedQuery: string,
+): number {
+  const slug = normalizeSearchValue(term.slug);
+  const label = normalizeSearchValue(term.label);
+  const aliases = term.aliases.map(normalizeSearchValue);
+  const definitions = [
+    normalizeSearchValue(term.shortDefinition),
+    normalizeSearchValue(term.detailedDefinition),
+  ];
+  const relatedTerms = term.relatedTerms.map(normalizeSearchValue);
+
+  if (slug === normalizedQuery || label === normalizedQuery) {
+    return 0;
+  }
+
+  if (
+    slug.startsWith(normalizedQuery) ||
+    label.startsWith(normalizedQuery) ||
+    aliases.some((alias) => alias === normalizedQuery)
+  ) {
+    return 1;
+  }
+
+  if (aliases.some((alias) => alias.includes(normalizedQuery))) {
+    return 2;
+  }
+
+  if (definitions.some((definition) => definition.includes(normalizedQuery))) {
+    return 3;
+  }
+
+  if (
+    relatedTerms.some((relatedTerm) => relatedTerm.includes(normalizedQuery))
+  ) {
+    return 4;
+  }
+
+  return 5;
 }
 
 function normalizeQueryToken(value: string): string {

--- a/packages/mobile-app/src/features/academy/application/academy.use-cases.ts
+++ b/packages/mobile-app/src/features/academy/application/academy.use-cases.ts
@@ -63,6 +63,7 @@ export function listAcademyGlossaryTermsUseCase(
   query = "",
 ): readonly GlossaryTerm[] {
   const normalizedQuery = normalizeQueryToken(query);
+  const matchScoreBySlug = new Map<string, number>();
 
   return repository
     .listGlossaryTerms()
@@ -71,7 +72,12 @@ export function listAcademyGlossaryTermsUseCase(
     )
     .slice()
     .sort((left, right) =>
-      compareGlossaryTermsForPresentation(left, right, normalizedQuery),
+      compareGlossaryTermsForPresentation(
+        left,
+        right,
+        normalizedQuery,
+        matchScoreBySlug,
+      ),
     );
 }
 
@@ -189,10 +195,19 @@ function compareGlossaryTermsForPresentation(
   left: GlossaryTerm,
   right: GlossaryTerm,
   normalizedQuery: string,
+  matchScoreBySlug: Map<string, number>,
 ): number {
   if (normalizedQuery) {
-    const leftScore = getGlossaryTermMatchScore(left, normalizedQuery);
-    const rightScore = getGlossaryTermMatchScore(right, normalizedQuery);
+    const leftScore = getCachedGlossaryTermMatchScore(
+      left,
+      normalizedQuery,
+      matchScoreBySlug,
+    );
+    const rightScore = getCachedGlossaryTermMatchScore(
+      right,
+      normalizedQuery,
+      matchScoreBySlug,
+    );
 
     if (leftScore !== rightScore) {
       return leftScore - rightScore;
@@ -200,6 +215,22 @@ function compareGlossaryTermsForPresentation(
   }
 
   return left.label.localeCompare(right.label, "fr", { sensitivity: "base" });
+}
+
+function getCachedGlossaryTermMatchScore(
+  term: GlossaryTerm,
+  normalizedQuery: string,
+  matchScoreBySlug: Map<string, number>,
+): number {
+  const cachedScore = matchScoreBySlug.get(term.slug);
+
+  if (typeof cachedScore === "number") {
+    return cachedScore;
+  }
+
+  const score = getGlossaryTermMatchScore(term, normalizedQuery);
+  matchScoreBySlug.set(term.slug, score);
+  return score;
 }
 
 function getGlossaryTermMatchScore(

--- a/packages/mobile-app/src/features/academy/presentation/AcademyGlossarySection.tsx
+++ b/packages/mobile-app/src/features/academy/presentation/AcademyGlossarySection.tsx
@@ -20,7 +20,7 @@ export function AcademyHighlightedGlossaryTerm({
 
   return (
     <Card style={styles.highlightedGlossaryCard} variant="subtle">
-      <Text style={styles.highlightedGlossaryEyebrow}>Terme recherché</Text>
+      <Text style={styles.highlightedGlossaryEyebrow}>Terme sélectionné</Text>
       <Text style={styles.highlightedGlossaryTitle}>{term.label}</Text>
       <Text style={styles.highlightedGlossarySummary}>
         {term.shortDefinition}

--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
@@ -50,6 +50,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
   const router = useRouter();
   const [glossaryQuery, setGlossaryQuery] = React.useState("");
   const bottomPadding = useNavigationFooterOffset();
+  const screenBottomPadding = bottomPadding + spacing.xl;
   const scrollViewRef = React.useRef<ScrollView>(null);
   const articleTopOffsetRef = React.useRef(0);
   const sectionOffsetsRef = React.useRef<Record<string, number>>({});
@@ -57,7 +58,6 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
   const normalizedTermSlug = normalizeRouteParam(termSlugParam);
   const topic = getAcademyTopicBySlug(normalizedSlug);
   const displayableTopic = getDisplayableAcademyTopicBySlug(normalizedSlug);
-  const calculatorLabel = "Ouvrir le calculateur";
   const generatedArticle = normalizedSlug
     ? getAcademyArticleBySlug(generatedAcademyRepository, normalizedSlug)
     : null;
@@ -92,6 +92,9 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
     null;
   const legacyCalculatorSlug = topic?.hasCalculator ? topic.slug : null;
   const calculatorSlug = generatedArticleCalculatorSlug ?? legacyCalculatorSlug;
+  const calculatorLabel = calculatorSlug
+    ? `Ouvrir le calculateur ${formatCalculatorSlugLabel(calculatorSlug)}`
+    : "Ouvrir le calculateur";
   const goBackOrAcademyHome = React.useCallback(() => {
     if (router.canGoBack()) {
       router.back();
@@ -164,8 +167,8 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
     return (
       <Screen>
         <ListHeader
-          title={publishedGeneratedArticle.metadata.title}
-          subtitle="Article Académie"
+          title="Académie brassicole"
+          subtitle="Article de référence"
           action={
             <HeaderBackButton
               label="Retour"
@@ -179,7 +182,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
           ref={scrollViewRef}
           contentContainerStyle={[
             styles.content,
-            { paddingBottom: bottomPadding },
+            { paddingBottom: screenBottomPadding },
           ]}
         >
           {calculatorSlug ? (
@@ -277,7 +280,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
       <ScrollView
         contentContainerStyle={[
           styles.content,
-          { paddingBottom: bottomPadding },
+          { paddingBottom: screenBottomPadding },
         ]}
       >
         <Card style={styles.heroCard}>
@@ -333,6 +336,17 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
         ) : null}
       </ScrollView>
     </Screen>
+  );
+}
+
+function formatCalculatorSlugLabel(slug: string): string {
+  return (
+    getAcademyArticleBySlug(generatedAcademyRepository, slug)?.metadata.title ??
+    getAcademyTopicBySlug(slug)?.title ??
+    slug
+      .split("-")
+      .filter((part) => part.length > 0)
+      .join(" ")
   );
 }
 

--- a/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
@@ -921,10 +921,11 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
     );
 
     expect(screen.getByText("2 termes trouvés")).toBeTruthy();
-    expect(screen.getAllByLabelText(/Consulter le terme/)).toEqual([
-      screen.getByLabelText("Consulter le terme Acide alpha"),
-      screen.getByLabelText("Consulter le terme IBU"),
-    ]);
+    expect(
+      screen
+        .getAllByLabelText(/^Consulter le terme (Acide alpha|IBU)$/)
+        .map((termAction) => termAction.props.accessibilityLabel),
+    ).toEqual(["Consulter le terme Acide alpha", "Consulter le terme IBU"]);
   });
 
   it("clears the glossary search input", () => {

--- a/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
@@ -912,7 +912,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
     ).toBe("");
   });
 
-  it("filters glossary terms from the glossary search input", () => {
+  it("ranks direct glossary search matches before related matches", () => {
     render(<AcademyTopicDetailsScreen slugParam="glossaire" />);
 
     fireEvent.changeText(
@@ -920,9 +920,11 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
       "alpha",
     );
 
-    expect(screen.getByText("1 terme trouvé")).toBeTruthy();
-    expect(screen.getByText("Acide alpha")).toBeTruthy();
-    expect(screen.queryByText("IBU")).toBeNull();
+    expect(screen.getByText("2 termes trouvés")).toBeTruthy();
+    expect(screen.getAllByLabelText(/Consulter le terme/)).toEqual([
+      screen.getByLabelText("Consulter le terme Acide alpha"),
+      screen.getByLabelText("Consulter le terme IBU"),
+    ]);
   });
 
   it("clears the glossary search input", () => {

--- a/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
@@ -602,6 +602,20 @@ const TOPICS_WITH_CALCULATOR = [
   "avances",
 ] as const;
 
+const CALCULATOR_LABEL_BY_TOPIC: Record<
+  (typeof TOPICS_WITH_CALCULATOR)[number],
+  string
+> = {
+  fermentescibles: "Ouvrir le calculateur Malts et fermentescibles",
+  couleur: "Ouvrir le calculateur Couleur",
+  houblons: "Ouvrir le calculateur Houblons",
+  eau: "Ouvrir le calculateur Eau de brassage",
+  rendement: "Ouvrir le calculateur Rendement",
+  levures: "Ouvrir le calculateur Levures et fermentation",
+  carbonatation: "Ouvrir le calculateur Carbonatation",
+  avances: "Ouvrir le calculateur Calculs avancés",
+};
+
 describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
   beforeEach(() => {
     mockPush.mockClear();
@@ -612,11 +626,11 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
   });
 
   it.each(TOPICS_WITH_CALCULATOR)(
-    'happy: %s topic shows "Ouvrir le calculateur" and navigates to its calculator',
+    "happy: %s topic shows the calculator CTA and navigates to its calculator",
     (slug) => {
       render(<AcademyTopicDetailsScreen slugParam={slug} />);
 
-      const button = screen.getByText("Ouvrir le calculateur");
+      const button = screen.getByText(CALCULATOR_LABEL_BY_TOPIC[slug]);
       fireEvent.press(button);
 
       expect(mockPush).toHaveBeenCalledWith({
@@ -641,7 +655,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
       const { unmount } = render(
         <AcademyTopicDetailsScreen slugParam={slug} />,
       );
-      expect(screen.queryByText("Ouvrir le calculateur")).toBeNull();
+      expect(screen.queryByText(/^Ouvrir le calculateur/)).toBeNull();
       unmount();
     }
   });
@@ -663,7 +677,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
       screen.getByText("Reference guide for hop roles in brewing."),
     ).toBeTruthy();
     expect(screen.getByText("Role du houblon")).toBeTruthy();
-    expect(screen.getByText("Ouvrir le calculateur")).toBeTruthy();
+    expect(screen.getByText(CALCULATOR_LABEL_BY_TOPIC.houblons)).toBeTruthy();
   });
 
   it("navigates from a generated article to a related article", () => {
@@ -725,7 +739,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
       <AcademyTopicDetailsScreen slugParam="glossaire" termSlugParam="ibu" />,
     );
 
-    expect(screen.getByText("Terme recherché")).toBeTruthy();
+    expect(screen.getByText("Terme sélectionné")).toBeTruthy();
     expect(screen.getAllByText("IBU").length).toBeGreaterThan(0);
     expect(
       screen.getAllByText("Estimation de l'amertume d'une bière.").length,
@@ -789,7 +803,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
 
     expect(screen.getByText("Generated yeast article summary.")).toBeTruthy();
     expect(screen.getByText("Pourquoi la levure est critique")).toBeTruthy();
-    expect(screen.getByText("Ouvrir le calculateur")).toBeTruthy();
+    expect(screen.getByText(CALCULATOR_LABEL_BY_TOPIC.levures)).toBeTruthy();
   });
 
   it("renders the generated water article and keeps the calculator route", () => {
@@ -797,7 +811,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
 
     expect(screen.getByText("Generated water article summary.")).toBeTruthy();
     expect(screen.getByText("Pourquoi l'eau est critique")).toBeTruthy();
-    expect(screen.getByText("Ouvrir le calculateur")).toBeTruthy();
+    expect(screen.getByText(CALCULATOR_LABEL_BY_TOPIC.eau)).toBeTruthy();
   });
 
   it("renders the generated malt and fermentables article with calculator route", () => {
@@ -810,7 +824,9 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
       screen.getAllByText("Malts et fermentescibles").length,
     ).toBeGreaterThan(0);
     expect(screen.getByText("Pourquoi le malt est central")).toBeTruthy();
-    expect(screen.getByText("Ouvrir le calculateur")).toBeTruthy();
+    expect(
+      screen.getByText(CALCULATOR_LABEL_BY_TOPIC.fermentescibles),
+    ).toBeTruthy();
   });
 
   it("renders the generated carbonation article with calculator route", () => {
@@ -822,7 +838,9 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
     expect(
       screen.getByText("Pourquoi la carbonatation est critique"),
     ).toBeTruthy();
-    expect(screen.getByText("Ouvrir le calculateur")).toBeTruthy();
+    expect(
+      screen.getByText(CALCULATOR_LABEL_BY_TOPIC.carbonatation),
+    ).toBeTruthy();
   });
 
   it("renders the generated color article with calculator route", () => {
@@ -832,7 +850,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
     expect(
       screen.getByText("Pourquoi la couleur est un repere cle"),
     ).toBeTruthy();
-    expect(screen.getByText("Ouvrir le calculateur")).toBeTruthy();
+    expect(screen.getByText(CALCULATOR_LABEL_BY_TOPIC.couleur)).toBeTruthy();
   });
 
   it("renders the generated efficiency article with calculator route", () => {
@@ -842,7 +860,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
       screen.getByText("Generated efficiency article summary."),
     ).toBeTruthy();
     expect(screen.getByText("Pourquoi le rendement est critique")).toBeTruthy();
-    expect(screen.getByText("Ouvrir le calculateur")).toBeTruthy();
+    expect(screen.getByText(CALCULATOR_LABEL_BY_TOPIC.rendement)).toBeTruthy();
   });
 
   it("renders the generated advanced article with calculator route", () => {
@@ -852,7 +870,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
       screen.getByText("Generated advanced article summary."),
     ).toBeTruthy();
     expect(screen.getByText("Pourquoi ces calculs sont avances")).toBeTruthy();
-    expect(screen.getByText("Ouvrir le calculateur")).toBeTruthy();
+    expect(screen.getByText(CALCULATOR_LABEL_BY_TOPIC.avances)).toBeTruthy();
   });
 
   it("renders the generated glossary article without a calculator route", () => {
@@ -866,7 +884,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
     expect(screen.getByText("2 termes")).toBeTruthy();
     expect(screen.getByText("Acide alpha")).toBeTruthy();
     expect(screen.getByText("IBU")).toBeTruthy();
-    expect(screen.queryByText("Ouvrir le calculateur")).toBeNull();
+    expect(screen.queryByText(/^Ouvrir le calculateur/)).toBeNull();
   });
 
   it("navigates from the glossary terms list to the selected term", () => {


### PR DESCRIPTION
## Summary

This stacked draft PR builds on #1333 and polishes the Brewing Academy mobile experience after the content-source/domain slice.

It focuses on three areas:

- Article detail UX: remove duplicated article-title treatment in the fixed header, add safer bottom spacing above the mobile footer, and make calculator CTAs explicit.
- Glossary UX and search: rename the focused glossary label, rank exact glossary matches before secondary matches, and include related glossary terms as a lower-priority search signal.
- Review documentation: record mobile visual review follow-ups, the next emulator checklist, the global scroll invariant, and the local Android/Expo workflow used for this worktree.

## Why

The Academy is becoming a reference knowledge base. The first mobile review showed that the content was usable, but a few details made reading and glossary lookup less precise on small screens: duplicated titles, generic calculator labels, bottom-navigation overlap risk, and glossary search results where secondary matches could outrank exact vocabulary matches.

## Validation

- [x] `npm -w packages/mobile-app test -- --runInBand packages/mobile-app/src/features/academy/application/__tests__/academy.use-cases.test.ts packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx`
- [x] `npm -w packages/mobile-app run ci:check`
- [x] `git diff --check`
- [ ] Final Android emulator visual pass pending local ADB access

## Notes

This PR is intentionally stacked on `feat/academy-domain-contracts` and should be reviewed after #1333. It does not close an issue.
