### PR TITLE
refactor(website): exact-set sitemap policy + O(n) duplicate check

### DIFF
--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -6,6 +6,7 @@ This script is intentionally dependency-free so it can run locally and in CI.
 
 from __future__ import annotations
 
+from collections import Counter
 from pathlib import Path
 import re
 import sys
@@ -14,6 +15,17 @@ import xml.etree.ElementTree as ET
 
 ROOT = Path(__file__).resolve().parent.parent
 HOMEPAGE_URL = "https://brasse-bouillon.com/"
+
+# URLs: the home page plus the four French legal pages. The English legal twins
+# and the `-en` stub are `noindex`, and any `.html` URL 308-redirects to its
+# clean form, so none of them may ever appear in the sitemap.
+SITEMAP_URLS = [
+    HOMEPAGE_URL,
+    f"{HOMEPAGE_URL}legal",
+    f"{HOMEPAGE_URL}privacy",
+    f"{HOMEPAGE_URL}cookies",
+    f"{HOMEPAGE_URL}terms",
+]
 
 REQUIRED_FILES = [
     "index.html",
@@ -249,11 +261,14 @@ def check_chat_widget(root: Path = ROOT) -> list[str]:
 
 
 def check_sitemap_policy(root: Path = ROOT) -> list[str]:
+    """The sitemap must advertise EXACTLY the indexable clean URLs (`SITEMAP_URLS`)
+    — nothing missing, nothing extra, no duplicate. This blocks re-adding a
+    `noindex` twin/stub or a `.html` (308-redirecting) URL, which would send
+    crawlers a contradictory signal. Order-independent (sitemap order is
+    irrelevant to search engines)."""
     sitemap_path = root / "sitemap.xml"
     if not sitemap_path.exists():
         return []
-
-    errors: list[str] = []
 
     try:
         xml_root = ET.parse(sitemap_path).getroot()
@@ -266,31 +281,27 @@ def check_sitemap_policy(root: Path = ROOT) -> list[str]:
         if (loc.text or "").strip()
     ]
 
-    # Indexable URLs allowed in the sitemap: the home + the FR legal pages, as
-    # the clean URLs Cloudflare Pages serves. The EN legal pages are noindex and
-    # MUST NOT appear here; nor may the `.html` forms (they 308-redirect).
-    allowed = {
-        HOMEPAGE_URL,
-        f"{HOMEPAGE_URL}legal",
-        f"{HOMEPAGE_URL}privacy",
-        f"{HOMEPAGE_URL}cookies",
-        f"{HOMEPAGE_URL}terms",
-    }
+    if sorted(loc_values) == sorted(SITEMAP_URLS):
+        return []
 
-    if HOMEPAGE_URL not in loc_values:
-        errors.append(f"sitemap.xml: l'URL d'accueil {HOMEPAGE_URL} est manquante")
+    counts = Counter(loc_values)
+    expected = set(SITEMAP_URLS)
+    missing = [url for url in SITEMAP_URLS if url not in counts]
+    forbidden = sorted(url for url in counts if url not in expected)
+    duplicates = sorted(url for url, count in counts.items() if count > 1)
 
-    for loc in loc_values:
-        if loc not in allowed:
-            errors.append(
-                f"sitemap.xml: URL non autorisée « {loc} » — seules l'accueil et "
-                "les pages légales FR (URLs propres, indexables) sont admises"
-            )
+    # At least one category is always non-empty here: the early return above
+    # already handled the exact-match case.
+    problems: list[str] = []
+    if missing:
+        problems.append("manquantes: " + ", ".join(missing))
+    if forbidden:
+        problems.append("interdites: " + ", ".join(forbidden))
+    if duplicates:
+        problems.append("dupliquées: " + ", ".join(duplicates))
 
-    for loc in sorted({loc for loc in loc_values if loc_values.count(loc) > 1}):
-        errors.append(f"sitemap.xml: URL en double « {loc} »")
-
-    return errors
+    detail = " ; ".join(problems)
+    return [f"sitemap.xml: doit lister exactement les URL indexables ({detail})"]
 
 
 def check_robots_policy(root: Path = ROOT) -> list[str]:

--- a/packages/website/tests/test_quality_gate.py
+++ b/packages/website/tests/test_quality_gate.py
@@ -110,6 +110,18 @@ def _create_valid_fixture(base: Path) -> None:
   <url>
     <loc>https://brasse-bouillon.com/</loc>
   </url>
+  <url>
+    <loc>https://brasse-bouillon.com/legal</loc>
+  </url>
+  <url>
+    <loc>https://brasse-bouillon.com/privacy</loc>
+  </url>
+  <url>
+    <loc>https://brasse-bouillon.com/cookies</loc>
+  </url>
+  <url>
+    <loc>https://brasse-bouillon.com/terms</loc>
+  </url>
 </urlset>
 """,
     )
@@ -367,6 +379,10 @@ class QualityGateTests(unittest.TestCase):
                 """<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://brasse-bouillon.com/</loc></url>
+  <url><loc>https://brasse-bouillon.com/legal</loc></url>
+  <url><loc>https://brasse-bouillon.com/privacy</loc></url>
+  <url><loc>https://brasse-bouillon.com/cookies</loc></url>
+  <url><loc>https://brasse-bouillon.com/terms</loc></url>
   <url><loc>https://brasse-bouillon.com/legal-en</loc></url>
   <url><loc>https://brasse-bouillon.com/legal.html</loc></url>
 </urlset>
@@ -375,9 +391,9 @@ class QualityGateTests(unittest.TestCase):
             )
 
             errors = quality_gate.check_sitemap_policy(root)
-            disallowed = [err for err in errors if "URL non autorisée" in err]
-            self.assertTrue(any("legal-en" in err for err in disallowed))
-            self.assertTrue(any("legal.html" in err for err in disallowed))
+            forbidden = [err for err in errors if "interdites" in err]
+            self.assertTrue(any("legal-en" in err for err in forbidden))
+            self.assertTrue(any("legal.html" in err for err in forbidden))
 
     def test_sitemap_allows_home_and_fr_legal_pages(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -405,19 +421,51 @@ class QualityGateTests(unittest.TestCase):
             root = Path(tmp_dir)
             _create_valid_fixture(root)
             sitemap_path = root / "sitemap.xml"
+            # Everything but the home page → the home URL is reported missing.
             sitemap_path.write_text(
                 """<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://brasse-bouillon.com/legal</loc></url>
+  <url><loc>https://brasse-bouillon.com/privacy</loc></url>
+  <url><loc>https://brasse-bouillon.com/cookies</loc></url>
+  <url><loc>https://brasse-bouillon.com/terms</loc></url>
 </urlset>
 """,
                 encoding="utf-8",
             )
 
             errors = quality_gate.check_sitemap_policy(root)
-            self.assertTrue(any("d'accueil" in err for err in errors))
+            self.assertTrue(
+                any("manquantes: https://brasse-bouillon.com/" in err for err in errors)
+            )
 
-    def test_detects_sitemap_duplicate_url(self) -> None:
+    def test_detects_sitemap_missing_legal_page(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            sitemap_path = root / "sitemap.xml"
+            # /terms omitted → the exact-set policy flags it missing. The former
+            # "allowed subset" gate would have wrongly passed this sitemap.
+            sitemap_path.write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://brasse-bouillon.com/</loc></url>
+  <url><loc>https://brasse-bouillon.com/legal</loc></url>
+  <url><loc>https://brasse-bouillon.com/privacy</loc></url>
+  <url><loc>https://brasse-bouillon.com/cookies</loc></url>
+</urlset>
+""",
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.check_sitemap_policy(root)
+            self.assertTrue(
+                any("manquantes" in err and "terms" in err for err in errors)
+            )
+
+    def test_detects_sitemap_renamed_page(self) -> None:
+        # A renamed/typo'd legal page is missing AND forbidden at once — the
+        # realistic mistake the exact-set policy exists to catch.
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
             _create_valid_fixture(root)
@@ -427,14 +475,49 @@ class QualityGateTests(unittest.TestCase):
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://brasse-bouillon.com/</loc></url>
   <url><loc>https://brasse-bouillon.com/legal</loc></url>
-  <url><loc>https://brasse-bouillon.com/legal</loc></url>
+  <url><loc>https://brasse-bouillon.com/privacy</loc></url>
+  <url><loc>https://brasse-bouillon.com/cookies</loc></url>
+  <url><loc>https://brasse-bouillon.com/terms-en</loc></url>
 </urlset>
 """,
                 encoding="utf-8",
             )
 
             errors = quality_gate.check_sitemap_policy(root)
-            self.assertTrue(any("en double" in err for err in errors))
+            self.assertTrue(
+                any(
+                    "manquantes" in err
+                    and "https://brasse-bouillon.com/terms" in err
+                    and "interdites" in err
+                    and "terms-en" in err
+                    for err in errors
+                )
+            )
+
+    def test_detects_sitemap_duplicate_url(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            sitemap_path = root / "sitemap.xml"
+            # Full valid set, but /legal is listed twice.
+            sitemap_path.write_text(
+                """<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://brasse-bouillon.com/</loc></url>
+  <url><loc>https://brasse-bouillon.com/legal</loc></url>
+  <url><loc>https://brasse-bouillon.com/legal</loc></url>
+  <url><loc>https://brasse-bouillon.com/privacy</loc></url>
+  <url><loc>https://brasse-bouillon.com/cookies</loc></url>
+  <url><loc>https://brasse-bouillon.com/terms</loc></url>
+</urlset>
+""",
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.check_sitemap_policy(root)
+            self.assertTrue(
+                any("dupliquées" in err and "legal" in err for err in errors)
+            )
 
     def test_detects_missing_robots_directive(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Salvage the sitemap gate-hardening from the closed, superseded PR #1387 (Lot 5 shipped via #1384). `check_sitemap_policy` now enforces the sitemap advertises **exactly** the indexable clean URLs (new `SITEMAP_URLS` constant): a **missing** legal page is now caught, whereas the previous allowed-subset gate only flagged extras and a missing home. Duplicate detection moves from an O(n²) `list.count()` comprehension to a linear `collections.Counter` (addresses the Copilot note on #1387).

## Context

Lot 5 of the 2026-07-09 SEO audit shipped to `main` via #1384; the parallel branch behind #1387 became a conflicting duplicate and was closed. Its only unique content — the stricter, linear sitemap gate — is preserved here as a clean, dedicated change off `main`.

## Checklist

- [x] `ruff check` clean (script + tests)
- [x] `python3 -m unittest tests.test_quality_gate` — 22 tests green
- [x] `python3 scripts/quality_gate.py` passes on the live site
- [x] Tests cover happy / sad / edge (missing legal page, renamed page = missing+forbidden, duplicate)
- [x] No behaviour change to any other gate check