### PR TITLE
fix(academy): align navigation onto the (app) route group + article scroll reset

### DIFF
--- a/packages/mobile-app/src/features/academy/presentation/AcademyGlossarySection.tsx
+++ b/packages/mobile-app/src/features/academy/presentation/AcademyGlossarySection.tsx
@@ -53,7 +53,7 @@ export function AcademyHighlightedGlossaryTerm({
       ) : null}
       {term.sources.length > 0 ? (
         <View style={styles.glossarySourcesSection}>
-          <Text style={styles.glossarySourcesTitle}>Sources</Text>
+          <Text style={styles.glossarySourcesTitle}>Sources du terme</Text>
           <View style={styles.glossarySourcesList}>
             {term.sources.map((source) => (
               <View key={source.id} style={styles.glossarySourceItem}>

--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
@@ -331,7 +331,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
           label="En savoir plus"
           onPress={() =>
             router.push({
-              pathname: "/academy/[slug]/learn",
+              pathname: "/(app)/academy/[slug]/learn",
               params: { slug: displayableTopic.slug },
             })
           }

--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
@@ -194,6 +194,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
         />
 
         <ScrollView
+          key={`${normalizedSlug ?? "unknown"}:${normalizedTermSlug ?? ""}`}
           ref={scrollViewRef}
           contentContainerStyle={[
             styles.content,

--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicPlaceholderScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicPlaceholderScreen.tsx
@@ -120,7 +120,7 @@ export function AcademyTopicPlaceholderScreen({ slugParam, mode }: Props) {
           label="Retour à la fiche thématique"
           onPress={() =>
             router.push({
-              pathname: "/academy/[slug]",
+              pathname: "/(app)/academy/[slug]",
               params: { slug: topic.slug },
             })
           }

--- a/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
@@ -660,6 +660,17 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
     }
   });
 
+  it("navigates from a legacy topic to its placeholder article route", () => {
+    render(<AcademyTopicDetailsScreen slugParam="histoire" />);
+
+    fireEvent.press(screen.getByText("En savoir plus"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/(app)/academy/[slug]/learn",
+      params: { slug: "histoire" },
+    });
+  });
+
   it("edge: every topic with hasCalculator=true is wired to a working calculator route", () => {
     const wired = academyTopics.filter((t) => t.hasCalculator);
     expect(wired.map((t) => t.slug).sort()).toEqual(

--- a/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
@@ -758,7 +758,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
     expect(
       screen.getByText("Alias : International Bitterness Units"),
     ).toBeTruthy();
-    expect(screen.getByText("Sources")).toBeTruthy();
+    expect(screen.getByText("Sources du terme")).toBeTruthy();
     expect(screen.getByText("How to Brew (2017)")).toBeTruthy();
     expect(screen.getByText("Termes associés")).toBeTruthy();
     expect(

--- a/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicPlaceholderScreen.test.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicPlaceholderScreen.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+import React from "react";
+
+import { AcademyTopicPlaceholderScreen } from "../AcademyTopicPlaceholderScreen";
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+const mockBack = jest.fn();
+const mockCanGoBack = jest.fn(() => true);
+
+jest.mock("@expo/vector-icons", () => {
+  return {
+    Ionicons: () => null,
+  };
+});
+
+jest.mock("expo-router", () => {
+  const actual = jest.requireActual("expo-router");
+
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: mockPush,
+      replace: mockReplace,
+      back: mockBack,
+      canGoBack: mockCanGoBack,
+    }),
+  };
+});
+
+describe("AcademyTopicPlaceholderScreen", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockReplace.mockClear();
+    mockBack.mockClear();
+    mockCanGoBack.mockReset();
+    mockCanGoBack.mockReturnValue(true);
+  });
+
+  it("navigates back to the topic details route from a placeholder article", () => {
+    render(<AcademyTopicPlaceholderScreen slugParam="histoire" mode="learn" />);
+
+    fireEvent.press(screen.getByText("Retour à la fiche thématique"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/(app)/academy/[slug]",
+      params: { slug: "histoire" },
+    });
+  });
+});

--- a/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicPlaceholderScreen.test.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicPlaceholderScreen.test.tsx
@@ -47,4 +47,49 @@ describe("AcademyTopicPlaceholderScreen", () => {
       params: { slug: "histoire" },
     });
   });
+
+  it("sad: renders the empty state and returns to the hub for an unknown topic", () => {
+    render(
+      <AcademyTopicPlaceholderScreen slugParam="__unknown__" mode="learn" />,
+    );
+
+    expect(screen.getByText("Impossible d'ouvrir cette page")).toBeTruthy();
+
+    fireEvent.press(screen.getByText("Retour à l'académie"));
+
+    expect(mockReplace).toHaveBeenCalledWith("/(app)/academy");
+  });
+
+  it("edge: uses navigation back from the header when history exists", () => {
+    mockCanGoBack.mockReturnValue(true);
+
+    render(<AcademyTopicPlaceholderScreen slugParam="histoire" mode="learn" />);
+
+    fireEvent.press(screen.getByLabelText("Retour à l'écran précédent"));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("edge: falls back to the academy hub from the header without history", () => {
+    mockCanGoBack.mockReturnValue(false);
+
+    render(<AcademyTopicPlaceholderScreen slugParam="histoire" mode="learn" />);
+
+    fireEvent.press(screen.getByLabelText("Retour à l'écran précédent"));
+
+    expect(mockBack).not.toHaveBeenCalled();
+    expect(mockReplace).toHaveBeenCalledWith("/(app)/academy");
+  });
+
+  it("edge: renders the calculator placeholder variant for mode=calculator", () => {
+    render(
+      <AcademyTopicPlaceholderScreen slugParam="histoire" mode="calculator" />,
+    );
+
+    expect(
+      screen.getByText("Le calculateur thématique arrive bientôt."),
+    ).toBeTruthy();
+    expect(screen.getByText("Calculateur")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary

Aligns the last two stray Academy navigation calls onto the `(app)` route group used by every other Academy/tools navigation call, and improves in-article navigation:

- `AcademyTopicDetailsScreen` — "En savoir plus" now pushes `/(app)/academy/[slug]/learn` (was `/academy/[slug]/learn`).
- `AcademyTopicPlaceholderScreen` — "Retour à la fiche thématique" now pushes `/(app)/academy/[slug]` (was `/academy/[slug]`).
- `AcademyTopicDetailsScreen` — the article `ScrollView` now remounts on slug/termSlug change (via `key`), so opening another article or glossary term starts at the top instead of keeping the previous scroll offset.
- `AcademyGlossarySection` — the highlighted glossary term sources heading now reads "Sources du terme" (was the ambiguous "Sources").

## Context

Both route-group paths were the only two Academy navigation calls still using the un-grouped form; every other call site (40+ across ingredients, recipes, shop, batches, academy) already uses the explicit `(app)`-prefixed form, and Expo Router typed-routes accept it.

Verified live on an Android emulator (demo mode): the two corrected navigations, the top-of-page scroll-reset invariant (article -> related article, and term -> related term), and the "Sources du terme" heading all behave as expected, with zero navigation errors in the logs.

Note: Expo Router elides route-group segments from the URL, so the un-grouped form also resolves at runtime. This change is therefore a consistency/convention alignment plus two genuine UX fixes (scroll reset + sources heading), not a broken-navigation fix.

## Checklist

- [x] `npm -w packages/mobile-app run ci:check` (lint + typecheck + format) green
- [x] Targeted Jest suites green (Academy details / placeholder / renderer — 46 tests)
- [x] New `AcademyTopicPlaceholderScreen` test covers happy + sad + edge (unknown topic, header back history/fallback, calculator-mode variant)
- [x] Live emulator pass (navigation, scroll reset, glossary sources heading)
- [x] No ADR violations; no forbidden patterns (`any`, default exports, inline styles, hardcoded tokens, direct `fetch`)
