### PR TITLE
fix(website): newsletter honeypot, badge contrast (AA), honest widget comment (Lot 6)

### DIFF
--- a/packages/website/404.html
+++ b/packages/website/404.html
@@ -17,7 +17,7 @@
   <!-- Root-absolute asset URLs: this page is served for ANY unmatched
        route (e.g. /foo/bar/), so relative URLs would resolve against the
        requested path and 404. Assets must be pinned to the site root. -->
-  <link rel="stylesheet" href="/site.css?v=20260526-3">
+  <link rel="stylesheet" href="/site.css?v=20260710">
 
   <!-- Page-specific layout only; all colours/typography come from the
        site.css design tokens (no hardcoded values). -->

--- a/packages/website/cookies-en.html
+++ b/packages/website/cookies-en.html
@@ -88,7 +88,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/cookies.html
+++ b/packages/website/cookies.html
@@ -89,7 +89,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/index-en.html
+++ b/packages/website/index-en.html
@@ -25,7 +25,7 @@
 
   <link rel="stylesheet" href="/fonts.css?v=20260709">
 
-  <link rel="stylesheet" href="site.css?v=20260526-3">
+  <link rel="stylesheet" href="site.css?v=20260710">
 </head>
 <body>
   <a class="skip-link" href="#mainContentEn">Skip to main content</a>
@@ -84,7 +84,7 @@
   </aside>
 
   <script src="site.js?v=20260523-2"></script>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
   <!-- FAQ chat widget — self-hosted; mounts on staging/localhost only (ADR-0022) -->
   <script type="module" src="chat-widget.js?v=20260701"></script>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -39,7 +39,7 @@
   <!-- Fonts -->
   <link rel="stylesheet" href="/fonts.css?v=20260709">
 
-  <link rel="stylesheet" href="site.css?v=20260526-3">
+  <link rel="stylesheet" href="site.css?v=20260710">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -306,6 +306,7 @@
           <input type="hidden" name="lang" value="fr">
           <input type="hidden" name="source" value="newsletter">
           <input type="hidden" name="message" value="Nouvelle inscription newsletter via le site (FR)">
+          <input class="honeypot" type="text" name="_gotcha">
 
           <label class="sr-only" for="newsletterEmailFr">Adresse email pour la waitlist</label>
           <input id="newsletterEmailFr" type="email" name="email" placeholder="ton@email.fr" required>
@@ -568,7 +569,7 @@
       }
     });
   </script>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
   <!-- FAQ chat widget — self-hosted; mounts on staging/localhost only (ADR-0022) -->
   <script type="module" src="chat-widget.js?v=20260701"></script>

--- a/packages/website/legal-en.html
+++ b/packages/website/legal-en.html
@@ -111,7 +111,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/legal.html
+++ b/packages/website/legal.html
@@ -111,7 +111,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -123,7 +123,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -123,7 +123,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -348,7 +348,9 @@
       width: 54px;
       height: 54px;
       border-radius: 50%;
-      background: var(--copper);
+      /* copper-deep (not copper) so the foam "18+" clears WCAG AA:
+         foam-on-copper is 3.2:1, foam-on-copper-deep is 6.07:1. */
+      background: var(--copper-deep);
       color: var(--foam);
       font-family: var(--font-display);
       font-weight: 700;

--- a/packages/website/terms-en.html
+++ b/packages/website/terms-en.html
@@ -114,7 +114,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — All rights reserved
   </footer>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>

--- a/packages/website/terms.html
+++ b/packages/website/terms.html
@@ -112,7 +112,7 @@
   <footer>
     © 2025-2026 Brasse-Bouillon — Tous droits réservés
   </footer>
-  <!-- Feedback widget — local loader; mounts the Cloudflare Worker widget on prod only -->
+  <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Lot 6 of the 2026-07-09 website audit — hygiene (last of the site-side remediation lots).

- **Newsletter honeypot**: the newsletter form gains the Formspree `_gotcha` honeypot the questionnaire already had (`.honeypot`, `display:none`) — closes the spam/abuse gap on the only unprotected form. Refs #1036.
- **Badge contrast (WCAG AA)**: the responsibility-band "18+" badge background `--copper` → `--copper-deep`. Foam text on copper was **3.2:1** (failing); on copper-deep it's **6.07:1**. Fixes the sole Lighthouse accessibility contrast failure (A11y was 96).
- **Honest widget comment**: the feedback-widget loader comment claimed it "mounts on prod only" — the **opposite** of reality (host-gated to staging/localhost, inert in production). Corrected on all 10 loading pages, keeping the code comments as accurate as the legal pages now are.
- **Cache-bust**: `site.css ?v=20260710` on all 3 pages that link it (index, index-en, 404).

## Review

Pre-push review: 0 Must, 1 Should (a missed 404.html cache-bust — **fixed** before push). Verified: honeypot hidden/non-tabbable + Formspree-correct, badge is the only consumer of the changed token, widget comment matches `feedback-widget.js` gating, FR/EN parity intact. Local: quality gate + 20 tests green; badge computed color + honeypot hidden state verified in the preview (`rgb(141,74,19)` = copper-deep, 6.07:1).

Refs #1036. After this, the site-side audit remediation (Lots 2–6) is complete; remaining: Lot 1 DNS (user) + deferred og-image 1200×630 (design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)