### PR TITLE
feat(website): put the FAQ chatbot live on production (ADR-0022 go-live)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -5,6 +5,14 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ---
 
+## 2026-07-13
+
+### FAQ chatbot — language lock closed + production go-live (ADR-0022)
+
+- **Language lock, 3 slices, all merged+deployed to Fly**: PR #1414 (`cc5bddf`) hardened the prompt rule (FR/EN scope, EN fallback for other languages, mixed message = word-majority dominant; eval 13→21 cases). PR #1416 (`6c44df1`) founder clause + `founder-who-en` case, after the production canary caught English founder questions answered in French (eval 22). PR #1418 (`d23d342`) few-shot founder example — A/B vs real `mistral-small` (exact prod assembly, temp 0.3, N=6/variant): rule-only 4/6 English, +example 6/6; offline-judge limits + live A/B methodology documented in `evals/AGENT.md`. Final production canary 4/4 English.
+- **Activation completed (Option A, single live API + kill-switch)**: Fly secrets set by the operator (`MISTRAL_API_KEY`, `ALTCHA_HMAC_KEY`, staged via `FAQ_BOT_ENABLED=false` then flipped `true`); ALTCHA challenge live; guardrail smoke green (off-topic / PII / founder / jailbreak). Plan: **free Experiment tier retained** (paid + ~20 EUR hard cap deferred until free-tier limits actually block the bot); **GDPR guards confirmed 2026-07-13** (Mistral console "Data usage for improving our services" disabled; no Labs models). Deploy gotcha recorded: `fly deploy` must run from the monorepo root with `--config packages/api/fly.toml --dockerfile packages/api/Dockerfile` (root build context).
+- **Go-live PR #1420**: production hosts added to `WIDGET_HOSTS` (cache-bust `v=20260713`, `en.html` regenerated); privacy twins list Mistral AI (France, EU) as processor + FAQ purpose + collected-data + no-retention lines; ADR-0022 go-live addendum; README de-staled. Rollback = `FAQ_BOT_ENABLED=false` (server-side, no redeploy). Refs ADR-0022, #1075.
+
 ## 2026-07-10
 
 ### PR #1394 merged (`801049c`) — feat(website): real English home at /en (i18n epic S1)

--- a/docs/architecture/decisions/0022-public-faq-chatbot-llm.md
+++ b/docs/architecture/decisions/0022-public-faq-chatbot-llm.md
@@ -215,8 +215,8 @@ update the widget.
 
 ## Activation addendum — production go-live (2026-07-13)
 
-The go-live flip is done: the production hosts (`brasse-bouillon.com`, `www`) are now in the
-widget's `WIDGET_HOSTS`. Preconditions verified before the flip:
+The go-live flip is done: the production hosts (`brasse-bouillon.com` and
+`www.brasse-bouillon.com`) are now in the widget's `WIDGET_HOSTS`. Preconditions verified before the flip:
 
 - **Language lock closed on the live model** (#1414, #1416, #1418): refusals and founder
   answers hold the visitor's language; final production canary 4/4 English. Key finding: the

--- a/docs/architecture/decisions/0022-public-faq-chatbot-llm.md
+++ b/docs/architecture/decisions/0022-public-faq-chatbot-llm.md
@@ -213,6 +213,27 @@ handshake could not complete (challenge endpoint down / unsolvable) — an avail
 not a malformed question. Any change to that guard/pipe order must preserve this contract or
 update the widget.
 
+## Activation addendum — production go-live (2026-07-13)
+
+The go-live flip is done: the production hosts (`brasse-bouillon.com`, `www`) are now in the
+widget's `WIDGET_HOSTS`. Preconditions verified before the flip:
+
+- **Language lock closed on the live model** (#1414, #1416, #1418): refusals and founder
+  answers hold the visitor's language; final production canary 4/4 English. Key finding: the
+  offline eval judge cannot catch live-model stochastic flips — a few-shot example (not an
+  abstract rule) fixed the founder case, and the live A/B methodology is documented in
+  `evals/AGENT.md` (Limits section). Eval baseline: 22/22.
+- **GDPR guards confirmed by the operator (2026-07-13)**: the Mistral console setting
+  "Data usage for improving our services" is disabled and no Labs model is used — API data is
+  therefore not used for training, which the privacy-policy wording relies on.
+- **Plan decision**: stay on Mistral's free Experiment tier for launch-scale traffic; upgrade
+  to pay-as-you-go with a ~20 EUR hard cap only if free-tier rate limits actually block the
+  bot. (The console hard-cap backstop paragraph above applies to the paid tier when adopted.)
+- **Privacy policy updated in the same change**: Mistral AI (France, EU) listed as processor,
+  FAQ-assistant purpose (legitimate interest, no PII), no conversation retention.
+
+Rollback stays server-side and instant: `FAQ_BOT_ENABLED=false` (no website redeploy).
+
 ---
 
 ## References

--- a/packages/website/README.md
+++ b/packages/website/README.md
@@ -33,8 +33,8 @@ It is maintained with a **build-in-public** approach and an epic-based simplifie
   `i18n/home.en.json` by `scripts/build_i18n.py`; do not edit by hand (ADR-0027)
 - `chat-widget.js`: self-hosted public FAQ chat widget — a floating bubble that answers
   visitors about the project only (not brewing help). First-party call to the NestJS
-  `faq-bot` API, ALTCHA proof-of-work solved client-side, no cookies/tracking, and it
-  mounts on staging/localhost only (never on the public site in v1). See ADR-0022.
+  `faq-bot` API, ALTCHA proof-of-work solved client-side, no cookies/tracking. Live on
+  production since the 2026-07-13 go-live (staging/localhost also allowed). See ADR-0022.
 - `favicon.ico`, `logo.png`, `logo-removebg-preview.png`: static assets
 - `_redirects`: Cloudflare Pages redirects (`/index-en` → `/en` 301)
 - `i18n/home.en.json`: EN string catalog for the generated home (with `srcHash`
@@ -82,12 +82,13 @@ python3 -m py_compile scripts/quality_gate.py scripts/build_i18n.py scripts/road
 
 ## 🤖 FAQ chat widget — manual test checklist
 
-`chat-widget.js` is host-gated to staging/localhost and is the FAQ chatbot's front-end
+`chat-widget.js` is host-gated (production + staging/localhost since the 2026-07-13
+go-live) and is the FAQ chatbot's front-end
 (ADR-0022). The static site has no JS test harness (like `feedback-widget.js`, it ships
 without unit tests), so a browser/DOM unit suite is a **deferred follow-up**. Until then,
 verify the widget manually with the API running (`npm run dev:api`) and the site on `localhost`:
 
-- [ ] **Mount / gate** — bubble appears on `localhost` / `127.0.0.1`; absent on a production-host build.
+- [ ] **Mount / gate** — bubble appears on `localhost` / `127.0.0.1` and on the production hosts; absent on any host not in `WIDGET_HOSTS`.
 - [ ] **Open / close** — click opens the panel (focus moves to the input); close button and `Escape` close it (focus returns to the launcher).
 - [ ] **Chips** — each question chip sends its question and renders an answer.
 - [ ] **Ask success** — a typed question returns a single-block answer (envelope `data.answer`).

--- a/packages/website/chat-widget.js
+++ b/packages/website/chat-widget.js
@@ -17,8 +17,10 @@
  * the launcher never appears on the public production site in v1.
  */
 
-/** Hosts where the widget is allowed to mount (staging + local review only). */
+/** Hosts where the widget is allowed to mount (production + staging + local review). */
 const WIDGET_HOSTS = [
+  'brasse-bouillon.com',
+  'www.brasse-bouillon.com',
   'staging.brasse-bouillon-website.pages.dev',
   'localhost',
   '127.0.0.1',
@@ -34,8 +36,8 @@ const LIVE_API_ORIGIN = 'https://brasse-bouillon-api.fly.dev';
  * the staging site canaries directly against the single live API, with exposure gated by the
  * server-side `FAQ_BOT_ENABLED` kill-switch. Until the bot is enabled the live API answers
  * `/ask` with 503 (or 400 when the anti-bot handshake cannot complete), so the widget shows
- * "unavailable" and nothing is exercised. The production hosts are wired here too but stay OUT
- * of `WIDGET_HOSTS` until the go-live flip, so the launcher still never mounts on prod in v1.
+ * "unavailable" and nothing is exercised. Production go-live flipped 2026-07-13 (bot enabled,
+ * language-lock verified by live canary): the production hosts are now in `WIDGET_HOSTS`.
  */
 const API_BASE_BY_HOST = {
   localhost: 'http://localhost:3000',
@@ -437,9 +439,9 @@ function mountChatWidget() {
   });
 }
 
-// Mount only on the allow-listed hosts. The production hosts are intentionally absent from
-// WIDGET_HOSTS (even though API_BASE_BY_HOST pre-wires them), so the launcher never appears on
-// brasse-bouillon.com until the go-live flip (ADR-0022 activation addendum, Option A).
+// Mount only on the allow-listed hosts (production included since the 2026-07-13 go-live —
+// ADR-0022 activation addendum, Option A). Instant rollback stays server-side: disabling
+// FAQ_BOT_ENABLED makes the widget show "unavailable" without any website redeploy.
 if (WIDGET_HOSTS.includes(window.location.hostname)) {
   mountChatWidget();
 }

--- a/packages/website/chat-widget.js
+++ b/packages/website/chat-widget.js
@@ -13,8 +13,9 @@
  *     made on page load. The first call happens only when the visitor actually asks,
  *     so the widget never fires before an explicit user action.
  *
- * Activation is host-gated to staging/localhost (same policy as feedback-widget.js):
- * the launcher never appears on the public production site in v1.
+ * Activation is host-gated via WIDGET_HOSTS; live on the public production site since the
+ * 2026-07-13 go-live (ADR-0022 activation addendum). Instant rollback stays server-side
+ * (FAQ_BOT_ENABLED=false) — no website redeploy needed.
  */
 
 /** Hosts where the widget is allowed to mount (production + staging + local review). */

--- a/packages/website/en.html
+++ b/packages/website/en.html
@@ -552,7 +552,7 @@
   </script>
   <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
-  <!-- FAQ chat widget — self-hosted; mounts on staging/localhost only (ADR-0022) -->
-  <script type="module" src="chat-widget.js?v=20260709"></script>
+  <!-- FAQ chat widget — self-hosted; live on production since 2026-07-13 (ADR-0022) -->
+  <script type="module" src="chat-widget.js?v=20260713"></script>
 </body>
 </html>

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -558,7 +558,7 @@
   </script>
   <!-- Feedback widget — local loader; the Cloudflare Worker widget mounts on staging/localhost only, inert in production -->
   <script type="module" src="feedback-widget.js?v=20260601"></script>
-  <!-- FAQ chat widget — self-hosted; mounts on staging/localhost only (ADR-0022) -->
-  <script type="module" src="chat-widget.js?v=20260709"></script>
+  <!-- FAQ chat widget — self-hosted; live on production since 2026-07-13 (ADR-0022) -->
+  <script type="module" src="chat-widget.js?v=20260713"></script>
 </body>
 </html>

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -61,6 +61,7 @@
       <li>Contact data (the message and details you provide) submitted through the site form.</li>
       <li>Newsletter subscription data (email).</li>
       <li>Product questionnaire data (profile, usage, priorities, suggestions).</li>
+      <li>Questions asked to the FAQ assistant (message text only — do not include personal data).</li>
     </ul>
     <p>
       The site uses no third-party audience measurement tool and no tracking cookies.

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -48,7 +48,7 @@
     <p class="lang-switch"><a href="/privacy" lang="fr">Lire en français</a></p>
 
     <h1>Privacy Policy</h1>
-    <p class="meta"><strong>Last updated:</strong> July 9, 2026</p>
+    <p class="meta"><strong>Last updated:</strong> July 13, 2026</p>
 
     <h2>1. Data controller</h2>
     <p>
@@ -73,6 +73,11 @@
       <li><strong>Replying to messages</strong>: legitimate interest and/or pre-contractual steps.</li>
       <li><strong>Sending newsletters</strong>: explicit consent (form checkbox).</li>
       <li><strong>Improving the product</strong> through questionnaire responses: explicit consent.</li>
+      <li>
+        <strong>Answering questions asked to the FAQ assistant</strong>: legitimate interest
+        (informing visitors about the project). Do not share personal data in your messages —
+        the assistant never asks for any.
+      </li>
     </ul>
 
     <h2>4. Recipients and international transfers</h2>
@@ -87,6 +92,11 @@
         under the <strong>EU-US Data Privacy Framework</strong>; the transfer to the US is covered by the
         European Commission's adequacy decision.
       </li>
+      <li>
+        <strong>Mistral AI</strong> (France, European Union) — generation of the website FAQ
+        assistant's answers. Questions asked to the assistant are sent to the Mistral AI API,
+        hosted in the EU; they are not used to train its models. No transfer outside the EU.
+      </li>
     </ul>
 
     <h2>5. Data retention</h2>
@@ -94,6 +104,7 @@
       <li>Contact data: up to 3 years after the last interaction.</li>
       <li>Newsletter data: until unsubscribe, or 3 years of inactivity.</li>
       <li>Questionnaire data: up to 3 years for product analysis.</li>
+      <li>FAQ assistant: conversations are not stored by the site.</li>
     </ul>
 
     <h2>6. Your rights</h2>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -47,7 +47,7 @@
     <p class="lang-switch"><a href="/privacy-en" lang="en">Read in English</a></p>
 
     <h1>Politique de confidentialité</h1>
-    <p class="meta"><strong>Dernière mise à jour :</strong> 9 juillet 2026</p>
+    <p class="meta"><strong>Dernière mise à jour :</strong> 13 juillet 2026</p>
 
     <h2>1. Responsable du traitement</h2>
     <p>
@@ -72,6 +72,11 @@
       <li><strong>Répondre aux messages</strong> : intérêt légitime et/ou mesures précontractuelles.</li>
       <li><strong>Envoyer la newsletter</strong> : consentement explicite (case à cocher au formulaire).</li>
       <li><strong>Améliorer le produit</strong> via questionnaire : consentement explicite.</li>
+      <li>
+        <strong>Répondre aux questions posées à l’assistant FAQ</strong> : intérêt légitime
+        (informer les visiteurs sur le projet). Ne partagez aucune donnée personnelle dans vos
+        messages — l’assistant n’en demande jamais.
+      </li>
     </ul>
 
     <h2>4. Destinataires et transferts internationaux</h2>
@@ -87,6 +92,12 @@
         <strong>EU-US Data Privacy Framework</strong> ; le transfert vers les États-Unis est couvert par
         la décision d’adéquation de la Commission européenne.
       </li>
+      <li>
+        <strong>Mistral AI</strong> (France, Union européenne) — génération des réponses de
+        l’assistant FAQ du site. Les questions posées à l’assistant sont transmises à l’API de
+        Mistral AI, hébergée dans l’UE ; elles ne sont pas utilisées pour entraîner ses modèles.
+        Aucun transfert hors UE.
+      </li>
     </ul>
 
     <h2>5. Durées de conservation</h2>
@@ -94,6 +105,7 @@
       <li>Contact : jusqu’à 3 ans après le dernier échange.</li>
       <li>Newsletter : jusqu’au désabonnement ou 3 ans d’inactivité.</li>
       <li>Questionnaire : jusqu’à 3 ans pour l’analyse produit.</li>
+      <li>Assistant FAQ : les conversations ne sont pas conservées par le site.</li>
     </ul>
 
     <h2>6. Vos droits</h2>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -60,6 +60,7 @@
       <li>Données de contact (message et coordonnées que vous fournissez) transmises via le formulaire du site.</li>
       <li>Données d’inscription newsletter (email).</li>
       <li>Données de questionnaire produit (profil, usages, priorités, suggestions).</li>
+      <li>Questions posées à l’assistant FAQ (texte du message uniquement — n’y incluez pas de données personnelles).</li>
     </ul>
     <p>
       Le site n’utilise aucun outil de mesure d’audience tiers et aucun cookie de tracking.


### PR DESCRIPTION
## What

**P5 — the final activation step (ADR-0022, Option A): the FAQ chatbot becomes visible on brasse-bouillon.com.** Everything upstream is done and verified: Fly secrets set, `FAQ_BOT_ENABLED=true`, ALTCHA live, language-lock closed (#1414 → #1416 → #1418) with a final 4/4 production canary on the real model, GDPR guards confirmed on the Mistral console (no training-data usage, no Labs models), free Experiment tier retained for launch.

## Changes

- **`chat-widget.js`** — production hosts added to `WIDGET_HOSTS` (API origins pre-wired by #1381); activation comments refreshed. **Rollback stays server-side and instant: `FAQ_BOT_ENABLED=false`, no website redeploy.**
- **`index.html`** — cache-bust `v=20260713`; **`en.html`** regenerated via `build_i18n.py`.
- **`privacy.html` + `privacy-en.html`** (hand-maintained twins) — Mistral AI (France, EU) listed as processor (EU-hosted API, no training on the data, no transfer outside the EU); FAQ-assistant purpose (legitimate interest, no PII); question text listed in §2 collected data; no-conversation-retention line; last-updated 2026-07-13.
- **ADR-0022** — dated go-live addendum: preconditions (canary, GDPR guards, plan decision), rollback path.
- **`README.md`** — three stale "staging/localhost only" claims updated.

## Tests

Quality gate passed · `build_i18n.py --check` clean · website tests **46/46** · zero TypeScript.

## Review

Pre-push ritual: **Codex** (2 Should Have: PROJECT_LOG entry — added in this PR; stale README — fixed) + **pr-pre-reviewer** (1 Must Have: unverified privacy no-training claim — **resolved**: operator confirmed the Mistral console guards on 2026-07-13, recorded in the ADR addendum; 2 Should Have: ADR addendum + privacy §2 — both done).

## Effect on merge

Cloudflare Pages auto-deploys `packages/website/**` → the chat bubble appears on production. 🍺