### PR TITLE
docs: record water slice-2 (#1374) + promote ADR-0025 to Accepted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,7 @@ Currently accepted ADRs (see each file for the `Status` line and full rationale)
 - [ADR-0020 — Equipment-driven batch sizing & volume planning (computed in the backend)](docs/architecture/decisions/0020-equipment-driven-volume-planning.md)
 - [ADR-0022 — Public FAQ chatbot: Mistral LLM + self-hosted ALTCHA, EU-sovereign](docs/architecture/decisions/0022-public-faq-chatbot-llm.md)
 - [ADR-0024 — Recipe brewing-difficulty badge: rule-based, max-dominates, backend-computed](docs/architecture/decisions/0024-recipe-difficulty-scoring.md)
+- [ADR-0025 — Local water profile: postal-code geolocation, live proxy first, append-only cache second](docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md)
 - [ADR-0026 — Equipment capacity fit-check: advisory pre-batch readiness, backend-computed](docs/architecture/decisions/0026-equipment-capacity-fit-check.md)
 
 When a new ADR is accepted, add its file link here (no dates, no per-ADR summaries — open the file for the live status and content). When reviewing a PR, flag any diff that violates these ADRs and cite the ADR number and clause in the review comment.

--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,14 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-07-09
 
+### PR #1374 merged (`7b91011`) — feat(api/water): append-only cache + conditional sync for /water (water-profile slice 2)
+
+- Branch `feat/api-water-cache`, 1 commit (`d71f494`). Backend slice-2 of the water-profile epic ([ADR-0025](docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md) § Slice-2), on top of slice-1 #1358. `GET /water` is now cache-backed: new append-only `water_measurements` table (migration `1809`) keyed uniquely on `(code_reseau, code_parametre, date_prelevement, code_prelevement)`; `WaterMeasurementCacheService` (append idempotent via `INSERT OR IGNORE`, max-date, bounded newest-N read); `WaterService` gains a conditional sync (cheap `size=1` `sort=desc` date-check gate → full fetch + append only when Hub'Eau is newer) with a DB fallback on any Hub'Eau outage; the DTO gains an additive `freshnessDate` (`max(date_prelevement)`). Endpoint contract otherwise unchanged (mobile unaffected; the dated-pastille render is a follow-up PR-B). 69 water unit tests; migration validated end-to-end. Public ARS/Hub'Eau data, not PII. ADR-0025 promoted `Proposed` → `Accepted` + added to the CLAUDE.md index in this same docs PR.
+- Refs #1358, #1355.
+- Reviews — pre-push adversarial multi-lens review: 1 MUST fixed (the full fetch was `size=100` unsorted vs the `sort=desc` gate → an arbitrary subset on a busy réseau that could gate off future syncs on an incomplete set; fixed with `sort=desc`) + 5 Should (bounded read, honest docs, test gaps). A follow-up automated review (fixed in `d71f494`): an empty-cache Hub'Eau outage now surfaces `502` not `404`; stale DTO description; `as string` casts replaced by a type guard. CI green, 3 threads resolved.
+- **Decisions**:
+  - `water-slice2-most-recent-bounded` — slice-2 aggregates the most-recent, bounded window of samples (DB read `sort=desc` + `limit`), a deterministic improvement over slice-1's arbitrary Hub'Eau-order page. Recorded in ADR-0025.
+
 ### PR #1366 merged (`b22477c`) — docs(adr): promote ADR-0026 to Accepted + CLAUDE.md index
 
 - Branch `docs/adr-0026-accepted`, 2 commits (`26c0b98`, `f5288e9`). Closes out the equipment fit-check leg (built end-to-end by #1362 + #1364): [ADR-0026](docs/architecture/decisions/0026-equipment-capacity-fit-check.md) `Proposed` → `Accepted` and added to the root [CLAUDE.md](CLAUDE.md) accepted-ADR index. Review also corrected [ADR-0022](docs/architecture/decisions/0022-public-faq-chatbot-llm.md) (FAQ chatbot), which was still `Proposed` while listed in that index though its decision shipped in #1293 → set to `Accepted`; verified the other 13 indexed ADRs are all Accepted. ADR-0026 header spacing realigned to the `README.md` template.

--- a/docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md
+++ b/docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md
@@ -1,7 +1,7 @@
 # ADR-0025 — Local water profile: postal-code geolocation, live proxy first, append-only cache second
 
-**Status**  Proposed
-**Date**  2026-07-06
+**Status**  Accepted
+**Date**    2026-07-06 (accepted 2026-07-09, both slices shipped: slice-1 #1358, slice-2 #1374)
 **Owners**  @benoit-bremaud
 
 ---

--- a/docs/architecture/diagrams/water-profile/03-sequence-slice2-cache-sync.md
+++ b/docs/architecture/diagrams/water-profile/03-sequence-slice2-cache-sync.md
@@ -53,6 +53,12 @@ sequenceDiagram
 - **Same key as slice 1**: slice 2 keeps `code_reseau` (the dominant network), so the aggregation
   semantics are unchanged; it only **adds** `code_prelevement` to the fetched `fields` (the live
   path does not request it) to key the append-only rows.
+- **Deterministic bounded read** (implemented in #1374): the full fetch and the DB read both order
+  by `date_prelevement DESC` — the fetch aligns with the `size=1` date-check gate (so the fetched
+  window always includes the max date the gate compares against, never an arbitrary page), and the
+  read returns the **most-recent, bounded** window. This aggregates the freshest samples
+  deterministically — an improvement over slice 1's arbitrary Hub'Eau-order page — and keeps
+  `sampleCount` stable as the append-only history accretes.
 - **Two-step sync is deliberate**: the size=1 date-check is cheap and gates the expensive full
   fetch — most lookups do **no** heavy call. Reduces Hub'Eau load and our latency.
 - **Append-only** (unique key `réseau + paramètre + date_prelevement + code_prelevement`) means


### PR DESCRIPTION
## Summary

Docs housekeeping for the water-profile slice-2 landing ([#1374](https://github.com/benoit-bremaud/brasse-bouillon/pull/1374), `7b91011`):

- **PROJECT_LOG** entry for #1374 (append-only water cache + conditional sync).
- **[ADR-0025](docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md) `Proposed` → `Accepted`** — both slices are now shipped (slice-1 #1358, slice-2 #1374) — and added to the root [CLAUDE.md](CLAUDE.md) accepted-ADR index (the promotion planned at slice-1 landing, done now).
- **Sequence diagram `03`** note aligned with the implemented behaviour: the deterministic bounded most-recent read (fetch + DB read both `sort=desc`, read `limit`), an improvement over slice-1's arbitrary page — closing the conception-vs-code gap the pre-push review flagged.

No code change; conception now matches the shipped reality (conception = contract).

## Checklist

- [x] ADR-0025 header follows the aligned template spacing
- [x] Index entry inserted numerically (0024 → 0025 → 0026)
- [x] Log entry is terse references, no AI attribution in the body
- [x] Merge SHA `7b91011` (slice-2) resolves on `main`