### PR TITLE
fix(tools): use app route group for calculator navigation

### DIFF
--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
@@ -206,7 +206,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
                 label={calculatorLabel}
                 onPress={() =>
                   router.push({
-                    pathname: "/tools/[slug]/calculator",
+                    pathname: "/(app)/tools/[slug]/calculator",
                     params: { slug: calculatorSlug },
                   })
                 }
@@ -242,7 +242,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
               }
               onCalculatorPress={(slug) =>
                 router.push({
-                  pathname: "/tools/[slug]/calculator",
+                  pathname: "/(app)/tools/[slug]/calculator",
                   params: { slug },
                 })
               }
@@ -342,7 +342,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
             label={calculatorLabel}
             onPress={() =>
               router.push({
-                pathname: "/tools/[slug]/calculator",
+                pathname: "/(app)/tools/[slug]/calculator",
                 params: { slug: displayableTopic.slug },
               })
             }

--- a/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/__tests__/AcademyTopicDetailsScreen.test.tsx
@@ -634,7 +634,7 @@ describe("AcademyTopicDetailsScreen — calculator CTA (Issue #616)", () => {
       fireEvent.press(button);
 
       expect(mockPush).toHaveBeenCalledWith({
-        pathname: "/tools/[slug]/calculator",
+        pathname: "/(app)/tools/[slug]/calculator",
         params: { slug },
       });
     },


### PR DESCRIPTION
## Summary

Aligns the three calculator-CTA navigation calls in `AcademyTopicDetailsScreen` onto the `(app)` route group, matching every other tools/calculator call site, and updates the calculator-CTA test assertion accordingly.

- `AcademyTopicDetailsScreen` — the three `router.push` calls to the topic calculator now use `/(app)/tools/[slug]/calculator` (was `/tools/[slug]/calculator`).
- `AcademyTopicDetailsScreen.test.tsx` — calculator-CTA assertion updated to the grouped path.

## Context

Fast-follow from the pre-push review of #1385: these were the last un-grouped `/tools/[slug]/calculator` paths in the mobile app; every other call site already uses the `(app)`-prefixed form (e.g. `RecipeDetailsScreen`, `ToolsHubScreen` tests).

Verified live on an Android emulator that the calculator CTA navigates correctly to the Fermentescibles calculator. The un-grouped form also resolves at runtime (Expo Router elides group segments from the URL), so this is a consistency/convention alignment with no behavior change.

## Checklist

- [x] `npm -w packages/mobile-app run ci:check` (lint + typecheck + format) green
- [x] Tools presentation Jest suites green (12 suites / 169 tests)
- [x] Live emulator pass (calculator CTA navigates)
- [x] No un-grouped `pathname: "/tools` remains in `packages/mobile-app/src`
- [x] No ADR violations; no forbidden patterns
