### PR TITLE
docs(website/architecture): website i18n epic conception (ADR-0027, UML, EN launch playbook)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,7 @@ Currently accepted ADRs (see each file for the `Status` line and full rationale)
 - [ADR-0024 — Recipe brewing-difficulty badge: rule-based, max-dominates, backend-computed](docs/architecture/decisions/0024-recipe-difficulty-scoring.md)
 - [ADR-0025 — Local water profile: postal-code geolocation, live proxy first, append-only cache second](docs/architecture/decisions/0025-water-profile-geolocation-and-caching.md)
 - [ADR-0026 — Equipment capacity fit-check: advisory pre-batch readiness, backend-computed](docs/architecture/decisions/0026-equipment-capacity-fit-check.md)
+- [ADR-0027 — Website internationalization strategy (bilingual FR+EN marketing site)](docs/architecture/decisions/0027-website-i18n-strategy.md)
 
 When a new ADR is accepted, add its file link here (no dates, no per-ADR summaries — open the file for the live status and content). When reviewing a PR, flag any diff that violates these ADRs and cite the ADR number and clause in the review comment.
 

--- a/docs/architecture/decisions/0027-website-i18n-strategy.md
+++ b/docs/architecture/decisions/0027-website-i18n-strategy.md
@@ -1,0 +1,287 @@
+# ADR-0027 — Website Internationalization Strategy (Bilingual FR+EN Marketing Site)
+
+**Status**  Proposed
+**Date**    2026-07-10
+**Owners**  @benoit-bremaud
+
+---
+
+## Context
+
+The marketing site (`packages/website`) is an intentionally **build-less** static
+HTML/CSS/JS site on Cloudflare Pages (ADR-0014). It is French-first: the English
+home (`index-en.html`) is an 83-line "coming soon" stub, `noindex,follow`, with a
+canonical pointing to the FR home — a **deliberate de-indexing decision** recorded
+in `SEO_RUNBOOK.md`. The 4 EN legal twins (`legal-en`, `privacy-en`, `cookies-en`,
+`terms-en`) exist and were rewritten for LCEN/RGPD compliance in PR #1379, but are
+also `noindex` while EN is a stub.
+
+The goal is now to promote the project on Reddit and international homebrewing
+communities (mostly English-speaking). A French-only landing page wastes that
+traffic. Bilingual FR+EN is already back in scope per epic #1075.
+
+Constraints and observations that shaped this decision:
+
+1. **Twin-drift pain is real and recent.** The house rule ("every FR change
+   requires an EN update in the same PR", `packages/website/CLAUDE.md`
+   § Languages) is enforced by discipline only. The 8 legal twins drifted before
+   #1379 fixed them. The home page is the **most-edited page** of the site
+   (Kinetic refresh, feature sections, an "Académie" section being designed in
+   parallel) — hand-maintained twins there guarantee drift.
+2. **The site must stay deploy-simple.** `website-deploy.yml` glob-copies flat
+   files into `_site/` and pushes to Cloudflare Pages. Any mechanism must not
+   force a deploy-time build.
+3. **A Python precedent exists.** `scripts/quality_gate.py` (stdlib-only, tested
+   by `tests/test_quality_gate.py`, run by the `website:` CI job) already polices
+   structural invariants — including, today, the `index-en.html` noindex and the
+   "sitemap = FR home only" policy, both of which this epic must update.
+4. **Groundwork is already in place.** Both Formspree forms already post a hidden
+   `lang=fr` field; `site.js` (`BBShared`) is already parameterized `fr`/`en` for
+   form/menu DOM ids. The legal pages already have visible `.lang-switch` links.
+5. **Privacy claims are load-bearing.** The site uses **no** cookies, no
+   localStorage, no analytics — and `cookies(-en).html` / `privacy(-en).html`
+   explicitly promise it (made accurate in #1379). Any language-preference
+   persistence must keep those pages truthful.
+
+### Documented study (why we are not guessing)
+
+A full repo reconnaissance (2026-07-10) inventoried: the page pairs and their
+URL scheme (`-en.html` suffix served at clean URLs), the exact `<head>` SEO state
+of every pair (FR home advertises `fr` + `x-default` only; legal pairs advertise
+`fr`+`en`), the 9 quality-gate check functions and which ones hard-code the
+current EN policy, the `_site/` staging steps, and the absence of any storage
+API usage in `site.js`. The matrices below score against those facts, not
+assumptions.
+
+## Decision
+
+### D1 — Content-maintenance strategy: hybrid (weighted decision matrix)
+
+Options considered:
+
+- **A. Guarded twins** — keep hand-maintained FR/EN twin files for every page;
+  add CI guards (structure-parity check + a freshness stamp: each EN page embeds
+  a hash of the FR twin it translates, recomputed by the gate).
+- **B. Full generation** — single content source for **all** public pages;
+  a stdlib Python script generates both languages; generated output committed.
+- **C. Hybrid (chosen)** — generation for the **home pair only** (the volatile
+  page); guarded twins (option A mechanics) for the **legal pages** (stable,
+  legally distinct prose that would be painful and pointless to templatize).
+
+| Criterion (weight) | A. Guarded twins | B. Full generation | **C. Hybrid** |
+|---|---|---|---|
+| Drift risk (30%) | 3 | 5 | **5** |
+| Recurring maintenance cost (20%) | 2 | 4 | **4** |
+| Contributor UX (15%) | 4 | 2 | **4** |
+| Tooling complexity (15%) | 4 | 2 | **3** |
+| Deploy-workflow impact (10%) | 5 | 4 | **4** |
+| Quality-gate compatibility (10%) | 4 | 3 | **4** |
+| **Weighted score** | **3.40** | **3.60** | **4.15** |
+
+Score rationale:
+
+- *Drift risk*: A only **detects** drift (CI red), a human still ports every
+  change twice; B and C make structural drift on generated pages impossible and
+  turn missing translations into CI failures.
+- *Recurring maintenance*: the home is edited weekly; A doubles every edit. B and
+  C reduce a copy change to "edit FR + update the flagged catalog keys".
+- *Contributor UX*: A and C keep plain hand-edited HTML where humans write prose
+  (all pages in A; legal pages and the FR home in C). B forces template
+  indirection everywhere, including page-long legal prose — the worst fit.
+- *Tooling complexity*: B must template 10 pages including legal prose extraction;
+  C scopes the generator to one page and reuses A's cheap stamp for the rest.
+- *Deploy impact*: B and C commit generated output, so the deploy workflow is
+  untouched except copying one new file; CI gains a regeneration-diff step.
+
+**Adopted mechanism (numbered clauses, citable in review):**
+
+1. `index.html` remains the **single authored source** for home content.
+   Translatable elements are annotated with `data-i18n="<key>"` (attribute
+   variants — `alt`, `aria-label`, `content` — via `data-i18n-attrs`).
+2. English strings live in `packages/website/i18n/home.en.json`
+   (key → EN HTML fragment).
+3. `scripts/build_i18n.py` (Python 3, **stdlib only**, same standard as
+   `quality_gate.py`) generates `en.html` from `index.html` + the catalog + a
+   head-override table (title, description, canonical — **self-referential to
+   `/en` from the first generation, even while S1 ships dark** (see D5 clause
+   1) —, hreflang, OG/Twitter, FAQPage JSON-LD, `lang` attributes, hidden form
+   `lang` field, `…Fr` → `…En` DOM id suffixes expected by `BBShared`).
+4. The generated `en.html` is **committed** (deploy stays build-less). It opens
+   with a `<!-- GENERATED FILE — edit index.html + i18n/home.en.json instead -->`
+   marker. CI enforces: (a) regeneration is clean (`build_i18n.py` then
+   `git diff --exit-code`), (b) **key parity** — every `data-i18n` key has a
+   catalog entry and vice versa. A FR copy change without its EN translation
+   fails CI: that is the drift guard.
+5. Legal twins stay hand-maintained. Each EN legal page embeds
+   `<!-- i18n-src: sha1:<hash of the FR twin> -->`; the quality gate recomputes
+   it and fails when the FR page changed without the EN twin being re-reviewed.
+   A helper (`build_i18n.py --stamp`) refreshes the stamp.
+6. `404.html` stays single and locale-agnostic (out of scope).
+
+### D2 — EN URL scheme (weighted decision matrix)
+
+Options: (a) keep `/index-en`; (b) rename the EN home file to `en.html`, served
+at **`/en`**, with a `301 /index-en → /en` in a new `_redirects` file; (c) migrate
+all EN pages into an `/en/` folder.
+
+| Criterion (weight) | a. Keep `/index-en` | **b. `/en` home, keep `-en` legal** | c. `/en/` folder |
+|---|---|---|---|
+| Promoted-URL quality (40%) | 2 | **5** | 5 |
+| Migration cost (20%) | 5 | **4** | 2 |
+| Workflow/gate impact (20%) | 5 | **4** | 2 |
+| Scheme consistency (20%) | 4 | **3** | 5 |
+| **Weighted score** | **3.60** | **4.20** | **3.80** |
+
+**Chosen: (b).** `https://brasse-bouillon.com/en` is the URL that goes on Reddit
+posts and stays forever; `/index-en` leaks an implementation detail. The EN pages
+are still `noindex` today, so **now is the cheapest moment ever** to fix the
+promoted URL — nothing is indexed yet. Option (c)'s folder purity is not worth
+recursive gate globs, `_site/` subfolder staging, and 4 legal-URL redirects on a
+10-page site. Clauses:
+
+1. EN home file = `en.html` (flat), served at `/en` by Cloudflare Pages'
+   clean-URL behavior — same mechanics as `privacy-en.html` → `/privacy-en`.
+2. New `_redirects` file with `/index-en /en 301`; `index-en.html` is deleted.
+   `website-deploy.yml` adds `_redirects` to its fail-loud copy list; the gate
+   adds it to `REQUIRED_FILES`.
+3. Legal EN pages keep their existing `-en` suffix URLs (already public,
+   already paired via hreflang).
+
+### D3 — EN forms reuse the FR Formspree endpoints
+
+The EN home posts to the **same** Formspree endpoints (`mqaqqvab` newsletter,
+`xeellqan` questionnaire) with the existing hidden `lang` field set to `en` —
+the discriminator is already in place on the FR forms. `site.js` gains an EN
+status/error message table (the `BBShared` `fr`/`en` parameter already selects
+DOM ids). The `_gotcha` honeypot is replicated. *Rejected alternative*: dedicated
+EN endpoints — splits submissions, burns Formspree free-tier form quota, and adds
+nothing the `lang` field doesn't already provide.
+
+### D4 — Language switcher: visible toggle, suggestion banner, no auto-redirect
+
+1. A visible **FR/EN toggle** (plain `<a>` links `/` ↔ `/en`) in the header nav
+   and footer of both homes — same pattern as the legal pages' `.lang-switch`.
+   Works without JavaScript (progressive enhancement).
+2. A **one-time suggestion banner** on the two homes only: shown when
+   `navigator.language` prefers the other language and no choice is stored.
+3. Any explicit action (toggle click, banner accept or dismiss) stores the
+   choice in `localStorage` key **`bb-lang`**; a stored choice suppresses the
+   banner permanently. **No automatic redirect, ever** — redirecting by
+   `Accept-Language`/`navigator.language` risks cloaking-style SEO issues
+   (crawlers mostly present `en-US`) and violates the project's
+   "advisory, never coercive" design philosophy (educated default + override).
+4. **Privacy disclosure**: `bb-lang` is a functional, user-initiated preference —
+   exempt from prior consent (CNIL functional-storage exemption) but it **must be
+   disclosed**. `cookies.html` + `cookies-en.html` gain a "Local storage" section
+   (key, purpose, lifetime, why no consent banner is required) in the same PR
+   that introduces the storage. The pages' "no tracking / no analytics" claims
+   remain true and untouched.
+
+### D5 — SEO switch (reverses the SEO_RUNBOOK de-index decision)
+
+1. Remove `noindex,follow` from the EN home and the 4 EN legal pages. Every EN
+   page canonicals to **itself** — the legal twins already do today, and the EN
+   home is generated self-canonical from S1 (D1 clause 3; Google honors
+   `noindex` regardless of canonical), so this clause reduces to dropping the
+   robots meta.
+2. Reciprocal hreflang cluster (`fr`, `en`, `x-default`) on **every** FR/EN pair.
+   `x-default` stays the **FR** page (FR-first project, status quo on the home).
+3. `sitemap.xml` lists exactly the two landing pages: `/` and `/en` (the
+   "landing pages only" sitemap policy is kept, not widened to legal pages).
+   `check_sitemap_policy` becomes an explicit allowlist — **coordinate with the
+   2026-07 audit Lot 5**, which also patches this check.
+4. The EN home gets full OG/Twitter meta and an EN FAQPage JSON-LD (the gate's
+   ban on `SoftwareApplication`/`Review`/`aggregateRating` schema applies to it
+   unchanged).
+5. `SEO_RUNBOOK.md` is rewritten to record the reversal (EN indexed from now on).
+
+## Consequences
+
+### Positive
+
+- A real, promotable `https://brasse-bouillon.com/en` — unblocks Reddit and
+  international community posting without wasting the traffic.
+- Drift on the most-edited page becomes **structurally impossible**; missing
+  translations become CI failures instead of silent rot.
+- Legal twins finally get a freshness guard (the exact pain lived before #1379).
+- Deploy stays build-less (generated output is committed); no new runtime
+  dependency, no framework, no CDN.
+
+### Negative
+
+- A generation step now exists on a deliberately tool-free site: after editing
+  home copy, a contributor must run `build_i18n.py` (CI fails loudly if
+  forgotten).
+- `data-i18n` attributes add markup noise to `index.html`; `en.html` diffs are
+  generated noise in PRs.
+- Mixed URL scheme: `/en` home vs `-en` suffixed legal pages.
+
+### Mitigations
+
+- The script is stdlib-only, documented in `packages/website/CLAUDE.md` and
+  `CONTRIBUTING.md`; the CI regen-diff makes "forgot to regenerate" impossible
+  to merge.
+- The generated-file marker + gate rule prevent hand edits to `en.html`;
+  reviewers collapse it and review `index.html` + the catalog instead.
+- Legal URLs are low-traffic and already public; hreflang pairs them correctly
+  regardless of scheme. A full `/en/` migration remains possible later (deferred).
+
+## Alternatives considered
+
+- **Client-side runtime i18n** (one URL, JS swaps strings): SEO-hostile (crawlers
+  and link previews see one language), breaks progressive enhancement, and makes
+  the OG link card — critical for Reddit — single-language. Rejected.
+- **Static-site generator** (Eleventy, Astro, …): solves i18n but contradicts the
+  deliberate build-less architecture (ADR-0014 spirit), adds a dependency tree to
+  a 10-page site, and forces a deploy-time build. Rejected.
+- **Server-side language negotiation** (redirect by `Accept-Language`): SEO
+  cloaking risk, removes user agency, cache complexity on Cloudflare. Rejected —
+  detection is advisory only (D4 banner).
+- **Full generation (option B)** and **guarded twins everywhere (option A)**:
+  scored in the D1 matrix; rejected on contributor UX / drift grounds
+  respectively.
+
+## Rollout (epic slices)
+
+| Slice | Content | Ships |
+|---|---|---|
+| **S1 — Real EN home** | D1 mechanism (annotations, catalog, `build_i18n.py`, committed `en.html`), D2 URL (`/en` + `_redirects` + workflow copy), D3 forms (`lang=en`, EN messages), EN OG/Twitter/JSON-LD, header/footer lang links, gate + pytest updates. `noindex` **kept** (ship dark, QA live); `en.html` self-canonical from day one so S2 is a robots-meta flip. | **Unblocks direct-link Reddit posting** |
+| **S2 — SEO switch** | D5 in full: de-noindex, self-canonicals, reciprocal hreflang, sitemap allowlist (coordinate Lot 5), SEO_RUNBOOK reversal. | Search traffic |
+| **S3 — Switcher UX** | D4: toggle polish, suggestion banner, `bb-lang` persistence, **cookies-page disclosure (FR+EN)**. | Language UX |
+| **S4 — Process hardening** | D1 clause 5 (legal freshness stamps), `packages/website/CLAUDE.md` § Languages rewrite (twin rule → source+catalog rule for home), CONTRIBUTING/README updates. | Anti-drift process |
+
+Coordination: the parallel "Académie" home-section work edits `index.html`
+(FR authored source) — whichever of it and S1 lands second rebases; if the
+Académie section lands **after** S1, its PR must add `data-i18n` keys + catalog
+entries, which the CI guard enforces automatically. EN copy voice/tone and the
+Reddit-readiness checklist live in `packages/website/docs/EN_LAUNCH_PLAYBOOK.md`.
+
+Deferred (explicitly out of scope): EN `404.html`; `/en/` folder migration;
+bilingual mobile-app UI (separate epic, #1075); year-round content localization
+beyond the home + legal set.
+
+## Verification
+
+- **CI (quality gate)**: regen-diff on `en.html`; `data-i18n` ↔ catalog key
+  parity; legal freshness stamps; `en.html` HTML rules (lang, marker, canonical,
+  schema bans); sitemap allowlist; cookies pages must list `bb-lang` once S3
+  lands.
+- **Tests**: `tests/test_quality_gate.py` extended; new `tests/test_build_i18n.py`
+  (happy: clean generation; sad: missing/orphaned key fails; edge: attribute
+  translations, JSON-LD, id-suffix rewrite).
+- **pr-pre-reviewer checklist**: flag any `packages/website` diff that edits
+  `en.html` by hand, or edits FR home copy without touching
+  `i18n/home.en.json`.
+
+## Relation to other ADRs / References
+
+- **ADR-0014** — hosting stays Cloudflare Pages, deploy stays build-less: the
+  generator runs at authoring time and its output is committed.
+- **Epic #1075** (marketing needs study) — bilingual FR+EN reach is the
+  international wedge this ADR implements for the marketing site.
+- **PR #1379** — rewrote the 8 legal pages (LCEN/RGPD); their accuracy
+  constraint drives D4 clause 4 (disclosed `bb-lang` storage).
+- **`packages/website/docs/SEO_RUNBOOK.md`** — records the EN de-index
+  decision that D5 reverses; updated in slice S2.
+- **`packages/website/docs/EN_LAUNCH_PLAYBOOK.md`** — editorial companion
+  (voice/tone, transcreation calibration, Reddit-readiness checklist).

--- a/docs/architecture/decisions/0027-website-i18n-strategy.md
+++ b/docs/architecture/decisions/0027-website-i18n-strategy.md
@@ -157,25 +157,54 @@ DOM ids). The `_gotcha` honeypot is replicated. *Rejected alternative*: dedicate
 EN endpoints — splits submissions, burns Formspree free-tier form quota, and adds
 nothing the `lang` field doesn't already provide.
 
-### D4 — Language switcher: visible toggle, suggestion banner, no auto-redirect
+### D4 — Language switcher: top-right autonym toggle, suggestion banner, no auto-redirect
 
-1. A visible **FR/EN toggle** (plain `<a>` links `/` ↔ `/en`) in the header nav
-   and footer of both homes — same pattern as the legal pages' `.lang-switch`.
-   Works without JavaScript (progressive enhancement).
-2. A **one-time suggestion banner** on the two homes only: shown when
-   `navigator.language` prefers the other language and no choice is stored.
-3. Any explicit action (toggle click, banner accept or dismiss) stores the
+Grounded in the `i18n` skill (Google Search Central, W3C, Nielsen Norman Group,
+MDN). Clauses:
+
+1. A visible language switcher in the **top-right of the header** (the
+   conventional, expected placement — NN/G) on both homes, mirrored in the
+   footer. It is a pair of plain `<a>` links `/` ↔ `/en` — same mechanics as the
+   legal pages' `.lang-switch` — so it works with **JavaScript disabled**
+   (progressive enhancement). The switcher points at the **translated equivalent
+   of the current page**, never the homepage.
+2. **Labels are autonyms** — `Français` / `English` (a short `FR / EN` toggle is
+   the compact variant), each language named in its own language. The active
+   language is visually marked. **No flags** — a flag denotes a country, not a
+   language ("flags are not languages", NN/G): English is not the US or UK flag,
+   French is not only France's. This is an explicit rejection of the
+   flag-toggle idea.
+3. A **one-time, dismissible suggestion banner** on the two homes only: on first
+   visit, if `navigator.languages` prefers the other language and no choice is
+   stored, it offers the twin ("This page is available in English →" / the FR
+   mirror). It **suggests**, it does not switch. Detection matches
+   `navigator.languages` by BCP 47 lookup (fall back `en-US` → `en`).
+4. Any explicit action (toggle click, banner accept or dismiss) stores the
    choice in `localStorage` key **`bb-lang`**; a stored choice suppresses the
-   banner permanently. **No automatic redirect, ever** — redirecting by
-   `Accept-Language`/`navigator.language` risks cloaking-style SEO issues
-   (crawlers mostly present `en-US`) and violates the project's
-   "advisory, never coercive" design philosophy (educated default + override).
-4. **Privacy disclosure**: `bb-lang` is a functional, user-initiated preference —
-   exempt from prior consent (CNIL functional-storage exemption) but it **must be
-   disclosed**. `cookies.html` + `cookies-en.html` gain a "Local storage" section
-   (key, purpose, lifetime, why no consent banner is required) in the same PR
-   that introduces the storage. The pages' "no tracking / no analytics" claims
-   remain true and untouched.
+   banner permanently. **No automatic redirect or auto-swap, ever.** Rationale
+   (Google *Managing Multi-Regional and Multilingual Sites*): "Avoid
+   automatically redirecting users … These redirections could prevent users
+   (and search engines) from viewing all the versions of your site." Googlebot
+   crawls from the US **without** an `Accept-Language` header, so a
+   language/geo redirect can leave the localized version un-crawled and
+   un-indexed. It also violates the project's advisory-never-coercive philosophy
+   (educated default + override). The site is static on Cloudflare Pages: it
+   cannot read `Accept-Language` at all without an edge worker — deliberately not
+   added.
+5. **Privacy disclosure**: `bb-lang` is a functional, user-initiated preference —
+   exempt from prior consent (CNIL functional-storage exemption; aligns with
+   WP29 Opinion 04/2012) but it **must be disclosed**. `cookies.html` +
+   `cookies-en.html` gain a "Local storage" section (key, purpose, lifetime, why
+   no consent banner is required) in the **same PR** that introduces the storage.
+   The pages' "no tracking / no analytics" claims remain true and untouched.
+
+*Rejected alternatives:* **flags as language labels** (country ≠ language, NN/G);
+**auto-display/redirect by browser language** (Google discourages it; un-crawled
+localized pages; needs an edge worker this site deliberately avoids);
+**English-by-default with a FR opt-out** (buries the current primary — French —
+audience, inverts `x-default`, and contradicts the FR-first project identity per
+`feedback_ui_french_only`; English visitors are already served by the
+suggestion banner + a shareable `/en` URL without demoting French).
 
 ### D5 — SEO switch (reverses the SEO_RUNBOOK de-index decision)
 

--- a/docs/architecture/decisions/0027-website-i18n-strategy.md
+++ b/docs/architecture/decisions/0027-website-i18n-strategy.md
@@ -1,7 +1,7 @@
 # ADR-0027 — Website Internationalization Strategy (Bilingual FR+EN Marketing Site)
 
-**Status**  Proposed
-**Date**    2026-07-10
+**Status**  Accepted
+**Date**    2026-07-10 (accepted 2026-07-10, after a 6-reviewer adversarial conception review folded in)
 **Owners**  @benoit-bremaud
 
 ---
@@ -127,11 +127,12 @@ Score rationale:
    hreflang, OG/Twitter **including `og:locale=en_US` + `og:locale:alternate`**,
    `lang` attributes, hidden form `lang` field. It also localizes the **bottom
    inline `<script>` block**: the `…Fr` → `…En` DOM id suffixes expected by
-   `BBShared`, the form **message/error tables**, `TOGGLE_LABELS.en`, and the
-   inline `onclick('fr' → 'en')` calls (the message tables are **not** in
-   `site.js` — they are inline in `index.html`, so the generator must swap them;
-   the alternative of moving them into the catalog / `site.js` to keep the inline
-   script language-neutral is the implementer's call in S1, and is preferred).
+   `BBShared`, `TOGGLE_LABELS.en`, and the inline `onclick('fr' → 'en')` calls.
+   **Decided (S1):** the form **message/error tables** are **moved out of the
+   inline `<script>` into `site.js` / the catalog** so the page's inline bootstrap
+   is language-neutral — the generator swaps DOM-id suffixes and the `onclick`
+   language argument, but does **not** rewrite JS string literals (a regex over
+   JS is fragile). This is a small one-time refactor of the existing FR home.
    The **FAQPage JSON-LD is derived from the same catalog keys as the visible
    `<details>` FAQ** — a single EN source, never a separately authored head
    entry — so the structured data cannot drift from the visible copy. The
@@ -204,9 +205,10 @@ recursive gate globs, `_site/` subfolder staging, and 4 legal-URL redirects on a
 The EN home posts to the **same** Formspree endpoints (`mqaqqvab` newsletter,
 `xeellqan` questionnaire) with the existing hidden `lang` field set to `en` —
 the discriminator is already in place on the FR forms. The form **status/error
-message tables live inline in `index.html`'s bottom `<script>`** (not in
-`site.js`, which only holds the `BBShared` `fr`/`en` DOM-id parameter); the
-generator localizes them per D1 clause 3. The `_gotcha` honeypot (present on the
+message tables currently live inline in `index.html`'s bottom `<script>`**; S1
+moves them into `site.js` / the catalog (D1 clause 3 decision) so they are
+localized like any other string, keeping the inline bootstrap language-neutral.
+The `_gotcha` honeypot (present on the
 questionnaire form) is preserved. The RGPD **consent-checkbox label and the
 consent note are `data-i18n` keys** (translated to EN), and the consent-note
 legal links are rewritten to the `-en` pages (D1 clause 3) so an EN submitter

--- a/docs/architecture/decisions/0027-website-i18n-strategy.md
+++ b/docs/architecture/decisions/0027-website-i18n-strategy.md
@@ -12,9 +12,10 @@ The marketing site (`packages/website`) is an intentionally **build-less** stati
 HTML/CSS/JS site on Cloudflare Pages (ADR-0014). It is French-first: the English
 home (`index-en.html`) is an 83-line "coming soon" stub, `noindex,follow`, with a
 canonical pointing to the FR home — a **deliberate de-indexing decision** recorded
-in `SEO_RUNBOOK.md`. The 4 EN legal twins (`legal-en`, `privacy-en`, `cookies-en`,
-`terms-en`) exist and were rewritten for LCEN/RGPD compliance in PR #1379, but are
-also `noindex` while EN is a stub.
+in `packages/website/docs/SEO_RUNBOOK.md`. The 4 EN legal twin files
+(`legal-en.html`, `privacy-en.html`, `cookies-en.html`, `terms-en.html`, served
+at their `-en` clean URLs) exist and were rewritten for LCEN/RGPD compliance in
+PR #1379, but are also `noindex` while EN is a stub.
 
 The goal is now to promote the project on Reddit and international homebrewing
 communities (mostly English-speaking). A French-only landing page wastes that
@@ -39,19 +40,27 @@ Constraints and observations that shaped this decision:
    `lang=fr` field; `site.js` (`BBShared`) is already parameterized `fr`/`en` for
    form/menu DOM ids. The legal pages already have visible `.lang-switch` links.
 5. **Privacy claims are load-bearing.** The site uses **no** cookies, no
-   localStorage, no analytics — and `cookies(-en).html` / `privacy(-en).html`
-   explicitly promise it (made accurate in #1379). Any language-preference
-   persistence must keep those pages truthful.
+   localStorage, no analytics. `cookies(-en).html` / `privacy(-en).html` promise
+   **no tracking cookies and no audience measurement/analytics** (made accurate
+   in #1379) — they do **not** literally claim "zero storage of any kind". A
+   functional, never-transmitted language preference contradicts none of those
+   sentences, but terminal storage must still be **disclosed** per ePrivacy
+   (see D4 clause 5).
 
 ### Documented study (why we are not guessing)
 
-A full repo reconnaissance (2026-07-10) inventoried: the page pairs and their
-URL scheme (`-en.html` suffix served at clean URLs), the exact `<head>` SEO state
-of every pair (FR home advertises `fr` + `x-default` only; legal pairs advertise
-`fr`+`en`), the 9 quality-gate check functions and which ones hard-code the
-current EN policy, the `_site/` staging steps, and the absence of any storage
-API usage in `site.js`. The matrices below score against those facts, not
-assumptions.
+A full repo reconnaissance (2026-07-10), extended by an adversarial 6-reviewer
+conception review, inventoried: the page pairs and their URL scheme (`-en.html`
+suffix served at clean URLs), the exact `<head>` SEO state of every pair — the FR
+home advertises `fr` + `x-default` only (**it does not yet advertise `en` → this
+epic must add it**, D5 clause 2); the legal pairs advertise `fr`+`en` but carry
+**no `x-default`** (which D5 clause 2 must add) — the 9 quality-gate check
+functions and which ones hard-code the current EN policy (`index-en.html` appears
+in **five** gate constants, see D2 clause 2), the `_site/` staging steps, the
+inline `<script>` at the bottom of `index.html` that holds the Formspree
+endpoints + form message tables + toggle labels (relevant to D1/D3), and the
+absence of any storage API usage in `site.js`. The matrices below score against
+those facts, not assumptions.
 
 ## Decision
 
@@ -96,22 +105,53 @@ Score rationale:
 **Adopted mechanism (numbered clauses, citable in review):**
 
 1. `index.html` remains the **single authored source** for home content.
-   Translatable elements are annotated with `data-i18n="<key>"` (attribute
-   variants — `alt`, `aria-label`, `content` — via `data-i18n-attrs`).
-2. English strings live in `packages/website/i18n/home.en.json`
-   (key → EN HTML fragment).
+   Translatable elements carry `data-i18n="<key>"` for their text content, and
+   `data-i18n-attrs="<attr>[:<key>][,<attr>…]"` for translatable attributes
+   (`alt`, `aria-label`, `title`; `<meta content>` is head-only and handled by
+   the head-override table, clause 3, not by `data-i18n-attrs`). **Attribute-key
+   convention**: `<elementKey>@<attr>` (e.g. `hero.logo@alt`). **Key convention**
+   (per the `i18n` skill): semantic, hierarchical, stable, one case style
+   (`home.hero.title`, `nav.faq`) — never the English string as the key, never a
+   key reused across two contexts. EN-only content that has **no FR source**
+   (e.g. the "app ships in French first" honesty line, D-note below) is authored
+   as a `data-i18n-en-only="<key>"` placeholder element that renders **empty in
+   FR** and is filled from the catalog in EN.
+2. Translated strings live in `packages/website/i18n/home.en.json` — a flat map
+   `key → EN HTML fragment` (whole elements; **never concatenated fragments**),
+   plus an `insertions` section for the `data-i18n-en-only` keys.
 3. `scripts/build_i18n.py` (Python 3, **stdlib only**, same standard as
-   `quality_gate.py`) generates `en.html` from `index.html` + the catalog + a
-   head-override table (title, description, canonical — **self-referential to
-   `/en` from the first generation, even while S1 ships dark** (see D5 clause
-   1) —, hreflang, OG/Twitter, FAQPage JSON-LD, `lang` attributes, hidden form
-   `lang` field, `…Fr` → `…En` DOM id suffixes expected by `BBShared`).
+   `quality_gate.py`) generates `en.html` from `index.html` + the catalog. It
+   substitutes annotated spans/attributes **in place** and applies a
+   **head-override table**: title, description, canonical (**self-referential to
+   `/en` from the first generation, even while S1 ships dark**, see D5 clause 1),
+   hreflang, OG/Twitter **including `og:locale=en_US` + `og:locale:alternate`**,
+   `lang` attributes, hidden form `lang` field. It also localizes the **bottom
+   inline `<script>` block**: the `…Fr` → `…En` DOM id suffixes expected by
+   `BBShared`, the form **message/error tables**, `TOGGLE_LABELS.en`, and the
+   inline `onclick('fr' → 'en')` calls (the message tables are **not** in
+   `site.js` — they are inline in `index.html`, so the generator must swap them;
+   the alternative of moving them into the catalog / `site.js` to keep the inline
+   script language-neutral is the implementer's call in S1, and is preferred).
+   The **FAQPage JSON-LD is derived from the same catalog keys as the visible
+   `<details>` FAQ** — a single EN source, never a separately authored head
+   entry — so the structured data cannot drift from the visible copy. The
+   consent-note legal links are rewritten `/{terms,privacy,cookies}` →
+   `/{…}-en`.
 4. The generated `en.html` is **committed** (deploy stays build-less). It opens
    with a `<!-- GENERATED FILE — edit index.html + i18n/home.en.json instead -->`
-   marker. CI enforces: (a) regeneration is clean (`build_i18n.py` then
-   `git diff --exit-code`), (b) **key parity** — every `data-i18n` key has a
-   catalog entry and vice versa. A FR copy change without its EN translation
-   fails CI: that is the drift guard.
+   marker. The generator is **deterministic**: it performs targeted in-place
+   substitution and **never re-serializes** the document (no HTML parser
+   round-trip that would flip attribute order / quotes / whitespace); output is
+   newline- and encoding-normalized. CI enforces: (a) regeneration is clean
+   (`build_i18n.py` then `git diff --exit-code`, byte-identical on re-run);
+   (b) **key parity** — every `data-i18n`/`data-i18n-attrs`/`data-i18n-en-only`
+   key has a catalog entry and vice versa; (c) **source-hash freshness** — each
+   catalog entry records a `srcHash` of the FR source text/attribute it
+   translates, and CI fails when the FR source changed but the EN value (and its
+   `srcHash`) were not updated. Clause (c) is the load-bearing drift guard:
+   without it, editing FR text **inside an already-annotated element** leaves the
+   key and catalog unchanged, regeneration stays clean, key parity still passes,
+   and stale EN would ship green.
 5. Legal twins stay hand-maintained. Each EN legal page embeds
    `<!-- i18n-src: sha1:<hash of the FR twin> -->`; the quality gate recomputes
    it and fails when the FR page changed without the EN twin being re-reviewed.
@@ -141,21 +181,38 @@ recursive gate globs, `_site/` subfolder staging, and 4 legal-URL redirects on a
 
 1. EN home file = `en.html` (flat), served at `/en` by Cloudflare Pages'
    clean-URL behavior — same mechanics as `privacy-en.html` → `/privacy-en`.
-2. New `_redirects` file with `/index-en /en 301`; `index-en.html` is deleted.
-   `website-deploy.yml` adds `_redirects` to its fail-loud copy list; the gate
-   adds it to `REQUIRED_FILES`.
-3. Legal EN pages keep their existing `-en` suffix URLs (already public,
-   already paired via hreflang).
+2. New `_redirects` file with **both** `/index-en /en 301` **and**
+   `/index-en.html /en 301` (the SEO runbook and older links use the `.html`
+   form; the clean-URL rule alone would 404 the deleted asset).
+   `website-deploy.yml` adds `_redirects` to its fail-loud copy list. **Gate
+   rename surgery (S1):** `index-en.html` is deleted and `en.html` created — this
+   requires updating **five** hard-coded constants in `quality_gate.py` in the
+   same PR, or CI goes red on a missing file: `REQUIRED_FILES` (drop
+   `index-en.html`, add `en.html` + `_redirects`), `WIDGET_HTML_FILES`,
+   `CHAT_WIDGET_HTML_FILES`, the `HTML_RULES` key, and the
+   `DISALLOWED_HTML_PATTERNS` key. The `HTML_RULES` entry for `en.html` keeps the
+   `noindex` requirement (S1 ships dark) but its **canonical rule flips from
+   "must be `/`" to "must be `/en`"** (else S1's self-canonical fails CI). S2 then
+   drops the `noindex` requirement (else S2's de-noindex fails CI).
+3. Legal EN pages keep their existing `-en` suffix URLs (already public, already
+   paired via hreflang). Their in-page nav is corrected in this epic: the "Home"
+   link (currently `/index-en`, dead after the delete) → `/en`, and the "site
+   form" link (currently `/#participerFr`, the FR home) → `/en#participer`.
 
 ### D3 — EN forms reuse the FR Formspree endpoints
 
 The EN home posts to the **same** Formspree endpoints (`mqaqqvab` newsletter,
 `xeellqan` questionnaire) with the existing hidden `lang` field set to `en` —
-the discriminator is already in place on the FR forms. `site.js` gains an EN
-status/error message table (the `BBShared` `fr`/`en` parameter already selects
-DOM ids). The `_gotcha` honeypot is replicated. *Rejected alternative*: dedicated
-EN endpoints — splits submissions, burns Formspree free-tier form quota, and adds
-nothing the `lang` field doesn't already provide.
+the discriminator is already in place on the FR forms. The form **status/error
+message tables live inline in `index.html`'s bottom `<script>`** (not in
+`site.js`, which only holds the `BBShared` `fr`/`en` DOM-id parameter); the
+generator localizes them per D1 clause 3. The `_gotcha` honeypot (present on the
+questionnaire form) is preserved. The RGPD **consent-checkbox label and the
+consent note are `data-i18n` keys** (translated to EN), and the consent-note
+legal links are rewritten to the `-en` pages (D1 clause 3) so an EN submitter
+gets EN consent wording and lands on EN legal pages. *Rejected alternative*:
+dedicated EN endpoints — splits submissions, burns Formspree free-tier form
+quota, and adds nothing the `lang` field doesn't already provide.
 
 ### D4 — Language switcher: top-right autonym toggle, suggestion banner, no auto-redirect
 
@@ -194,9 +251,13 @@ MDN). Clauses:
 5. **Privacy disclosure**: `bb-lang` is a functional, user-initiated preference —
    exempt from prior consent (CNIL functional-storage exemption; aligns with
    WP29 Opinion 04/2012) but it **must be disclosed**. `cookies.html` +
-   `cookies-en.html` gain a "Local storage" section (key, purpose, lifetime, why
-   no consent banner is required) in the **same PR** that introduces the storage.
-   The pages' "no tracking / no analytics" claims remain true and untouched.
+   `cookies-en.html` gain a "Local storage" section (key `bb-lang`, purpose =
+   remember language choice, **lifetime = persistent until the visitor clears
+   site data**, why no consent banner is required) in the **same PR** that
+   introduces the storage. The cookies page is the correct home (ePrivacy/CNIL
+   treat cookies + localStorage as one `traceurs` family); the privacy page does
+   not additionally need it. The pages' "no tracking / no analytics" claims
+   remain true and untouched.
 
 *Rejected alternatives:* **flags as language labels** (country ≠ language, NN/G);
 **auto-display/redirect by browser language** (Google discourages it; un-crawled
@@ -209,19 +270,37 @@ suggestion banner + a shareable `/en` URL without demoting French).
 ### D5 — SEO switch (reverses the SEO_RUNBOOK de-index decision)
 
 1. Remove `noindex,follow` from the EN home and the 4 EN legal pages. Every EN
-   page canonicals to **itself** — the legal twins already do today, and the EN
-   home is generated self-canonical from S1 (D1 clause 3; Google honors
-   `noindex` regardless of canonical), so this clause reduces to dropping the
-   robots meta.
+   page canonicals to **itself**. Note the EN home canonical is an **active
+   defect being corrected**: `index-en.html` currently canonicals to the FR root
+   (`/`), i.e. it canonicalizes a locale to the master — a real SEO bug that
+   drops EN from the index. The generator must emit `canonical=/en` (never `/`)
+   from S1; because S1 keeps `noindex` and Google honors `noindex` regardless of
+   canonical, S2 reduces to dropping the robots meta.
 2. Reciprocal hreflang cluster (`fr`, `en`, `x-default`) on **every** FR/EN pair.
-   `x-default` stays the **FR** page (FR-first project, status quo on the home).
-3. `sitemap.xml` lists exactly the two landing pages: `/` and `/en` (the
-   "landing pages only" sitemap policy is kept, not widened to legal pages).
-   `check_sitemap_policy` becomes an explicit allowlist — **coordinate with the
-   2026-07 audit Lot 5**, which also patches this check.
-4. The EN home gets full OG/Twitter meta and an EN FAQPage JSON-LD (the gate's
-   ban on `SoftwareApplication`/`Review`/`aggregateRating` schema applies to it
-   unchanged).
+   This requires two additions the recon surfaced: (a) the **FR home
+   `index.html` gains `hreflang="en" → /en`** (today it advertises only `fr` +
+   `x-default`); without the return tag the whole cluster is ignored by Google.
+   (b) the **4 legal pairs gain `x-default` → the FR clean URL** (today they have
+   none). `x-default` stays the **FR** page (FR-first project). A new gate check
+   asserts hreflang **reciprocity + self-reference completeness** across every
+   pair (not just the existing "no `.html` in href" guard).
+3. `sitemap.xml`: **`check_sitemap_policy` was already widened by the
+   now-merged PR #1384 (audit Lot 5, commit `803693a`)** to a set allowlist
+   `{/, /legal, /privacy, /cookies, /terms}` (membership check) plus the matching
+   `sitemap.xml` entries — the earlier "landing-pages-only" intent is superseded.
+   This epic's contribution is **additive**: S2 adds `/en` to that allowlist and
+   to `sitemap.xml`. Target end state = `{/, /legal, /privacy, /cookies, /terms,
+   /en}`. The **4 EN legal pages stay OUT of the sitemap** even after S2
+   de-noindexes them (secondary pages, paired to their FR twin via hreflang);
+   S2 updates Lot 5's inline "because noindex" rationale comment accordingly.
+4. The EN home gets full OG/Twitter meta **including `og:locale=en_US` +
+   `og:locale:alternate=fr_FR`** (FR home gets `fr_FR` + `en_US` alternate);
+   without `og:locale`, LinkedIn/Facebook default the card to `en_US` and the
+   FR/EN distinction is invisible to scrapers. The EN FAQPage JSON-LD is
+   catalog-derived (D1 clause 3), and the gate's ban on
+   `SoftwareApplication`/`Review`/`aggregateRating` schema applies to `en.html`
+   unchanged. **This OG/JSON-LD is shipped in S1** (see rollout); S2 only asserts
+   it via the gate rather than re-authoring it.
 5. `SEO_RUNBOOK.md` is rewritten to record the reversal (EN indexed from now on).
 
 ## Consequences
@@ -243,7 +322,13 @@ suggestion banner + a shareable `/en` URL without demoting French).
   forgotten).
 - `data-i18n` attributes add markup noise to `index.html`; `en.html` diffs are
   generated noise in PRs.
-- Mixed URL scheme: `/en` home vs `-en` suffixed legal pages.
+- Mixed URL scheme: `/en` home vs `-en` suffixed legal pages. (Confirmed a
+  cosmetic-only tradeoff: hreflang/canonical use absolute URLs and are
+  scheme-agnostic — no reciprocity or indexing impact.)
+- The generator scope is larger than "translate element text": it must also
+  localize the inline bootstrap `<script>` (message tables, toggle labels,
+  `onclick` language arg) and derive the FAQPage JSON-LD — the genuinely hard
+  part of S1.
 
 ### Mitigations
 
@@ -274,16 +359,26 @@ suggestion banner + a shareable `/en` URL without demoting French).
 
 | Slice | Content | Ships |
 |---|---|---|
-| **S1 — Real EN home** | D1 mechanism (annotations, catalog, `build_i18n.py`, committed `en.html`), D2 URL (`/en` + `_redirects` + workflow copy), D3 forms (`lang=en`, EN messages), EN OG/Twitter/JSON-LD, header/footer lang links, gate + pytest updates. `noindex` **kept** (ship dark, QA live); `en.html` self-canonical from day one so S2 is a robots-meta flip. | **Unblocks direct-link Reddit posting** |
-| **S2 — SEO switch** | D5 in full: de-noindex, self-canonicals, reciprocal hreflang, sitemap allowlist (coordinate Lot 5), SEO_RUNBOOK reversal. | Search traffic |
-| **S3 — Switcher UX** | D4: toggle polish, suggestion banner, `bb-lang` persistence, **cookies-page disclosure (FR+EN)**. | Language UX |
+| **S1 — Real EN home** | D1 mechanism (annotations + attr/EN-only grammar, catalog with `srcHash`, `build_i18n.py`, committed `en.html`), D2 URL (`/en` + `_redirects` incl. `.html`, workflow copy, **5-constant gate rename** + canonical-rule flip to `/en`), D3 forms (`lang=en`, inline-script + consent localization, `-en` legal links), EN OG/Twitter incl. `og:locale`, catalog-derived FAQPage JSON-LD, the **"app ships in French first" honesty line + name gloss** (EN-only inserts), header/footer autonym lang links (D4 clause 1, JS-free), EN legal in-page nav fix (`/en`, `/en#participer`), gate + pytest updates. `noindex` **kept** (ship dark, QA live); `en.html` self-canonical from day one so S2 is a robots-meta flip. | **Unblocks direct-link Reddit posting** |
+| **S2 — SEO switch** | D5: de-noindex EN pages, add `hreflang="en"` to the FR home + `x-default` to the 4 legal pairs (reciprocity gate), add `/en` to the merged #1384 sitemap allowlist + `sitemap.xml`, SEO_RUNBOOK reversal. | Search traffic |
+| **S3 — Switcher UX** | D4 clauses 3–5: suggestion banner (`navigator.languages`), `bb-lang` persistence, **cookies-page disclosure (FR+EN)**. (Clause 1–2 — the plain autonym toggle — already shipped in S1. This slice adds the only new privacy-disclosure surface; it is the first to cut if scope tightens.) | Language UX |
 | **S4 — Process hardening** | D1 clause 5 (legal freshness stamps), `packages/website/CLAUDE.md` § Languages rewrite (twin rule → source+catalog rule for home), CONTRIBUTING/README updates. | Anti-drift process |
 
-Coordination: the parallel "Académie" home-section work edits `index.html`
-(FR authored source) — whichever of it and S1 lands second rebases; if the
-Académie section lands **after** S1, its PR must add `data-i18n` keys + catalog
-entries, which the CI guard enforces automatically. EN copy voice/tone and the
-Reddit-readiness checklist live in `packages/website/docs/EN_LAUNCH_PLAYBOOK.md`.
+Coordination:
+
+- **PR #1384 (audit Lot 5 — sitemap/social/favicon) is now MERGED** (`803693a`,
+  2026-07-10). It edited `index.html`, all legal pages, `sitemap.xml`, and
+  rewrote `check_sitemap_policy` to a legal-inclusive set allowlist. The epic
+  branch **rebases onto the current `main`** (which includes it); S2 adds `/en`
+  to the already-widened allowlist rather than defining a new one. Note #1384
+  also added OG/Twitter meta to `index.html` and the (soon-replaced) EN stub —
+  S1's generator work builds on that OG baseline.
+- The parallel **"Académie" home-section** work also edits `index.html` (FR
+  authored source) — whichever of it and S1 lands second rebases; if it lands
+  **after** S1, its PR must add `data-i18n` keys + catalog entries, which the CI
+  key-parity + `srcHash` guard enforces automatically.
+- EN copy voice/tone and the Reddit-readiness checklist live in
+  `packages/website/docs/EN_LAUNCH_PLAYBOOK.md`.
 
 Deferred (explicitly out of scope): EN `404.html`; `/en/` folder migration;
 bilingual mobile-app UI (separate epic, #1075); year-round content localization
@@ -291,13 +386,18 @@ beyond the home + legal set.
 
 ## Verification
 
-- **CI (quality gate)**: regen-diff on `en.html`; `data-i18n` ↔ catalog key
-  parity; legal freshness stamps; `en.html` HTML rules (lang, marker, canonical,
-  schema bans); sitemap allowlist; cookies pages must list `bb-lang` once S3
-  lands.
+- **CI (quality gate)**: regen-diff on `en.html` (byte-identical); key parity
+  (`data-i18n`/`data-i18n-attrs`/`data-i18n-en-only` ↔ catalog); **`srcHash`
+  freshness** (FR source changed ⇒ EN value + hash must change); **hreflang
+  reciprocity + self-reference completeness** across every pair; **FAQPage
+  JSON-LD text == visible `<details>` text**; legal freshness stamps; `en.html`
+  HTML rules (lang, marker, canonical `= /en`, schema bans); sitemap allowlist
+  (`/en` a member after #1384); cookies pages must list `bb-lang` once S3 lands.
 - **Tests**: `tests/test_quality_gate.py` extended; new `tests/test_build_i18n.py`
-  (happy: clean generation; sad: missing/orphaned key fails; edge: attribute
-  translations, JSON-LD, id-suffix rewrite).
+  (happy: clean generation; sad: missing/orphaned key fails, FR-changed-without-
+  EN fails via `srcHash`; edge: attribute translations, EN-only inserts, inline
+  `<script>` message-table + `onclick` swap, catalog-derived JSON-LD, id-suffix
+  rewrite, byte-identical re-run).
 - **pr-pre-reviewer checklist**: flag any `packages/website` diff that edits
   `en.html` by hand, or edits FR home copy without touching
   `i18n/home.en.json`.
@@ -309,8 +409,16 @@ beyond the home + legal set.
 - **Epic #1075** (marketing needs study) — bilingual FR+EN reach is the
   international wedge this ADR implements for the marketing site.
 - **PR #1379** — rewrote the 8 legal pages (LCEN/RGPD); their accuracy
-  constraint drives D4 clause 4 (disclosed `bb-lang` storage).
+  constraint drives D4 clause 5 (disclosed `bb-lang` storage).
+- **PR #1384** — audit Lot 5 (sitemap/social/favicon), merged `803693a`; widened
+  `check_sitemap_policy` to `{/, /legal, /privacy, /cookies, /terms}`; S2 adds
+  `/en` to it (see Coordination).
 - **`packages/website/docs/SEO_RUNBOOK.md`** — records the EN de-index
   decision that D5 reverses; updated in slice S2.
 - **`packages/website/docs/EN_LAUNCH_PLAYBOOK.md`** — editorial companion
   (voice/tone, transcreation calibration, Reddit-readiness checklist).
+
+**Realized by** (UML deliverables):
+- `docs/architecture/diagrams/website-i18n/01-use-case.md`
+- `docs/architecture/diagrams/website-i18n/02-sequence-language-switch.md`
+- `docs/architecture/diagrams/website-i18n/03-data-flow-content-pipeline.md`

--- a/docs/architecture/diagrams/website-i18n/01-use-case.md
+++ b/docs/architecture/diagrams/website-i18n/01-use-case.md
@@ -1,0 +1,77 @@
+# Use case diagram — website-i18n — bilingual FR+EN marketing site
+
+> **Feature**: website i18n epic (bilingual FR+EN marketing site, Reddit-readiness)
+> **Related ADRs**: ADR-0027, ADR-0014
+> **Decisions captured**: ADR-0027 D1 (hybrid content strategy), D3 (shared forms), D4 (switcher)
+
+## Context
+
+`uc — Website i18n`. Who wants what from a bilingual marketing site — visitors
+(reading, switching language, participating) and the maintainer (publishing
+without drift). This diagram does NOT cover how pages are generated (see
+`03-data-flow-content-pipeline.md`) nor SEO/crawler mechanics (not actor goals).
+
+## Diagram
+
+```mermaid
+flowchart LR
+  EnVisitor(("International homebrewer<br/>(Reddit / EN communities)"))
+  FrVisitor(("French visitor"))
+  Maintainer(("Maintainer<br/>(Benoît)"))
+  subgraph SYSTEM ["Brasse-Bouillon marketing site"]
+    subgraph Visit ["Visit domain"]
+      UC1(("UC1 Read the home<br/>in my language"))
+      UC2(("UC2 Switch the<br/>site language"))
+    end
+    subgraph Participate ["Participate domain"]
+      UC3(("UC3 Join the waitlist<br/>in my language"))
+      UC4(("UC4 Answer the brewers<br/>questionnaire in my language"))
+    end
+    subgraph Maintain ["Content-maintenance domain"]
+      UC5(("UC5 Publish a home copy<br/>change in both languages"))
+      UC6(("UC6 Update a legal<br/>page pair"))
+    end
+  end
+  EnVisitor --> UC1
+  EnVisitor --> UC2
+  EnVisitor --> UC3
+  EnVisitor --> UC4
+  FrVisitor --> UC1
+  FrVisitor --> UC2
+  FrVisitor --> UC3
+  FrVisitor --> UC4
+  Maintainer --> UC5
+  Maintainer --> UC6
+```
+
+## Notes
+
+- **Textual specs (Cockburn-lite).**
+  - **UC2 — Switch the site language** (planned, slice S3): precondition —
+    visitor is on a page that has a twin. Main: 1. visitor clicks the FR/EN
+    toggle; 2. browser navigates to the twin URL; 3. choice stored (`bb-lang`).
+    Extensions: 1a. first visit, browser language differs from page language and
+    no stored choice → a suggestion banner offers the twin (accept = navigate +
+    store; dismiss = store current language, never nag again). Realized by
+    `02-sequence-language-switch.md`.
+  - **UC5 — Publish a home copy change in both languages** (planned, slice S1):
+    main: 1. maintainer edits `index.html` (FR source); 2. updates the flagged
+    keys in `i18n/home.en.json`; 3. runs `build_i18n.py`; 4. commits — CI fails
+    on any missing/orphaned key or stale `en.html`. Realized by
+    `03-data-flow-content-pipeline.md`.
+  - **UC6 — Update a legal page pair** (planned, slice S4): main: edit FR page,
+    re-review + edit EN twin, refresh the freshness stamp; CI fails when the FR
+    page changed and the stamp did not.
+  - UC1/UC3/UC4 are plain reads/submits — textual spec only, no sequence
+    (proportionality rule); UC3/UC4 post to the shared Formspree endpoints with
+    `lang` set per page (ADR-0027 D3).
+- Search-engine crawling/indexing is deliberately absent: "be indexed" is not an
+  actor-initiated goal (UML 2.5 orthodoxy); the SEO switch is captured as
+  ADR-0027 D5, not as a use case.
+- Both visitor actors share UC1–UC4 on purpose — the feature's whole point is
+  goal parity across languages; no actor generalization is needed.
+- Component, class and state diagrams are deliberately skipped
+  (proportionality rule): the site is a flat static package with no new runtime
+  component (the authoring/CI/deploy structure lives in
+  `03-data-flow-content-pipeline.md`), no new domain types, and no stateful
+  entity beyond the one-shot banner already covered by the sequence diagram.

--- a/docs/architecture/diagrams/website-i18n/01-use-case.md
+++ b/docs/architecture/diagrams/website-i18n/01-use-case.md
@@ -47,17 +47,19 @@ flowchart LR
 ## Notes
 
 - **Textual specs (Cockburn-lite).**
-  - **UC2 — Switch the site language** (planned, slice S3): precondition —
-    visitor is on a page that has a twin. Main: 1. visitor clicks the FR/EN
-    toggle; 2. browser navigates to the twin URL; 3. choice stored (`bb-lang`).
-    Extensions: 1a. first visit, browser language differs from page language and
-    no stored choice → a suggestion banner offers the twin (accept = navigate +
-    store; dismiss = store current language, never nag again). Realized by
-    `02-sequence-language-switch.md`.
+  - **UC2 — Switch the site language** (plain autonym toggle ships in **S1**;
+    banner + `bb-lang` persistence in **S3**): precondition — visitor is on a
+    page that has a twin. Main: 1. visitor clicks the FR/EN autonym toggle
+    (top-right); 2. browser navigates to the twin URL (translated equivalent).
+    Extensions: 1a. first visit, browser language (`navigator.languages`)
+    differs from page language and no stored choice → a suggestion banner offers
+    the twin (accept = navigate + store `bb-lang`; dismiss = store current
+    language, never nag again). Realized by `02-sequence-language-switch.md`.
   - **UC5 — Publish a home copy change in both languages** (planned, slice S1):
     main: 1. maintainer edits `index.html` (FR source); 2. updates the flagged
     keys in `i18n/home.en.json`; 3. runs `build_i18n.py`; 4. commits — CI fails
-    on any missing/orphaned key or stale `en.html`. Realized by
+    on any missing/orphaned key, a changed FR source whose EN value + `srcHash`
+    were not updated, or a stale `en.html`. Realized by
     `03-data-flow-content-pipeline.md`.
   - **UC6 — Update a legal page pair** (planned, slice S4): main: edit FR page,
     re-review + edit EN twin, refresh the freshness stamp; CI fails when the FR

--- a/docs/architecture/diagrams/website-i18n/02-sequence-language-switch.md
+++ b/docs/architecture/diagrams/website-i18n/02-sequence-language-switch.md
@@ -2,7 +2,7 @@
 
 > **Feature**: website i18n epic (bilingual FR+EN marketing site)
 > **Related ADRs**: ADR-0027 (D4 — switcher, no auto-redirect, disclosed persistence)
-> **Decisions captured**: D4 clauses 1–4
+> **Decisions captured**: D4 clauses 1–5
 
 ## Context
 
@@ -25,7 +25,7 @@ sequenceDiagram
   P->>JS: init(pageLang="fr")
   JS->>LS: read "bb-lang"
   LS-->>JS: null
-  alt navigator.language prefers the other language
+  alt navigator.languages prefers the other language
     JS->>P: show suggestion banner ("This page exists in English")
     alt visitor accepts
       V->>JS: click "View in English"
@@ -43,14 +43,15 @@ sequenceDiagram
     V->>P: click FR/EN toggle link
     P->>JS: click handler (enhancement only)
     JS->>LS: write bb-lang=target
-    P->>P: plain <a> navigation to the twin URL
+    P->>P: plain anchor-tag navigation to the twin URL
   end
 ```
 
 ## Notes
 
 - **No automatic redirect on any path** — detection only ever *suggests*
-  (ADR-0027 D4 clause 3): crawler-safe, cache-safe, user-agency-safe.
+  (ADR-0027 D4 clause 4; the banner itself is clause 3): crawler-safe,
+  cache-safe, user-agency-safe.
 - The toggle is a plain `<a href>` in the **top-right of the header**, labelled
   by **autonym** (`Français` / `English`, or a compact `FR / EN`) — **no flags**
   (ADR-0027 D4 clauses 1-2; "flags are not languages", NN/G). It targets the
@@ -61,7 +62,7 @@ sequenceDiagram
   automatic switch (ADR-0027 D4 clause 4; Google discourages language
   auto-redirect).
 - `bb-lang` is the **first persistent storage on the site**: the same slice
-  (S3) must update `cookies.html` + `cookies-en.html` disclosure (D4 clause 4).
+  (S3) must update `cookies.html` + `cookies-en.html` disclosure (D4 clause 5).
   Reviewers should block any version of this flow that lands without the
   disclosure.
 - A stored choice never triggers navigation by itself; it only suppresses the

--- a/docs/architecture/diagrams/website-i18n/02-sequence-language-switch.md
+++ b/docs/architecture/diagrams/website-i18n/02-sequence-language-switch.md
@@ -1,0 +1,61 @@
+# Sequence diagram — website-i18n — language detection, suggestion banner and switch
+
+> **Feature**: website i18n epic (bilingual FR+EN marketing site)
+> **Related ADRs**: ADR-0027 (D4 — switcher, no auto-redirect, disclosed persistence)
+> **Decisions captured**: D4 clauses 1–4
+
+## Context
+
+`sd — UC2 Switch the site language`. The only non-trivial client flow of the
+epic: first-visit language suggestion, explicit switch, and remembered choice.
+It does NOT cover page generation (build-time, see `03-data-flow`) and applies
+to the two home pages only — legal pages keep their existing plain
+`.lang-switch` links.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor V as Visitor
+  participant P as Home page (/ or /en)
+  participant JS as site.js (BBShared)
+  participant LS as localStorage
+
+  V->>P: GET / (first visit, browser prefers en)
+  P->>JS: init(pageLang="fr")
+  JS->>LS: read "bb-lang"
+  LS-->>JS: null
+  alt navigator.language prefers the other language
+    JS->>P: show suggestion banner ("This page exists in English")
+    alt visitor accepts
+      V->>JS: click "View in English"
+      JS->>LS: write bb-lang="en"
+      JS->>P: navigate to /en
+    else visitor dismisses
+      V->>JS: click dismiss
+      JS->>LS: write bb-lang="fr"
+      JS->>P: hide banner (suppressed on all future visits)
+    end
+  else same language or choice already stored
+    JS->>JS: no banner
+  end
+  opt any visit — explicit toggle (works without JS)
+    V->>P: click FR/EN toggle link
+    P->>JS: click handler (enhancement only)
+    JS->>LS: write bb-lang=target
+    P->>P: plain <a> navigation to the twin URL
+  end
+```
+
+## Notes
+
+- **No automatic redirect on any path** — detection only ever *suggests*
+  (ADR-0027 D4 clause 3): crawler-safe, cache-safe, user-agency-safe.
+- The toggle is a plain `<a href>`; JS only adds persistence — the whole flow
+  degrades gracefully with JS disabled (banner simply never appears).
+- `bb-lang` is the **first persistent storage on the site**: the same slice
+  (S3) must update `cookies.html` + `cookies-en.html` disclosure (D4 clause 4).
+  Reviewers should block any version of this flow that lands without the
+  disclosure.
+- A stored choice never triggers navigation by itself; it only suppresses the
+  banner and sets the toggle's highlighted state.

--- a/docs/architecture/diagrams/website-i18n/02-sequence-language-switch.md
+++ b/docs/architecture/diagrams/website-i18n/02-sequence-language-switch.md
@@ -51,8 +51,15 @@ sequenceDiagram
 
 - **No automatic redirect on any path** — detection only ever *suggests*
   (ADR-0027 D4 clause 3): crawler-safe, cache-safe, user-agency-safe.
-- The toggle is a plain `<a href>`; JS only adds persistence — the whole flow
-  degrades gracefully with JS disabled (banner simply never appears).
+- The toggle is a plain `<a href>` in the **top-right of the header**, labelled
+  by **autonym** (`Français` / `English`, or a compact `FR / EN`) — **no flags**
+  (ADR-0027 D4 clauses 1-2; "flags are not languages", NN/G). It targets the
+  translated equivalent of the current page. JS only adds persistence — the whole
+  flow degrades gracefully with JS disabled (banner simply never appears).
+- Detection reads `navigator.languages` (ordered BCP 47 list, matched by lookup
+  with `en-US` → `en` fallback), a *hint* only — it drives the banner, never an
+  automatic switch (ADR-0027 D4 clause 4; Google discourages language
+  auto-redirect).
 - `bb-lang` is the **first persistent storage on the site**: the same slice
   (S3) must update `cookies.html` + `cookies-en.html` disclosure (D4 clause 4).
   Reviewers should block any version of this flow that lands without the

--- a/docs/architecture/diagrams/website-i18n/03-data-flow-content-pipeline.md
+++ b/docs/architecture/diagrams/website-i18n/03-data-flow-content-pipeline.md
@@ -32,7 +32,7 @@ flowchart LR
     CF["Cloudflare Pages<br/>brasse-bouillon.com"]
   end
   V(("Visitors FR/EN"))
-  FS(["Formspree (US, CCT)"])
+  FS(["Formspree (US, SCC)"])
   LS[("localStorage<br/>bb-lang")]
 
   M -->|"edits FR copy"| FR
@@ -59,11 +59,12 @@ flowchart LR
 - The generator runs at **authoring time**, never at deploy time — `en.html` is
   committed, so `website-deploy.yml` stays a dumb copy (`_redirects` added to its
   fail-loud copy list, ADR-0027 D2 clause 2).
-- CI is the drift guard: stale `en.html`, missing/orphaned catalog keys, or a
-  stale legal stamp all fail the PR (D1 clause 4–5).
+- CI is the drift guard: stale `en.html`, missing/orphaned catalog keys, a
+  changed FR source whose EN value + `srcHash` were not updated, or a stale legal
+  stamp all fail the PR (D1 clause 4–5).
 - **PII edges**: only the existing Formspree submissions carry PII (email,
   contact field, questionnaire answers) — unchanged by this epic, EN adds
   `lang=en` only. `bb-lang` is a non-PII functional preference that never leaves
-  the browser; it must be disclosed on the cookies pages (D4 clause 4).
+  the browser; it must be disclosed on the cookies pages (D4 clause 5).
 - Legal twins deliberately bypass the generator: stable, jurisdiction-specific
   prose (guarded by stamp, not templated).

--- a/docs/architecture/diagrams/website-i18n/03-data-flow-content-pipeline.md
+++ b/docs/architecture/diagrams/website-i18n/03-data-flow-content-pipeline.md
@@ -1,0 +1,69 @@
+# Data-flow diagram — website-i18n — bilingual content pipeline (authoring → deploy)
+
+> **Feature**: website i18n epic (bilingual FR+EN marketing site)
+> **Related ADRs**: ADR-0027 (D1 — hybrid strategy; D2 — URL scheme), ADR-0014
+> **Decisions captured**: D1 clauses 1–5, D2 clause 2
+
+## Context
+
+Where bilingual content comes from and how it reaches production. Contingent on
+ADR-0027 acceptance (hybrid: generated EN home, guarded legal twins). Also flags
+the only two visitor-side data flows (form submissions, language preference) so
+the privacy review cannot be skipped.
+
+## Diagram
+
+```mermaid
+flowchart LR
+  M((Maintainer))
+  subgraph Authoring ["Authoring (git, packages/website)"]
+    FR["index.html<br/>(FR source, data-i18n annotated)"]
+    CAT["i18n/home.en.json<br/>(EN catalog)"]
+    GEN["scripts/build_i18n.py<br/>(stdlib only)"]
+    EN["en.html<br/>(GENERATED, committed)"]
+    LFR["legal twins FR<br/>(hand-edited)"]
+    LEN["legal twins EN<br/>(hand-edited + i18n-src stamp)"]
+  end
+  subgraph CI ["CI (PR gate)"]
+    QG["quality_gate.py<br/>+ regen diff + key parity<br/>+ stamp freshness"]
+  end
+  subgraph Deploy ["Deploy (main)"]
+    SITE["_site/ staging<br/>(website-deploy.yml)"]
+    CF["Cloudflare Pages<br/>brasse-bouillon.com"]
+  end
+  V(("Visitors FR/EN"))
+  FS(["Formspree (US, CCT)"])
+  LS[("localStorage<br/>bb-lang")]
+
+  M -->|"edits FR copy"| FR
+  M -->|"translates flagged keys"| CAT
+  FR --> GEN
+  CAT --> GEN
+  GEN -->|"generates"| EN
+  M -->|"edits + re-reviews twin"| LFR
+  M --> LEN
+  FR --> QG
+  EN --> QG
+  CAT --> QG
+  LFR --> QG
+  LEN --> QG
+  QG -->|"merge when green"| SITE
+  SITE --> CF
+  CF -->|"/ and /en (301 from /index-en)"| V
+  V -->|"PII: email, contact, answers (form POST, lang=fr/en)"| FS
+  V -->|"language preference (no PII, client-only)"| LS
+```
+
+## Notes
+
+- The generator runs at **authoring time**, never at deploy time — `en.html` is
+  committed, so `website-deploy.yml` stays a dumb copy (`_redirects` added to its
+  fail-loud copy list, ADR-0027 D2 clause 2).
+- CI is the drift guard: stale `en.html`, missing/orphaned catalog keys, or a
+  stale legal stamp all fail the PR (D1 clause 4–5).
+- **PII edges**: only the existing Formspree submissions carry PII (email,
+  contact field, questionnaire answers) — unchanged by this epic, EN adds
+  `lang=en` only. `bb-lang` is a non-PII functional preference that never leaves
+  the browser; it must be disclosed on the cookies pages (D4 clause 4).
+- Legal twins deliberately bypass the generator: stable, jurisdiction-specific
+  prose (guarded by stamp, not templated).

--- a/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
+++ b/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
@@ -1,0 +1,114 @@
+# EN Launch Playbook — voice, transcreation and Reddit readiness
+
+> Companion to ADR-0027 (website i18n strategy). This document owns the
+> **editorial** side of the EN launch: how the English copy must sound, how the
+> FR copy is transcreated (not translated), and what must be true before
+> promoting the site on Reddit / international homebrewing communities.
+> Not deployed — `website-deploy.yml` excludes `docs/` except `ROADMAP.md`.
+
+## 1. Voice and tone
+
+The FR voice is playful, direct, second-person singular ("Brasse ta première
+bière sans peur de rater."). The EN voice must land for r/Homebrewing natives —
+a community allergic to marketing speak. Principles:
+
+1. **Transcreate, never translate literally.** Rewrite each segment for intent
+   and rhythm; a faithful-but-flat translation is a failure.
+2. **Peer-to-peer builder voice.** Sound like a homebrewer who codes, not a
+   brand. First person allowed ("I'm building…") on community posts; the site
+   itself stays product-voiced but plain.
+3. **Banned register**: "revolutionary", "ultimate", "game-changer",
+   "unleash", exclamation-mark stacking, feature hype. If a sentence would be
+   downvoted as an ad on r/Homebrewing, rewrite it.
+4. **Homebrewer-native vocabulary** (BJCP / BeerXML terms, per house rule):
+   batch, mash, boil, pitch, OG/FG, IBU, ABV, fermentation, bottling day.
+   Prefer "batch" over "beer" when referring to a brew run.
+5. **Dry humor survives; puns must be earned.** Keep the reassuring,
+   demystifying angle — the app's maître-mot is that it *teaches*.
+
+## 2. Sample transcreations (calibration set)
+
+| FR (authored) | EN (transcreation) | Why |
+|---|---|---|
+| Brasse ta première bière sans peur de rater. | Brew your first batch without the fear of screwing it up. | "batch" is native; keeps the reassurance, adds the community's own bluntness. |
+| De la recette à la dégustation | From recipe to first sip | "tasting" is flat; "first sip" lands the payoff moment. |
+| L'essentiel, rien que l'essentiel | The essentials. Nothing else. | Two fragments punch harder in EN than a mirrored repetition. |
+| Une bière t'a plu ? Scanne-la. | Liked a beer? Scan it. | Preserves the two-beat rhythm. |
+| Rejoins la première fournée | Join the first batch | The fournée/batch double meaning survives intact — keep it. |
+| Les doutes avant de se lancer | The doubts before you brew | FAQ heading; "before you brew" beats a literal "before starting". |
+
+These six are the calibration set: every other segment in `i18n/home.en.json`
+is reviewed against their register.
+
+## 3. Terminology and units
+
+- **Metric-first, imperial gloss where cheap.** The app is metric (L, °C, EBC).
+  Keep metric as primary; add a parenthetical gloss only in copy examples where
+  it helps a US reader, e.g. "19 L (5 gal)". Never convert the app's actual UI
+  values in screenshots or claims.
+- **Color**: EBC in FR copy stays EBC in EN with SRM gloss if a value appears
+  ("EBC 8 (~4 SRM)").
+- Keep proper nouns and brand terms untouched: Brasse-Bouillon (with a one-line
+  name gloss on the EN home — see Honesty rules).
+
+## 4. Honesty rules (non-negotiable for Reddit credibility)
+
+1. **Say the app ships in French first.** The EN home carries a plain line such
+   as: "The app currently ships in French — an English UI is on the roadmap.
+   The site, waitlist and questionnaire are fully in English." Reddit will find
+   out in one tap; being upfront converts skeptics, hiding it burns the launch.
+2. **Screenshots are the real (French) UI** — caption them as such rather than
+   mocking up fake English screens.
+3. **No app-store claims**: the app is pre-release; the only CTA is the
+   waitlist + questionnaire. Never imply availability.
+4. Explain the name once: "Brasse-Bouillon — roughly 'brew-broth', a French
+   nod to homebrew kettles" (final wording at S1 copy review).
+
+## 5. FAQ adaptation
+
+Transcreate the 5 FAQ entries for an international audience; keep the FAQPage
+JSON-LD in sync (generated, ADR-0027 D1 clause 3). France-specific content
+(18+ responsibility band, legal references) stays as-is — the site is operated
+from France and the EN legal twins already state it.
+
+## 6. Reddit-readiness checklist
+
+Technical — **must be true before any link is posted** (all land in slice S1):
+
+- [ ] `https://brasse-bouillon.com/en` live, full feature parity with FR
+      (hero, journey, pillars, scan, FAQ, forms), final URL (no later rename).
+- [ ] EN OG/Twitter meta present — the Reddit link card is built from it.
+- [ ] Both forms accept EN submissions (`lang=en`) with EN success/error
+      messages in `site.js`.
+- [ ] The "app is French-first" honesty line is visible in or immediately
+      below the hero section.
+- [ ] EN legal pages linked in the EN footer (already true today).
+- [ ] Lighthouse spot-check on `/en` (SEO/A11y/BP — parity with FR scores).
+
+Recommended before posting (slice S2 — search benefit, not blocking for
+direct links): noindex removed, reciprocal hreflang, `/en` in the sitemap.
+
+Community etiquette — per subreddit, before posting:
+
+- [ ] Read the target subreddit's self-promotion rules (r/Homebrewing enforces
+      participate-first, roughly 9:1 contribution-to-promo etiquette).
+- [ ] Post from an account with genuine participation history; consider
+      messaging the mods first for a "I built a thing" post.
+- [ ] Frame as a builder-journey post ("I'm building a free companion app to
+      guide first-time brewers — honest feedback welcome"), never a bare link
+      drop.
+- [ ] Be upfront: pre-release, French-first UI, solo project.
+- [ ] Prepare the two inevitable answers: "where's the app?" (waitlist,
+      pre-release) and "why French?" (built alongside my own first real brew;
+      English UI on the roadmap).
+- [ ] Be available to reply for the first 24 h after posting.
+
+## 7. Content cadence — keeping EN alive after launch
+
+- A FR home copy change **cannot merge** without its EN counterpart: the CI key
+  parity + regen-diff guard (ADR-0027 D1 clause 4) enforces it mechanically.
+- Legal pages: the freshness stamp (D1 clause 5) forces an explicit EN
+  re-review whenever a FR legal page changes.
+- New home sections (e.g. the Académie section designed in parallel) are
+  authored FR-first with `data-i18n` keys; their EN transcreation is written in
+  the same PR, reviewed against the §2 calibration set.

--- a/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
+++ b/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
@@ -77,9 +77,14 @@ Technical — **must be true before any link is posted** (all land in slice S1):
 
 - [ ] `https://brasse-bouillon.com/en` live, full feature parity with FR
       (hero, journey, pillars, scan, FAQ, forms), final URL (no later rename).
-- [ ] EN OG/Twitter meta present — the Reddit link card is built from it.
+- [ ] EN OG/Twitter meta present, incl. `og:locale=en_US` — the Reddit link
+      card is built from it.
+- [ ] `og:image`: verify the shared `og-image.png` carries no baked-in French
+      text; if it does, ship a localized EN card image (else the EN card shows
+      French).
 - [ ] Both forms accept EN submissions (`lang=en`) with EN success/error
-      messages in `site.js`.
+      messages (the message tables are inline in `index.html`, localized by the
+      generator — not in `site.js`).
 - [ ] The "app is French-first" honesty line is visible in or immediately
       below the hero section.
 - [ ] EN legal pages linked in the EN footer (already true today).

--- a/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
+++ b/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
@@ -83,8 +83,8 @@ Technical — **must be true before any link is posted** (all land in slice S1):
       text; if it does, ship a localized EN card image (else the EN card shows
       French).
 - [ ] Both forms accept EN submissions (`lang=en`) with EN success/error
-      messages (the message tables are inline in `index.html`, localized by the
-      generator — not in `site.js`).
+      messages (the message tables are moved into `site.js`/the catalog in S1,
+      so EN strings come from the catalog like any other text).
 - [ ] The "app is French-first" honesty line is visible in or immediately
       below the hero section.
 - [ ] EN legal pages linked in the EN footer (already true today).


### PR DESCRIPTION
## Summary

Conception-first deliverables for the **website i18n epic** (turn the marketing site genuinely bilingual FR+EN to promote the project on Reddit / international homebrewing communities). **No implementation code** — slices S1–S4 follow once this conception is merged.

- **ADR-0027 (Proposed)** — `docs/architecture/decisions/0027-website-i18n-strategy.md`
  - **D1 — hybrid content strategy** (weighted matrix 4.15 vs 3.60/3.40): the EN home is *generated* from the annotated FR source (`index.html` + `i18n/home.en.json` + stdlib `build_i18n.py`, output committed → deploy stays build-less); legal pages stay hand-maintained twins guarded by a CI freshness stamp. A FR copy change without its EN translation fails CI.
  - **D2 — URL scheme** (matrix): EN home at **`/en`** (`en.html` + `_redirects` 301 from `/index-en`); legal pages keep their `-en` suffix URLs.
  - **D3 — forms**: reuse the existing Formspree endpoints with the already-present hidden `lang` field set to `en`.
  - **D4 — switcher**: visible FR/EN toggle + one-time suggestion banner, **no auto-redirect**, `bb-lang` localStorage choice **disclosed on the cookies pages** (first persistent storage on the site — keeps the #1379 accuracy intact).
  - **D5 — SEO switch**: de-noindex EN pages, reciprocal hreflang (`fr`/`en`/`x-default`=FR), sitemap = `/` + `/en` (coordinate with audit Lot 5 on `check_sitemap_policy`); reverses the SEO_RUNBOOK de-index decision.
- **UML** (`docs/architecture/diagrams/website-i18n/`): use-case (6 UCs, Cockburn-lite specs), sequence (language detection/switch/persistence), data-flow (bilingual content pipeline with PII flags). Component/class/state deliberately skipped (proportionality).
- **EN launch playbook** (`packages/website/docs/EN_LAUNCH_PLAYBOOK.md`): transcreation voice/tone for r/Homebrewing natives, 6-sample calibration set, honesty rules (app is French-first, pre-release), Reddit-readiness checklist, content cadence.

## Context

Validated with Benoît (2026-07-10): hybrid strategy, `/en` URL, Reddit posting after S1+S2. Rollout: S1 real EN home (ships dark, `noindex` kept, self-canonical) → S2 SEO switch → S3 switcher UX + cookies disclosure → S4 process hardening. Coordination captured in the ADR: the parallel "Académie" home-section work and audit Lot 5 (no in-flight branch collides today).

## Checklist

- [x] Conception only — no implementation code, no gate/workflow changes
- [x] Local pre-push review ritual run: `pr-pre-reviewer` report (0 Must Have; 3 Should Have fixed: ADR header format, S1 canonical clarified, Mermaid label quoting). Codex helper could not run (`codex exec review` CLI flag drift — fix task flagged separately)
- [x] UML 2.5 orthodoxy + Mermaid house conventions (quoted labels, no trailing fence, domain-grouped use cases)
- [x] English-only artifacts
- [ ] Follow-up at acceptance: flip ADR-0027 to Accepted + add it to the root `CLAUDE.md` ADR list

Refs #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)