### PR TITLE
fix(website): legal pages compliance — real host, drop false claims (LCEN/RGPD)

### DIFF
--- a/packages/website/cookies-en.html
+++ b/packages/website/cookies-en.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cookie Policy — Brasse-Bouillon</title>
-  <meta name="description" content="Brasse-Bouillon cookie policy: opt-in consent and preference management.">
+  <meta name="description" content="Brasse-Bouillon cookie policy: no tracking cookies or audience measurement, no banner required.">
   <meta name="robots" content="noindex,follow">
   <link rel="canonical" href="https://brasse-bouillon.com/cookies-en">
   <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/cookies">
@@ -37,7 +37,7 @@
     <p class="lang-switch"><a href="/cookies" lang="fr">Lire en français</a></p>
 
     <h1>Cookie Policy</h1>
-    <p class="meta"><strong>Last updated:</strong> April 30, 2026</p>
+    <p class="meta"><strong>Last updated:</strong> July 9, 2026</p>
 
     <h2>1. What is a cookie?</h2>
     <p>
@@ -54,11 +54,6 @@
       Forms (newsletter, questionnaire, contact) embedded via Formspree may rely on the provider’s
       own technical mechanisms to transmit messages. No advertising or profiling cookie is set by
       the website itself.
-    </p>
-    <p>
-      The feedback widget (“Report”) uses your browser’s <strong>local storage</strong> (not cookies),
-      for purely technical purposes: rate-limiting submissions and queuing your messages if the network
-      drops. This data stays on your device and is not used for any tracking.
     </p>
 
     <h2>3. Legal basis</h2>
@@ -77,8 +72,7 @@
 
     <h2>5. Contact</h2>
     <p>
-      For any cookie-related question:
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      For any cookie-related question, use the <a href="/#participerFr">site form</a>.
     </p>
   </main>
 

--- a/packages/website/cookies.html
+++ b/packages/website/cookies.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Politique cookies — Brasse-Bouillon</title>
-  <meta name="description" content="Politique cookies Brasse-Bouillon : consentement opt-in et gestion des préférences.">
+  <meta name="description" content="Politique cookies Brasse-Bouillon : aucun cookie de traceur ni mesure d’audience, pas de bandeau requis.">
   <link rel="canonical" href="https://brasse-bouillon.com/cookies">
   <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/cookies">
   <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/cookies-en">
@@ -36,7 +36,7 @@
     <p class="lang-switch"><a href="/cookies-en" lang="en">Read in English</a></p>
 
     <h1>Politique cookies</h1>
-    <p class="meta"><strong>Dernière mise à jour :</strong> 30 avril 2026</p>
+    <p class="meta"><strong>Dernière mise à jour :</strong> 9 juillet 2026</p>
 
     <h2>1. Qu’est-ce qu’un cookie ?</h2>
     <p>
@@ -53,12 +53,6 @@
       Les formulaires (newsletter, questionnaire, contact) intégrés via Formspree peuvent reposer
       sur des mécanismes techniques propres au prestataire pour la transmission des messages.
       Aucun cookie publicitaire ni de profilage n’est déposé par le site lui-même.
-    </p>
-    <p>
-      Le widget de retour (« Signaler ») utilise le <strong>stockage local</strong> de votre navigateur
-      (et non des cookies), à des fins purement techniques : limiter le rythme des envois et mettre vos
-      messages en file d’attente en cas de coupure réseau. Ces données restent sur votre appareil et ne
-      servent à aucun suivi.
     </p>
 
     <h2>3. Base légale</h2>
@@ -78,8 +72,8 @@
 
     <h2>5. Contact</h2>
     <p>
-      Pour toute question relative à la politique cookies :
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      Pour toute question relative à la politique cookies, utilisez le
+      <a href="/#participerFr">formulaire du site</a>.
     </p>
   </main>
 

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -38,11 +38,11 @@
         <h1>English version <em>coming soon.</em></h1>
         <p class="intro">
           Brasse-Bouillon is currently presented in French only. An English edition is on the roadmap.
-          In the meantime, visit the French homepage or email us directly.
+          In the meantime, visit the French homepage or reach us via the site form.
         </p>
         <div class="hero-actions">
           <a class="btn btn-primary" href="/">Voir le site (FR)</a>
-          <a class="btn btn-ghost" href="mailto:contact@brasse-bouillon.com">Email us</a>
+          <a class="btn btn-ghost" href="/#participerFr">Contact us</a>
         </div>
         <div class="hero-mascot">
           <img class="logo" src="logo-hero.webp" alt="Official Brasse-Bouillon mascot" loading="eager" width="180" height="180">
@@ -52,7 +52,7 @@
       <footer class="footer">
         <div class="footer-brand">
           <span class="footer-mark">B·B</span>
-          <p>Contact: <strong>contact@brasse-bouillon.com</strong></p>
+          <p>Contact: via the <a href="/#participerFr">site form</a>.</p>
         </div>
         <div class="footer-links">
           <a href="/legal-en">Legal Notice</a>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -52,15 +52,9 @@
     "url": "https://brasse-bouillon.com/",
     "logo": "https://brasse-bouillon.com/logo.png",
     "description": "Projet d’application mobile de brassage amateur pour créer des recettes de bière, calculer IBU/ABV et suivre la fermentation.",
-    "email": "contact@brasse-bouillon.com",
     "founder": {
       "@type": "Person",
       "name": "Benoît Bremaud"
-    },
-    "contactPoint": {
-      "@type": "ContactPoint",
-      "email": "contact@brasse-bouillon.com",
-      "contactType": "customer service"
     },
     "knowsAbout": [
       "Brassage amateur",
@@ -334,7 +328,7 @@
               <span>Partager ton avis</span>
               <svg class="btn-chevron" viewBox="0 0 12 8" fill="none" aria-hidden="true"><path d="M1 1.5L6 6.5L11 1.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
             </button>
-            <a class="btn btn-ghost" href="mailto:contact@brasse-bouillon.com">Nous écrire</a>
+            <button class="btn btn-ghost" type="button" aria-controls="questionnaireFormFr" onclick="toggleQuestionnaire('fr')">Nous écrire</button>
           </div>
         </form>
         <p id="newsletterStatusFr" class="form-status" role="status" aria-live="polite"></p>
@@ -497,7 +491,7 @@
       <footer class="footer">
         <div class="footer-brand">
           <span class="footer-mark">B·B</span>
-          <p>Brasse-Bouillon, l’app du brasseur amateur curieux. Contact : <strong>contact@brasse-bouillon.com</strong></p>
+          <p>Brasse-Bouillon, l’app du brasseur amateur curieux. Contact : via le <a href="/#participerFr">formulaire du site</a>.</p>
         </div>
         <div class="footer-links">
           <a href="/legal">Mentions légales</a>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -328,7 +328,7 @@
               <span>Partager ton avis</span>
               <svg class="btn-chevron" viewBox="0 0 12 8" fill="none" aria-hidden="true"><path d="M1 1.5L6 6.5L11 1.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
             </button>
-            <button class="btn btn-ghost" type="button" aria-controls="questionnaireFormFr" onclick="toggleQuestionnaire('fr')">Nous écrire</button>
+            <button class="btn btn-ghost" type="button" onclick="toggleQuestionnaire('fr')">Nous écrire</button>
           </div>
         </form>
         <p id="newsletterStatusFr" class="form-status" role="status" aria-live="polite"></p>

--- a/packages/website/legal-en.html
+++ b/packages/website/legal-en.html
@@ -36,19 +36,22 @@
     <p class="lang-switch"><a href="/legal" lang="fr">Lire en français</a></p>
 
     <h1>Legal Notice</h1>
-    <p class="meta"><strong>Last updated:</strong> February 27, 2026</p>
+    <p class="meta"><strong>Last updated:</strong> July 9, 2026</p>
 
     <h2>1. Website publisher</h2>
     <p>
-      The <strong>Brasse-Bouillon</strong> website is published by Benoît Bremaud (contact:
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>).<br>
-      The project is currently in a <strong>pre-incubation phase</strong> (no incorporated company yet).
+      The <strong>Brasse-Bouillon</strong> website is published by <strong>Benoît Bremaud</strong>.<br>
+      <strong>Publication director:</strong> Benoît Bremaud.<br>
+      The project is currently in a <strong>pre-incubation phase</strong> (no incorporated company yet).<br>
+      Contact: via the <a href="/#participerFr">site form</a>.
     </p>
 
     <h2>2. Hosting</h2>
     <p>
-      The website is hosted by <strong>GitHub Pages</strong> (GitHub, Inc., 88 Colin P. Kelly Jr. Street,
-      San Francisco, CA 94107, USA).
+      The website is hosted on <strong>Cloudflare Pages</strong>, a service of
+      <strong>Cloudflare Portugal, Unipessoal, Lda.</strong> — Av. da Índia 10, 6º Piso,
+      1300-299 Lisboa, Portugal — Tel. +351 21 123 0932.<br>
+      <span class="meta">(A company of the Cloudflare, Inc. group, 101 Townsend Street, San Francisco, CA 94107, USA.)</span>
     </p>
 
     <h2>3. Purpose of the website</h2>
@@ -72,9 +75,8 @@
 
     <h2>6. Cookies</h2>
     <p>
-      Cookie usage is detailed in the
-      <a href="/cookies-en">Cookie Policy</a>.
-      Audience measurement cookies are only activated after opt-in consent.
+      The site <strong>uses no audience-measurement cookies and no trackers</strong>; therefore no consent
+      banner is required. Details are provided in the <a href="/cookies-en">Cookie Policy</a>.
     </p>
 
     <h2>7. Liability</h2>
@@ -93,8 +95,7 @@
     <h2>9. Governing law and disputes</h2>
     <p>
       Unless mandatory local law provides otherwise, these legal notices are governed by French law.
-      For any claim, please contact us first at
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      For any claim, please contact us first via the <a href="/#participerFr">site form</a>.
     </p>
   </main>
 

--- a/packages/website/legal.html
+++ b/packages/website/legal.html
@@ -35,19 +35,22 @@
     <p class="lang-switch"><a href="/legal-en" lang="en">Read in English</a></p>
 
     <h1>Mentions légales</h1>
-    <p class="meta"><strong>Dernière mise à jour :</strong> 27 février 2026</p>
+    <p class="meta"><strong>Dernière mise à jour :</strong> 9 juillet 2026</p>
 
     <h2>1. Éditeur du site</h2>
     <p>
-      Le site <strong>Brasse-Bouillon</strong> est édité par Benoît Bremaud (contact :
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>).<br>
-      Le projet est actuellement en <strong>phase de pré-incubation</strong> (pas encore de société immatriculée).
+      Le site <strong>Brasse-Bouillon</strong> est édité par <strong>Benoît Bremaud</strong>.<br>
+      <strong>Directeur de la publication :</strong> Benoît Bremaud.<br>
+      Le projet est actuellement en <strong>phase de pré-incubation</strong> (pas encore de société immatriculée).<br>
+      Contact : via le <a href="/#participerFr">formulaire du site</a>.
     </p>
 
     <h2>2. Hébergement</h2>
     <p>
-      Le site est hébergé par <strong>GitHub Pages</strong> (GitHub, Inc., 88 Colin P. Kelly Jr. Street,
-      San Francisco, CA 94107, États-Unis).
+      Le site est hébergé par <strong>Cloudflare Pages</strong>, service de
+      <strong>Cloudflare Portugal, Unipessoal, Lda.</strong> — Av. da Índia 10, 6º Piso,
+      1300-299 Lisboa, Portugal — Tél. +351 21 123 0932.<br>
+      <span class="meta">(Entité du groupe Cloudflare, Inc., 101 Townsend Street, San Francisco, CA 94107, États-Unis.)</span>
     </p>
 
     <h2>3. Objet du site</h2>
@@ -71,9 +74,8 @@
 
     <h2>6. Cookies</h2>
     <p>
-      Les règles d’utilisation des cookies sont détaillées dans la
-      <a href="/cookies">Politique cookies</a>.
-      Les cookies de mesure d’audience sont activés uniquement après consentement (opt-in).
+      Le site <strong>n’utilise aucun cookie de mesure d’audience ni traceur</strong> ; aucun bandeau
+      de consentement n’est donc requis. Les détails figurent dans la <a href="/cookies">Politique cookies</a>.
     </p>
 
     <h2>7. Responsabilité</h2>
@@ -92,8 +94,8 @@
     <h2>9. Droit applicable et litiges</h2>
     <p>
       Sauf disposition impérative contraire applicable localement, les présentes mentions sont régies
-      par le droit français. Pour toute réclamation, merci de nous contacter d’abord à
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      par le droit français. Pour toute réclamation, merci de nous contacter d’abord via le
+      <a href="/#participerFr">formulaire du site</a>.
     </p>
   </main>
 

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -37,30 +37,24 @@
     <p class="lang-switch"><a href="/privacy" lang="fr">Lire en français</a></p>
 
     <h1>Privacy Policy</h1>
-    <p class="meta"><strong>Last updated:</strong> April 30, 2026</p>
+    <p class="meta"><strong>Last updated:</strong> July 9, 2026</p>
 
     <h2>1. Data controller</h2>
     <p>
-      Processing activities described below are carried out by Brasse-Bouillon (pre-incubation project),
-      contact: <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      The data controller is <strong>Benoît Bremaud</strong> (Brasse-Bouillon, pre-incubation project).
+      Contact: via the <a href="/#participerFr">site form</a>.
     </p>
 
     <h2>2. Data we collect</h2>
     <ul>
-      <li>Contact details (email, message) through the contact form.</li>
+      <li>Contact data (the message and details you provide) submitted through the site form.</li>
       <li>Newsletter subscription data (email).</li>
       <li>Product questionnaire data (profile, usage, priorities, suggestions).</li>
-      <li>
-        Feedback sent through the “Report” widget: the feedback <em>content</em> (the message you write
-        + minimal technical context — the page, the previous page, browser, screen size, language) is
-        sent only when you click to submit. Note: simply loading the widget on the page already issues a
-        request to the third-party processor (Cloudflare), which then receives your IP address and the
-        request's standard headers.
-      </li>
     </ul>
     <p>
       The site uses no third-party audience measurement tool and no tracking cookies.
-      No browsing data is collected for analytics purposes.
+      No browsing data is collected for analytics purposes. Web fonts are <strong>self-hosted</strong>:
+      no data is sent to a third-party font provider.
     </p>
 
     <h2>3. Purposes and legal bases</h2>
@@ -68,32 +62,34 @@
       <li><strong>Replying to messages</strong>: legitimate interest and/or pre-contractual steps.</li>
       <li><strong>Sending newsletters</strong>: explicit consent (form checkbox).</li>
       <li><strong>Improving the product</strong> through questionnaire responses: explicit consent.</li>
-      <li><strong>Handling feedback</strong> sent via the “Report” widget: legitimate interest (fixing and improving the site/product).</li>
     </ul>
 
     <h2>4. Recipients and international transfers</h2>
-    <p>
-      Data may be processed by technical processors (Formspree for receiving forms, a Cloudflare
-      Workers service for receiving the “Report” widget feedback, GitHub Pages for static hosting).
-      These services may involve transfers outside the EU (including the US).
-      Where required, appropriate safeguards are used (such as standard contractual clauses or
-      equivalent mechanisms).
-    </p>
+    <p>Data may be processed by the following technical processors:</p>
+    <ul>
+      <li>
+        <strong>Formspree, Inc.</strong> (USA) — receiving forms. The transfer outside the EU is governed
+        by <strong>Standard Contractual Clauses</strong> (GDPR art. 46); a copy is available on request.
+      </li>
+      <li>
+        <strong>Cloudflare</strong> — website hosting (Cloudflare Pages). Cloudflare, Inc. is certified
+        under the <strong>EU-US Data Privacy Framework</strong>; the transfer to the US is covered by the
+        European Commission's adequacy decision.
+      </li>
+    </ul>
 
     <h2>5. Data retention</h2>
     <ul>
       <li>Contact data: up to 3 years after the last interaction.</li>
       <li>Newsletter data: until unsubscribe, or 3 years of inactivity.</li>
       <li>Questionnaire data: up to 3 years for product analysis.</li>
-      <li>“Report” widget feedback: up to 2 years, then deleted or anonymized.</li>
     </ul>
 
     <h2>6. Your rights</h2>
     <p>
       Depending on your country of residence (EU GDPR, US local laws such as CPRA, etc.),
       you may request access, correction, deletion, restriction, objection, portability,
-      and withdrawal of consent at any time. To exercise your rights:
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      and withdrawal of consent at any time. To exercise your rights, use the <a href="/#participerFr">site form</a>.
     </p>
 
     <h2>7. Security</h2>
@@ -109,8 +105,9 @@
 
     <h2>9. Complaints</h2>
     <p>
-      Please contact us first for any privacy question. If you are in the EU, you may also contact
-      your local data protection authority.
+      Please contact us first for any privacy question. You also have the right to lodge a complaint with
+      the French data protection authority, the <strong>CNIL</strong> (<a href="https://www.cnil.fr">www.cnil.fr</a>),
+      or with the supervisory authority of your EU country of residence.
     </p>
   </main>
 

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -36,30 +36,24 @@
     <p class="lang-switch"><a href="/privacy-en" lang="en">Read in English</a></p>
 
     <h1>Politique de confidentialité</h1>
-    <p class="meta"><strong>Dernière mise à jour :</strong> 30 avril 2026</p>
+    <p class="meta"><strong>Dernière mise à jour :</strong> 9 juillet 2026</p>
 
     <h2>1. Responsable du traitement</h2>
     <p>
-      Les traitements décrits ci-dessous sont réalisés par Brasse-Bouillon (projet en pré-incubation),
-      contact : <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      Le responsable du traitement est <strong>Benoît Bremaud</strong> (Brasse-Bouillon, projet en
+      pré-incubation). Contact : via le <a href="/#participerFr">formulaire du site</a>.
     </p>
 
     <h2>2. Données collectées</h2>
     <ul>
-      <li>Données de contact (email, message) via formulaire de contact.</li>
+      <li>Données de contact (message et coordonnées que vous fournissez) transmises via le formulaire du site.</li>
       <li>Données d’inscription newsletter (email).</li>
       <li>Données de questionnaire produit (profil, usages, priorités, suggestions).</li>
-      <li>
-        Retours envoyés via le widget « Signaler » : le <em>contenu</em> du retour (le message que vous
-        rédigez + un contexte technique minimal — page concernée, page précédente, navigateur, taille
-        d’écran, langue) n’est transmis que lorsque vous cliquez pour envoyer. À noter : le simple
-        chargement du widget sur la page déclenche déjà une requête vers le prestataire tiers
-        (Cloudflare), qui reçoit alors votre adresse IP et les en-têtes standard de la requête.
-      </li>
     </ul>
     <p>
       Le site n’utilise aucun outil de mesure d’audience tiers et aucun cookie de tracking.
-      Aucune donnée de navigation n’est collectée à des fins analytiques.
+      Aucune donnée de navigation n’est collectée à des fins analytiques. Les polices d’écriture
+      sont <strong>auto-hébergées</strong> : aucune donnée n’est transmise à un fournisseur de polices tiers.
     </p>
 
     <h2>3. Finalités et bases légales</h2>
@@ -67,32 +61,35 @@
       <li><strong>Répondre aux messages</strong> : intérêt légitime et/ou mesures précontractuelles.</li>
       <li><strong>Envoyer la newsletter</strong> : consentement explicite (case à cocher au formulaire).</li>
       <li><strong>Améliorer le produit</strong> via questionnaire : consentement explicite.</li>
-      <li><strong>Traiter les retours</strong> envoyés via le widget « Signaler » : intérêt légitime (corriger et améliorer le site/produit).</li>
     </ul>
 
     <h2>4. Destinataires et transferts internationaux</h2>
-    <p>
-      Les données peuvent être traitées par des sous-traitants techniques (Formspree pour la réception
-      des formulaires, un service Cloudflare Workers pour la réception des retours du widget « Signaler »,
-      GitHub Pages pour l’hébergement statique). Ces services peuvent impliquer des
-      transferts hors UE (notamment vers les États-Unis). Lorsque nécessaire, des garanties appropriées
-      sont utilisées (clauses contractuelles types ou mécanisme équivalent).
-    </p>
+    <p>Les données peuvent être traitées par des sous-traitants techniques :</p>
+    <ul>
+      <li>
+        <strong>Formspree, Inc.</strong> (États-Unis) — réception des formulaires. Le transfert hors UE
+        est encadré par les <strong>Clauses Contractuelles Types</strong> (art. 46 RGPD) ; une copie est
+        disponible sur demande.
+      </li>
+      <li>
+        <strong>Cloudflare</strong> — hébergement du site (Cloudflare Pages). Cloudflare, Inc. est certifié
+        <strong>EU-US Data Privacy Framework</strong> ; le transfert vers les États-Unis est couvert par
+        la décision d’adéquation de la Commission européenne.
+      </li>
+    </ul>
 
     <h2>5. Durées de conservation</h2>
     <ul>
       <li>Contact : jusqu’à 3 ans après le dernier échange.</li>
       <li>Newsletter : jusqu’au désabonnement ou 3 ans d’inactivité.</li>
       <li>Questionnaire : jusqu’à 3 ans pour l’analyse produit.</li>
-      <li>Retours du widget « Signaler » : jusqu’à 2 ans, puis suppression ou anonymisation.</li>
     </ul>
 
     <h2>6. Vos droits</h2>
     <p>
       Selon votre pays de résidence (RGPD UE, droits locaux US/CPRA, etc.), vous pouvez demander l’accès,
       la rectification, l’effacement, la limitation, l’opposition, la portabilité, et le retrait du consentement
-      à tout moment. Pour exercer ces droits :
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      à tout moment. Pour exercer ces droits, utilisez le <a href="/#participerFr">formulaire du site</a>.
     </p>
 
     <h2>7. Sécurité</h2>
@@ -108,8 +105,9 @@
 
     <h2>9. Réclamations</h2>
     <p>
-      Vous pouvez nous contacter d’abord pour toute question. Si vous êtes dans l’UE,
-      vous pouvez également saisir votre autorité de protection des données locale.
+      Vous pouvez nous contacter d’abord pour toute question. Vous avez également le droit d’introduire
+      une réclamation auprès de la <strong>CNIL</strong> (autorité française de protection des données —
+      <a href="https://www.cnil.fr">www.cnil.fr</a>) ou de l’autorité de votre pays de résidence dans l’UE.
     </p>
   </main>
 

--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -342,6 +342,23 @@ def check_no_external_fonts(root: Path = ROOT) -> list[str]:
     return errors
 
 
+def check_no_stale_host(root: Path = ROOT) -> list[str]:
+    """The site is hosted on Cloudflare Pages (ADR-0014), not GitHub Pages.
+    The legally-required hosting disclosure in the mentions légales must name
+    the real host — guards against re-introducing the stale "GitHub Pages"
+    host anywhere in the HTML (a factual/legal inaccuracy fixed in the legal
+    pages overhaul)."""
+    pattern = re.compile(r"GitHub\s+Pages", flags=REGEX_FLAGS)
+    errors: list[str] = []
+    for path in sorted(root.glob("*.html")):
+        if pattern.search(path.read_text(encoding="utf-8")):
+            errors.append(
+                f"{path.name}: mention « GitHub Pages » — l'hébergeur est "
+                "Cloudflare Pages (ADR-0014) ; corriger la disclosure d'hébergement"
+            )
+    return errors
+
+
 def collect_errors(root: Path = ROOT) -> list[str]:
     errors: list[str] = []
     errors.extend(check_required_files(root))
@@ -352,6 +369,7 @@ def collect_errors(root: Path = ROOT) -> list[str]:
     errors.extend(check_robots_policy(root))
     errors.extend(check_clean_seo_urls(root))
     errors.extend(check_no_external_fonts(root))
+    errors.extend(check_no_stale_host(root))
     return errors
 
 

--- a/packages/website/terms-en.html
+++ b/packages/website/terms-en.html
@@ -37,7 +37,7 @@
     <p class="lang-switch"><a href="/terms" lang="fr">Lire en français</a></p>
 
     <h1>Terms of Use</h1>
-    <p class="meta"><strong>Last updated:</strong> February 27, 2026</p>
+    <p class="meta"><strong>Last updated:</strong> July 9, 2026</p>
 
     <h2>1. Purpose</h2>
     <p>
@@ -98,8 +98,7 @@
 
     <h2>10. Contact</h2>
     <p>
-      For legal questions:
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      For legal questions, use the <a href="/#participerFr">site form</a>.
     </p>
   </main>
 

--- a/packages/website/terms.html
+++ b/packages/website/terms.html
@@ -36,7 +36,7 @@
     <p class="lang-switch"><a href="/terms-en" lang="en">Read in English</a></p>
 
     <h1>Conditions d’utilisation</h1>
-    <p class="meta"><strong>Dernière mise à jour :</strong> 27 février 2026</p>
+    <p class="meta"><strong>Dernière mise à jour :</strong> 9 juillet 2026</p>
 
     <h2>1. Objet</h2>
     <p>
@@ -96,8 +96,7 @@
 
     <h2>10. Contact</h2>
     <p>
-      Pour toute question juridique :
-      <a href="mailto:contact@brasse-bouillon.com">contact@brasse-bouillon.com</a>.
+      Pour toute question juridique, utilisez le <a href="/#participerFr">formulaire du site</a>.
     </p>
   </main>
 

--- a/packages/website/tests/test_quality_gate.py
+++ b/packages/website/tests/test_quality_gate.py
@@ -208,6 +208,22 @@ class QualityGateTests(unittest.TestCase):
             errors = quality_gate.collect_errors(root)
             self.assertTrue(any("Google Fonts" in err for err in errors))
 
+    def test_detects_stale_github_pages_host(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            legal_path = root / "legal.html"
+            legal_path.write_text(
+                legal_path.read_text(encoding="utf-8").replace(
+                    "</body>",
+                    "<p>Le site est hébergé par GitHub Pages.</p></body>",
+                ),
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.collect_errors(root)
+            self.assertTrue(any("GitHub Pages" in err for err in errors))
+
     def test_detects_canonical_pointing_to_html(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)


### PR DESCRIPTION
## Summary

Meticulous compliance rewrite of all **8 legal pages** (FR + EN) plus removal of the dead `contact@` mailbox from the homepages. The site moved to Cloudflare Pages (ADR-0014) but the legal pages still named GitHub Pages as host and over/under-disclosed data flows. Aligned to **LCEN art. 1-1** (loi SREN 2024) and **RGPD art. 13**.

## Legal pages (legal / privacy / cookies / terms + EN twins)

- **Hosting disclosure** → **Cloudflare Portugal, Unipessoal, Lda.** (Av. da Índia 10, Lisboa, +351 21 123 0932); add the **publication director** (LCEN).
- Remove the **false "audience-measurement cookies, opt-in"** claim (no such cookie — GA removed #817; it contradicted the cookies/privacy pages) and the "opt-in preferences" cookie meta description.
- Remove the **"Signaler" feedback-widget** data flow (Cloudflare Workers + localStorage) described as active — it is host-gated **OFF in production**.
- Fix **sub-processors + transfer safeguards**: Formspree (US, **SCC** art. 46) and Cloudflare (host, **EU-US DPF** adequacy). Fonts are self-hosted (no Google).
- Make the **CNIL** complaint right explicit; harmonise all dates to 2026-07-09.
- Contact → the **working site form** (`contact@` mailbox not yet routed).

## Homepages (index / index-en)

- Remove the dead `contact@brasse-bouillon.com`: "Nous écrire"/"Email us" now open/point to the questionnaire form (functionally verified), footer → site form, and the schema.org JSON-LD `email`/`contactPoint` are dropped.

## Guard + review

- Quality gate: new **`check_no_stale_host`** forbids re-introducing "GitHub Pages" in any HTML (+ test).
- **Two-lens pre-push review** (standards + legal-accuracy): **0 Must Have**, 0 factual error — Cloudflare host block exact, DPF/SCC correctly attributed, all art. 13 elements present, FR/EN parity clean.
- Local: quality gate + **17 tests** pass; legal/privacy rendered & "Nous écrire" verified.

Refs #1044.

Deferred (noted): stale `packages/website/CLAUDE.md` host line (separate docs pass); re-add a direct contact email once Cloudflare Email Routing is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)