### PR TITLE
refactor(website): drop the redundant footer language switcher

### DIFF
--- a/docs/architecture/decisions/0027-website-i18n-strategy.md
+++ b/docs/architecture/decisions/0027-website-i18n-strategy.md
@@ -227,7 +227,9 @@ MDN). Clauses:
    plain `<a>` links `/` ↔ `/en` — same mechanics as the legal pages'
    `.lang-switch` — so it works with **JavaScript disabled** (progressive
    enhancement). The switcher points at the **translated equivalent of the
-   current page**, never the homepage. *(Amended 2026-07-13: the original
+   current page** — `/` ↔ `/en` on the homes, `/privacy` ↔ `/privacy-en` on the
+   legal pages — never a reset to the other language's homepage when switching
+   from a deeper page. *(Amended 2026-07-13: the original
    clause also mirrored the switcher in the footer; the mirror was dropped
    after the maintainer's UX review — the header is sticky, so the primary
    switcher is already visible at every scroll position, making the footer

--- a/docs/architecture/decisions/0027-website-i18n-strategy.md
+++ b/docs/architecture/decisions/0027-website-i18n-strategy.md
@@ -2,6 +2,7 @@
 
 **Status**  Accepted
 **Date**    2026-07-10 (accepted 2026-07-10, after a 6-reviewer adversarial conception review folded in)
+**Amended** 2026-07-13 — D4 clause 1: footer switcher mirror dropped (maintainer UX review; sticky header keeps the primary switcher always visible)
 **Owners**  @benoit-bremaud
 
 ---
@@ -222,11 +223,16 @@ Grounded in the `i18n` skill (Google Search Central, W3C, Nielsen Norman Group,
 MDN). Clauses:
 
 1. A visible language switcher in the **top-right of the header** (the
-   conventional, expected placement — NN/G) on both homes, mirrored in the
-   footer. It is a pair of plain `<a>` links `/` ↔ `/en` — same mechanics as the
-   legal pages' `.lang-switch` — so it works with **JavaScript disabled**
-   (progressive enhancement). The switcher points at the **translated equivalent
-   of the current page**, never the homepage.
+   conventional, expected placement — NN/G) on both homes. It is a pair of
+   plain `<a>` links `/` ↔ `/en` — same mechanics as the legal pages'
+   `.lang-switch` — so it works with **JavaScript disabled** (progressive
+   enhancement). The switcher points at the **translated equivalent of the
+   current page**, never the homepage. *(Amended 2026-07-13: the original
+   clause also mirrored the switcher in the footer; the mirror was dropped
+   after the maintainer's UX review — the header is sticky, so the primary
+   switcher is already visible at every scroll position, making the footer
+   copy redundant. On mobile the header switcher sits one tap away behind the
+   burger; the S3 suggestion banner covers first-visit discovery.)*
 2. **Labels are autonyms** — `Français` / `English` (a short `FR / EN` toggle is
    the compact variant), each language named in its own language. The active
    language is visually marked. **No flags** — a flag denotes a country, not a
@@ -361,7 +367,7 @@ suggestion banner + a shareable `/en` URL without demoting French).
 
 | Slice | Content | Ships |
 |---|---|---|
-| **S1 — Real EN home** | D1 mechanism (annotations + attr/EN-only grammar, catalog with `srcHash`, `build_i18n.py`, committed `en.html`), D2 URL (`/en` + `_redirects` incl. `.html`, workflow copy, **5-constant gate rename** + canonical-rule flip to `/en`), D3 forms (`lang=en`, inline-script + consent localization, `-en` legal links), EN OG/Twitter incl. `og:locale`, catalog-derived FAQPage JSON-LD, the **"app ships in French first" honesty line + name gloss** (EN-only inserts), header/footer autonym lang links (D4 clause 1, JS-free), EN legal in-page nav fix (`/en`, `/en#participer`), gate + pytest updates. `noindex` **kept** (ship dark, QA live); `en.html` self-canonical from day one so S2 is a robots-meta flip. | **Unblocks direct-link Reddit posting** |
+| **S1 — Real EN home** | D1 mechanism (annotations + attr/EN-only grammar, catalog with `srcHash`, `build_i18n.py`, committed `en.html`), D2 URL (`/en` + `_redirects` incl. `.html`, workflow copy, **5-constant gate rename** + canonical-rule flip to `/en`), D3 forms (`lang=en`, inline-script + consent localization, `-en` legal links), EN OG/Twitter incl. `og:locale`, catalog-derived FAQPage JSON-LD, the **"app ships in French first" honesty line + name gloss** (EN-only inserts), header autonym lang links (D4 clause 1, JS-free; the footer mirror shipped in S1 was dropped post-S1 — see the clause's 2026-07-13 amendment), EN legal in-page nav fix (`/en`, `/en#participer`), gate + pytest updates. `noindex` **kept** (ship dark, QA live); `en.html` self-canonical from day one so S2 is a robots-meta flip. | **Unblocks direct-link Reddit posting** |
 | **S2 — SEO switch** | D5: de-noindex EN pages, add `hreflang="en"` to the FR home + `x-default` to the 4 legal pairs (reciprocity gate), add `/en` to the merged #1384 sitemap allowlist + `sitemap.xml`, SEO_RUNBOOK reversal. | Search traffic |
 | **S3 — Switcher UX** | D4 clauses 3–5: suggestion banner (`navigator.languages`), `bb-lang` persistence, **cookies-page disclosure (FR+EN)**. (Clause 1–2 — the plain autonym toggle — already shipped in S1. This slice adds the only new privacy-disclosure surface; it is the first to cut if scope tightens.) | Language UX |
 | **S4 — Process hardening** | D1 clause 5 (legal freshness stamps), `packages/website/CLAUDE.md` § Languages rewrite (twin rule → source+catalog rule for home), CONTRIBUTING/README updates. | Anti-drift process |

--- a/packages/website/en.html
+++ b/packages/website/en.html
@@ -531,10 +531,6 @@
           <a href="/cookies-en" data-i18n="footer.cookies" data-i18n-attrs="href:footer.cookies.href">Cookies</a>
           <a href="/terms-en" data-i18n="footer.terms" data-i18n-attrs="href:footer.terms.href">Terms of use</a>
         </div>
-        <div class="lang-switch footer-lang" role="group" aria-label="Langue / Language">
-          <a class="lang-switch__link" href="/" lang="fr" data-lang-link="fr">FR</a>
-          <a class="lang-switch__link" href="/en" lang="en" aria-current="page" data-lang-link="en">EN</a>
-        </div>
       </footer>
     </div>
   </main>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -534,10 +534,6 @@
           <a href="/cookies" data-i18n="footer.cookies" data-i18n-attrs="href:footer.cookies.href">Cookies</a>
           <a href="/terms" data-i18n="footer.terms" data-i18n-attrs="href:footer.terms.href">Conditions d’utilisation</a>
         </div>
-        <div class="lang-switch footer-lang" role="group" aria-label="Langue / Language">
-          <a class="lang-switch__link" href="/" lang="fr" aria-current="page" data-lang-link="fr">FR</a>
-          <a class="lang-switch__link" href="/en" lang="en" data-lang-link="en">EN</a>
-        </div>
       </footer>
     </div>
   </main>

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -265,8 +265,6 @@
       cursor: default;
     }
 
-    .footer-lang { margin-top: 4px; }
-
     /* The EN-only honesty line renders as an empty <p> on the FR home
        (data-i18n-en-only); collapse it so it leaves no gap there. */
     .hero-honesty:empty { display: none; }


### PR DESCRIPTION
## Summary

Maintainer UX review of the shipped i18n S1: the FR/EN switcher appeared twice — top-right header AND footer. The header is **sticky**, so the primary switcher is already visible at every scroll position; the footer mirror added nothing on desktop and only saved one burger tap on mobile (first-visit discovery belongs to the S3 suggestion banner). Removed.

- `index.html`: footer `.lang-switch.footer-lang` div removed; `en.html` regenerated (`--check` clean).
- `site.css`: dead `.footer-lang` rule dropped. **No cache-bust bump, deliberately**: the removed rule only matched markup deleted in the same commit, so a stale cached stylesheet renders identically — a narrowly-scoped exception to the bump-on-every-CSS-change rule.
- **ADR-0027 amended in the same PR** (conception-is-contract): D4 clause 1 inline amendment + a header-level `**Amended** 2026-07-13` line per the ADR-0021 precedent.
- Side benefit (flagged by the pre-push review): the page no longer exposes two identically-labelled `role="group" aria-label="Langue / Language"` groups — removes a duplicate-landmark ambiguity for screen-reader users.

## Checklist

- [x] Conventional Commits
- [x] `en.html` regenerated, never hand-edited (`build_i18n.py --check` clean)
- [x] Quality gate + 46 unit tests green locally
- [x] Browser-verified on both homes: exactly one switcher (header), correct active language, footer clean; legal pages' own `.lang-switch` untouched
- [x] Pre-push review ritual: 0 Must Have; Should Have applied (ADR header `Amended` line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)