### PR TITLE
fix(website): disclose the FR-interface screenshots on the EN home

### DIFF
--- a/packages/website/404.html
+++ b/packages/website/404.html
@@ -17,7 +17,7 @@
   <!-- Root-absolute asset URLs: this page is served for ANY unmatched
        route (e.g. /foo/bar/), so relative URLs would resolve against the
        requested path and 404. Assets must be pinned to the site root. -->
-  <link rel="stylesheet" href="/site.css?v=20260710">
+  <link rel="stylesheet" href="/site.css?v=20260713">
 
   <!-- Page-specific layout only; all colours/typography come from the
        site.css design tokens (no hardcoded values). -->

--- a/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
+++ b/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
@@ -87,6 +87,11 @@ Technical — **must be true before any link is posted** (all land in slice S1):
       so EN strings come from the catalog like any other text).
 - [ ] The "app is French-first" honesty line is visible in or immediately
       below the hero section.
+- [ ] The FR-interface screenshots are disclosed: the `journey.screensNote`
+      EN-only note sits above the FIRST screenshots section (linear readers and
+      the root `/en` link we promote both pass it; deep anchor links skip it —
+      accepted tradeoff over repeating the note 4x). The app UI is French-only
+      until the mobile-app i18n epic (#1075) ships; re-shoot EN screenshots then.
 - [ ] EN legal pages linked in the EN footer (already true today).
 - [ ] Lighthouse spot-check on `/en` (SEO/A11y/BP — parity with FR scores).
 

--- a/packages/website/en.html
+++ b/packages/website/en.html
@@ -43,7 +43,7 @@
   <!-- Fonts -->
   <link rel="stylesheet" href="/fonts.css?v=20260709">
 
-  <link rel="stylesheet" href="site.css?v=20260710">
+  <link rel="stylesheet" href="site.css?v=20260713">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -177,6 +177,9 @@
         <p class="section-eyebrow" data-i18n="journey.eyebrow">The journey</p>
         <h2 class="section-title" data-i18n="journey.title">From recipe to <em>first pour</em></h2>
         <p class="section-intro" data-i18n="journey.intro">Four steps, a copilot at every moment. You’re never left alone in front of the kettle.</p>
+        <!-- EN-only disclosure: rendered empty on the FR page, filled from the
+             catalog insertions on en.html (the app UI is French-only today). -->
+        <p class="screens-note" data-i18n-en-only="journey.screensNote">Screenshots throughout this page show the app’s French interface — the English app UI is in the works.</p>
         <ol class="journey-grid">
           <li class="journey-step">
             <span class="journey-num" aria-hidden="true">01</span>

--- a/packages/website/i18n/home.en.json
+++ b/packages/website/i18n/home.en.json
@@ -34,7 +34,8 @@
     ]
   },
   "insertions": {
-    "hero.honesty": "Heads-up for English speakers: the app’s interface launches in French first — an English version is on the way. This site is already in English so you can follow along today."
+    "hero.honesty": "Heads-up for English speakers: the app’s interface launches in French first — an English version is on the way. This site is already in English so you can follow along today.",
+    "journey.screensNote": "Screenshots throughout this page show the app’s French interface — the English app UI is in the works."
   },
   "strings": {
     "nav.logo.href": {

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -43,7 +43,7 @@
   <!-- Fonts -->
   <link rel="stylesheet" href="/fonts.css?v=20260709">
 
-  <link rel="stylesheet" href="site.css?v=20260710">
+  <link rel="stylesheet" href="site.css?v=20260713">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -167,6 +167,9 @@
         <p class="section-eyebrow" data-i18n="journey.eyebrow">Le parcours</p>
         <h2 class="section-title" data-i18n="journey.title">De la recette à la <em>dégustation</em></h2>
         <p class="section-intro" data-i18n="journey.intro">Quatre étapes, un copilote à chaque moment. Tu n’es jamais seul devant tes cuves.</p>
+        <!-- EN-only disclosure: rendered empty on the FR page, filled from the
+             catalog insertions on en.html (the app UI is French-only today). -->
+        <p class="screens-note" data-i18n-en-only="journey.screensNote"></p>
         <ol class="journey-grid">
           <li class="journey-step">
             <span class="journey-num" aria-hidden="true">01</span>

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -952,6 +952,23 @@
       line-height: 1.65;
     }
 
+    /* EN-only screenshots disclosure (data-i18n-en-only): the FR page renders
+       the element empty, so hide it entirely there to leave no stray gap. */
+    .screens-note {
+      /* -32px collapses with .section-intro's 48px bottom margin -> net 16px gap */
+      margin: -32px auto 48px;
+      max-width: 54ch;
+      color: var(--muted);
+      text-align: center;
+      font-size: 0.92rem;
+      font-style: italic;
+      line-height: 1.5;
+    }
+
+    .screens-note:empty {
+      display: none;
+    }
+
     /* ========================================================================
        Journey — big numerals + animated connector
        ====================================================================== */


### PR DESCRIPTION
## Summary

The EN home (`/en`) shows 11 app screenshots whose UI is French — the app itself is French-only until the mobile i18n epic (#1075) — with no explanation at the point of dissonance (the hero honesty line sits three screens above). This adds a sober, EN-only disclosure note above the first screenshots section:

> *Screenshots throughout this page show the app's French interface — the English app UI is in the works.*

- Uses the existing `data-i18n-en-only` mechanism (ADR-0027 D1 clause 1): the element is committed **empty** in `index.html` and filled from the catalog `insertions` at generation — the FR page hides it entirely via a new `.screens-note:empty` rule.
- `site.css` gains the `.screens-note` style (muted/italic, `var(--muted)` token, margin-collapse comment); cache-bust bumped on all three pages referencing it (`index.html`, `en.html`, `404.html`).
- Reddit-readiness checklist updated (`EN_LAUNCH_PLAYBOOK.md`): single-note placement is an explicit, accepted tradeoff (linear readers and the promoted root `/en` link both pass it; repeating the note 4× would degrade the primary reading path). EN screenshot re-shoot is deferred to the app i18n epic #1075.

## Context

Raised by the maintainer while reviewing `/en`: French screenshots on the English page undermine the page for r/Homebrewing promotion. Mocking up fake English screens was rejected (the honesty rules in the playbook forbid promising a UI that doesn't exist); honest disclosure at the point of dissonance is the Reddit-credible fix.

## Checklist

- [x] Conventional Commits
- [x] `en.html` regenerated (`build_i18n.py --check` clean), never hand-edited
- [x] Quality gate + 46 unit tests green locally
- [x] Browser-verified: note visible on `/en` above the journey screenshots; `display:none` + empty on the FR page
- [x] Pre-push review ritual: 0 Must Have; Should Haves applied (404.html cache-bust, playbook wording matched to actual coverage) or consciously decided (single note vs 4×)

🤖 Generated with [Claude Code](https://claude.com/claude-code)