### PR TITLE
feat(website): add security response headers via Cloudflare Pages _headers

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -60,7 +60,10 @@ jobs:
           done
 
           # Required scalar files — fail loudly if any go missing.
-          for required in favicon.ico sitemap.xml robots.txt; do
+          # `_headers` has no extension, so it is not matched by the glob
+          # copies above and must be staged explicitly (Cloudflare Pages
+          # reads it from the deployment root to set response headers).
+          for required in favicon.ico sitemap.xml robots.txt _headers; do
             cp "$src/$required" _site/
           done
 

--- a/packages/website/_headers
+++ b/packages/website/_headers
@@ -1,0 +1,22 @@
+# Cloudflare Pages — response headers for every route.
+#
+# Security hardening from the 2026-07-09 audit (defense-in-depth for a
+# static marketing site: no auth, no cookies, no server-side code).
+#
+# Only the headers NOT already emitted by the Cloudflare edge are set here,
+# to avoid duplicate header lines — the edge already sends
+# `X-Content-Type-Options: nosniff` and `Referrer-Policy`.
+#
+# Deliberately deferred, each to its own careful step:
+#   - HSTS `includeSubDomains` + `preload` (issue #1033): needs a full
+#     *.brasse-bouillon.com subdomain audit first (includeSubDomains asserts
+#     every subdomain is HTTPS-only; preload is hard to reverse). Apex-only now.
+#   - Content-Security-Policy (issue #1032): needs origin enumeration (staging
+#     feedback/chat widgets on *.workers.dev + staging-api, Formspree, Google
+#     Fonts) and a Report-Only rollout before enforcement, or it would break
+#     staging. Prerequisite: move the inline <script>/onclick out of index.html.
+/*
+  Strict-Transport-Security: max-age=31536000
+  X-Frame-Options: DENY
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), usb=(), payment=()
+  Cross-Origin-Opener-Policy: same-origin

--- a/packages/website/_headers
+++ b/packages/website/_headers
@@ -4,8 +4,12 @@
 # static marketing site: no auth, no cookies, no server-side code).
 #
 # Only the headers NOT already emitted by the Cloudflare edge are set here,
-# to avoid duplicate header lines — the edge already sends
-# `X-Content-Type-Options: nosniff` and `Referrer-Policy`.
+# to avoid duplicate header lines. As of 2026-07-09, live responses (prod,
+# www, staging) carry `X-Content-Type-Options: nosniff` and `Referrer-Policy`
+# from the edge, and NO HSTS at all — verified with `curl -sSI`. (The
+# 2026-05-21 audit doc docs/audit-report/findings.md predates this edge
+# behavior and is stale; re-verify live before assuming an upstream header
+# exists.)
 #
 # Deliberately deferred, each to its own careful step:
 #   - HSTS `includeSubDomains` + `preload` (issue #1033): needs a full


### PR DESCRIPTION
## Summary

Add a Cloudflare Pages `_headers` file setting the security response headers the 2026-07-09 audit found missing on the static marketing site: **HSTS** (apex, 1 year), **X-Frame-Options: DENY** (anti-clickjacking), **Permissions-Policy** (deny unused powerful features), **Cross-Origin-Opener-Policy: same-origin**. Stage the extensionless file in the deploy workflow so Cloudflare actually receives it.

## Context

- Only the headers **not** already emitted by the Cloudflare edge are set (the edge already sends `X-Content-Type-Options: nosniff` and `Referrer-Policy`) → no duplicate header lines.
- **CSP (#1032)** and **HSTS `includeSubDomains`/`preload` (#1033)** are deliberately deferred, each to its own step (documented in the file): CSP needs origin enumeration (staging widgets on `*.workers.dev` + `staging-api`, Formspree, Google Fonts) + a Report-Only rollout + moving the inline `<script>`/`onclick` out of `index.html`; `includeSubDomains` needs a full subdomain audit first.
- The `_headers` file has no extension, so it is not matched by the deploy workflow's `*.html`/`*.css` globs and is staged explicitly.

## Review

Reviewed by two independent pre-push lenses — 0 blockers:
- **Standards/ADR** (`pr-pre-reviewer`): 0 Must Have; `_headers` syntax + workflow change validated; ADR-0014 respected.
- **Adversarial deploy-risk**: verified live the 4 headers exist nowhere today (no duplication) and that `X-Frame-Options`/`COOP`/`Permissions-Policy`/`HSTS` do not affect the feedback/chat widgets, the ALTCHA Web-Crypto proof-of-work, `target=_blank` links (already `noopener`), or `www`. No functional regression on prod or staging.

**Operator notes (not code):** do not also configure these headers via a Cloudflare dashboard transform/managed rule (would duplicate); after deploy, sanity-check the staging widgets still mount.

## Checklist

- [x] Quality gate + unit tests pass locally (11/11)
- [x] `_headers` syntax validated (Cloudflare Pages format; `#` comments OK)
- [x] Deploy staging simulated — `_headers` lands at the `_site/` root
- [x] Two-lens pre-push review: 0 Must Have, 0 blockers
- [x] No forbidden patterns / ADR conflicts (ADR-0014 is the Cloudflare Pages mechanism)

Refs #1032, #1033 (partial: adds X-Frame-Options + Permissions-Policy + base HSTS; CSP and HSTS includeSubDomains/preload remain open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)