### PR TITLE
perf(website): cut sustained animation load (fewer bubbles + pause off-screen loops)

### DIFF
--- a/packages/website/404.html
+++ b/packages/website/404.html
@@ -17,7 +17,7 @@
   <!-- Root-absolute asset URLs: this page is served for ANY unmatched
        route (e.g. /foo/bar/), so relative URLs would resolve against the
        requested path and 404. Assets must be pinned to the site root. -->
-  <link rel="stylesheet" href="/site.css?v=20260713c">
+  <link rel="stylesheet" href="/site.css?v=20260715">
 
   <!-- Page-specific layout only; all colours/typography come from the
        site.css design tokens (no hardcoded values). -->

--- a/packages/website/en.html
+++ b/packages/website/en.html
@@ -45,7 +45,7 @@
   <!-- Fonts -->
   <link rel="stylesheet" href="/fonts.css?v=20260709">
 
-  <link rel="stylesheet" href="site.css?v=20260713c">
+  <link rel="stylesheet" href="site.css?v=20260715">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -547,7 +547,7 @@
     </div>
   </aside>
 
-  <script src="site.js?v=20260713"></script>
+  <script src="site.js?v=20260715"></script>
   <script>
     // Language-neutral home bootstrap. All UI strings live in site.js catalogs;
     // build_i18n.py swaps the 'fr' argument to 'en' when it generates en.html

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -44,7 +44,7 @@
   <!-- Fonts -->
   <link rel="stylesheet" href="/fonts.css?v=20260709">
 
-  <link rel="stylesheet" href="site.css?v=20260713c">
+  <link rel="stylesheet" href="site.css?v=20260715">
 
   <!-- Organization Schema -->
   <script type="application/ld+json">
@@ -555,7 +555,7 @@
     </div>
   </aside>
 
-  <script src="site.js?v=20260713"></script>
+  <script src="site.js?v=20260715"></script>
   <script>
     // Language-neutral home bootstrap. All UI strings live in site.js catalogs;
     // build_i18n.py swaps the 'fr' argument to 'en' when it generates en.html

--- a/packages/website/site.css
+++ b/packages/website/site.css
@@ -512,6 +512,20 @@
     .anim-paused .bubble,
     .anim-paused .dew-run { animation-play-state: paused; }
 
+    /* Scrolled out of view: site.js (setupOffscreenAnimationPausing) tags each
+       in-place ambient element that leaves the viewport, so the compositor stops
+       animating motion nobody can see — the main cure for slowdown on a long
+       visit. Tripled class reaches specificity (0,3,0) so it outranks even the
+       (0,2,0) descendant `animation:` selectors declared later in this file
+       (e.g. `.hero-mascot .logo`, `.participate .btn-primary`), regardless of
+       source order (same specificity-trick family as `.dew-layer.dew-layer`).
+       The ::before/::after variants pause pseudo-element loops (e.g. the hero's
+       floatSlow blobs) once site.js tags their host. Transiting effects (rising
+       bubbles/embers) are excluded in JS, never tagged here. */
+    .bb-anim-off.bb-anim-off.bb-anim-off,
+    .bb-anim-off.bb-anim-off.bb-anim-off::before,
+    .bb-anim-off.bb-anim-off.bb-anim-off::after { animation-play-state: paused; }
+
     @media (prefers-reduced-motion: reduce) {
       .bubbles { display: none; }
     }

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -284,7 +284,8 @@
     // Bubble count adapts to the device so big screens feel lush while weaker
     // phones stay smooth. Each bubble is a richly-painted, continuously
     // animated element, so we keep the compositor comfortable:
-    //  - scale with viewport area (≈ 1 bubble per 6500 px²),
+    //  - scale with viewport area (≈ 1 bubble per 9000 px²), capped at 100 —
+    //    the cap is the main lever against sustained GPU load on big screens,
     //  - halve it on low-memory / few-core devices,
     //  - drop to a minimum when Data Saver is on,
     //  - (prefers-reduced-motion already disabled the layer above).
@@ -478,12 +479,10 @@
       return;
     }
 
-    // Keyframes that travel across the viewport: pausing one off-screen breaks
-    // the effect (a frozen bubble never rises back into view), so they stay
-    // always-on. NOTE: pausing is element-wide (the CSS sets animation-play-state
-    // on the whole element), so this exclusion only holds while no element mixes a
-    // transiting keyframe with another infinite loop — keep bubbles/embers
-    // single-animation or this guard silently stops sparing them.
+    // Keyframes that travel across the viewport: pausing one off-screen breaks the
+    // effect (a frozen bubble never rises back into view), so their host stays
+    // always-on — enforced per-element below (any transiting animation vetoes its
+    // whole host), not just per-animation.
     const TRANSITING = new Set(['bubble-rise', 'bubble-sway', 'emberRise']);
 
     const observer = new IntersectionObserver(
@@ -496,20 +495,39 @@
       { rootMargin: '200px' }
     );
 
-    const targets = new Set();
-    document.getAnimations().forEach((anim) => {
+    // A ::before/::after animation's target is a CSSPseudoElement (no nodeType);
+    // resolve it to its originating element so the host is what we tag (the CSS
+    // rule pauses the pseudo-element via its ::before/::after variants — this is
+    // what pauses the hero's large floatSlow gradient blobs off-screen).
+    const hostOf = (anim) => {
+      const target = anim.effect && anim.effect.target;
+      if (!target) return null;
+      const host = target.nodeType === 1 ? target : target.element;
+      return host && host.nodeType === 1 ? host : null;
+    };
+
+    const infinite = document.getAnimations().filter((anim) => {
       const timing =
         anim.effect && anim.effect.getTiming ? anim.effect.getTiming() : null;
-      const target = anim.effect && anim.effect.target;
-      if (!target || !timing || timing.iterations !== Infinity) return;
+      return timing && timing.iterations === Infinity;
+    });
+
+    // Pause is element-wide, so any transiting animation vetoes its whole host: if
+    // an element ever carried both a transiting loop (bubble/ember) and another
+    // infinite one, tagging it would freeze the transiting stream too. Collect the
+    // vetoed hosts first, then observe only the non-transiting hosts left clear.
+    const excluded = new Set();
+    infinite.forEach((anim) => {
+      if (!TRANSITING.has(anim.animationName)) return;
+      const host = hostOf(anim);
+      if (host) excluded.add(host);
+    });
+
+    const targets = new Set();
+    infinite.forEach((anim) => {
       if (TRANSITING.has(anim.animationName)) return;
-      // A ::before/::after animation's target is a CSSPseudoElement (no nodeType).
-      // Resolve it to its originating element so the host gets tagged — the CSS
-      // rule then pauses the pseudo-element via its ::before/::after variants (this
-      // is what pauses the hero's large floatSlow gradient blobs off-screen).
-      const host = target.nodeType === 1 ? target : target.element;
-      if (!host || host.nodeType !== 1) return;
-      targets.add(host);
+      const host = hostOf(anim);
+      if (host && !excluded.has(host)) targets.add(host);
     });
     targets.forEach((el) => observer.observe(el));
   }

--- a/packages/website/site.js
+++ b/packages/website/site.js
@@ -290,17 +290,19 @@
     //  - (prefers-reduced-motion already disabled the layer above).
     function adaptiveBubbleCount() {
       const area = window.innerWidth * window.innerHeight;
-      let n = Math.round(area / 6500);
-      // Data Saver: a deliberate hard minimum of 60, intentionally below the
-      // normal floor (lightest possible while still hinting the effect).
-      if (navigator.connection?.saveData) return 60;
+      let n = Math.round(area / 9000);
+      // Data Saver: a deliberate hard minimum, below the normal floor (lightest
+      // possible while still hinting the effect).
+      if (navigator.connection?.saveData) return 45;
       const memory = navigator.deviceMemory;
       const cores = navigator.hardwareConcurrency;
       if ((memory && memory <= 4) || (cores && cores <= 4)) n = Math.round(n * 0.5);
-      // Otherwise floor low so small screens really are sparser; cap kept
-      // moderate so big screens stay lush but smooth. Gradient (≈): phone ~70,
-      // tablet ~120, laptop ~160, desktop/ultrawide capped at 200.
-      return Math.max(70, Math.min(n, 200));
+      // Each bubble is a continuously-composited gradient, so the count is kept
+      // deliberately lean: a big screen doesn't need hundreds to read as "fizzy",
+      // and the cap is what spares laptops/desktops from sustained GPU work (and
+      // the thermal throttling it causes) on a long visit. Gradient (≈): phone
+      // ~50, tablet ~85, laptop/desktop capped at 100.
+      return Math.max(50, Math.min(n, 100));
     }
 
     const count = (options && options.count) || adaptiveBubbleCount();
@@ -457,6 +459,62 @@
   }
 
   /**
+   * Pause in-place ambient loops (decorative spins, shimmers, "breathing"
+   * micro-animations) while their element is scrolled out of view, and resume
+   * them when it returns. CSS animations keep compositing off-screen by default,
+   * so on a long visit that motion heats the device and makes it throttle for
+   * nothing. Transiting effects (rising bubbles/embers) are deliberately kept
+   * always-on — freezing one off-screen would strand it and drain the stream —
+   * and one-shot entrance animations are ignored since they finish on their own.
+   * No-op under prefers-reduced-motion or without IntersectionObserver /
+   * getAnimations support.
+   */
+  function setupOffscreenAnimationPausing() {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    if (
+      typeof IntersectionObserver !== 'function' ||
+      typeof document.getAnimations !== 'function'
+    ) {
+      return;
+    }
+
+    // Keyframes that travel across the viewport: pausing one off-screen breaks
+    // the effect (a frozen bubble never rises back into view), so they stay
+    // always-on. NOTE: pausing is element-wide (the CSS sets animation-play-state
+    // on the whole element), so this exclusion only holds while no element mixes a
+    // transiting keyframe with another infinite loop — keep bubbles/embers
+    // single-animation or this guard silently stops sparing them.
+    const TRANSITING = new Set(['bubble-rise', 'bubble-sway', 'emberRise']);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          entry.target.classList.toggle('bb-anim-off', !entry.isIntersecting);
+        });
+      },
+      // Resume a touch before the element scrolls in so it is never visibly frozen.
+      { rootMargin: '200px' }
+    );
+
+    const targets = new Set();
+    document.getAnimations().forEach((anim) => {
+      const timing =
+        anim.effect && anim.effect.getTiming ? anim.effect.getTiming() : null;
+      const target = anim.effect && anim.effect.target;
+      if (!target || !timing || timing.iterations !== Infinity) return;
+      if (TRANSITING.has(anim.animationName)) return;
+      // A ::before/::after animation's target is a CSSPseudoElement (no nodeType).
+      // Resolve it to its originating element so the host gets tagged — the CSS
+      // rule then pauses the pseudo-element via its ::before/::after variants (this
+      // is what pauses the hero's large floatSlow gradient blobs off-screen).
+      const host = target.nodeType === 1 ? target : target.element;
+      if (!host || host.nodeType !== 1) return;
+      targets.add(host);
+    });
+    targets.forEach((el) => observer.observe(el));
+  }
+
+  /**
    * One-call bootstrap for a home page (FR `index.html` or the generated EN
    * `en.html`). Wires the mobile menu and both Formspree forms for the given
    * language, pulling every UI string from the catalogs above. The page's
@@ -505,11 +563,17 @@
     document.documentElement.classList.toggle('anim-paused', document.hidden);
   });
 
-  // Dew density depends on final card sizes — run once layout is settled.
-  if (document.readyState === 'complete') {
+  // Dew density depends on final card sizes — run once layout is settled, then
+  // register the off-screen pauser. The rAF lets the freshly-appended dew/bubble
+  // elements' animations show up in document.getAnimations() before we scan.
+  function setupAmbientAfterLayout() {
     setupDew();
+    requestAnimationFrame(setupOffscreenAnimationPausing);
+  }
+  if (document.readyState === 'complete') {
+    setupAmbientAfterLayout();
   } else {
-    window.addEventListener('load', setupDew);
+    window.addEventListener('load', setupAmbientAfterLayout);
   }
 
   global.BBShared = {


### PR DESCRIPTION
## Summary

Fixes the "site gets laggy the longer you stay" report. Root cause (measured — not a memory leak, the heap stays flat): the home page runs a large number of continuous CSS animations that keep the GPU compositing non-stop. On a desktop viewport that was **~480 running animations**, dominated by **~200 rising bubbles** (×2 keyframes each). Sustained compositing heats the device until it thermally throttles.

Two levers:

- **Fewer bubbles.** `adaptiveBubbleCount`: density `area/6500 → /9000`, floor `70 → 50`, and above all the cap `200 → 100` (data-saver `60 → 45`). The cap is what spares big screens, which don't need hundreds of bubbles to read as fizzy. ~-50% bubbles on desktop.
- **Pause off-screen loops.** A new `IntersectionObserver` (`setupOffscreenAnimationPausing`) pauses in-place ambient loops (spins, shimmers, "breathing" micro-animations) whose element has scrolled out of the viewport, resuming them on return. Pseudo-element loops (the hero's large `floatSlow` gradient blobs) are covered by resolving `CSSPseudoElement` targets to their host; the pause rule uses `(0,3,0)` specificity to outrank later `(0,2,0)` descendant `animation:` selectors. Transiting particle effects (rising bubbles/embers) are deliberately excluded so their stream never freezes off-screen. No-op under `prefers-reduced-motion` or without `IntersectionObserver`/`getAnimations`.

Invisible for on-screen content — only motion nobody can see is paused.

## Measured (Chrome, 1440×900)

| | Before | After |
|---|---|---|
| Bubbles | 199 | 100 |
| Running animations | 484 | ~269 (-44%) |
| Hero `::before/::after` off-screen | running | paused |
| `.hero-mascot .logo`, `.participate .btn-primary` off-screen | running | paused |
| Bubbles wrongly paused | — | 0 |

## Review

Pre-push ritual (pr-pre-reviewer + Codex) — both flagged the same blind spot: pseudo-element animations were skipped by the `nodeType` guard, so the hero blobs never paused off-screen. Fixed (resolve `CSSPseudoElement` → host) + verified. Codex's specificity concern (later `(0,2,0)` selectors winning the cascade tie) fixed via `(0,3,0)` + verified. Should-Have comment documenting the transiting-exclusion assumption added.

## Checklist

- [x] Verified in the browser (desktop): bubble count, off-screen pausing (incl. hero pseudo blobs), bubbles never frozen
- [x] Quality gate + i18n check green; 50 Python tests pass
- [x] `en.html` regenerated (not hand-edited); cache-bust bumped to `v=20260715`
- [x] `prefers-reduced-motion` honored; no `innerHTML`, no hardcoded colors
