### PR TITLE
feat(api/water): append-only cache + conditional sync for /water (water-profile slice 2)

### DIFF
--- a/packages/api/src/database/migrations/1809000000000-CreateWaterMeasurements.ts
+++ b/packages/api/src/database/migrations/1809000000000-CreateWaterMeasurements.ts
@@ -1,0 +1,43 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Creates the append-only Hub'Eau water-measurements cache (ADR-0025, slice 2).
+ *
+ * Rows are never updated; a full sync appends with `INSERT OR IGNORE` on the
+ * unique key `(code_reseau, code_parametre, date_prelevement, code_prelevement)`
+ * so re-syncing the same window is idempotent and history accrues. The
+ * secondary `(code_reseau, date_prelevement)` index serves the two hot reads:
+ * `max(date_prelevement)` (the conditional-sync gate) and the year-windowed
+ * profile read. This holds public ARS/Hub'Eau reference data — not PII.
+ */
+export class CreateWaterMeasurements1809000000000 implements MigrationInterface {
+  name = 'CreateWaterMeasurements1809000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "water_measurements" (
+        "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        "code_reseau" varchar(64) NOT NULL,
+        "code_parametre" varchar(16) NOT NULL,
+        "date_prelevement" varchar(10) NOT NULL,
+        "code_prelevement" varchar(64) NOT NULL,
+        "libelle_parametre" varchar(255) NOT NULL,
+        "resultat_numerique" real,
+        "conformite" varchar(8),
+        "created_at" datetime NOT NULL DEFAULT (CURRENT_TIMESTAMP)
+      )`,
+    );
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "UQ_water_measurements_key" ON "water_measurements" ("code_reseau", "code_parametre", "date_prelevement", "code_prelevement")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_water_measurements_reseau_date" ON "water_measurements" ("code_reseau", "date_prelevement")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "IDX_water_measurements_reseau_date"`);
+    await queryRunner.query(`DROP INDEX "UQ_water_measurements_key"`);
+    await queryRunner.query(`DROP TABLE "water_measurements"`);
+  }
+}

--- a/packages/api/src/database/typeorm.config.ts
+++ b/packages/api/src/database/typeorm.config.ts
@@ -37,6 +37,7 @@ import { StyleOrmEntity } from '../catalog/style/entities/style.orm.entity';
 import { TastingOrmEntity } from '../batch/entities/tasting.orm.entity';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { User } from '../user/entities/user.entity';
+import { WaterMeasurementOrmEntity } from '../water/entities/water-measurement.orm.entity';
 import { WaterOrmEntity } from '../catalog/water/entities/water.orm.entity';
 import { YeastDistributorOrmEntity } from '../catalog/yeast/entities/yeast-distributor.orm.entity';
 import { YeastOrmEntity } from '../catalog/yeast/entities/yeast.orm.entity';
@@ -73,6 +74,7 @@ export const ormEntities = [
   MashProfileOrmEntity,
   MashStepOrmEntity,
   WaterOrmEntity,
+  WaterMeasurementOrmEntity,
   EquipmentTemplateOrmEntity,
   MiscTemplateOrmEntity,
   ProducerOrmEntity,

--- a/packages/api/src/water/domain/entities/water-profile.entity.ts
+++ b/packages/api/src/water/domain/entities/water-profile.entity.ts
@@ -18,6 +18,11 @@ export interface WaterProfileEntityProps {
   readonly conformity: WaterConformity;
   readonly mineralsMgL: WaterMineralsMgL;
   readonly hardnessFrench: number | null;
+  /**
+   * Honest data currency — `max(date_prelevement)` of the aggregated samples
+   * (`YYYY-MM-DD`), or null when unknown. Never the fetch date (ADR-0025).
+   */
+  readonly freshnessDate: string | null;
 }
 
 export class WaterProfileEntity {
@@ -29,6 +34,7 @@ export class WaterProfileEntity {
   readonly conformity: WaterConformity;
   readonly mineralsMgL: WaterMineralsMgL;
   readonly hardnessFrench: number | null;
+  readonly freshnessDate: string | null;
 
   constructor(props: WaterProfileEntityProps) {
     this.provider = props.provider;
@@ -39,5 +45,6 @@ export class WaterProfileEntity {
     this.conformity = props.conformity;
     this.mineralsMgL = props.mineralsMgL;
     this.hardnessFrench = props.hardnessFrench;
+    this.freshnessDate = props.freshnessDate;
   }
 }

--- a/packages/api/src/water/domain/ports/water-quality-provider.port.ts
+++ b/packages/api/src/water/domain/ports/water-quality-provider.port.ts
@@ -9,6 +9,12 @@ export interface WaterSample {
   readonly parameterLabel: string;
   readonly numericResult: number | null;
   readonly conformity: string | null;
+  /** SANDRE parameter code — cache key part (slice 2); null on the live path. */
+  readonly parameterCode: string | null;
+  /** Sampling date `YYYY-MM-DD` — freshness + cache key part (slice 2). */
+  readonly datePrelevement: string | null;
+  /** Physical-sample id — cache key part (slice 2). */
+  readonly codePrelevement: string | null;
 }
 
 export interface WaterQualityProviderPort {
@@ -21,4 +27,14 @@ export interface WaterQualityProviderPort {
     year: number;
     size: number;
   }): Promise<WaterSample[]>;
+
+  /**
+   * Cheap conditional-sync gate (ADR-0025, slice 2): the most recent sampling
+   * date the source holds for this network within the year window, or null when
+   * it has none. Keeps latency low (size=1) so most lookups do no heavy fetch.
+   */
+  getNetworkLatestSampleDate(input: {
+    networkCode: string;
+    year: number;
+  }): Promise<string | null>;
 }

--- a/packages/api/src/water/domain/services/water-aggregation-domain.service.spec.ts
+++ b/packages/api/src/water/domain/services/water-aggregation-domain.service.spec.ts
@@ -1,6 +1,17 @@
 import { WaterAggregationDomainService } from './water-aggregation-domain.service';
 import { WaterConformity } from '../enums/water-conformity.enum';
 import { WaterProviderKey } from '../enums/water-provider-key.enum';
+import type { WaterSample } from '../ports/water-quality-provider.port';
+
+const sample = (overrides: Partial<WaterSample> = {}): WaterSample => ({
+  parameterLabel: 'Calcium',
+  numericResult: 50,
+  conformity: 'C',
+  parameterCode: '1374',
+  datePrelevement: '2024-03-15',
+  codePrelevement: 'P-1',
+  ...overrides,
+});
 
 describe('WaterAggregationDomainService', () => {
   const service = new WaterAggregationDomainService();
@@ -13,31 +24,19 @@ describe('WaterAggregationDomainService', () => {
       networkName: 'NANTES SUD',
       maxSamples: 50,
       samples: [
-        {
+        sample({
           parameterLabel: 'Calcium',
           numericResult: 50,
           conformity: 'c',
-        },
-        {
+        }),
+        sample({
           parameterLabel: 'Calcium',
           numericResult: 54,
           conformity: 'c',
-        },
-        {
-          parameterLabel: 'Magnesium',
-          numericResult: 8,
-          conformity: 'C',
-        },
-        {
-          parameterLabel: 'Sulfates',
-          numericResult: 27.2,
-          conformity: 'C',
-        },
-        {
-          parameterLabel: 'Hydrogénocarbonates',
-          numericResult: 141.1,
-          conformity: 'C',
-        },
+        }),
+        sample({ parameterLabel: 'Magnesium', numericResult: 8 }),
+        sample({ parameterLabel: 'Sulfates', numericResult: 27.2 }),
+        sample({ parameterLabel: 'Hydrogénocarbonates', numericResult: 141.1 }),
       ],
     });
 
@@ -65,16 +64,16 @@ describe('WaterAggregationDomainService', () => {
       networkName: null,
       maxSamples: 10,
       samples: [
-        {
+        sample({
           parameterLabel: 'Unknown',
           numericResult: 50,
           conformity: 'X',
-        },
-        {
+        }),
+        sample({
           parameterLabel: 'Calcium',
           numericResult: null,
           conformity: null,
-        },
+        }),
       ],
     });
 
@@ -95,16 +94,8 @@ describe('WaterAggregationDomainService', () => {
       networkName: 'MARSEILLE',
       maxSamples: 1,
       samples: [
-        {
-          parameterLabel: 'Calcium',
-          numericResult: 10,
-          conformity: 'C',
-        },
-        {
-          parameterLabel: 'Calcium',
-          numericResult: 100,
-          conformity: 'C',
-        },
+        sample({ parameterLabel: 'Calcium', numericResult: 10 }),
+        sample({ parameterLabel: 'Calcium', numericResult: 100 }),
       ],
     });
 
@@ -120,21 +111,21 @@ describe('WaterAggregationDomainService', () => {
       networkName: 'BORDEAUX',
       maxSamples: 10,
       samples: [
-        {
+        sample({
           parameterLabel: 'Calcium',
           numericResult: 40,
           conformity: 'C',
-        },
-        {
+        }),
+        sample({
           parameterLabel: 'Magnesium',
           numericResult: 6,
           conformity: 'D',
-        },
-        {
+        }),
+        sample({
           parameterLabel: 'Sulfates',
           numericResult: 20,
           conformity: 'N',
-        },
+        }),
       ],
     });
 
@@ -149,21 +140,9 @@ describe('WaterAggregationDomainService', () => {
       networkName: 'QUIMPER',
       maxSamples: 10,
       samples: [
-        {
-          parameterLabel: 'Magnesium',
-          numericResult: 9,
-          conformity: 'C',
-        },
-        {
-          parameterLabel: 'Chlorures',
-          numericResult: 17,
-          conformity: 'C',
-        },
-        {
-          parameterLabel: 'Hydrogénocarbonates',
-          numericResult: 122,
-          conformity: 'C',
-        },
+        sample({ parameterLabel: 'Magnesium', numericResult: 9 }),
+        sample({ parameterLabel: 'Chlorures', numericResult: 17 }),
+        sample({ parameterLabel: 'Hydrogénocarbonates', numericResult: 122 }),
       ],
     });
 
@@ -185,25 +164,57 @@ describe('WaterAggregationDomainService', () => {
       networkName: 'LILLE',
       maxSamples: 50,
       samples: [
-        { parameterLabel: 'Chlore libre', numericResult: 0.3, conformity: 'C' },
-        {
+        sample({ parameterLabel: 'Chlore libre', numericResult: 0.3 }),
+        sample({
           parameterLabel: 'Chlorure de vinyl monomère',
           numericResult: 0.4,
-          conformity: 'C',
-        },
-        { parameterLabel: 'Chloroforme', numericResult: 5, conformity: 'C' },
-        { parameterLabel: 'Carbonates', numericResult: 10, conformity: 'C' },
-        { parameterLabel: 'Chlorures', numericResult: 51, conformity: 'C' },
-        {
-          parameterLabel: 'Hydrogénocarbonates',
-          numericResult: 340,
-          conformity: 'C',
-        },
+        }),
+        sample({ parameterLabel: 'Chloroforme', numericResult: 5 }),
+        sample({ parameterLabel: 'Carbonates', numericResult: 10 }),
+        sample({ parameterLabel: 'Chlorures', numericResult: 51 }),
+        sample({ parameterLabel: 'Hydrogénocarbonates', numericResult: 340 }),
       ],
     });
 
     // Only the real ions are aggregated — the compounds are ignored.
     expect(profile.mineralsMgL.cl).toBe(51);
     expect(profile.mineralsMgL.hco3).toBe(340);
+  });
+
+  it('exposes the most recent sampling date as the freshness signal (over the full set)', () => {
+    const profile = service.aggregate({
+      provider: WaterProviderKey.HUBEAU,
+      codeInsee: '59350',
+      year: 2024,
+      networkName: 'LILLE',
+      maxSamples: 1, // freshness must consider all samples, not just the capped slice
+      samples: [
+        sample({ numericResult: 50, datePrelevement: '2024-02-01' }),
+        sample({ numericResult: 52, datePrelevement: '2024-11-20' }),
+        sample({ numericResult: 48, datePrelevement: '2024-06-10' }),
+      ],
+    });
+
+    expect(profile.freshnessDate).toBe('2024-11-20');
+  });
+
+  it('returns a null freshness date when no sample carries one', () => {
+    const profile = service.aggregate({
+      provider: WaterProviderKey.HUBEAU,
+      codeInsee: '59350',
+      year: 2024,
+      networkName: 'LILLE',
+      maxSamples: 50,
+      samples: [
+        sample({ datePrelevement: null }),
+        sample({
+          parameterLabel: 'Magnesium',
+          numericResult: 8,
+          datePrelevement: null,
+        }),
+      ],
+    });
+
+    expect(profile.freshnessDate).toBeNull();
   });
 });

--- a/packages/api/src/water/domain/services/water-aggregation-domain.service.ts
+++ b/packages/api/src/water/domain/services/water-aggregation-domain.service.ts
@@ -135,7 +135,25 @@ export class WaterAggregationDomainService {
         hco3,
       },
       hardnessFrench: this.computeHardnessFrench(ca, mg),
+      freshnessDate: this.computeFreshnessDate(input.samples),
     });
+  }
+
+  /**
+   * The most recent `YYYY-MM-DD` sampling date across all samples (honest data
+   * currency, ADR-0025), or null when none carries one — e.g. slice-1's live
+   * path, which does not request `date_prelevement`. Computed over the full
+   * sample set (not the capped slice) so it never understates the currency.
+   */
+  private computeFreshnessDate(samples: WaterSample[]): string | null {
+    let latest: string | null = null;
+    for (const sample of samples) {
+      const date = sample.datePrelevement;
+      if (date !== null && (latest === null || date > latest)) {
+        latest = date;
+      }
+    }
+    return latest;
   }
 
   private computeAverage(bucket: AggregateBucket): number | null {

--- a/packages/api/src/water/dtos/water-profile.dto.ts
+++ b/packages/api/src/water/dtos/water-profile.dto.ts
@@ -46,6 +46,14 @@ export class WaterProfileDto {
   @ApiPropertyOptional({ nullable: true, example: 55.9 })
   hardnessFrench: number | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    example: '2024-03-15',
+    description:
+      'Most recent sampling date (max date_prelevement, YYYY-MM-DD) — honest data currency, never the fetch date. Present whenever a profile is returned; null only if no returned sample carries a date.',
+  })
+  freshnessDate: string | null;
+
   static fromEntity(entity: WaterProfileEntity): WaterProfileDto {
     const dto = new WaterProfileDto();
     dto.provider = entity.provider;
@@ -62,6 +70,7 @@ export class WaterProfileDto {
       hco3: entity.mineralsMgL.hco3,
     };
     dto.hardnessFrench = entity.hardnessFrench;
+    dto.freshnessDate = entity.freshnessDate;
     return dto;
   }
 }

--- a/packages/api/src/water/entities/water-measurement.orm.entity.ts
+++ b/packages/api/src/water/entities/water-measurement.orm.entity.ts
@@ -1,0 +1,69 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+/**
+ * Append-only cache of Hub'Eau water-quality measurements (ADR-0025, slice 2).
+ *
+ * One row per raw Hub'Eau `resultats_dis` measurement. Rows are **never
+ * updated** — a full sync appends with `INSERT OR IGNORE` on the unique key, so
+ * history accrues for free and re-syncing the same window is idempotent. The
+ * commune → dominant-network link is resolved at read time (as in slice 1), so
+ * the cache keys on `code_reseau` (the dominant network), NOT `code_commune`
+ * (which would blend all networks and shift the average).
+ *
+ * The unique key `(code_reseau, code_parametre, date_prelevement,
+ * code_prelevement)` mirrors ADR-0025 § Slice-2 design: a single physical
+ * sample (`code_prelevement`) yields one measurement per parameter per date on
+ * a given network. This is public ARS/Hub'Eau reference data — NOT PII.
+ */
+@Entity('water_measurements')
+@Index(
+  'UQ_water_measurements_key',
+  ['code_reseau', 'code_parametre', 'date_prelevement', 'code_prelevement'],
+  { unique: true },
+)
+@Index('IDX_water_measurements_reseau_date', [
+  'code_reseau',
+  'date_prelevement',
+])
+export class WaterMeasurementOrmEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  /** Dominant-network code (Hub'Eau `code_reseau`). */
+  @Column({ type: 'varchar', length: 64, nullable: false })
+  code_reseau: string;
+
+  /** SANDRE parameter code (e.g. `1374` = Calcium). */
+  @Column({ type: 'varchar', length: 16, nullable: false })
+  code_parametre: string;
+
+  /** Sampling date, stored as `YYYY-MM-DD` so `max()` sorts lexicographically. */
+  @Column({ type: 'varchar', length: 10, nullable: false })
+  date_prelevement: string;
+
+  /** Physical-sample id (Hub'Eau `code_prelevement`) — part of the dedupe key. */
+  @Column({ type: 'varchar', length: 64, nullable: false })
+  code_prelevement: string;
+
+  /** Raw parameter label (`libelle_parametre`) — matched to an ion at read time. */
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  libelle_parametre: string;
+
+  /** Measured value in mg/L; null when Hub'Eau reports no numeric result. */
+  @Column({ type: 'real', nullable: true })
+  resultat_numerique: number | null;
+
+  /** Per-sample physico-chemical conformity short code (C/N/D/S), if present. */
+  @Column({ type: 'varchar', length: 8, nullable: true })
+  conformite: string | null;
+
+  /** When we ingested this row (audit only — freshness uses `date_prelevement`). */
+  @CreateDateColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  created_at: Date;
+}

--- a/packages/api/src/water/providers/hubeau-water-quality.provider.spec.ts
+++ b/packages/api/src/water/providers/hubeau-water-quality.provider.spec.ts
@@ -234,24 +234,37 @@ describe('HubeauWaterQualityProvider', () => {
         Promise.resolve({
           data: [
             {
+              code_parametre: '1374',
               libelle_parametre: 'Calcium',
               resultat_numerique: '42,5',
               conformite_limites_pc_prelevement: 'C',
+              date_prelevement: '2024-03-15',
+              code_prelevement: 'P-1',
             },
             {
+              code_parametre: '1372',
               libelle_parametre: 'Magnésium',
               resultat_numerique: 9,
               conformite_limites_pc_prelevement: null,
+              // A time component must be trimmed to the YYYY-MM-DD date part.
+              date_prelevement: '2024-06-20T09:30:00',
+              code_prelevement: 'P-2',
             },
             {
+              code_parametre: '1337',
               libelle_parametre: '',
               resultat_numerique: 10,
               conformite_limites_pc_prelevement: 'C',
+              date_prelevement: '2024-07-01',
+              code_prelevement: 'P-X',
             },
             {
+              code_parametre: '1337',
               libelle_parametre: 'Chlorures',
               resultat_numerique: 'not-a-number',
               conformite_limites_pc_prelevement: 'N',
+              date_prelevement: '2024-09-01',
+              code_prelevement: 'P-3',
             },
           ],
         }),
@@ -278,15 +291,77 @@ describe('HubeauWaterQualityProvider', () => {
     expect(requestUrl).toContain(
       'code_parametre=1374%2C1372%2C1338%2C1337%2C1327',
     );
+    // Slice-2 additionally requests the cache-key + freshness fields.
+    expect(requestUrl).toContain('code_parametre%2Clibelle_parametre');
+    expect(requestUrl).toContain('date_prelevement%2Ccode_prelevement');
     expect(requestUrl).toContain('date_min_prelevement=2024-01-01');
     expect(requestUrl).toContain('date_max_prelevement=2024-12-31');
+    // Newest-first, aligned with the date-check gate so the fetched window
+    // always includes the max date the gate compares against.
+    expect(requestUrl).toContain('sort=desc');
     expect(requestUrl).toContain('size=3');
 
     expect(samples).toEqual([
-      { parameterLabel: 'Calcium', numericResult: 42.5, conformity: 'C' },
-      { parameterLabel: 'Magnésium', numericResult: 9, conformity: null },
-      { parameterLabel: 'Chlorures', numericResult: null, conformity: 'N' },
+      {
+        parameterLabel: 'Calcium',
+        numericResult: 42.5,
+        conformity: 'C',
+        parameterCode: '1374',
+        datePrelevement: '2024-03-15',
+        codePrelevement: 'P-1',
+      },
+      {
+        parameterLabel: 'Magnésium',
+        numericResult: 9,
+        conformity: null,
+        parameterCode: '1372',
+        datePrelevement: '2024-06-20',
+        codePrelevement: 'P-2',
+      },
+      {
+        parameterLabel: 'Chlorures',
+        numericResult: null,
+        conformity: 'N',
+        parameterCode: '1337',
+        datePrelevement: '2024-09-01',
+        codePrelevement: 'P-3',
+      },
     ]);
+  });
+
+  it('date-check: returns the latest sampling date (size=1, sort desc)', async () => {
+    fetchMock.mockResolvedValue(
+      buildResponse(200, () =>
+        Promise.resolve({ data: [{ date_prelevement: '2024-11-02' }] }),
+      ),
+    );
+
+    const latest = await provider.getNetworkLatestSampleDate({
+      networkCode: 'R-2',
+      year: 2024,
+    });
+
+    const requestUrl = fetchMock.mock.calls[0]?.[0];
+    expect(typeof requestUrl).toBe('string');
+    if (typeof requestUrl !== 'string') {
+      throw new Error('Expected fetch URL to be a string');
+    }
+    expect(requestUrl).toContain('/resultats_dis?');
+    expect(requestUrl).toContain('code_reseau=R-2');
+    expect(requestUrl).toContain('sort=desc');
+    expect(requestUrl).toContain('size=1');
+    expect(requestUrl).toContain('fields=date_prelevement');
+    expect(latest).toBe('2024-11-02');
+  });
+
+  it('date-check: returns null when the network has no sample for the window', async () => {
+    fetchMock.mockResolvedValue(
+      buildResponse(200, () => Promise.resolve({ data: [] })),
+    );
+
+    await expect(
+      provider.getNetworkLatestSampleDate({ networkCode: 'R-2', year: 2024 }),
+    ).resolves.toBeNull();
   });
 
   it('should throw BadGatewayException on non-ok responses', async () => {

--- a/packages/api/src/water/providers/hubeau-water-quality.provider.ts
+++ b/packages/api/src/water/providers/hubeau-water-quality.provider.ts
@@ -31,14 +31,28 @@ interface HubEauCommuneUdiResponse {
 // `resultats_dis` renamed `nom_parametre`→`libelle_parametre`; the old
 // `conclusion_conformite_prelevement_pc` short code now lives in
 // `conformite_limites_pc_prelevement` (the physico-chemical limits verdict).
+// Slice 2 additionally requests `code_parametre`, `date_prelevement` and
+// `code_prelevement` to key the append-only cache and expose freshness.
 interface HubEauResultatsRecord {
   readonly libelle_parametre: string;
   readonly resultat_numerique: number | string | null;
   readonly conformite_limites_pc_prelevement: string | null;
+  readonly code_parametre: string | null;
+  readonly date_prelevement: string | null;
+  readonly code_prelevement: string | null;
 }
 
 interface HubEauResultatsResponse {
   readonly data: HubEauResultatsRecord[];
+}
+
+// Slim projection for the cheap conditional-sync date-check (only the date).
+interface HubEauSampleDateRecord {
+  readonly date_prelevement: string | null;
+}
+
+interface HubEauSampleDateResponse {
+  readonly data: HubEauSampleDateRecord[];
 }
 
 /**
@@ -160,9 +174,16 @@ export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
         code_reseau: input.networkCode,
         code_parametre: ION_PARAMETER_CODES.join(','),
         fields:
-          'libelle_parametre,resultat_numerique,conformite_limites_pc_prelevement',
+          'code_parametre,libelle_parametre,resultat_numerique,conformite_limites_pc_prelevement,date_prelevement,code_prelevement',
         date_min_prelevement: `${input.year}-01-01`,
         date_max_prelevement: `${input.year}-12-31`,
+        // Newest-first — same order as the size=1 date-check gate. A busy réseau
+        // can hold far more than `size` ion rows in a year; without this the
+        // capped page is an arbitrary subset that may never include the max
+        // date, so the sync gate would never close (re-fetch every request) or
+        // close on an incomplete set. Sorting desc guarantees the fetched window
+        // includes the newest rows the gate compares against.
+        sort: 'desc',
         size: String(input.size),
       },
       this.waterConfig.hubeauTimeoutMs,
@@ -178,7 +199,32 @@ export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
         parameterLabel: row.libelle_parametre,
         numericResult: this.toNullableNumber(row.resultat_numerique),
         conformity: row.conformite_limites_pc_prelevement,
+        parameterCode: this.toNullableString(row.code_parametre),
+        datePrelevement: this.toDateOnly(row.date_prelevement),
+        codePrelevement: this.toNullableString(row.code_prelevement),
       }));
+  }
+
+  async getNetworkLatestSampleDate(input: {
+    networkCode: string;
+    year: number;
+  }): Promise<string | null> {
+    const response = await this.fetchHubEau<HubEauSampleDateResponse>(
+      `${this.waterConfig.hubeauBaseUrl}/resultats_dis`,
+      {
+        code_reseau: input.networkCode,
+        code_parametre: ION_PARAMETER_CODES.join(','),
+        fields: 'date_prelevement',
+        date_min_prelevement: `${input.year}-01-01`,
+        date_max_prelevement: `${input.year}-12-31`,
+        sort: 'desc',
+        size: '1',
+      },
+      this.waterConfig.hubeauTimeoutMs,
+    );
+
+    const [latest] = response.data;
+    return latest ? this.toDateOnly(latest.date_prelevement) : null;
   }
 
   private async fetchHubEau<T>(
@@ -238,6 +284,27 @@ export class HubeauWaterQualityProvider implements WaterQualityProviderPort {
 
     const parsed = Number(normalized);
     return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  private toNullableString(value: string | null): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const trimmed = value.trim();
+    return trimmed.length ? trimmed : null;
+  }
+
+  /**
+   * Coerces a Hub'Eau `date_prelevement` to a `YYYY-MM-DD` string. Keeps only
+   * the date part (some rows carry a time) and returns null on anything that is
+   * not an ISO date, so the append-only key and `max()` freshness stay sortable.
+   */
+  private toDateOnly(value: string | null): string | null {
+    if (typeof value !== 'string') {
+      return null;
+    }
+    const match = /^(\d{4}-\d{2}-\d{2})/.exec(value.trim());
+    return match ? match[1] : null;
   }
 
   private isTimeoutError(error: unknown): boolean {

--- a/packages/api/src/water/services/water-measurement-cache.service.spec.ts
+++ b/packages/api/src/water/services/water-measurement-cache.service.spec.ts
@@ -1,0 +1,211 @@
+import { DataSource, Repository } from 'typeorm';
+
+import { WaterMeasurementCacheService } from './water-measurement-cache.service';
+import { WaterMeasurementOrmEntity } from '../entities/water-measurement.orm.entity';
+import { WaterSample } from '../domain/ports/water-quality-provider.port';
+
+const sample = (overrides: Partial<WaterSample> = {}): WaterSample => ({
+  parameterLabel: 'Calcium',
+  numericResult: 50,
+  conformity: 'C',
+  parameterCode: '1374',
+  datePrelevement: '2024-03-15',
+  codePrelevement: 'P-1',
+  ...overrides,
+});
+
+describe('WaterMeasurementCacheService', () => {
+  let dataSource: DataSource;
+  let repo: Repository<WaterMeasurementOrmEntity>;
+  let service: WaterMeasurementCacheService;
+
+  beforeAll(async () => {
+    dataSource = new DataSource({
+      type: 'better-sqlite3',
+      database: ':memory:',
+      entities: [WaterMeasurementOrmEntity],
+      synchronize: true,
+    });
+    await dataSource.initialize();
+    repo = dataSource.getRepository(WaterMeasurementOrmEntity);
+    service = new WaterMeasurementCacheService(repo);
+  });
+
+  afterAll(async () => {
+    await dataSource.destroy();
+  });
+
+  beforeEach(async () => {
+    await repo.clear();
+  });
+
+  it('happy: appends samples and reads them back as WaterSamples, most recent first', async () => {
+    await service.appendMeasurements('R-1', [
+      sample({ datePrelevement: '2024-02-01', codePrelevement: 'P-1' }),
+      sample({
+        parameterLabel: 'Magnésium',
+        parameterCode: '1372',
+        numericResult: 8,
+        datePrelevement: '2024-09-10',
+        codePrelevement: 'P-2',
+      }),
+    ]);
+
+    const read = await service.readSamples({
+      networkCode: 'R-1',
+      year: 2024,
+      limit: 100,
+    });
+
+    expect(read).toHaveLength(2);
+    // Ordered by date DESC → the September sample comes first.
+    expect(read[0]).toEqual({
+      parameterLabel: 'Magnésium',
+      numericResult: 8,
+      conformity: 'C',
+      parameterCode: '1372',
+      datePrelevement: '2024-09-10',
+      codePrelevement: 'P-2',
+    });
+    expect(read[1].datePrelevement).toBe('2024-02-01');
+  });
+
+  it('idempotent: re-appending the same window inserts no duplicate (INSERT OR IGNORE)', async () => {
+    const rows = [
+      sample({ datePrelevement: '2024-03-15', codePrelevement: 'P-1' }),
+      sample({
+        parameterCode: '1372',
+        datePrelevement: '2024-03-15',
+        codePrelevement: 'P-1',
+      }),
+    ];
+    await service.appendMeasurements('R-1', rows);
+    await service.appendMeasurements('R-1', rows);
+
+    expect(await repo.count()).toBe(2);
+  });
+
+  it('edge: skips samples missing any part of the unique key', async () => {
+    await service.appendMeasurements('R-1', [
+      sample({ parameterCode: null }),
+      sample({ datePrelevement: null }),
+      sample({ codePrelevement: null }),
+      sample({ codePrelevement: 'P-KEEP' }), // the only fully-keyed row
+    ]);
+
+    expect(await repo.count()).toBe(1);
+    const read = await service.readSamples({
+      networkCode: 'R-1',
+      year: 2024,
+      limit: 100,
+    });
+    expect(read).toHaveLength(1);
+    expect(read[0].codePrelevement).toBe('P-KEEP');
+  });
+
+  it('getStoredMaxDate: returns the newest stored date for the network + year', async () => {
+    await service.appendMeasurements('R-1', [
+      sample({ datePrelevement: '2024-01-05', codePrelevement: 'P-1' }),
+      sample({
+        parameterCode: '1372',
+        datePrelevement: '2024-08-22',
+        codePrelevement: 'P-2',
+      }),
+    ]);
+
+    await expect(
+      service.getStoredMaxDate({ networkCode: 'R-1', year: 2024 }),
+    ).resolves.toBe('2024-08-22');
+  });
+
+  it('getStoredMaxDate: returns null when nothing is stored for the network + year', async () => {
+    await service.appendMeasurements('R-1', [
+      sample({ datePrelevement: '2023-05-05', codePrelevement: 'P-OLD' }),
+    ]);
+
+    // Same network, different year → out of window.
+    await expect(
+      service.getStoredMaxDate({ networkCode: 'R-1', year: 2024 }),
+    ).resolves.toBeNull();
+    // Different network → out of scope.
+    await expect(
+      service.getStoredMaxDate({ networkCode: 'R-2', year: 2023 }),
+    ).resolves.toBeNull();
+  });
+
+  it('readSamples: filters by network and year window', async () => {
+    await service.appendMeasurements('R-1', [
+      sample({ datePrelevement: '2024-04-04', codePrelevement: 'IN' }),
+      sample({
+        parameterCode: '1372',
+        datePrelevement: '2023-12-31',
+        codePrelevement: 'PREV-YEAR',
+      }),
+    ]);
+    await service.appendMeasurements('R-2', [
+      sample({ datePrelevement: '2024-04-04', codePrelevement: 'OTHER-NET' }),
+    ]);
+
+    const read = await service.readSamples({
+      networkCode: 'R-1',
+      year: 2024,
+      limit: 100,
+    });
+
+    expect(read).toHaveLength(1);
+    expect(read[0].codePrelevement).toBe('IN');
+  });
+
+  it('bounds the read to the `limit` newest rows (sampleCount stays comparable as history accretes)', async () => {
+    await service.appendMeasurements('R-1', [
+      sample({ datePrelevement: '2024-01-01', codePrelevement: 'OLD' }),
+      sample({
+        parameterCode: '1372',
+        datePrelevement: '2024-05-01',
+        codePrelevement: 'MID',
+      }),
+      sample({
+        parameterCode: '1337',
+        datePrelevement: '2024-09-01',
+        codePrelevement: 'NEW',
+      }),
+    ]);
+
+    const read = await service.readSamples({
+      networkCode: 'R-1',
+      year: 2024,
+      limit: 2,
+    });
+
+    expect(read.map((s) => s.codePrelevement)).toEqual(['NEW', 'MID']);
+  });
+
+  it('includes the inclusive year boundaries (01-01 and 12-31)', async () => {
+    await service.appendMeasurements('R-1', [
+      sample({ datePrelevement: '2024-01-01', codePrelevement: 'JAN1' }),
+      sample({
+        parameterCode: '1372',
+        datePrelevement: '2024-12-31',
+        codePrelevement: 'DEC31',
+      }),
+    ]);
+
+    const read = await service.readSamples({
+      networkCode: 'R-1',
+      year: 2024,
+      limit: 100,
+    });
+    expect(read.map((s) => s.codePrelevement).sort()).toEqual([
+      'DEC31',
+      'JAN1',
+    ]);
+    await expect(
+      service.getStoredMaxDate({ networkCode: 'R-1', year: 2024 }),
+    ).resolves.toBe('2024-12-31');
+  });
+
+  it('edge: appending an empty list is a no-op', async () => {
+    await service.appendMeasurements('R-1', []);
+    expect(await repo.count()).toBe(0);
+  });
+});

--- a/packages/api/src/water/services/water-measurement-cache.service.ts
+++ b/packages/api/src/water/services/water-measurement-cache.service.ts
@@ -1,0 +1,135 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { WaterMeasurementOrmEntity } from '../entities/water-measurement.orm.entity';
+import { WaterSample } from '../domain/ports/water-quality-provider.port';
+
+/**
+ * Durable append-only cache for Hub'Eau measurements (ADR-0025, slice 2). It is
+ * the persistence seam between the Hub'Eau provider and the domain aggregation:
+ * a full sync appends rows idempotently, and the profile is read back from here
+ * — the same `WaterSample` shape in and out. All reads/writes key on
+ * `code_reseau` (the dominant network) and the requested year window.
+ *
+ * The read returns the **most recent** samples first, bounded to a limit, so the
+ * aggregated average is deterministic and reflects the freshest measurements
+ * (an improvement over slice 1, which averaged an arbitrary Hub'Eau-order page).
+ * The bound also keeps `sampleCount` stable as history accretes across syncs.
+ */
+@Injectable()
+export class WaterMeasurementCacheService {
+  constructor(
+    @InjectRepository(WaterMeasurementOrmEntity)
+    private readonly repo: Repository<WaterMeasurementOrmEntity>,
+  ) {}
+
+  /**
+   * The most recent `date_prelevement` we hold for this network within the year
+   * window, or null when we hold none — the local side of the sync-gate compare.
+   */
+  async getStoredMaxDate(input: {
+    networkCode: string;
+    year: number;
+  }): Promise<string | null> {
+    const { min, max } = yearBounds(input.year);
+    const row = await this.repo
+      .createQueryBuilder('m')
+      .select('MAX(m.date_prelevement)', 'maxDate')
+      .where('m.code_reseau = :networkCode', {
+        networkCode: input.networkCode,
+      })
+      .andWhere('m.date_prelevement BETWEEN :min AND :max', { min, max })
+      .getRawOne<{ maxDate: string | null }>();
+
+    return row?.maxDate ?? null;
+  }
+
+  /**
+   * Append the fetched samples (idempotent). Rows missing any part of the unique
+   * key (`code_parametre` / `date_prelevement` / `code_prelevement`) can't be
+   * deduped, so they are skipped rather than risk duplicate history. `orIgnore()`
+   * turns a re-sync of the same window into a no-op (`INSERT OR IGNORE`).
+   */
+  async appendMeasurements(
+    networkCode: string,
+    samples: WaterSample[],
+  ): Promise<void> {
+    const rows = samples.filter(isFullyKeyed).map((sample) => ({
+      code_reseau: networkCode,
+      code_parametre: sample.parameterCode,
+      date_prelevement: sample.datePrelevement,
+      code_prelevement: sample.codePrelevement,
+      libelle_parametre: sample.parameterLabel,
+      resultat_numerique: sample.numericResult,
+      conformite: sample.conformity,
+    }));
+
+    if (!rows.length) {
+      return;
+    }
+
+    await this.repo
+      .createQueryBuilder()
+      .insert()
+      .into(WaterMeasurementOrmEntity)
+      .values(rows)
+      .orIgnore()
+      .execute();
+  }
+
+  /**
+   * Read this network's stored samples for the year window, most recent first,
+   * bounded to `limit` rows, mapped back to the provider's `WaterSample` shape
+   * so the domain aggregation consumes them exactly as it consumes live-fetched
+   * samples. The bound keeps the read (and thus `sampleCount`) comparable to a
+   * single slice-1 fetch even as the append-only table accretes history.
+   */
+  async readSamples(input: {
+    networkCode: string;
+    year: number;
+    limit: number;
+  }): Promise<WaterSample[]> {
+    const { min, max } = yearBounds(input.year);
+    const rows = await this.repo
+      .createQueryBuilder('m')
+      .where('m.code_reseau = :networkCode', {
+        networkCode: input.networkCode,
+      })
+      .andWhere('m.date_prelevement BETWEEN :min AND :max', { min, max })
+      .orderBy('m.date_prelevement', 'DESC')
+      .addOrderBy('m.id', 'DESC')
+      .limit(input.limit)
+      .getMany();
+
+    return rows.map((row) => ({
+      parameterLabel: row.libelle_parametre,
+      numericResult: row.resultat_numerique,
+      conformity: row.conformite,
+      parameterCode: row.code_parametre,
+      datePrelevement: row.date_prelevement,
+      codePrelevement: row.code_prelevement,
+    }));
+  }
+}
+
+/** A sample carrying every part of the append-only unique key (non-null). */
+type KeyedSample = WaterSample & {
+  parameterCode: string;
+  datePrelevement: string;
+  codePrelevement: string;
+};
+
+/** Type guard: keeps only samples that can be keyed (and thus deduped) safely. */
+function isFullyKeyed(sample: WaterSample): sample is KeyedSample {
+  return (
+    sample.parameterCode !== null &&
+    sample.datePrelevement !== null &&
+    sample.codePrelevement !== null
+  );
+}
+
+/** Inclusive `YYYY-MM-DD` bounds for a calendar year (ISO strings sort chronologically). */
+function yearBounds(year: number): { min: string; max: string } {
+  return { min: `${year}-01-01`, max: `${year}-12-31` };
+}

--- a/packages/api/src/water/services/water.service.spec.ts
+++ b/packages/api/src/water/services/water.service.spec.ts
@@ -4,8 +4,12 @@ import { WATER_CONFIG, WATER_PROVIDERS } from '../water.constants';
 
 import type { WaterConfig } from '../../config/water.config';
 import { WaterConformity } from '../domain/enums/water-conformity.enum';
+import { WaterMeasurementCacheService } from './water-measurement-cache.service';
 import { WaterProviderKey } from '../domain/enums/water-provider-key.enum';
-import type { WaterQualityProviderPort } from '../domain/ports/water-quality-provider.port';
+import type {
+  WaterQualityProviderPort,
+  WaterSample,
+} from '../domain/ports/water-quality-provider.port';
 import { WaterService } from './water.service';
 
 const waterConfigFixture: WaterConfig = {
@@ -18,34 +22,71 @@ const waterConfigFixture: WaterConfig = {
   hubeauResultatsDisSize: 100,
 };
 
-describe('WaterService', () => {
+const sample = (overrides: Partial<WaterSample> = {}): WaterSample => ({
+  parameterLabel: 'Calcium',
+  numericResult: 50,
+  conformity: 'C',
+  parameterCode: '1374',
+  datePrelevement: '2024-03-15',
+  codePrelevement: 'P-1',
+  ...overrides,
+});
+
+describe('WaterService (slice-2 cache-backed)', () => {
   let module: TestingModule;
   let service: WaterService;
 
   const findDominantNetworkByInsee = jest.fn();
   const getNetworkSamples = jest.fn();
+  const getNetworkLatestSampleDate = jest.fn();
+
+  const getStoredMaxDate = jest.fn();
+  const appendMeasurements = jest.fn();
+  const readSamples = jest.fn();
 
   const providerMock: WaterQualityProviderPort = {
     key: WaterProviderKey.HUBEAU,
     findDominantNetworkByInsee,
     getNetworkSamples,
+    getNetworkLatestSampleDate,
+  };
+
+  const cacheMock: Pick<
+    WaterMeasurementCacheService,
+    'getStoredMaxDate' | 'appendMeasurements' | 'readSamples'
+  > = {
+    getStoredMaxDate,
+    appendMeasurements,
+    readSamples,
   };
 
   beforeEach(async () => {
-    findDominantNetworkByInsee.mockReset();
-    getNetworkSamples.mockReset();
+    [
+      findDominantNetworkByInsee,
+      getNetworkSamples,
+      getNetworkLatestSampleDate,
+      getStoredMaxDate,
+      appendMeasurements,
+      readSamples,
+    ].forEach((fn) => fn.mockReset());
+
+    // Sensible defaults; individual tests override.
+    findDominantNetworkByInsee.mockResolvedValue({
+      code: 'UDI-001',
+      name: 'NANTES SUD',
+    });
+    getNetworkLatestSampleDate.mockResolvedValue('2024-03-15');
+    getStoredMaxDate.mockResolvedValue(null);
+    getNetworkSamples.mockResolvedValue([sample()]);
+    appendMeasurements.mockResolvedValue(undefined);
+    readSamples.mockResolvedValue([sample()]);
 
     module = await Test.createTestingModule({
       providers: [
         WaterService,
-        {
-          provide: WATER_CONFIG,
-          useValue: waterConfigFixture,
-        },
-        {
-          provide: WATER_PROVIDERS,
-          useValue: [providerMock],
-        },
+        { provide: WATER_CONFIG, useValue: waterConfigFixture },
+        { provide: WATER_PROVIDERS, useValue: [providerMock] },
+        { provide: WaterMeasurementCacheService, useValue: cacheMock },
       ],
     }).compile();
 
@@ -58,22 +99,16 @@ describe('WaterService', () => {
     }
   });
 
-  it('should build a water profile from provider data', async () => {
-    findDominantNetworkByInsee.mockResolvedValue({
-      code: 'UDI-001',
-      name: 'NANTES SUD',
-    });
-    getNetworkSamples.mockResolvedValue([
-      {
-        parameterLabel: 'Calcium',
-        numericResult: 50,
-        conformity: 'C',
-      },
-      {
+  it('happy: syncs when Hub’Eau is newer, appends, and serves the profile from the DB', async () => {
+    getStoredMaxDate.mockResolvedValue(null); // empty cache → stale
+    readSamples.mockResolvedValue([
+      sample({ parameterLabel: 'Calcium', numericResult: 50 }),
+      sample({
         parameterLabel: 'Magnesium',
         numericResult: 8,
-        conformity: 'C',
-      },
+        parameterCode: '1372',
+        codePrelevement: 'P-2',
+      }),
     ]);
 
     const profile = await service.getWaterProfile({
@@ -81,47 +116,143 @@ describe('WaterService', () => {
       year: 2024,
     });
 
-    expect(findDominantNetworkByInsee).toHaveBeenCalledWith('44109');
+    expect(getNetworkLatestSampleDate).toHaveBeenCalledWith({
+      networkCode: 'UDI-001',
+      year: 2024,
+    });
     expect(getNetworkSamples).toHaveBeenCalledWith({
       networkCode: 'UDI-001',
       year: 2024,
       size: 100,
     });
-
-    expect(profile.provider).toBe(WaterProviderKey.HUBEAU);
-    expect(profile.codeInsee).toBe('44109');
-    expect(profile.year).toBe(2024);
+    // The fetched samples flow through to the cache verbatim (not just "an array").
+    expect(appendMeasurements).toHaveBeenCalledWith('UDI-001', [
+      expect.objectContaining({
+        parameterCode: '1374',
+        codePrelevement: 'P-1',
+      }),
+    ]);
+    expect(readSamples).toHaveBeenCalledWith({
+      networkCode: 'UDI-001',
+      year: 2024,
+      limit: 100,
+    });
     expect(profile.networkName).toBe('NANTES SUD');
     expect(profile.conformity).toBe(WaterConformity.C);
+    expect(profile.mineralsMgL.ca).toBe(50);
+    expect(profile.freshnessDate).toBe('2024-03-15');
   });
 
-  it('should cache results for identical requests', async () => {
-    findDominantNetworkByInsee.mockResolvedValue({
-      code: 'UDI-001',
-      name: 'NANTES SUD',
-    });
-    getNetworkSamples.mockResolvedValue([
-      {
-        parameterLabel: 'Calcium',
-        numericResult: 50,
-        conformity: 'C',
-      },
+  it('edge: syncs incrementally when the cache is non-empty but older than Hub’Eau', async () => {
+    getStoredMaxDate.mockResolvedValue('2024-01-05'); // we hold data …
+    getNetworkLatestSampleDate.mockResolvedValue('2024-03-15'); // … but Hub’Eau is newer
+
+    await service.getWaterProfile({ codeInsee: '44109', year: 2024 });
+
+    expect(getNetworkSamples).toHaveBeenCalledTimes(1);
+    expect(appendMeasurements).toHaveBeenCalledTimes(1);
+  });
+
+  it('edge: end-to-end freshness reflects the newest date across the read samples', async () => {
+    readSamples.mockResolvedValue([
+      sample({ datePrelevement: '2024-02-01', codePrelevement: 'A' }),
+      sample({ datePrelevement: '2024-11-20', codePrelevement: 'B' }),
+      sample({ datePrelevement: '2024-06-10', codePrelevement: 'C' }),
     ]);
 
-    await service.getWaterProfile({
-      codeInsee: '44109',
-      year: 2024,
-    });
-    await service.getWaterProfile({
+    const profile = await service.getWaterProfile({
       codeInsee: '44109',
       year: 2024,
     });
 
-    expect(findDominantNetworkByInsee).toHaveBeenCalledTimes(1);
-    expect(getNetworkSamples).toHaveBeenCalledTimes(1);
+    expect(profile.freshnessDate).toBe('2024-11-20');
   });
 
-  it('should throw NotFound when no network is found', async () => {
+  it('edge: skips the full fetch when the DB is already current', async () => {
+    getStoredMaxDate.mockResolvedValue('2024-03-15'); // == Hub’Eau latest
+
+    await service.getWaterProfile({ codeInsee: '44109', year: 2024 });
+
+    expect(getNetworkSamples).not.toHaveBeenCalled();
+    expect(appendMeasurements).not.toHaveBeenCalled();
+    expect(readSamples).toHaveBeenCalled();
+  });
+
+  it('edge: serves the in-memory cache on a repeated identical request', async () => {
+    await service.getWaterProfile({ codeInsee: '44109', year: 2024 });
+    await service.getWaterProfile({ codeInsee: '44109', year: 2024 });
+
+    expect(findDominantNetworkByInsee).toHaveBeenCalledTimes(1);
+    expect(getNetworkLatestSampleDate).toHaveBeenCalledTimes(1);
+    expect(readSamples).toHaveBeenCalledTimes(1);
+  });
+
+  it('resilience: falls back to the DB when the Hub’Eau date-check fails', async () => {
+    getNetworkLatestSampleDate.mockRejectedValue(
+      new BadGatewayException("Hub'Eau request failed"),
+    );
+    readSamples.mockResolvedValue([sample()]);
+
+    const profile = await service.getWaterProfile({
+      codeInsee: '44109',
+      year: 2024,
+    });
+
+    expect(getNetworkSamples).not.toHaveBeenCalled();
+    expect(appendMeasurements).not.toHaveBeenCalled();
+    expect(profile.mineralsMgL.ca).toBe(50);
+  });
+
+  it('resilience: falls back to the DB when the full fetch fails after a positive date-check', async () => {
+    getStoredMaxDate.mockResolvedValue(null); // stale → would fetch
+    getNetworkSamples.mockRejectedValue(
+      new BadGatewayException("Hub'Eau request timed out"),
+    );
+    readSamples.mockResolvedValue([sample()]);
+
+    const profile = await service.getWaterProfile({
+      codeInsee: '44109',
+      year: 2024,
+    });
+
+    expect(appendMeasurements).not.toHaveBeenCalled();
+    expect(profile.mineralsMgL.ca).toBe(50);
+  });
+
+  it('sad: throws NotFound when neither Hub’Eau nor the DB has data', async () => {
+    getNetworkLatestSampleDate.mockResolvedValue(null); // Hub’Eau empty
+    readSamples.mockResolvedValue([]); // DB empty
+
+    await expect(
+      service.getWaterProfile({ codeInsee: '44109', year: 2024 }),
+    ).rejects.toThrow(NotFoundException);
+    expect(getNetworkSamples).not.toHaveBeenCalled();
+  });
+
+  it('sad: surfaces the Hub’Eau outage (not 404) when the date-check fails and nothing is cached', async () => {
+    getNetworkLatestSampleDate.mockRejectedValue(
+      new BadGatewayException("Hub'Eau request failed"),
+    );
+    readSamples.mockResolvedValue([]); // empty cache → no fallback
+
+    await expect(
+      service.getWaterProfile({ codeInsee: '44109', year: 2024 }),
+    ).rejects.toThrow(BadGatewayException);
+  });
+
+  it('sad: surfaces the Hub’Eau outage when the full fetch fails and nothing is cached', async () => {
+    getStoredMaxDate.mockResolvedValue(null); // stale → would fetch
+    getNetworkSamples.mockRejectedValue(
+      new BadGatewayException("Hub'Eau request timed out"),
+    );
+    readSamples.mockResolvedValue([]); // empty cache → no fallback
+
+    await expect(
+      service.getWaterProfile({ codeInsee: '44109', year: 2024 }),
+    ).rejects.toThrow(BadGatewayException);
+  });
+
+  it('sad: throws NotFound when no network is found', async () => {
     findDominantNetworkByInsee.mockResolvedValue(null);
 
     await expect(
@@ -129,19 +260,7 @@ describe('WaterService', () => {
     ).rejects.toThrow(NotFoundException);
   });
 
-  it('should throw NotFound when no sample is available', async () => {
-    findDominantNetworkByInsee.mockResolvedValue({
-      code: 'UDI-001',
-      name: 'NANTES SUD',
-    });
-    getNetworkSamples.mockResolvedValue([]);
-
-    await expect(
-      service.getWaterProfile({ codeInsee: '44109', year: 2024 }),
-    ).rejects.toThrow(NotFoundException);
-  });
-
-  it('should throw BadGateway when provider key is unsupported', async () => {
+  it('sad: throws BadGateway when the provider key is unsupported', async () => {
     await expect(
       service.getWaterProfile({
         codeInsee: '44109',

--- a/packages/api/src/water/services/water.service.ts
+++ b/packages/api/src/water/services/water.service.ts
@@ -7,9 +7,13 @@ import {
 
 import type { WaterConfig } from '../../config/water.config';
 import { WATER_CONFIG, WATER_PROVIDERS } from '../water.constants';
+import { WaterMeasurementCacheService } from './water-measurement-cache.service';
 import { WaterProfileEntity } from '../domain/entities/water-profile.entity';
 import { WaterProviderKey } from '../domain/enums/water-provider-key.enum';
-import { WaterQualityProviderPort } from '../domain/ports/water-quality-provider.port';
+import {
+  WaterQualityProviderPort,
+  WaterSample,
+} from '../domain/ports/water-quality-provider.port';
 import { WaterAggregationDomainService } from '../domain/services/water-aggregation-domain.service';
 
 interface CacheEntry {
@@ -35,6 +39,7 @@ export class WaterService {
     private readonly providers: WaterQualityProviderPort[],
     @Inject(WATER_CONFIG)
     private readonly waterConfig: WaterConfig,
+    private readonly cacheService: WaterMeasurementCacheService,
   ) {}
 
   async getWaterProfile(
@@ -54,18 +59,35 @@ export class WaterService {
     }
 
     const provider = this.selectProvider(providerKey);
+    // Network resolution stays live (communes_udi) as in slice 1 (ADR-0025 §
+    // Storage). A full Hub'Eau outage here has no cached fallback — the
+    // commune→network cache is a deferred enhancement.
     const network = await provider.findDominantNetworkByInsee(input.codeInsee);
     if (!network) {
       throw new NotFoundException('No water network found for this INSEE code');
     }
 
-    const samples = await provider.getNetworkSamples({
+    // Slice-2: refresh our append-only cache only when Hub'Eau is genuinely
+    // newer, then serve from the DB. A Hub'Eau failure is captured (not thrown)
+    // so we can still fall back to cached data below.
+    const syncError = await this.syncNetworkIfStale(
+      provider,
+      network.code,
+      input.year,
+    );
+
+    const samples = await this.cacheService.readSamples({
       networkCode: network.code,
       year: input.year,
-      size: this.waterConfig.hubeauResultatsDisSize,
+      limit: this.waterConfig.hubeauResultatsDisSize,
     });
 
     if (!samples.length) {
+      // Nothing cached to fall back on: if that is because Hub'Eau failed,
+      // surface the outage (502) rather than masking it as "no data" (404).
+      if (syncError) {
+        throw syncError;
+      }
       throw new NotFoundException(
         'No sample available for this network and year',
       );
@@ -82,6 +104,67 @@ export class WaterService {
 
     this.setCached(cacheKey, profile);
     return profile;
+  }
+
+  /**
+   * Conditional sync (ADR-0025, slice 2): a cheap size=1 date-check gates the
+   * expensive full fetch, so most lookups do no heavy Hub'Eau call. A Hub'Eau
+   * failure during the check or fetch is returned (not thrown) so the caller
+   * can fall back to the last known DB data; the caller re-surfaces it only when
+   * nothing is cached. A genuine no-data window and an up-to-date cache both
+   * skip the fetch and return null (no error).
+   *
+   * Two concurrent requests for a stale network can both fetch-and-append before
+   * either closes the gate; this is safe (the append is idempotent on the unique
+   * key), only mildly wasteful. Per-key in-flight coalescing is a deferred
+   * optimisation.
+   *
+   * @returns the swallowed Hub'Eau error, or null when the sync succeeded/was a no-op.
+   */
+  private async syncNetworkIfStale(
+    provider: WaterQualityProviderPort,
+    networkCode: string,
+    year: number,
+  ): Promise<Error | null> {
+    let hubeauLatest: string | null;
+    try {
+      hubeauLatest = await provider.getNetworkLatestSampleDate({
+        networkCode,
+        year,
+      });
+    } catch (error) {
+      // Hub'Eau unreachable during the date-check → serve last known (DB).
+      return toError(error);
+    }
+
+    if (hubeauLatest === null) {
+      // Hub'Eau holds nothing for this window → nothing to sync.
+      return null;
+    }
+
+    const storedLatest = await this.cacheService.getStoredMaxDate({
+      networkCode,
+      year,
+    });
+    if (storedLatest !== null && storedLatest >= hubeauLatest) {
+      // Our cache is already current → no full fetch.
+      return null;
+    }
+
+    let samples: WaterSample[];
+    try {
+      samples = await provider.getNetworkSamples({
+        networkCode,
+        year,
+        size: this.waterConfig.hubeauResultatsDisSize,
+      });
+    } catch (error) {
+      // Full fetch failed → serve last known (DB).
+      return toError(error);
+    }
+
+    await this.cacheService.appendMeasurements(networkCode, samples);
+    return null;
   }
 
   private selectProvider(
@@ -144,4 +227,11 @@ export class WaterService {
       }
     }
   }
+}
+
+/** Normalise a caught value to an Error (the provider always throws a Nest HttpException). */
+function toError(error: unknown): Error {
+  return error instanceof Error
+    ? error
+    : new BadGatewayException("Hub'Eau request failed");
 }

--- a/packages/api/src/water/water.module.spec.ts
+++ b/packages/api/src/water/water.module.spec.ts
@@ -3,14 +3,21 @@ import { WATER_CONFIG, WATER_PROVIDERS } from './water.constants';
 import { HubeauWaterQualityProvider } from './providers/hubeau-water-quality.provider';
 import { Test } from '@nestjs/testing';
 import { WaterConfig } from '../config/water.config';
+import { WaterMeasurementOrmEntity } from './entities/water-measurement.orm.entity';
 import { WaterModule } from './water.module';
 import { WaterService } from './services/water.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
 
 describe('WaterModule', () => {
   it('should expose water config and providers tokens', async () => {
+    // The append-only cache repository (slice 2) needs a DataSource this unit
+    // test does not mount — override it with a fake so DI resolves.
     const moduleRef = await Test.createTestingModule({
       imports: [WaterModule],
-    }).compile();
+    })
+      .overrideProvider(getRepositoryToken(WaterMeasurementOrmEntity))
+      .useValue({})
+      .compile();
 
     const waterConfig = moduleRef.get<WaterConfig>(WATER_CONFIG);
     const providers = moduleRef.get<unknown[]>(WATER_PROVIDERS);

--- a/packages/api/src/water/water.module.ts
+++ b/packages/api/src/water/water.module.ts
@@ -2,14 +2,19 @@ import { WATER_CONFIG, WATER_PROVIDERS } from './water.constants';
 
 import { HubeauWaterQualityProvider } from './providers/hubeau-water-quality.provider';
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { WaterController } from './controllers/water.controller';
+import { WaterMeasurementCacheService } from './services/water-measurement-cache.service';
+import { WaterMeasurementOrmEntity } from './entities/water-measurement.orm.entity';
 import { WaterService } from './services/water.service';
 import { waterConfig } from '../config/water.config';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([WaterMeasurementOrmEntity])],
   controllers: [WaterController],
   providers: [
     HubeauWaterQualityProvider,
+    WaterMeasurementCacheService,
     WaterService,
     {
       provide: WATER_CONFIG,


### PR DESCRIPTION
## Summary

Makes `GET /water` cache-backed — **water-profile slice 2** ([ADR-0025](docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md) § Slice-2), following slice-1 ([#1358](https://github.com/benoit-bremaud/brasse-bouillon/pull/1358)) and the conception ([#1355](https://github.com/benoit-bremaud/brasse-bouillon/pull/1355), sequence `03-sequence-slice2-cache-sync`).

New append-only `water_measurements` table (migration `1809`), keyed uniquely on `(code_reseau, code_parametre, date_prelevement, code_prelevement)` — history accrues, re-sync is idempotent (`INSERT OR IGNORE`). `WaterService.getWaterProfile` now:

1. in-memory TTL cache (unchanged fast path) →
2. resolve dominant network (live `communes_udi`, as slice 1) →
3. **conditional sync**: a cheap `size=1` date-check vs our stored max; a full fetch + append **only when Hub'Eau is newer** →
4. read the profile from the DB → aggregate (domain service unchanged) →
5. DTO gains an **additive** `freshnessDate` (`max(date_prelevement)`).

Any Hub'Eau failure during the check/fetch is swallowed → **fallback to the last known DB data** (resilience slice 1 lacked). The endpoint contract, the 5 ions / hardness / conformity / network are otherwise **unchanged**, so the mobile keeps working — the dated-pastille render is a follow-up **PR-B** (backend-first split, same shape as the equipment-fit leg).

## Design notes

- **Keys on `code_reseau`** (dominant network), never `code_commune` (which would blend networks and shift the average) — aggregation stays semantically slice-1.
- **Fetch aligned with the gate**: the full fetch uses `sort=desc` (newest-first), matching the `size=1` date-check, so the fetched window always includes the max date the gate compares against — a busy réseau can hold far more than `size` ion rows in a year.
- **Bounded read**: `readSamples` returns the most-recent N (limit), so `sampleCount` stays comparable to a single slice-1 fetch as history accretes, and the average reflects the freshest samples deterministically (an improvement over slice-1's arbitrary Hub'Eau-order page).
- **RGPD**: public ARS/Hub'Eau reference data, **not PII**. The user's location is not stored (deferred "remember my water" slice).
- **Known limitation**: network resolution stays live; a *full* Hub'Eau outage has no cached fallback (the commune→network cache is a deferred enhancement).

## Review

Ran a 6-lens adversarial review with independent per-finding verification. One **MUST** fixed: the full fetch was `size=100` **unsorted** while the gate used `sort=desc` — on the demo commune (Lille 59350 holds 700+ ion rows/year) the capped page was an arbitrary subset, so the gate could close on an incomplete set (silently wrong chemistry) or never close (wasted calls). Fixed by sorting the fetch `desc`. Five Should items (bounded read / honest docs / test gaps) addressed; Nice items (concurrency coalescing, full-year average, per-ion cap) deferred with in-code notes.

## Deferred / follow-ups

- **PR-B mobile**: upgrade the year-granular freshness line to a dated pastille (green < 6 months / orange / grey).
- **ADR-0025 → Accepted + CLAUDE.md index** + a sequence-diagram note on the bounded most-recent read (separate docs PR, on this landing).
- Full-year average, per-key in-flight sync coalescing, commune→network cache.

## Testing

- 67 water unit tests (H/S/E across provider, cache service, orchestration, aggregation, DTO), full API suite green.
- The cache-service spec exercises real SQL on an in-memory better-sqlite3 DataSource (append-only, dedupe, max-date, year-window, bounded read).
- Migration `1809` validated end-to-end (full chain run; table + both indexes created); CI e2e runs migrations.

## Checklist

- [x] Lint + build + tests green locally
- [x] No `any`, named exports, no raw SQL outside the query builder
- [x] Additive DTO change — endpoint contract unchanged (mobile unaffected)
- [x] Adversarial review run; MUST + Should addressed
