### PR TITLE
fix(website): faq-bot widget 400-vs-503 UX (#1314) + wire live API origin

### DIFF
--- a/docs/architecture/decisions/0022-public-faq-chatbot-llm.md
+++ b/docs/architecture/decisions/0022-public-faq-chatbot-llm.md
@@ -183,6 +183,38 @@ invisible proof-of-work step (no user interaction in the common case).
 
 ---
 
+## Activation addendum (2026-07-09) — Option A rollout & budget backstop
+
+Recorded when activating the shipped module (#1293). Refines, does not overturn, the
+Locked v1 parameters above.
+
+**Rollout topology — "Option A" (single API + kill-switch).** Rather than standing up a
+separate staging faq-bot API (the earlier `staging-api.brasse-bouillon.com` placeholder, now
+dropped), the website **staging** host canaries directly against the single live API
+(`brasse-bouillon-api.fly.dev`), with exposure gated by the server-side `FAQ_BOT_ENABLED`
+kill-switch. This reverses the widget's original "staging must not point at the prod API" note.
+Rationale: the faq-bot module is isolated and additive, protected by ALTCHA + throttle + budget
+cap + kill-switch, and "one live API for all consumers" is already the monorepo precedent
+(ADR-0002; `eas.json` points the mobile preview builds at the same instance). The production
+hosts are pre-wired in `API_BASE_BY_HOST` but kept **out of `WIDGET_HOSTS`** until the go-live
+flip, so the launcher still never mounts on production before then. Residual risk (operational,
+not code): staging-canary traffic shares the single monthly budget cap.
+
+**Budget backstop.** The authoritative monthly ceiling is a **hard spending limit set
+Mistral-console-side** (workspace-level — a genuine hard stop that suspends API access at the
+cap), because the in-memory `FaqBotMetrics` counter resets on Fly scale-to-zero and so cannot
+guarantee a monthly cap under sporadic traffic. The in-memory gate stays as a secondary
+fast-fail; counter persistence remains v2.
+
+**Widget availability UX (#1314).** The widget maps an HTTP `400` on `/ask` with **no anti-bot
+proof attached** to the "unavailable" message (not the generic retry message), because
+`BotCheckGuard` runs before the `ValidationPipe`, so such a 400 can only mean the ALTCHA
+handshake could not complete (challenge endpoint down / unsolvable) — an availability problem,
+not a malformed question. Any change to that guard/pipe order must preserve this contract or
+update the widget.
+
+---
+
 ## References
 
 - ADR-0001 (build for today) · ADR-0002 (proxy) · ADR-0003 / ADR-0012 (RGPD) · ADR-0019 (tests).

--- a/packages/website/chat-widget.js
+++ b/packages/website/chat-widget.js
@@ -182,6 +182,7 @@ const WIDGET_STYLES = `
 .bb-chat__msg--error { background: var(--color-accent-soft); color: var(--color-error); }
 .bb-chat__msg--pending { opacity: 0.7; font-style: italic; }
 .bb-chat__chips { display: flex; flex-wrap: wrap; gap: 8px; padding: 0 16px 12px; }
+.bb-chat__chips[hidden] { display: none; }
 .bb-chat__chip { padding: 7px 12px; cursor: pointer; font: inherit; font-size: 0.85rem;
   color: var(--copper-deep); background: transparent;
   border: 1px solid var(--line); border-radius: var(--radius-xl);
@@ -361,6 +362,9 @@ function mountChatWidget() {
     busy = true;
     submit.disabled = true;
     input.value = '';
+    // Suggestion chips are conversation starters: hide them once the first question is
+    // sent so the freed space (~25% of the panel) goes to reading the bot's answers.
+    chips.hidden = true;
     addMessage('user', trimmed);
     const pending = addMessage('bot', t.thinking, 'pending');
 

--- a/packages/website/chat-widget.js
+++ b/packages/website/chat-widget.js
@@ -24,17 +24,25 @@ const WIDGET_HOSTS = [
   '127.0.0.1',
 ];
 
+/** The single live NestJS API on Fly (the faq-bot module is part of it). */
+const LIVE_API_ORIGIN = 'https://brasse-bouillon-api.fly.dev';
+
 /**
  * NestJS `faq-bot` API origin per host. Localhost points at the dev API (PORT=3000).
- * The staging origin is a deploy-time placeholder — it must point at the deployed STAGING
- * faq-bot API, never at production, so staging never exercises the prod API. Set the real
- * origin (or inject it at deploy) once the backend is deployed with the ALTCHA/Mistral keys.
+ *
+ * Activation topology (ADR-0022, Option A): rather than standing up a separate staging API,
+ * the staging site canaries directly against the single live API, with exposure gated by the
+ * server-side `FAQ_BOT_ENABLED` kill-switch. Until the bot is enabled the live API answers
+ * `/ask` with 503 (or 400 when the anti-bot handshake cannot complete), so the widget shows
+ * "unavailable" and nothing is exercised. The production hosts are wired here too but stay OUT
+ * of `WIDGET_HOSTS` until the go-live flip, so the launcher still never mounts on prod in v1.
  */
 const API_BASE_BY_HOST = {
   localhost: 'http://localhost:3000',
   '127.0.0.1': 'http://localhost:3000',
-  // TODO(deploy): set to the deployed STAGING faq-bot API origin (must NOT be the prod API).
-  'staging.brasse-bouillon-website.pages.dev': 'https://staging-api.brasse-bouillon.com',
+  'staging.brasse-bouillon-website.pages.dev': LIVE_API_ORIGIN,
+  'brasse-bouillon.com': LIVE_API_ORIGIN,
+  'www.brasse-bouillon.com': LIVE_API_ORIGIN,
 };
 
 /** Upper bound for the proof-of-work search (must be >= the server's maxnumber). */
@@ -328,11 +336,18 @@ function mountChatWidget() {
     }
   };
 
-  const errorFor = (status) => {
+  const errorFor = (status, hadProof) => {
     if (status === 429) {
       return t.errorRate;
     }
     if (status === 503) {
+      return t.errorUnavailable;
+    }
+    // #1314: a 400 with no anti-bot proof attached means the ALTCHA challenge round-trip
+    // failed (endpoint down / unsolvable) and the guard rejected the unproven request. That
+    // is an availability problem, not a malformed question — surface "unavailable", not the
+    // generic "try again in a moment". (In dev the guard bypasses, so this path never hits.)
+    if (status === 400 && !hadProof) {
       return t.errorUnavailable;
     }
     return t.errorGeneric;
@@ -370,7 +385,7 @@ function mountChatWidget() {
       });
 
       if (!res.ok) {
-        pending.textContent = errorFor(res.status);
+        pending.textContent = errorFor(res.status, Boolean(altcha));
         pending.classList.remove('bb-chat__msg--pending');
         pending.classList.add('bb-chat__msg--error');
         return;
@@ -418,6 +433,9 @@ function mountChatWidget() {
   });
 }
 
+// Mount only on the allow-listed hosts. The production hosts are intentionally absent from
+// WIDGET_HOSTS (even though API_BASE_BY_HOST pre-wires them), so the launcher never appears on
+// brasse-bouillon.com until the go-live flip (ADR-0022 activation addendum, Option A).
 if (WIDGET_HOSTS.includes(window.location.hostname)) {
   mountChatWidget();
 }

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -78,6 +78,6 @@
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
   <!-- FAQ chat widget — self-hosted; mounts on staging/localhost only (ADR-0022) -->
-  <script type="module" src="chat-widget.js?v=20260701"></script>
+  <script type="module" src="chat-widget.js?v=20260709"></script>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -572,6 +572,6 @@
   <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
   <!-- FAQ chat widget — self-hosted; mounts on staging/localhost only (ADR-0022) -->
-  <script type="module" src="chat-widget.js?v=20260701"></script>
+  <script type="module" src="chat-widget.js?v=20260709"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Last-mile activation prep for the public FAQ chatbot (ADR-0022). The widget stays gated **off** production — nothing is activated by this PR.

- **#1314 fix** — `errorFor(status, hadProof)` now maps an HTTP `400` on `/ask` with no anti-bot proof attached to the "unavailable" message instead of the generic retry message. Unaffected in local dev (there `/challenge` returns 503 but `/ask` bypasses the guard, so no 400 arises).
- **Option A topology** — single live API + `FAQ_BOT_ENABLED` kill-switch: the staging host and (pre-wired, inert) production hosts point at `brasse-bouillon-api.fly.dev`; production hosts stay **out of `WIDGET_HOSTS`** until the go-live flip, so the launcher never mounts on prod in v1.
- **Cache-bust** — `chat-widget.js?v=20260709` on both landing pages (FR + EN).
- **ADR-0022** — activation addendum documenting Option A, the Mistral-console budget backstop, and the widget 400→unavailable availability contract.

## Context

Activation of the shipped-but-inert faq-bot (#1293 / #1311 / #1315). Agent-side "Phase 2" of the phased go-live (widget correctness + origin wiring). It activates nothing on its own: the bot only comes alive once the Fly secrets (`MISTRAL_API_KEY`, `ALTCHA_HMAC_KEY`) are set and `FAQ_BOT_ENABLED=true` — separate operator steps. The prompt eval gate is green (13/13).

## Checklist

- [x] Widget stays off production (`WIDGET_HOSTS` unchanged)
- [x] Local dev path unaffected by the 400 mapping
- [x] Website quality gate passes
- [x] `node --check` on the widget passes
- [x] EN/FR cache-bust parity
- [x] ADR-0022 updated in lockstep (conception = contract)
- [x] Pre-push review (Claude `pr-pre-reviewer`); Codex CLI unavailable this run (arg break) — noted

Closes #1314