### PR TITLE
feat(mobile/recipes): dated water freshness pastille (water-profile PR-B)

### DIFF
--- a/packages/mobile-app/src/features/recipes/application/__tests__/water-profile.use-cases.test.ts
+++ b/packages/mobile-app/src/features/recipes/application/__tests__/water-profile.use-cases.test.ts
@@ -4,6 +4,7 @@ import {
   getLiveWaterProfile,
 } from "@/features/recipes/data/water-profile.api";
 import {
+  describeWaterFreshness,
   isValidPostalCode,
   loadWaterProfile,
   resolveCommunes,
@@ -30,7 +31,11 @@ const profile: LiveWaterProfile = {
   conformity: "C",
   mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
   hardnessFrench: 125.4,
+  freshnessDate: null,
 };
+
+// Fixed reference date so freshness ages are deterministic: 2024-09-15.
+const NOW = new Date(2024, 8, 15);
 
 describe("water-profile.use-cases", () => {
   afterEach(() => jest.clearAllMocks());
@@ -98,5 +103,61 @@ describe("water-profile.use-cases", () => {
       await expect(loadWaterProfile("59350")).rejects.toBeInstanceOf(HttpError);
       expect(mockGetProfile).toHaveBeenCalledTimes(1);
     });
+  });
+
+  describe("describeWaterFreshness", () => {
+    it("marks a date under 6 months old as a green « Récent » pastille", () => {
+      const view = describeWaterFreshness("2024-06-01", NOW); // ~3.5 months
+      expect(view).toEqual({
+        tone: "success",
+        label: "Récent",
+        dateLabel: "01/06/2024",
+      });
+    });
+
+    it("marks a 6–24 month old date as an orange « À confirmer » pastille", () => {
+      const view = describeWaterFreshness("2023-06-01", NOW); // ~15 months
+      expect(view?.tone).toBe("warning");
+      expect(view?.label).toBe("À confirmer");
+      expect(view?.dateLabel).toBe("01/06/2023");
+    });
+
+    it("marks a date over 24 months old as a grey « Ancien » pastille", () => {
+      const view = describeWaterFreshness("2021-01-10", NOW); // ~44 months
+      expect(view?.tone).toBe("neutral");
+      expect(view?.label).toBe("Ancien");
+    });
+
+    it("treats exactly 6 months as « À confirmer » (boundary is inclusive of orange)", () => {
+      const view = describeWaterFreshness("2024-03-15", NOW); // exactly 6 months
+      expect(view?.tone).toBe("warning");
+    });
+
+    it("treats exactly 24 months as « À confirmer » (orange is inclusive of 24)", () => {
+      const view = describeWaterFreshness("2022-09-15", NOW); // exactly 24 months
+      expect(view?.tone).toBe("warning");
+    });
+
+    it("treats over 24 months as grey « Ancien »", () => {
+      const view = describeWaterFreshness("2022-08-15", NOW); // 25 months
+      expect(view?.tone).toBe("neutral");
+      expect(view?.label).toBe("Ancien");
+    });
+
+    it("returns null for a null date so the panel falls back to the year line", () => {
+      expect(describeWaterFreshness(null, NOW)).toBeNull();
+    });
+
+    it("returns null for a future date (never a reassuring « Récent »)", () => {
+      // Clock skew or a bad backend max date → fall back, don't render green.
+      expect(describeWaterFreshness("2025-01-01", NOW)).toBeNull();
+    });
+
+    it.each(["2024-13-01", "2024-02-31", "15/03/2024", "garbage", ""])(
+      "returns null for the malformed date %s",
+      (value) => {
+        expect(describeWaterFreshness(value, NOW)).toBeNull();
+      },
+    );
   });
 });

--- a/packages/mobile-app/src/features/recipes/application/water-profile.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/water-profile.use-cases.ts
@@ -47,3 +47,100 @@ export async function loadWaterProfile(
     throw error;
   }
 }
+
+/** Tone of the freshness pastille — maps 1:1 to the UI `Badge` variants. */
+export type WaterFreshnessTone = "success" | "warning" | "neutral";
+
+/** Display model for the dated freshness pastille (ADR-0025 slice 2). */
+export interface WaterFreshnessDisplay {
+  readonly tone: WaterFreshnessTone;
+  readonly label: string;
+  /** The sampling date as `JJ/MM/AAAA`. */
+  readonly dateLabel: string;
+}
+
+const RECENT_MAX_MONTHS = 6;
+const AGEING_MAX_MONTHS = 24;
+
+/**
+ * Maps the backend `freshnessDate` (`YYYY-MM-DD`, max date_prelevement) to a
+ * dated pastille: green « Récent » (< 6 months), orange « À confirmer »
+ * (6–24 months), grey « Ancien » (> 24 months). Pure — `now` is injected so the
+ * age is testable. Returns null when there is no usable date (or the date is in
+ * the future — clock skew or a bad backend max date), so the panel falls back to
+ * the year-granular freshness line rather than fabricate a reassuring age.
+ */
+export function describeWaterFreshness(
+  freshnessDate: string | null,
+  now: Date,
+): WaterFreshnessDisplay | null {
+  const parsed = parseIsoDate(freshnessDate);
+  if (!parsed) {
+    return null;
+  }
+
+  const months = completedMonthsBetween(parsed, now);
+  // A future sampling date is anomalous — never render it as a reassuring
+  // « Récent » (ADR-0025 forbids anomalies reading as a legitimate state).
+  if (months < 0) {
+    return null;
+  }
+  if (months < RECENT_MAX_MONTHS) {
+    return {
+      tone: "success",
+      label: "Récent",
+      dateLabel: formatFrDate(parsed),
+    };
+  }
+  if (months <= AGEING_MAX_MONTHS) {
+    // Inclusive of 24 months — grey « Ancien » is strictly > 24 months.
+    return {
+      tone: "warning",
+      label: "À confirmer",
+      dateLabel: formatFrDate(parsed),
+    };
+  }
+  return { tone: "neutral", label: "Ancien", dateLabel: formatFrDate(parsed) };
+}
+
+/** Parses a strict `YYYY-MM-DD` date to a local Date, or null if malformed. */
+function parseIsoDate(value: string | null): Date | null {
+  if (!value) {
+    return null;
+  }
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    return null;
+  }
+  const [year, month, day] = [
+    Number(match[1]),
+    Number(match[2]),
+    Number(match[3]),
+  ];
+  const date = new Date(year, month - 1, day);
+  // Reject impossible dates that JS would roll over (e.g. 2024-02-31).
+  const valid =
+    date.getFullYear() === year &&
+    date.getMonth() === month - 1 &&
+    date.getDate() === day;
+  return valid ? date : null;
+}
+
+/**
+ * Whole months elapsed from `from` to `now` (negative if `from` is in the
+ * future). Local-time arithmetic on purpose (matches `parseIsoDate`'s local
+ * `Date`); do NOT switch to `Date.UTC`, which would drift by a day at DST edges.
+ */
+function completedMonthsBetween(from: Date, now: Date): number {
+  const months =
+    (now.getFullYear() - from.getFullYear()) * 12 +
+    (now.getMonth() - from.getMonth()) -
+    (now.getDate() < from.getDate() ? 1 : 0);
+  return months;
+}
+
+function formatFrDate(date: Date): string {
+  const dd = String(date.getDate()).padStart(2, "0");
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  return `${dd}/${mm}/${date.getFullYear()}`;
+}

--- a/packages/mobile-app/src/features/recipes/data/__tests__/water-profile.api.test.ts
+++ b/packages/mobile-app/src/features/recipes/data/__tests__/water-profile.api.test.ts
@@ -64,6 +64,7 @@ describe("water-profile.api", () => {
         conformity: "N",
         mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
         hardnessFrench: 125.4,
+        freshnessDate: "2024-03-15",
       });
 
       expect(profile).toEqual({
@@ -74,7 +75,22 @@ describe("water-profile.api", () => {
         conformity: "N",
         mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
         hardnessFrench: 125.4,
+        freshnessDate: "2024-03-15",
       });
+    });
+
+    it("defaults a missing freshnessDate to null (pre-slice-2 backend)", () => {
+      const profile = mapWaterProfile({
+        codeInsee: "59350",
+        year: 2024,
+        networkName: "LILLE",
+        sampleCount: 100,
+        conformity: "C",
+        mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
+        hardnessFrench: 125.4,
+      });
+
+      expect(profile.freshnessDate).toBeNull();
     });
 
     it("tolerates a null minerals block and null values (partial data)", () => {

--- a/packages/mobile-app/src/features/recipes/data/water-profile.api.ts
+++ b/packages/mobile-app/src/features/recipes/data/water-profile.api.ts
@@ -63,6 +63,9 @@ interface WaterProfileDto {
   readonly conformity: string;
   readonly mineralsMgL: WaterMineralsMgLDto | null;
   readonly hardnessFrench: number | null;
+  // Added by slice-2 (ADR-0025). Optional here so a pre-slice-2 backend still
+  // maps cleanly to a null freshness date.
+  readonly freshnessDate?: string | null;
 }
 
 const CONFORMITY_VALUES: readonly WaterConformity[] = [
@@ -97,6 +100,7 @@ export function mapWaterProfile(dto: WaterProfileDto): LiveWaterProfile {
       hco3: minerals?.hco3 ?? null,
     },
     hardnessFrench: dto.hardnessFrench,
+    freshnessDate: dto.freshnessDate ?? null,
   };
 }
 

--- a/packages/mobile-app/src/features/recipes/domain/water-profile.types.ts
+++ b/packages/mobile-app/src/features/recipes/domain/water-profile.types.ts
@@ -37,4 +37,11 @@ export interface LiveWaterProfile {
   readonly conformity: WaterConformity;
   readonly mineralsMgL: LiveWaterMinerals;
   readonly hardnessFrench: number | null;
+  /**
+   * Most recent sampling date `YYYY-MM-DD` (max date_prelevement) — the honest
+   * data currency (ADR-0025 slice 2), never the fetch date. Null when the
+   * backend returns none (e.g. a pre-slice-2 response) → the panel falls back to
+   * the year-granular freshness line.
+   */
+  readonly freshnessDate: string | null;
 }

--- a/packages/mobile-app/src/features/recipes/presentation/components/LiveWaterProfilePanel.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/LiveWaterProfilePanel.tsx
@@ -5,6 +5,7 @@ import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
 import { colors, radius, spacing, typography } from "@/core/theme";
 
+import { describeWaterFreshness } from "@/features/recipes/application/water-profile.use-cases";
 import type {
   LiveWaterMinerals,
   LiveWaterProfile,
@@ -71,6 +72,7 @@ export function LiveWaterProfilePanel({ profile }: Props) {
     ION_ORDER.some((ion) => minerals[ion] === null) ||
     profile.hardnessFrench === null;
   const pedagogy = hardnessSentence(profile.hardnessFrench);
+  const freshness = describeWaterFreshness(profile.freshnessDate, new Date());
 
   return (
     <Card variant="subtle" style={styles.card} testID="water-profile-panel">
@@ -120,9 +122,22 @@ export function LiveWaterProfilePanel({ profile }: Props) {
         </Text>
       ) : null}
 
-      <Text style={styles.source}>
-        Analyses {profile.year} — source ARS via Hub'Eau.
-      </Text>
+      {freshness ? (
+        <View style={styles.freshnessRow} testID="water-freshness">
+          <Badge
+            label={freshness.label}
+            variant={freshness.tone}
+            accessibilityLabel={`Fraîcheur des analyses : ${freshness.label}, dernière analyse le ${freshness.dateLabel}`}
+          />
+          <Text style={styles.source}>
+            Dernière analyse : {freshness.dateLabel} — source ARS via Hub'Eau.
+          </Text>
+        </View>
+      ) : (
+        <Text style={styles.source} testID="water-freshness-fallback">
+          Analyses {profile.year} — source ARS via Hub'Eau.
+        </Text>
+      )}
     </Card>
   );
 }
@@ -186,6 +201,13 @@ const styles = StyleSheet.create({
   source: {
     fontSize: typography.size.caption,
     color: colors.neutral.textSecondary,
+    marginTop: spacing.xxs,
+  },
+  freshnessRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: spacing.xs,
     marginTop: spacing.xxs,
   },
 });

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LiveWaterProfilePanel.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LiveWaterProfilePanel.test.tsx
@@ -15,6 +15,9 @@ const baseProfile: LiveWaterProfile = {
   conformity: "C",
   mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
   hardnessFrench: 125.4,
+  // Null by default so the existing assertions exercise the year-line fallback;
+  // the dated-pastille branch has its own test below.
+  freshnessDate: null,
 };
 
 const withProfile = (patch: Partial<LiveWaterProfile>) => ({
@@ -105,5 +108,29 @@ describe("LiveWaterProfilePanel", () => {
       <LiveWaterProfilePanel profile={withProfile({ networkName: null })} />,
     );
     expect(screen.getByText("Réseau d'eau local")).toBeTruthy();
+  });
+
+  it("renders the dated freshness pastille when a freshnessDate is present", () => {
+    render(
+      <LiveWaterProfilePanel
+        profile={withProfile({ freshnessDate: "2024-03-15" })}
+      />,
+    );
+
+    expect(screen.getByTestId("water-freshness")).toBeTruthy();
+    expect(screen.getByText(/Dernière analyse : 15\/03\/2024/)).toBeTruthy();
+    // The year-granular fallback is replaced by the dated line.
+    expect(screen.queryByTestId("water-freshness-fallback")).toBeNull();
+    expect(screen.queryByText(/Analyses 2024/)).toBeNull();
+  });
+
+  it("falls back to the year-granular freshness line when no date is available", () => {
+    render(
+      <LiveWaterProfilePanel profile={withProfile({ freshnessDate: null })} />,
+    );
+
+    expect(screen.getByTestId("water-freshness-fallback")).toBeTruthy();
+    expect(screen.getByText(/Analyses 2024/)).toBeTruthy();
+    expect(screen.queryByTestId("water-freshness")).toBeNull();
   });
 });

--- a/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LocalWaterByPostalCode.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/__tests__/LocalWaterByPostalCode.test.tsx
@@ -51,6 +51,7 @@ const profile: LiveWaterProfile = {
   conformity: "C",
   mineralsMgL: { ca: 116.7, mg: 21.2, cl: 50.2, so4: 98.9, hco3: 322.5 },
   hardnessFrench: 125.4,
+  freshnessDate: null,
 };
 
 function renderComponent() {


### PR DESCRIPTION
## Summary

Mobile **PR-B** of the water-profile epic ([ADR-0025](docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md)) — the dated freshness pastille. Consumes the additive `freshnessDate` that the slice-2 backend ([#1374](https://github.com/benoit-bremaud/brasse-bouillon/pull/1374)) added to the `/water` DTO.

On the recipe **Water tab**, `LiveWaterProfilePanel` now upgrades the year-granular line to a dated pastille:

- Green **« Récent »** (< 6 months), orange **« À confirmer »** (6–24 months), grey **« Ancien »** (> 24 months), with `Dernière analyse : JJ/MM/AAAA — source ARS via Hub'Eau`.
- **Fallback** to the previous `Analyses {année}` line when no date is available (a pre-slice-2 backend response) — no fabricated age.

## Design

- Pure `describeWaterFreshness(freshnessDate, now): WaterFreshnessDisplay | null` in the **application** layer — `now` injected so the age is deterministic in tests. Strict `YYYY-MM-DD` parsing (rejects calendar rollovers like `2024-02-31`), local-time month arithmetic (documented — not `Date.UTC`).
- `LiveWaterProfile` + the DTO mapper gain the field (DTO optional → domain `string | null`, mapper defaults to `null`).
- Clean Architecture respected (domain ← application ← data; presentation calls the use-case only), design tokens + `StyleSheet.create`, no `any`, named exports.

## Review

Pre-push `pr-pre-reviewer`: **0 Must, 1 Should fixed**, 2 Nice, 2 Disagree (intentional). The Should: a **future** `freshnessDate` (clock skew / bad backend max date) would have rendered a reassuring green « Récent » — now guarded to fall back (ADR-0025 forbids anomalies reading as a legitimate state), with a test.

## Testing

- Freshness H/S/E + boundaries: exactly 6 months, exactly 24 months, future date → null, null → null, 5 malformed-date variants; the pastille-vs-fallback render branch and the `JJ/MM/AAAA` formatting.
- Full mobile suite green (139 suites / 1376 tests); typecheck + lint + format clean.

## Checklist

- [x] `ci:check` (lint + typecheck + format) + full test suite green locally
- [x] Additive consumption — no endpoint/contract change
- [x] Pre-push review run; Must + Should addressed
- [x] Clean Architecture, tokens, no `any`, named exports
