### PR TITLE
docs(website): freeze the r/Homebrewing launch post + account runway plan

### DIFF
--- a/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
+++ b/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
@@ -127,24 +127,33 @@ Community etiquette — per subreddit, before posting:
 ## 8. Launch post — frozen draft (2026-07-13)
 
 Validated with the maintainer on 2026-07-13. Constraints baked in: **no
-"build in public" claim** (the repo is heading private), **no beta-tester
+"build in public" claim** (maintainer decision), **no beta-tester
 recruiting** (the app UI is French-only; recruiting anglophone testers would
 either frustrate them or create delivery pressure on the EN UI), recipe
 studio/management leads the feature list, waitlist is the only CTA.
 
-### 8.1 Account runway (blocking — no Reddit account exists yet)
+### 8.1 Account runway
 
-A fresh account posting a project link gets auto-removed (AutoMod age/karma
-filters) and reads as astroturfing. Sequence:
+The post goes out from the maintainer's **existing personal account** — the
+right kind: r/Homebrewing culture trusts people, not brand accounts, and a
+fresh or brand-named account posting a project link gets auto-removed
+(AutoMod age/karma filters) or read as astroturfing. The handle is
+deliberately NOT recorded here: posting will publicly link it to the project
+(and, via the site's legal pages, to the maintainer's real name) — that
+linkage is made at posting time, not before.
 
-1. **Create the account now** — a personal, brewer-flavored handle, NOT the
-   brand name (a "BrasseBouillon" account kills the peer-to-peer voice, and
-   handles cannot be renamed). Enable 2FA.
-2. **Participate genuinely for 2–4 weeks** — nothing to fake: ask real
-   first-batch questions in the Daily Q&A (water profile, hop schedule,
-   kettle sizing), then post the actual first 4 L blonde brew day as a
-   genuine "first all-grain batch" post. That content is beloved there and
-   builds history without any growth-hacking.
+Before the launch post:
+
+1. **Check the account clears the bar**: reasonable age and karma (young or
+   near-zero-karma accounts trip AutoMod), and a quick self-review of the
+   public history — everything visible there gets associated with the
+   project the moment the post lands.
+2. **Build r/Homebrewing-specific history (~2–4 weeks, less if the account
+   is already seasoned)** — nothing to fake: ask real first-batch questions
+   in the Daily Q&A (water profile, hop schedule, kettle sizing), then post
+   the actual first 4 L blonde brew day as a genuine "first all-grain batch"
+   post. That content is beloved there and builds subreddit trust without
+   any growth-hacking.
 3. **Then post the launch draft below**, ideally referencing the brew post:
    "I posted my first batch here a few weeks ago — this is the app I built
    alongside it."

--- a/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
+++ b/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
@@ -123,3 +123,103 @@ Community etiquette — per subreddit, before posting:
 - New home sections (e.g. the Académie section designed in parallel) are
   authored FR-first with `data-i18n` keys; their EN transcreation is written in
   the same PR, reviewed against the §2 calibration set.
+
+## 8. Launch post — frozen draft (2026-07-13)
+
+Validated with the maintainer on 2026-07-13. Constraints baked in: **no
+"build in public" claim** (the repo is heading private), **no beta-tester
+recruiting** (the app UI is French-only; recruiting anglophone testers would
+either frustrate them or create delivery pressure on the EN UI), recipe
+studio/management leads the feature list, waitlist is the only CTA.
+
+### 8.1 Account runway (blocking — no Reddit account exists yet)
+
+A fresh account posting a project link gets auto-removed (AutoMod age/karma
+filters) and reads as astroturfing. Sequence:
+
+1. **Create the account now** — a personal, brewer-flavored handle, NOT the
+   brand name (a "BrasseBouillon" account kills the peer-to-peer voice, and
+   handles cannot be renamed). Enable 2FA.
+2. **Participate genuinely for 2–4 weeks** — nothing to fake: ask real
+   first-batch questions in the Daily Q&A (water profile, hop schedule,
+   kettle sizing), then post the actual first 4 L blonde brew day as a
+   genuine "first all-grain batch" post. That content is beloved there and
+   builds history without any growth-hacking.
+3. **Then post the launch draft below**, ideally referencing the brew post:
+   "I posted my first batch here a few weeks ago — this is the app I built
+   alongside it."
+
+### 8.2 Title options
+
+- A. I'm a French homebrewer + developer building a companion app that walks
+  you through your first batch — honest feedback welcome
+- B. Building an app so first-timers can brew without the fear of screwing it
+  up — what do you wish had guided YOUR first batch? *(preferred: asks the
+  community a real question)*
+- C. My first all-grain batch scared me into building a brewing companion app
+  — roast my feature list
+
+### 8.3 Body (frozen)
+
+> Hey r/Homebrewing,
+>
+> French homebrewer here, career-changer into software. When I planned my
+> first real all-grain batch (a modest 4 L blonde), I realized what I
+> actually wanted didn't exist: not another calculator, but something that
+> tells a beginner what to do, when, and — the part that matters — **why**,
+> at every step from recipe to first pour.
+>
+> So I've been building it for the past year, alongside the batch itself.
+> It's called **Brasse-Bouillon** — roughly "brew-broth", a French nod to
+> homebrew kettles. What it does today:
+>
+> - **Recipe studio + your own notebook**: build and tweak recipes with the
+>   numbers recalculating live as you touch the grain bill or hop schedule
+>   (IBU, ABV, color) — including a reverse hop calculator (target IBU → your
+>   additions) and BU:GU balance. Batches scale to YOUR actual kettle and
+>   fermenter, not a generic 5 gal assumption. Keep recipes private or share
+>   them.
+> - **Community clone recipes**: pick a rated, battle-tested recipe instead
+>   of improvising your first batch — or import one into your notebook and
+>   make it yours. Scan a commercial beer's label and it suggests equivalent
+>   community recipes.
+> - **Brew-day guidance**: mash/boil/chill steps with timers, target temps,
+>   and the reasoning behind each move — no jargon walls, no mental math.
+> - **Fermentation tracking**: days, gravity, temperature — one glance and
+>   you know where you stand.
+> - **A brewing academy**: sourced articles + glossary, because the goal is
+>   that you eventually don't need the app at all.
+>
+> Full honesty, because you'd find out in one tap anyway: it's
+> **pre-release** (waitlist only), the app UI ships **in French first**
+> (English UI is on the roadmap — the website is already fully in English so
+> you can follow along), and it's a **solo project**.
+>
+> What I'd love from you: what do you wish had guided your first batch? What
+> almost made you quit? I'd rather build that than another feature nobody
+> needs.
+>
+> Site (English): https://brasse-bouillon.com/en
+
+### 8.4 Prepared replies (the two inevitable questions, §6)
+
+**"Where's the app? / Can I try it?"**
+
+> Not yet — progressive beta in 2026, waitlist first. I'd rather ship
+> something that actually survives contact with a first-time brewer than
+> rush it. The site has the full feature tour with real screenshots (French
+> UI for now — that's what ships first).
+
+**"Why French?"**
+
+> Because I built it alongside my own first real batch, in my own language,
+> and I'd rather nail the guidance in one language than be mediocre in two.
+> English UI is on the roadmap; the site is already fully English so
+> English-speaking brewers aren't locked out in the meantime.
+
+### 8.5 Mod pre-message (optional)
+
+> Hi mods — French homebrewer/dev here. I'd like to post a "building a
+> first-timer companion app, honest feedback welcome" post (pre-release, no
+> sales, waitlist only). Happy to adjust framing to fit the self-promo
+> rules. OK to post?

--- a/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
+++ b/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
@@ -105,9 +105,10 @@ Community etiquette — per subreddit, before posting:
       participate-first, roughly 9:1 contribution-to-promo etiquette).
 - [ ] Post from an account with genuine participation history; consider
       messaging the mods first for a "I built a thing" post.
-- [ ] Frame as a builder-journey post ("I'm building a free companion app to
+- [ ] Frame as a builder-journey post ("I'm building a companion app to
       guide first-time brewers — honest feedback welcome"), never a bare link
-      drop.
+      drop. (No "free" claim — pricing is undecided; the §8 frozen draft
+      deliberately avoids it.)
 - [ ] Be upfront: pre-release, French-first UI, solo project.
 - [ ] Prepare the two inevitable answers: "where's the app?" (waitlist,
       pre-release) and "why French?" (built alongside my own first real brew;
@@ -173,13 +174,13 @@ Before the launch post:
 > Hey r/Homebrewing,
 >
 > French homebrewer here, career-changer into software. When I planned my
-> first real all-grain batch (a modest 4 L blonde), I realized what I
-> actually wanted didn't exist: not another calculator, but something that
+> first real all-grain batch (a modest 4 L / ~1 gal blonde), I realized what I
+> actually wanted didn't exist: not just another calculator, but something that
 > tells a beginner what to do, when, and — the part that matters — **why**,
 > at every step from recipe to first pour.
 >
-> So I've been building it for the past year, alongside the batch itself.
-> It's called **Brasse-Bouillon** — roughly "brew-broth", a French nod to
+> So I've been building it for the past year and a half, alongside the
+> batch itself. It's called **Brasse-Bouillon** — roughly "brew-broth", a French nod to
 > homebrew kettles. What it does today:
 >
 > - **Recipe studio + your own notebook**: build and tweak recipes with the
@@ -194,8 +195,9 @@ Before the launch post:
 >   community recipes.
 > - **Brew-day guidance**: mash/boil/chill steps with timers, target temps,
 >   and the reasoning behind each move — no jargon walls, no mental math.
-> - **Fermentation tracking**: days, gravity, temperature — one glance and
->   you know where you stand.
+> - **Fermentation tracking**: log gravity and temperature day by day so
+>   you actually know where your batch stands (an at-a-glance summary card
+>   is in the works).
 > - **A brewing academy**: sourced articles + glossary, because the goal is
 >   that you eventually don't need the app at all.
 >

--- a/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
+++ b/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
@@ -139,9 +139,9 @@ The post goes out from the maintainer's **existing personal account** — the
 right kind: r/Homebrewing culture trusts people, not brand accounts, and a
 fresh or brand-named account posting a project link gets auto-removed
 (AutoMod age/karma filters) or read as astroturfing. The handle is
-deliberately NOT recorded here: posting will publicly link it to the project
-(and, via the site's legal pages, to the maintainer's real name) — that
-linkage is made at posting time, not before.
+deliberately NOT recorded here: posting is what publicly ties the account to
+the project — that link is made at posting time, by the maintainer, not
+before and not by this repo.
 
 Before the launch post:
 
@@ -173,7 +173,8 @@ Before the launch post:
 
 > Hey r/Homebrewing,
 >
-> French homebrewer here, career-changer into software. When I planned my
+> French homebrewer here — I switched careers into software a few years
+> back. When I planned my
 > first real all-grain batch (a modest 4 L / ~1 gal blonde), I realized what I
 > actually wanted didn't exist: not just another calculator, but something that
 > tells a beginner what to do, when, and — the part that matters — **why**,

--- a/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
+++ b/packages/website/docs/EN_LAUNCH_PLAYBOOK.md
@@ -130,8 +130,9 @@ Community etiquette — per subreddit, before posting:
 Validated with the maintainer on 2026-07-13. Constraints baked in: **no
 "build in public" claim** (maintainer decision), **no beta-tester
 recruiting** (the app UI is French-only; recruiting anglophone testers would
-either frustrate them or create delivery pressure on the EN UI), recipe
-studio/management leads the feature list, waitlist is the only CTA.
+either frustrate them or create delivery pressure on the EN UI), recipes
+lead the feature list (catalog live today; the recipe studio is pitched
+as the beta's headline, NOT as shipped), waitlist is the only CTA.
 
 ### 8.1 Account runway
 
@@ -182,25 +183,27 @@ Before the launch post:
 >
 > So I've been building it for the past year and a half, alongside the
 > batch itself. It's called **Brasse-Bouillon** — roughly "brew-broth", a French nod to
-> homebrew kettles. What it does today:
+> homebrew kettles. What's live today:
 >
-> - **Recipe studio + your own notebook**: build and tweak recipes with the
->   numbers recalculating live as you touch the grain bill or hop schedule
->   (IBU, ABV, color) — including a reverse hop calculator (target IBU → your
->   additions) and BU:GU balance. Batches scale to YOUR actual kettle and
->   fermenter, not a generic 5 gal assumption. Keep recipes private or share
->   them.
-> - **Community clone recipes**: pick a rated, battle-tested recipe instead
->   of improvising your first batch — or import one into your notebook and
->   make it yours. Scan a commercial beer's label and it suggests equivalent
->   community recipes.
+> - **Community clone recipes**: browse rated, battle-tested recipes with
+>   their IBU/ABV/volume instead of improvising your first batch — and scan
+>   a commercial beer's barcode to pull up the beer and equivalent community
+>   recipes.
 > - **Brew-day guidance**: mash/boil/chill steps with timers, target temps,
 >   and the reasoning behind each move — no jargon walls, no mental math.
+>   Batches scale to YOUR actual kettle and fermenter, not a generic 5 gal
+>   assumption.
+> - **Brewing calculators**: a hop calculator with quick, reverse (target
+>   IBU → your additions) and BU:GU balance modes.
 > - **Fermentation tracking**: log gravity and temperature day by day so
 >   you actually know where your batch stands (an at-a-glance summary card
 >   is in the works).
 > - **A brewing academy**: sourced articles + glossary, because the goal is
 >   that you eventually don't need the app at all.
+>
+> And the beta's headline feature is the **recipe studio**: build and tweak
+> your own recipes — grain bill, hop schedule — with IBU, ABV and color
+> recalculating live as you type, then keep them private or share them.
 >
 > Full honesty, because you'd find out in one tap anyway: it's
 > **pre-release** (waitlist only), the app UI ships **in French first**


### PR DESCRIPTION
## Summary

Playbook §8: the maintainer-validated r/Homebrewing launch post, frozen so it survives until posting time (~2-3 weeks of account runway).

- **The frozen draft**: 3 title options, body (recipe studio leads the feature list), the two prepared replies ("where's the app?", "why French?"), and the mod pre-message.
- **Constraints baked in**: no "build in public" claim, no beta-tester recruiting (the app UI is French-only), waitlist as the only CTA, no "free" claim (pricing undecided — §6's stale example aligned).
- **Account runway (§8.1)**: the post goes out from the maintainer's existing personal account (aged, low-karma lurker); the handle is deliberately NOT recorded in this public doc (posting is what links it to the project — and to the maintainer's real name via the legal pages). Runway: r/Homebrewing participation + the real first-brew post, then the launch post referencing it.
- **Pre-push review caught a real over-promise** by fact-checking the draft against the mobile-app code: the at-a-glance fermentation card is demo-mode only (live = manual measurement logging; dashboard deferred to the fermenter-integration epic). The bullet now claims exactly what ships. Also fixed: 4 L (~1 gal) gloss per §3, "past year" → "past year and a half" (repo history), softened calculator contrast.

Docs-only (`docs/` is not deployed). Gate + 50 unit tests green.

## Checklist

- [x] Conventional Commits
- [x] English-only repo doc, no handle/identity leakage
- [x] Pre-push review ritual: 1 Must Have (fermentation over-claim) + 3 Should fixed before PR
- [x] Quality gate + unit suites green (docs untouched by both — sanity run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)