### PR TITLE
refactor(academy): stabilize presentation helpers

### DIFF
--- a/packages/mobile-app/src/features/academy/presentation/AcademyArticleRenderer.tsx
+++ b/packages/mobile-app/src/features/academy/presentation/AcademyArticleRenderer.tsx
@@ -11,12 +11,15 @@ import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
 import {
   AcademyArticle,
-  AcademyCategory,
   AcademyContentBlock,
-  AcademyLevel,
   AcademySection,
   CalloutTone,
 } from "../domain";
+import {
+  formatAcademyCategoryLabel,
+  formatAcademyLevelLabel,
+  formatAcademyReadTime,
+} from "./academy-display-formatters";
 import React from "react";
 
 type Props = {
@@ -48,15 +51,17 @@ export function AcademyArticleRenderer({
         <Text style={styles.summary}>{article.metadata.summary}</Text>
         <View style={styles.metaRow}>
           <Badge
-            label={formatLevelLabel(article.metadata.level)}
+            label={formatAcademyLevelLabel(article.metadata.level)}
             variant="info"
           />
           <Badge
-            label={formatReadTime(article.metadata.estimatedReadTimeMinutes)}
+            label={formatAcademyReadTime(
+              article.metadata.estimatedReadTimeMinutes,
+            )}
             variant="neutral"
           />
           <Badge
-            label={formatCategoryLabel(article.metadata.category)}
+            label={formatAcademyCategoryLabel(article.metadata.category)}
             variant="neutral"
           />
         </View>
@@ -626,46 +631,6 @@ const styles = StyleSheet.create({
     color: colors.neutral.textSecondary,
   },
 });
-
-function formatLevelLabel(level: AcademyLevel): string {
-  switch (level) {
-    case "beginner":
-      return "Débutant";
-    case "intermediate":
-      return "Intermédiaire";
-    case "advanced":
-      return "Avancé";
-  }
-}
-
-function formatCategoryLabel(category: AcademyCategory): string {
-  switch (category) {
-    case "getting-started":
-      return "Premiers pas";
-    case "ingredients":
-      return "Ingrédients";
-    case "process":
-      return "Process";
-    case "fermentation":
-      return "Fermentation";
-    case "water":
-      return "Eau";
-    case "equipment":
-      return "Matériel";
-    case "beer-styles":
-      return "Styles";
-    case "safety":
-      return "Sécurité";
-    case "troubleshooting":
-      return "Dépannage";
-    case "glossary":
-      return "Glossaire";
-  }
-}
-
-function formatReadTime(minutes: number): string {
-  return `${minutes} min`;
-}
 
 function formatArticleSlugLabel(slug: string): string {
   return slug

--- a/packages/mobile-app/src/features/academy/presentation/__tests__/academy-display-formatters.test.ts
+++ b/packages/mobile-app/src/features/academy/presentation/__tests__/academy-display-formatters.test.ts
@@ -1,0 +1,17 @@
+import {
+  formatAcademyCategoryLabel,
+  formatAcademyLevelLabel,
+  formatAcademyReadTime,
+} from "../academy-display-formatters";
+
+describe("academy display formatters", () => {
+  it("formats article metadata labels for presentation", () => {
+    expect(formatAcademyLevelLabel("beginner")).toBe("Débutant");
+    expect(formatAcademyLevelLabel("intermediate")).toBe("Intermédiaire");
+    expect(formatAcademyLevelLabel("advanced")).toBe("Avancé");
+    expect(formatAcademyCategoryLabel("getting-started")).toBe("Premiers pas");
+    expect(formatAcademyCategoryLabel("ingredients")).toBe("Ingrédients");
+    expect(formatAcademyCategoryLabel("glossary")).toBe("Glossaire");
+    expect(formatAcademyReadTime(6)).toBe("6 min");
+  });
+});

--- a/packages/mobile-app/src/features/academy/presentation/__tests__/academy-topic-details.presenter.test.ts
+++ b/packages/mobile-app/src/features/academy/presentation/__tests__/academy-topic-details.presenter.test.ts
@@ -1,0 +1,160 @@
+import { AcademyArticle, GlossaryTerm } from "../../domain";
+import {
+  formatAcademyCalculatorButtonLabel,
+  getPublishedAcademyArticleNavigation,
+  listRelatedAcademyGlossaryTerms,
+  resolveAcademyCalculatorSlug,
+} from "../academy-topic-details.presenter";
+
+const article: AcademyArticle = {
+  slug: "houblons",
+  metadata: {
+    title: "Houblons",
+    summary: "Reference guide for hop roles.",
+    category: "ingredients",
+    level: "beginner",
+    status: "published",
+    version: "1.0.0",
+    estimatedReadTimeMinutes: 6,
+    tags: [],
+    updatedAt: "2026-07-09",
+    relatedArticles: [],
+    relatedGlossaryTerms: [],
+    relatedCalculators: [
+      {
+        slug: "houblons",
+        label: "Hop calculator",
+        reason: "Estimate bitterness.",
+        target: {
+          type: "calculator",
+          slug: "houblons",
+        },
+      },
+    ],
+    learningObjectives: [],
+    prerequisites: [],
+    teaches: [],
+    sensitive: false,
+    riskTopics: [],
+    sources: [],
+    review: null,
+  },
+  body: {
+    sections: [],
+  },
+};
+
+const ibuTerm: GlossaryTerm = {
+  slug: "ibu",
+  label: "IBU",
+  aliases: [],
+  shortDefinition: "Amertume calculee.",
+  detailedDefinition: "International Bitterness Units.",
+  relatedTerms: ["acide-alpha", "missing"],
+  sources: [],
+};
+
+const alphaAcidTerm: GlossaryTerm = {
+  slug: "acide-alpha",
+  label: "Acide alpha",
+  aliases: [],
+  shortDefinition: "Compose du houblon.",
+  detailedDefinition: "Compose isomerise pendant l'ebullition.",
+  relatedTerms: [],
+  sources: [],
+};
+
+describe("academy topic details presenter", () => {
+  it("resolves calculator CTA slugs from generated article metadata first", () => {
+    expect(
+      resolveAcademyCalculatorSlug(article, {
+        slug: "legacy-houblons",
+        hasCalculator: true,
+      }),
+    ).toBe("houblons");
+    expect(
+      resolveAcademyCalculatorSlug(null, {
+        slug: "legacy-houblons",
+        hasCalculator: true,
+      }),
+    ).toBe("legacy-houblons");
+    expect(
+      resolveAcademyCalculatorSlug(null, {
+        slug: "history",
+        hasCalculator: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("formats calculator labels with resolver fallback", () => {
+    expect(
+      formatAcademyCalculatorButtonLabel("houblons", (slug) =>
+        slug === "houblons" ? "Houblons" : null,
+      ),
+    ).toBe("Ouvrir le calculateur Houblons");
+    expect(formatAcademyCalculatorButtonLabel("dry-hop", () => null)).toBe(
+      "Ouvrir le calculateur dry hop",
+    );
+    expect(formatAcademyCalculatorButtonLabel(null, () => null)).toBe(
+      "Ouvrir le calculateur",
+    );
+  });
+
+  it("lists related glossary terms and ignores stale references", () => {
+    expect(
+      listRelatedAcademyGlossaryTerms(ibuTerm, (slug) =>
+        slug === alphaAcidTerm.slug ? alphaAcidTerm : null,
+      ),
+    ).toEqual([alphaAcidTerm]);
+    expect(listRelatedAcademyGlossaryTerms(null, () => alphaAcidTerm)).toEqual(
+      [],
+    );
+  });
+
+  it("resolves previous and next generated article navigation", () => {
+    const cards = [
+      {
+        slug: "legacy",
+        title: "Legacy",
+        summary: "Legacy topic.",
+        focus: "Legacy",
+        order: 0,
+        estimatedReadTime: "4 min",
+        hasCalculator: false,
+        source: "legacy" as const,
+      },
+      {
+        slug: "introduction",
+        title: "Introduction",
+        summary: "Start here.",
+        focus: "Premiers pas",
+        order: 1,
+        estimatedReadTime: "5 min",
+        hasCalculator: false,
+        source: "generated" as const,
+      },
+      {
+        slug: "houblons",
+        title: "Houblons",
+        summary: "Hop roles.",
+        focus: "Ingrédients",
+        order: 2,
+        estimatedReadTime: "6 min",
+        hasCalculator: true,
+        source: "generated" as const,
+      },
+    ];
+
+    expect(getPublishedAcademyArticleNavigation("houblons", cards)).toEqual({
+      previous: {
+        slug: "introduction",
+        title: "Introduction",
+      },
+      next: null,
+    });
+    expect(getPublishedAcademyArticleNavigation("missing", cards)).toEqual({
+      previous: null,
+      next: null,
+    });
+  });
+});

--- a/packages/mobile-app/src/features/academy/presentation/academy-display-formatters.ts
+++ b/packages/mobile-app/src/features/academy/presentation/academy-display-formatters.ts
@@ -1,0 +1,41 @@
+import { AcademyCategory, AcademyLevel } from "../domain";
+
+export function formatAcademyLevelLabel(level: AcademyLevel): string {
+  switch (level) {
+    case "beginner":
+      return "Débutant";
+    case "intermediate":
+      return "Intermédiaire";
+    case "advanced":
+      return "Avancé";
+  }
+}
+
+export function formatAcademyCategoryLabel(category: AcademyCategory): string {
+  switch (category) {
+    case "getting-started":
+      return "Premiers pas";
+    case "ingredients":
+      return "Ingrédients";
+    case "process":
+      return "Process";
+    case "fermentation":
+      return "Fermentation";
+    case "water":
+      return "Eau";
+    case "equipment":
+      return "Matériel";
+    case "beer-styles":
+      return "Styles";
+    case "safety":
+      return "Sécurité";
+    case "troubleshooting":
+      return "Dépannage";
+    case "glossary":
+      return "Glossaire";
+  }
+}
+
+export function formatAcademyReadTime(minutes: number): string {
+  return `${minutes} min`;
+}

--- a/packages/mobile-app/src/features/academy/presentation/academy-hub.presenter.ts
+++ b/packages/mobile-app/src/features/academy/presentation/academy-hub.presenter.ts
@@ -1,4 +1,8 @@
 import { AcademyArticle } from "../domain";
+import {
+  formatAcademyCategoryLabel,
+  formatAcademyReadTime,
+} from "./academy-display-formatters";
 
 export interface AcademyLegacyHubTopic {
   readonly slug: string;
@@ -46,9 +50,9 @@ export function createAcademyHubCards(
         slug: article.slug,
         title: article.metadata.title,
         shortDescription: article.metadata.summary,
-        focus: createCategoryLabel(article.metadata.category),
+        focus: formatAcademyCategoryLabel(article.metadata.category),
         order: legacyTopics.length + index,
-        estimatedReadTime: formatReadTime(
+        estimatedReadTime: formatAcademyReadTime(
           article.metadata.estimatedReadTimeMinutes,
         ),
         hasCalculator: article.metadata.relatedCalculators.length > 0,
@@ -103,9 +107,9 @@ function createGeneratedHubCard(
     slug: article.slug,
     title: article.metadata.title,
     summary: article.metadata.summary,
-    focus: createCategoryLabel(article.metadata.category) || fallback.focus,
+    focus: formatAcademyCategoryLabel(article.metadata.category),
     order: fallback.order,
-    estimatedReadTime: formatReadTime(
+    estimatedReadTime: formatAcademyReadTime(
       article.metadata.estimatedReadTimeMinutes,
     ),
     hasCalculator: article.metadata.relatedCalculators.length > 0,
@@ -135,35 +139,6 @@ function createLegacyHubCard(
     hasCalculator: topic.hasCalculator ?? false,
     source: "legacy",
   };
-}
-
-function formatReadTime(minutes: number): string {
-  return `${minutes} min`;
-}
-
-function createCategoryLabel(category: AcademyArticle["metadata"]["category"]) {
-  switch (category) {
-    case "getting-started":
-      return "Premiers pas";
-    case "ingredients":
-      return "Ingrédients";
-    case "process":
-      return "Process";
-    case "fermentation":
-      return "Fermentation";
-    case "water":
-      return "Eau";
-    case "equipment":
-      return "Matériel";
-    case "beer-styles":
-      return "Styles";
-    case "safety":
-      return "Sécurité";
-    case "troubleshooting":
-      return "Dépannage";
-    case "glossary":
-      return "Glossaire";
-  }
 }
 
 function normalizeSearchValue(value: string): string {

--- a/packages/mobile-app/src/features/academy/presentation/academy-topic-details.presenter.ts
+++ b/packages/mobile-app/src/features/academy/presentation/academy-topic-details.presenter.ts
@@ -1,0 +1,85 @@
+import { AcademyArticle, GlossaryTerm } from "../domain";
+import { AcademyHubCardViewModel } from "./academy-hub.presenter";
+
+export type AcademyCalculatorTopicFallback = {
+  readonly slug: string;
+  readonly hasCalculator?: boolean;
+};
+
+export type AcademyArticleNavigationItem = {
+  readonly slug: string;
+  readonly title: string;
+};
+
+export type AcademyPublishedArticleNavigation = {
+  readonly previous: AcademyArticleNavigationItem | null;
+  readonly next: AcademyArticleNavigationItem | null;
+};
+
+export function resolveAcademyCalculatorSlug(
+  article: AcademyArticle | null,
+  fallbackTopic: AcademyCalculatorTopicFallback | undefined,
+): string | null {
+  return (
+    article?.metadata.relatedCalculators[0]?.target.slug ??
+    (fallbackTopic?.hasCalculator ? fallbackTopic.slug : null)
+  );
+}
+
+export function formatAcademyCalculatorButtonLabel(
+  calculatorSlug: string | null,
+  resolveCalculatorLabel: (slug: string) => string | null,
+): string {
+  if (!calculatorSlug) {
+    return "Ouvrir le calculateur";
+  }
+
+  return `Ouvrir le calculateur ${
+    resolveCalculatorLabel(calculatorSlug) ?? formatSlugLabel(calculatorSlug)
+  }`;
+}
+
+export function listRelatedAcademyGlossaryTerms(
+  term: GlossaryTerm | null,
+  resolveGlossaryTerm: (slug: string) => GlossaryTerm | null,
+): readonly GlossaryTerm[] {
+  if (!term) {
+    return [];
+  }
+
+  return term.relatedTerms
+    .map(resolveGlossaryTerm)
+    .filter((relatedTerm): relatedTerm is GlossaryTerm => relatedTerm !== null);
+}
+
+export function getPublishedAcademyArticleNavigation(
+  currentSlug: string,
+  cards: readonly AcademyHubCardViewModel[],
+): AcademyPublishedArticleNavigation {
+  const generatedCards = cards.filter((card) => card.source === "generated");
+  const currentIndex = generatedCards.findIndex(
+    (card) => card.slug === currentSlug,
+  );
+
+  if (currentIndex < 0) {
+    return { previous: null, next: null };
+  }
+
+  return {
+    previous: toArticleNavigationItem(generatedCards[currentIndex - 1] ?? null),
+    next: toArticleNavigationItem(generatedCards[currentIndex + 1] ?? null),
+  };
+}
+
+function toArticleNavigationItem(
+  card: AcademyHubCardViewModel | null,
+): AcademyArticleNavigationItem | null {
+  return card ? { slug: card.slug, title: card.title } : null;
+}
+
+function formatSlugLabel(slug: string): string {
+  return slug
+    .split("-")
+    .filter((part) => part.length > 0)
+    .join(" ");
+}

--- a/packages/mobile-app/src/features/academy/presentation/index.ts
+++ b/packages/mobile-app/src/features/academy/presentation/index.ts
@@ -1,3 +1,5 @@
+export * from "./academy-display-formatters";
 export * from "./academy-hub.presenter";
+export * from "./academy-topic-details.presenter";
 export * from "./AcademyArticleRenderer";
 export * from "./AcademyGlossarySection";

--- a/packages/mobile-app/src/features/tools/presentation/AcademyHubScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyHubScreen.tsx
@@ -205,6 +205,10 @@ export function AcademyHubScreen() {
             card.slug === "glossaire"
               ? colors.semantic.warning
               : colors.brand.primary;
+          const iconBackgroundStyle =
+            card.slug === "glossaire"
+              ? styles.itemIconWarning
+              : styles.itemIconPrimary;
 
           return (
             <Pressable
@@ -224,12 +228,7 @@ export function AcademyHubScreen() {
             >
               <Card style={styles.card}>
                 <View style={styles.cardRow}>
-                  <View
-                    style={[
-                      styles.itemIcon,
-                      { backgroundColor: iconColor + "25" },
-                    ]}
-                  >
+                  <View style={[styles.itemIcon, iconBackgroundStyle]}>
                     <Ionicons
                       name={ACADEMY_ICONS[card.slug] ?? "book-outline"}
                       size={24}
@@ -381,6 +380,12 @@ const styles = StyleSheet.create({
     borderRadius: radius.md,
     justifyContent: "center",
     alignItems: "center",
+  },
+  itemIconPrimary: {
+    backgroundColor: colors.state.infoBackground,
+  },
+  itemIconWarning: {
+    backgroundColor: colors.state.warningBackground,
   },
   cardInfo: {
     flex: 1,

--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
@@ -66,13 +66,19 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
     : null;
   const publishedGeneratedArticle =
     generatedArticle?.metadata.status === "published" ? generatedArticle : null;
-  const academyCards = createAcademyHubCards(
-    listPublishedAcademyArticlesUseCase(generatedAcademyRepository),
-    academyTopics,
-  );
-  const publishedArticleNavigation = normalizedSlug
-    ? getPublishedAcademyArticleNavigation(normalizedSlug, academyCards)
-    : null;
+  const publishedArticleNavigation = React.useMemo(() => {
+    if (!normalizedSlug) {
+      return null;
+    }
+
+    return getPublishedAcademyArticleNavigation(
+      normalizedSlug,
+      createAcademyHubCards(
+        listPublishedAcademyArticlesUseCase(generatedAcademyRepository),
+        academyTopics,
+      ),
+    );
+  }, [normalizedSlug]);
   const highlightedGlossaryTerm =
     normalizedSlug === "glossaire" && normalizedTermSlug
       ? getAcademyGlossaryTermBySlug(

--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
@@ -18,12 +18,15 @@ import {
   listPublishedAcademyArticlesUseCase,
 } from "@/features/academy/application";
 import { generatedAcademyRepository } from "@/features/academy/data";
-import { GlossaryTerm } from "@/features/academy/domain";
 import {
   AcademyArticleRenderer,
   AcademyGlossaryTermsList,
   AcademyHighlightedGlossaryTerm,
   createAcademyHubCards,
+  formatAcademyCalculatorButtonLabel,
+  getPublishedAcademyArticleNavigation,
+  listRelatedAcademyGlossaryTerms,
+  resolveAcademyCalculatorSlug,
 } from "@/features/academy/presentation";
 import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
@@ -63,8 +66,12 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
     : null;
   const publishedGeneratedArticle =
     generatedArticle?.metadata.status === "published" ? generatedArticle : null;
+  const academyCards = createAcademyHubCards(
+    listPublishedAcademyArticlesUseCase(generatedAcademyRepository),
+    academyTopics,
+  );
   const publishedArticleNavigation = normalizedSlug
-    ? getPublishedArticleNavigation(normalizedSlug)
+    ? getPublishedAcademyArticleNavigation(normalizedSlug, academyCards)
     : null;
   const highlightedGlossaryTerm =
     normalizedSlug === "glossaire" && normalizedTermSlug
@@ -74,7 +81,9 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
         )
       : null;
   const relatedGlossaryTerms = highlightedGlossaryTerm
-    ? getRelatedGlossaryTerms(highlightedGlossaryTerm)
+    ? listRelatedAcademyGlossaryTerms(highlightedGlossaryTerm, (slug) =>
+        getAcademyGlossaryTermBySlug(generatedAcademyRepository, slug),
+      )
     : [];
   const glossaryTerms =
     normalizedSlug === "glossaire"
@@ -87,14 +96,14 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
     normalizedSlug === "glossaire"
       ? listAcademyGlossaryTermsUseCase(generatedAcademyRepository).length
       : 0;
-  const generatedArticleCalculatorSlug =
-    publishedGeneratedArticle?.metadata.relatedCalculators[0]?.target.slug ??
-    null;
-  const legacyCalculatorSlug = topic?.hasCalculator ? topic.slug : null;
-  const calculatorSlug = generatedArticleCalculatorSlug ?? legacyCalculatorSlug;
-  const calculatorLabel = calculatorSlug
-    ? `Ouvrir le calculateur ${formatCalculatorSlugLabel(calculatorSlug)}`
-    : "Ouvrir le calculateur";
+  const calculatorSlug = resolveAcademyCalculatorSlug(
+    publishedGeneratedArticle,
+    topic,
+  );
+  const calculatorLabel = formatAcademyCalculatorButtonLabel(
+    calculatorSlug,
+    resolveCalculatorLabel,
+  );
   const goBackOrAcademyHome = React.useCallback(() => {
     if (router.canGoBack()) {
       router.back();
@@ -339,55 +348,17 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
   );
 }
 
-function formatCalculatorSlugLabel(slug: string): string {
-  return (
-    getAcademyArticleBySlug(generatedAcademyRepository, slug)?.metadata.title ??
-    getAcademyTopicBySlug(slug)?.title ??
-    slug
-      .split("-")
-      .filter((part) => part.length > 0)
-      .join(" ")
-  );
-}
-
-function getRelatedGlossaryTerms(term: GlossaryTerm): readonly GlossaryTerm[] {
-  return term.relatedTerms
-    .map((slug) =>
-      getAcademyGlossaryTermBySlug(generatedAcademyRepository, slug),
-    )
-    .filter((relatedTerm): relatedTerm is GlossaryTerm => relatedTerm !== null);
-}
-
 type ArticleNavigationItem = {
   readonly slug: string;
   readonly title: string;
 };
 
-type PublishedArticleNavigation = {
-  readonly previous: ArticleNavigationItem | null;
-  readonly next: ArticleNavigationItem | null;
-};
-
-function getPublishedArticleNavigation(
-  currentSlug: string,
-): PublishedArticleNavigation {
-  const cards = createAcademyHubCards(
-    listPublishedAcademyArticlesUseCase(generatedAcademyRepository),
-    academyTopics,
-  ).filter((card) => card.source === "generated");
-  const currentIndex = cards.findIndex((card) => card.slug === currentSlug);
-
-  if (currentIndex < 0) {
-    return { previous: null, next: null };
-  }
-
-  const previous = cards[currentIndex - 1] ?? null;
-  const next = cards[currentIndex + 1] ?? null;
-
-  return {
-    previous: previous ? { slug: previous.slug, title: previous.title } : null,
-    next: next ? { slug: next.slug, title: next.title } : null,
-  };
+function resolveCalculatorLabel(slug: string): string | null {
+  return (
+    getAcademyArticleBySlug(generatedAcademyRepository, slug)?.metadata.title ??
+    getAcademyTopicBySlug(slug)?.title ??
+    null
+  );
 }
 
 type AcademyArticleFooterNavigationProps = {


### PR DESCRIPTION
## Summary

- Extract shared Academy presentation formatters for category, level, and read-time labels.
- Move topic-detail calculations into pure Academy presenter helpers for calculator CTAs, glossary related terms, and previous/next article navigation.
- Replace the Academy hub inline alpha color composition with named token-backed styles.
- Add focused presenter/formatter tests while keeping the route-level behavior unchanged.

## Context

Follow-up stabilization after #1369. The intent is to reduce duplicated presentation logic and keep `AcademyTopicDetailsScreen` closer to route orchestration while preserving the transitional legacy topic fallback.

## Checklist

- [x] Happy path + sad path + edge cases covered (tests when code changes)
- [x] `npm run ci:all` (or package-local equivalent) passes locally
- [x] No `any`, no default exports for screens/use-cases/API modules
- [x] No inline styles, no hardcoded colors, spacing, or font values in `packages/mobile-app/` (use design tokens)
- [x] No new ADR violations (see [docs/architecture/decisions/](docs/architecture/decisions/))
- [ ] `PROJECT_LOG.md` will be updated after merge (entry per the [`project-log-entry`](.claude/skills/project-log-entry/SKILL.md) skill)

Local validation used:

- `npm -w packages/mobile-app test -- --runInBand packages/mobile-app/src/features/academy/presentation/__tests__/academy-display-formatters.test.ts packages/mobile-app/src/features/academy/presentation/__tests__/academy-topic-details.presenter.test.ts packages/mobile-app/src/features/academy/presentation/__tests__/academy-hub.presenter.test.ts packages/mobile-app/src/features/academy/presentation/__tests__/AcademyArticleRenderer.test.tsx packages/mobile-app/src/features/tools/presentation/__tests__/AcademyHubScreen.test.tsx packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx`
- `npm -w packages/mobile-app run typecheck`
- `npm -w packages/mobile-app run ci:check`

## Linked issue

Refs #1369