### PR TITLE
fix(website): point canonical/hreflang/links at clean URLs; noindex EN legal

### DIFF
--- a/packages/website/cookies-en.html
+++ b/packages/website/cookies-en.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cookie Policy — Brasse-Bouillon</title>
   <meta name="description" content="Brasse-Bouillon cookie policy: opt-in consent and preference management.">
-  <link rel="canonical" href="https://brasse-bouillon.com/cookies-en.html">
-  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/cookies.html">
-  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/cookies-en.html">
+  <meta name="robots" content="noindex,follow">
+  <link rel="canonical" href="https://brasse-bouillon.com/cookies-en">
+  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/cookies">
+  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/cookies-en">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -29,13 +30,13 @@
 <body>
   <main class="container">
     <nav class="policy-nav" aria-label="Legal navigation">
-      <a href="index-en.html">Home</a>
-      <a href="legal-en.html">Legal Notice</a>
-      <a href="privacy-en.html">Privacy</a>
-      <a href="cookies-en.html">Cookies</a>
-      <a href="terms-en.html">Terms of Use</a>
+      <a href="/index-en">Home</a>
+      <a href="/legal-en">Legal Notice</a>
+      <a href="/privacy-en">Privacy</a>
+      <a href="/cookies-en">Cookies</a>
+      <a href="/terms-en">Terms of Use</a>
     </nav>
-    <p class="lang-switch"><a href="cookies.html" lang="fr">Lire en français</a></p>
+    <p class="lang-switch"><a href="/cookies" lang="fr">Lire en français</a></p>
 
     <h1>Cookie Policy</h1>
     <p class="meta"><strong>Last updated:</strong> April 30, 2026</p>

--- a/packages/website/cookies.html
+++ b/packages/website/cookies.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Politique cookies — Brasse-Bouillon</title>
   <meta name="description" content="Politique cookies Brasse-Bouillon : consentement opt-in et gestion des préférences.">
-  <link rel="canonical" href="https://brasse-bouillon.com/cookies.html">
-  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/cookies.html">
-  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/cookies-en.html">
+  <link rel="canonical" href="https://brasse-bouillon.com/cookies">
+  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/cookies">
+  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/cookies-en">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -30,12 +30,12 @@
   <main class="container">
     <nav class="policy-nav" aria-label="Navigation juridique">
       <a href="/">Accueil</a>
-      <a href="legal.html">Mentions légales</a>
-      <a href="privacy.html">Confidentialité</a>
-      <a href="cookies.html">Cookies</a>
-      <a href="terms.html">Conditions d’utilisation</a>
+      <a href="/legal">Mentions légales</a>
+      <a href="/privacy">Confidentialité</a>
+      <a href="/cookies">Cookies</a>
+      <a href="/terms">Conditions d’utilisation</a>
     </nav>
-    <p class="lang-switch"><a href="cookies-en.html" lang="en">Read in English</a></p>
+    <p class="lang-switch"><a href="/cookies-en" lang="en">Read in English</a></p>
 
     <h1>Politique cookies</h1>
     <p class="meta"><strong>Dernière mise à jour :</strong> 30 avril 2026</p>

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -26,7 +26,7 @@
 
   <header class="site-header">
     <div class="header-inner">
-      <a href="index.html" class="header-logo">
+      <a href="/" class="header-logo">
         <img src="logo-hero.webp" alt="" width="50" height="50">
         <span>Brasse-Bouillon</span>
       </a>
@@ -43,7 +43,7 @@
           In the meantime, visit the French homepage or email us directly.
         </p>
         <div class="hero-actions">
-          <a class="btn btn-primary" href="index.html">Voir le site (FR)</a>
+          <a class="btn btn-primary" href="/">Voir le site (FR)</a>
           <a class="btn btn-ghost" href="mailto:contact@brasse-bouillon.com">Email us</a>
         </div>
         <div class="hero-mascot">
@@ -57,10 +57,10 @@
           <p>Contact: <strong>contact@brasse-bouillon.com</strong></p>
         </div>
         <div class="footer-links">
-          <a href="legal-en.html">Legal Notice</a>
-          <a href="privacy-en.html">Privacy</a>
-          <a href="cookies-en.html">Cookies</a>
-          <a href="terms-en.html">Terms of Use</a>
+          <a href="/legal-en">Legal Notice</a>
+          <a href="/privacy-en">Privacy</a>
+          <a href="/cookies-en">Cookies</a>
+          <a href="/terms-en">Terms of Use</a>
         </div>
       </footer>
     </div>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -116,7 +116,7 @@
 
   <header class="site-header">
     <div class="header-inner">
-      <a href="index.html" class="header-logo">
+      <a href="/" class="header-logo">
         <img src="logo-hero.webp" alt="" width="50" height="50">
         <span>Brasse-Bouillon</span>
       </a>
@@ -325,9 +325,9 @@
           </label>
           <p class="consent-note">
             En t’abonnant, tu acceptes nos
-            <a href="terms.html" target="_blank" rel="noopener noreferrer">conditions</a>,
-            notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">politique de confidentialité</a>
-            et notre <a href="cookies.html" target="_blank" rel="noopener noreferrer">politique cookies</a>.
+            <a href="/terms" target="_blank" rel="noopener noreferrer">conditions</a>,
+            notre <a href="/privacy" target="_blank" rel="noopener noreferrer">politique de confidentialité</a>
+            et notre <a href="/cookies" target="_blank" rel="noopener noreferrer">politique cookies</a>.
           </p>
 
           <div class="actions actions-compact">
@@ -484,8 +484,8 @@
               J’accepte que mes réponses soient utilisées dans le cadre du développement de Brasse-Bouillon.
             </label>
             <p class="consent-note">
-              Voir notre <a href="privacy.html" target="_blank" rel="noopener noreferrer">politique de confidentialité</a>
-              et nos <a href="terms.html" target="_blank" rel="noopener noreferrer">conditions</a>.
+              Voir notre <a href="/privacy" target="_blank" rel="noopener noreferrer">politique de confidentialité</a>
+              et nos <a href="/terms" target="_blank" rel="noopener noreferrer">conditions</a>.
             </p>
 
             <div class="actions actions-compact">
@@ -502,10 +502,10 @@
           <p>Brasse-Bouillon, l’app du brasseur amateur curieux. Contact : <strong>contact@brasse-bouillon.com</strong></p>
         </div>
         <div class="footer-links">
-          <a href="legal.html">Mentions légales</a>
-          <a href="privacy.html">Confidentialité</a>
-          <a href="cookies.html">Cookies</a>
-          <a href="terms.html">Conditions d’utilisation</a>
+          <a href="/legal">Mentions légales</a>
+          <a href="/privacy">Confidentialité</a>
+          <a href="/cookies">Cookies</a>
+          <a href="/terms">Conditions d’utilisation</a>
         </div>
       </footer>
     </div>

--- a/packages/website/legal-en.html
+++ b/packages/website/legal-en.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Legal Notice — Brasse-Bouillon</title>
   <meta name="description" content="Legal notice for Brasse-Bouillon (pre-incubation project).">
-  <link rel="canonical" href="https://brasse-bouillon.com/legal-en.html">
-  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/legal.html">
-  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/legal-en.html">
+  <meta name="robots" content="noindex,follow">
+  <link rel="canonical" href="https://brasse-bouillon.com/legal-en">
+  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/legal">
+  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/legal-en">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -28,13 +29,13 @@
 <body>
   <main class="container">
     <nav class="policy-nav" aria-label="Legal navigation">
-      <a href="index-en.html">Home</a>
-      <a href="legal-en.html">Legal Notice</a>
-      <a href="privacy-en.html">Privacy</a>
-      <a href="cookies-en.html">Cookies</a>
-      <a href="terms-en.html">Terms of Use</a>
+      <a href="/index-en">Home</a>
+      <a href="/legal-en">Legal Notice</a>
+      <a href="/privacy-en">Privacy</a>
+      <a href="/cookies-en">Cookies</a>
+      <a href="/terms-en">Terms of Use</a>
     </nav>
-    <p class="lang-switch"><a href="legal.html" lang="fr">Lire en français</a></p>
+    <p class="lang-switch"><a href="/legal" lang="fr">Lire en français</a></p>
 
     <h1>Legal Notice</h1>
     <p class="meta"><strong>Last updated:</strong> February 27, 2026</p>
@@ -67,14 +68,14 @@
     <h2>5. Personal data</h2>
     <p>
       Data processing details are provided in the
-      <a href="privacy-en.html">Privacy Policy</a>.
+      <a href="/privacy-en">Privacy Policy</a>.
       Forms rely on explicit user consent.
     </p>
 
     <h2>6. Cookies</h2>
     <p>
       Cookie usage is detailed in the
-      <a href="cookies-en.html">Cookie Policy</a>.
+      <a href="/cookies-en">Cookie Policy</a>.
       Audience measurement cookies are only activated after opt-in consent.
     </p>
 

--- a/packages/website/legal.html
+++ b/packages/website/legal.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Mentions légales — Brasse-Bouillon</title>
   <meta name="description" content="Mentions légales du site Brasse-Bouillon (projet en pré-incubation).">
-  <link rel="canonical" href="https://brasse-bouillon.com/legal.html">
-  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/legal.html">
-  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/legal-en.html">
+  <link rel="canonical" href="https://brasse-bouillon.com/legal">
+  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/legal">
+  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/legal-en">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -29,12 +29,12 @@
   <main class="container">
     <nav class="policy-nav" aria-label="Navigation juridique">
       <a href="/">Accueil</a>
-      <a href="legal.html">Mentions légales</a>
-      <a href="privacy.html">Confidentialité</a>
-      <a href="cookies.html">Cookies</a>
-      <a href="terms.html">Conditions d’utilisation</a>
+      <a href="/legal">Mentions légales</a>
+      <a href="/privacy">Confidentialité</a>
+      <a href="/cookies">Cookies</a>
+      <a href="/terms">Conditions d’utilisation</a>
     </nav>
-    <p class="lang-switch"><a href="legal-en.html" lang="en">Read in English</a></p>
+    <p class="lang-switch"><a href="/legal-en" lang="en">Read in English</a></p>
 
     <h1>Mentions légales</h1>
     <p class="meta"><strong>Dernière mise à jour :</strong> 27 février 2026</p>
@@ -67,14 +67,14 @@
     <h2>5. Données personnelles</h2>
     <p>
       Le traitement des données est décrit dans la
-      <a href="privacy.html">Politique de confidentialité</a>.
+      <a href="/privacy">Politique de confidentialité</a>.
       Les formulaires reposent sur un consentement explicite.
     </p>
 
     <h2>6. Cookies</h2>
     <p>
       Les règles d’utilisation des cookies sont détaillées dans la
-      <a href="cookies.html">Politique cookies</a>.
+      <a href="/cookies">Politique cookies</a>.
       Les cookies de mesure d’audience sont activés uniquement après consentement (opt-in).
     </p>
 

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy — Brasse-Bouillon</title>
   <meta name="description" content="Brasse-Bouillon privacy policy (EU, US and other markets).">
-  <link rel="canonical" href="https://brasse-bouillon.com/privacy-en.html">
-  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/privacy.html">
-  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/privacy-en.html">
+  <meta name="robots" content="noindex,follow">
+  <link rel="canonical" href="https://brasse-bouillon.com/privacy-en">
+  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/privacy">
+  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/privacy-en">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -29,13 +30,13 @@
 <body>
   <main class="container">
     <nav class="policy-nav" aria-label="Legal navigation">
-      <a href="index-en.html">Home</a>
-      <a href="legal-en.html">Legal Notice</a>
-      <a href="privacy-en.html">Privacy</a>
-      <a href="cookies-en.html">Cookies</a>
-      <a href="terms-en.html">Terms of Use</a>
+      <a href="/index-en">Home</a>
+      <a href="/legal-en">Legal Notice</a>
+      <a href="/privacy-en">Privacy</a>
+      <a href="/cookies-en">Cookies</a>
+      <a href="/terms-en">Terms of Use</a>
     </nav>
-    <p class="lang-switch"><a href="privacy.html" lang="fr">Lire en français</a></p>
+    <p class="lang-switch"><a href="/privacy" lang="fr">Lire en français</a></p>
 
     <h1>Privacy Policy</h1>
     <p class="meta"><strong>Last updated:</strong> April 30, 2026</p>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Politique de confidentialité — Brasse-Bouillon</title>
   <meta name="description" content="Politique de confidentialité de Brasse-Bouillon (UE, US et autres marchés).">
-  <link rel="canonical" href="https://brasse-bouillon.com/privacy.html">
-  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/privacy.html">
-  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/privacy-en.html">
+  <link rel="canonical" href="https://brasse-bouillon.com/privacy">
+  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/privacy">
+  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/privacy-en">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -30,12 +30,12 @@
   <main class="container">
     <nav class="policy-nav" aria-label="Navigation juridique">
       <a href="/">Accueil</a>
-      <a href="legal.html">Mentions légales</a>
-      <a href="privacy.html">Confidentialité</a>
-      <a href="cookies.html">Cookies</a>
-      <a href="terms.html">Conditions d’utilisation</a>
+      <a href="/legal">Mentions légales</a>
+      <a href="/privacy">Confidentialité</a>
+      <a href="/cookies">Cookies</a>
+      <a href="/terms">Conditions d’utilisation</a>
     </nav>
-    <p class="lang-switch"><a href="privacy-en.html" lang="en">Read in English</a></p>
+    <p class="lang-switch"><a href="/privacy-en" lang="en">Read in English</a></p>
 
     <h1>Politique de confidentialité</h1>
     <p class="meta"><strong>Dernière mise à jour :</strong> 30 avril 2026</p>

--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -298,6 +298,28 @@ def check_robots_policy(root: Path = ROOT) -> list[str]:
     return errors
 
 
+def check_clean_seo_urls(root: Path = ROOT) -> list[str]:
+    """`rel="canonical"` and `rel="alternate"` (hreflang) targets must be the
+    clean, non-redirecting URLs Cloudflare Pages serves — never the `.html`
+    form, which 308-redirects to the clean URL and weakens/splits the SEO
+    signal. Guards against re-introducing the canonical-to-redirect defect
+    fixed in the clean-URL sweep."""
+    pattern = re.compile(
+        r'<link\s+rel="(?:canonical|alternate)"[^>]*href="[^"]*\.html"',
+        flags=REGEX_FLAGS,
+    )
+    errors: list[str] = []
+    # Flat layout: every HTML page lives at the package root (no nested dirs
+    # today), so a non-recursive glob covers the whole site.
+    for path in sorted(root.glob("*.html")):
+        if pattern.search(path.read_text(encoding="utf-8")):
+            errors.append(
+                f"{path.name}: canonical/hreflang pointe vers une URL .html "
+                "(doit être l'URL propre sans extension)"
+            )
+    return errors
+
+
 def collect_errors(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     errors.extend(check_required_files(root))
@@ -306,6 +328,7 @@ def collect_errors(root: Path = ROOT) -> list[str]:
     errors.extend(check_chat_widget(root))
     errors.extend(check_sitemap_policy(root))
     errors.extend(check_robots_policy(root))
+    errors.extend(check_clean_seo_urls(root))
     return errors
 
 

--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -303,20 +303,24 @@ def check_clean_seo_urls(root: Path = ROOT) -> list[str]:
     clean, non-redirecting URLs Cloudflare Pages serves — never the `.html`
     form, which 308-redirects to the clean URL and weakens/splits the SEO
     signal. Guards against re-introducing the canonical-to-redirect defect
-    fixed in the clean-URL sweep."""
-    pattern = re.compile(
-        r'<link\s+rel="(?:canonical|alternate)"[^>]*href="[^"]*\.html"',
-        flags=REGEX_FLAGS,
-    )
+    fixed in the clean-URL sweep. Attribute-order-independent: a `<link>` is
+    flagged when the SAME tag carries both a canonical/alternate `rel` and an
+    `href` ending in `.html`, whichever attribute comes first."""
+    link_tag = re.compile(r"<link\b[^>]*>", flags=REGEX_FLAGS)
+    seo_rel = re.compile(r'rel="(?:canonical|alternate)"', flags=REGEX_FLAGS)
+    html_href = re.compile(r'href="[^"]*\.html"', flags=REGEX_FLAGS)
     errors: list[str] = []
     # Flat layout: every HTML page lives at the package root (no nested dirs
     # today), so a non-recursive glob covers the whole site.
     for path in sorted(root.glob("*.html")):
-        if pattern.search(path.read_text(encoding="utf-8")):
-            errors.append(
-                f"{path.name}: canonical/hreflang pointe vers une URL .html "
-                "(doit être l'URL propre sans extension)"
-            )
+        content = path.read_text(encoding="utf-8")
+        for tag in link_tag.findall(content):
+            if seo_rel.search(tag) and html_href.search(tag):
+                errors.append(
+                    f"{path.name}: canonical/hreflang pointe vers une URL .html "
+                    "(doit être l'URL propre sans extension)"
+                )
+                break
     return errors
 
 

--- a/packages/website/terms-en.html
+++ b/packages/website/terms-en.html
@@ -5,9 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terms of Use — Brasse-Bouillon</title>
   <meta name="description" content="Terms of use for the Brasse-Bouillon website.">
-  <link rel="canonical" href="https://brasse-bouillon.com/terms-en.html">
-  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/terms.html">
-  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/terms-en.html">
+  <meta name="robots" content="noindex,follow">
+  <link rel="canonical" href="https://brasse-bouillon.com/terms-en">
+  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/terms">
+  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/terms-en">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -29,13 +30,13 @@
 <body>
   <main class="container">
     <nav class="policy-nav" aria-label="Legal navigation">
-      <a href="index-en.html">Home</a>
-      <a href="legal-en.html">Legal Notice</a>
-      <a href="privacy-en.html">Privacy</a>
-      <a href="cookies-en.html">Cookies</a>
-      <a href="terms-en.html">Terms of Use</a>
+      <a href="/index-en">Home</a>
+      <a href="/legal-en">Legal Notice</a>
+      <a href="/privacy-en">Privacy</a>
+      <a href="/cookies-en">Cookies</a>
+      <a href="/terms-en">Terms of Use</a>
     </nav>
-    <p class="lang-switch"><a href="terms.html" lang="fr">Lire en français</a></p>
+    <p class="lang-switch"><a href="/terms" lang="fr">Lire en français</a></p>
 
     <h1>Terms of Use</h1>
     <p class="meta"><strong>Last updated:</strong> February 27, 2026</p>

--- a/packages/website/terms.html
+++ b/packages/website/terms.html
@@ -5,9 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Conditions d’utilisation — Brasse-Bouillon</title>
   <meta name="description" content="Conditions d’utilisation du site Brasse-Bouillon.">
-  <link rel="canonical" href="https://brasse-bouillon.com/terms.html">
-  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/terms.html">
-  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/terms-en.html">
+  <link rel="canonical" href="https://brasse-bouillon.com/terms">
+  <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/terms">
+  <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/terms-en">
   <link rel="icon" href="favicon.ico" sizes="any">
   <link rel="icon" type="image/svg+xml" href="logo-icon.svg">
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -30,12 +30,12 @@
   <main class="container">
     <nav class="policy-nav" aria-label="Navigation juridique">
       <a href="/">Accueil</a>
-      <a href="legal.html">Mentions légales</a>
-      <a href="privacy.html">Confidentialité</a>
-      <a href="cookies.html">Cookies</a>
-      <a href="terms.html">Conditions d’utilisation</a>
+      <a href="/legal">Mentions légales</a>
+      <a href="/privacy">Confidentialité</a>
+      <a href="/cookies">Cookies</a>
+      <a href="/terms">Conditions d’utilisation</a>
     </nav>
-    <p class="lang-switch"><a href="terms-en.html" lang="en">Read in English</a></p>
+    <p class="lang-switch"><a href="/terms-en" lang="en">Read in English</a></p>
 
     <h1>Conditions d’utilisation</h1>
     <p class="meta"><strong>Dernière mise à jour :</strong> 27 février 2026</p>

--- a/packages/website/tests/test_quality_gate.py
+++ b/packages/website/tests/test_quality_gate.py
@@ -171,7 +171,54 @@ class QualityGateTests(unittest.TestCase):
 
             errors = quality_gate.collect_errors(root)
             self.assertTrue(
-                any("meta robots noindex manquant dans 404.html" in err for err in errors)
+                any(
+                    "meta robots noindex manquant dans 404.html" in err
+                    for err in errors
+                )
+            )
+
+    def test_detects_canonical_pointing_to_html(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            legal_path = root / "legal.html"
+            legal_path.write_text(
+                legal_path.read_text(encoding="utf-8").replace(
+                    "</head>",
+                    '<link rel="canonical" '
+                    'href="https://brasse-bouillon.com/legal.html"></head>',
+                ),
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.collect_errors(root)
+            self.assertTrue(
+                any(
+                    "canonical/hreflang pointe vers une URL .html" in err
+                    for err in errors
+                )
+            )
+
+    def test_detects_hreflang_pointing_to_html(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            legal_path = root / "legal.html"
+            legal_path.write_text(
+                legal_path.read_text(encoding="utf-8").replace(
+                    "</head>",
+                    '<link rel="alternate" hreflang="en" '
+                    'href="https://brasse-bouillon.com/legal-en.html"></head>',
+                ),
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.collect_errors(root)
+            self.assertTrue(
+                any(
+                    "canonical/hreflang pointe vers une URL .html" in err
+                    for err in errors
+                )
             )
 
     def test_detects_disallowed_software_application_schema(self) -> None:

--- a/packages/website/tests/test_quality_gate.py
+++ b/packages/website/tests/test_quality_gate.py
@@ -221,6 +221,28 @@ class QualityGateTests(unittest.TestCase):
                 )
             )
 
+    def test_detects_canonical_html_href_before_rel(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            legal_path = root / "legal.html"
+            legal_path.write_text(
+                legal_path.read_text(encoding="utf-8").replace(
+                    "</head>",
+                    '<link href="https://brasse-bouillon.com/legal.html" '
+                    'rel="canonical"></head>',
+                ),
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.collect_errors(root)
+            self.assertTrue(
+                any(
+                    "canonical/hreflang pointe vers une URL .html" in err
+                    for err in errors
+                )
+            )
+
     def test_detects_disallowed_software_application_schema(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)


### PR DESCRIPTION
## Summary

Clean-URL SEO sweep from the 2026-07-09 audit: point every self-canonical, hreflang alternate, and internal link at the clean URLs Cloudflare Pages serves. Add `noindex,follow` to the 4 EN legal pages (EN is a "coming soon" stub). Add a `quality_gate` guard forbidding a canonical/hreflang target ending in `.html`.

## Context

- On Cloudflare Pages `/legal.html` **308-redirects** to `/legal`. The 8 legal/EN pages self-canonicalized (and hreflang-pointed) to the `.html` forms → Google was told the canonical URL is one that immediately redirects. Now pointed at the clean served URLs.
- Every internal nav link used `*.html` → a 308 hop on each click/crawl. Rewritten to clean root-absolute URLs (`/legal`, `/`, `/index-en`, ...).
- The EN legal pages were indexable while the EN home is noindexed (coming-soon) — inconsistent. **Option (a)**: `noindex,follow` the 4 EN legal pages until EN launches (kept legally reachable, out of the index).
- Guard: `check_clean_seo_urls` + covering test forbids re-introducing a `.html` canonical/hreflang.

## Review

Two independent pre-push lenses — **0 Must Have, 0 blockers**:
- **Standards/ADR** (`pr-pre-reviewer`): ADR-0014 honored, no forbidden patterns.
- **Adversarial sweep-correctness**: verified all 8 checks — self-canonicals correct, hreflang reciprocity, no residual/mis-targeted `.html`, `noindex` on exactly the 4 EN pages, no over-replacement (assets/sitemap/robots untouched), well-formed.

## Checklist

- [x] Quality gate + 13 unit tests pass locally
- [x] All 11 pages well-formed after the sweep (HTML parser)
- [x] No `.html` remaining in canonical/hreflang/internal links (grep-verified)
- [x] `noindex,follow` on exactly the 4 EN legal pages; FR pages stay indexable
- [x] Two-lens pre-push review: 0 blockers

Refs #1045 (partial: the canonical/hreflang-EN-incoherence half; OG tags are a later lot).

Deferred follow-ups: hreflang `x-default` on legal pages; refresh the stale `packages/website/CLAUDE.md` deploy section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)