### PR TITLE
feat(website): legal-twin freshness stamps — close i18n S4 (ADR-0027 D1.5)

### DIFF
--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -42,8 +42,14 @@ packages/website/
   `python3 scripts/build_i18n.py` and commit the regenerated `en.html` in the
   same PR. CI fails on a stale `en.html`, a missing/orphaned catalog key, or a
   FR copy change whose EN translation was not updated (`srcHash` guard).
-- **Legal pages:** hand-maintained `-en.html` twins. Keep them in sync — any FR
-  change requires the EN twin update in the same PR.
+- **Legal pages:** hand-maintained `-en.html` twins (NOT generated). Keep them
+  in sync — any FR change requires the EN twin update in the same PR. This is
+  gate-enforced: each EN twin embeds an `<!-- i18n-src: sha1:… -->` stamp of its
+  FR source; after editing a FR legal page and its EN twin, run
+  `python3 scripts/build_i18n.py --stamp` and commit — a stale stamp fails CI
+  (ADR-0027 D1 clause 5). The stamp hashes the whole FR file, so a sitewide
+  `<head>` sweep (e.g. a cache-bust bump) also needs a `--stamp` re-run — that
+  sweep touches the EN twin in the same PR anyway.
 - **Internal artefacts (commits, PR bodies, comments, docs/, CHANGELOG.md):** English only (memory `feedback_github_artifacts_english_only.md`).
 
 ## Design Tokens

--- a/packages/website/cookies-en.html
+++ b/packages/website/cookies-en.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- i18n-src: sha1:55e922edefadf79d2ea36a4b4b21f7d00f015180 -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Cookie Policy - Brasse-Bouillon</title>

--- a/packages/website/en.html
+++ b/packages/website/en.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
 <head>
-  <!-- GENERATED FILE — edit index.html + i18n/home.en.json instead. Regenerate with: python scripts/build_i18n.py -->
+  <!-- GENERATED FILE — edit index.html + i18n/home.en.json instead. Regenerate with: python3 scripts/build_i18n.py -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Progressive enhancement: flip to `js` so the mobile nav only

--- a/packages/website/legal-en.html
+++ b/packages/website/legal-en.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- i18n-src: sha1:a527ef8dda47d6f4e9a0c47f7550f42ea76add88 -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Legal Notice - Brasse-Bouillon</title>

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- i18n-src: sha1:76481d280c1872cf160cc1361549f4b9cd24b61d -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy - Brasse-Bouillon</title>

--- a/packages/website/scripts/build_i18n.py
+++ b/packages/website/scripts/build_i18n.py
@@ -9,11 +9,11 @@ re-serialises the document, so everything the annotations do not touch stays
 byte-for-byte identical (a hard requirement for the CI regeneration-diff check).
 
 Usage:
-    python scripts/build_i18n.py              # generate en.html (default)
-    python scripts/build_i18n.py --check      # generate in memory, fail if en.html is stale
-    python scripts/build_i18n.py --update-hashes
+    python3 scripts/build_i18n.py              # generate en.html (default)
+    python3 scripts/build_i18n.py --check      # generate in memory, fail if en.html is stale
+    python3 scripts/build_i18n.py --update-hashes
                                               # rewrite catalog srcHash fields after a FR edit
-    python scripts/build_i18n.py --stamp      # refresh the EN legal twins' i18n-src freshness stamp
+    python3 scripts/build_i18n.py --stamp      # refresh the EN legal twins' i18n-src freshness stamp
 
 The drift guard: each catalog entry stores `srcHash`, the sha1 of the French
 source (element inner HTML or attribute value) it translates. On generate/check,
@@ -59,7 +59,7 @@ VOID_TAGS = frozenset(
 CANONICAL_EN = "https://brasse-bouillon.com/en"
 GENERATED_MARKER = (
     "<!-- GENERATED FILE — edit index.html + i18n/home.en.json instead. "
-    "Regenerate with: python scripts/build_i18n.py -->"
+    "Regenerate with: python3 scripts/build_i18n.py -->"
 )
 
 
@@ -300,7 +300,7 @@ def generate(source: str, catalog: dict, *, check_hashes: bool = True) -> str:
         raise BuildError(
             "French source changed for: "
             f"{keys}\n  → update the EN translation in i18n/home.en.json, then run "
-            "`python scripts/build_i18n.py --update-hashes`."
+            "`python3 scripts/build_i18n.py --update-hashes`."
         )
 
     out = _apply_ops(source, ops)
@@ -661,7 +661,7 @@ def main(argv: list[str]) -> int:
             )
             if current != generated:
                 print(
-                    "en.html is stale — run `python scripts/build_i18n.py` and commit.",
+                    "en.html is stale — run `python3 scripts/build_i18n.py` and commit.",
                     file=sys.stderr,
                 )
                 return 1

--- a/packages/website/scripts/build_i18n.py
+++ b/packages/website/scripts/build_i18n.py
@@ -13,11 +13,17 @@ Usage:
     python scripts/build_i18n.py --check      # generate in memory, fail if en.html is stale
     python scripts/build_i18n.py --update-hashes
                                               # rewrite catalog srcHash fields after a FR edit
+    python scripts/build_i18n.py --stamp      # refresh the EN legal twins' i18n-src freshness stamp
 
 The drift guard: each catalog entry stores `srcHash`, the sha1 of the French
 source (element inner HTML or attribute value) it translates. On generate/check,
 a mismatch is a hard error — a FR copy change without its EN update fails CI. The
 author updates the EN value, runs --update-hashes, and commits deliberately.
+
+The legal twins (`legal`, `privacy`, `cookies`, `terms`) are hand-maintained,
+not generated; the same idea guards them via `--stamp`: each EN twin embeds a
+sha1 of its FR source, and the quality gate fails when a FR legal edit skipped
+the EN re-review + re-stamp (ADR-0027 D1 clause 5).
 """
 
 from __future__ import annotations
@@ -35,6 +41,13 @@ WEBSITE_DIR = Path(__file__).resolve().parent.parent
 INDEX_PATH = WEBSITE_DIR / "index.html"
 CATALOG_PATH = WEBSITE_DIR / "i18n" / "home.en.json"
 OUTPUT_PATH = WEBSITE_DIR / "en.html"
+
+# Hand-maintained legal twins (S4, ADR-0027 D1 clause 5). Unlike the home, they
+# are NOT generated; instead each `{stem}-en.html` embeds a sha1 of its FR
+# source so the gate can flag a FR legal edit that skipped the EN re-review.
+# `--stamp` refreshes the marker once the twin has been re-reviewed.
+LEGAL_STEMS = ("legal", "privacy", "cookies", "terms")
+_LEGAL_STAMP_RE = re.compile(r"<!-- i18n-src: sha1:([0-9a-f]{40}) -->")
 
 # Void elements never hold inner content, so they must not be pushed on the
 # element stack (they have no end tag). They may still carry translatable
@@ -553,18 +566,79 @@ def update_hashes(source: str, catalog: dict) -> dict:
 # --------------------------------------------------------------------------- #
 
 
+def read_legal_stamp(en_html: str) -> str | None:
+    """Return the sha1 embedded in an EN legal page, or None if unstamped."""
+    match = _LEGAL_STAMP_RE.search(en_html)
+    return match.group(1) if match else None
+
+
+def fr_legal_hash(website_dir: Path, stem: str) -> str:
+    """sha1 of the FR legal source `{stem}.html` (the twin the EN page tracks).
+
+    Hashes the WHOLE file, not just `<body>` prose, on purpose: the `<head>`
+    metadata (title, description, og:*) is itself translatable content that must
+    stay in sync between twins, so a FR head edit should also demand an EN
+    re-review. A sitewide, legal-neutral sweep (e.g. an `og-image` cache-bust)
+    does touch this hash, but such sweeps touch the EN twin in the same PR — so
+    re-running `--stamp` there is a legitimate, one-command acknowledgment, not
+    a false positive.
+    """
+    return sha1((website_dir / f"{stem}.html").read_text(encoding="utf-8"))
+
+
+def stamp_legal_pages(website_dir: Path = WEBSITE_DIR) -> list[str]:
+    """Refresh the `i18n-src` freshness stamp on every EN legal twin.
+
+    Embeds `<!-- i18n-src: sha1:<hash of the FR twin> -->` in each
+    `{stem}-en.html` (inserted right after `<head>` on first run, replaced in
+    place afterwards). Returns the EN files that changed. Run after re-reviewing
+    an EN twin against a FR legal edit; the gate (`check_legal_freshness`) stays
+    red until the stamp matches. Idempotent when everything is already current.
+    """
+    changed: list[str] = []
+    for stem in LEGAL_STEMS:
+        fr_path = website_dir / f"{stem}.html"
+        en_path = website_dir / f"{stem}-en.html"
+        if not fr_path.exists() or not en_path.exists():
+            raise BuildError(f"legal twin missing for stem '{stem}'")
+        marker = f"<!-- i18n-src: sha1:{fr_legal_hash(website_dir, stem)} -->"
+        en_html = en_path.read_text(encoding="utf-8")
+        if _LEGAL_STAMP_RE.search(en_html):
+            new_html = _LEGAL_STAMP_RE.sub(marker, en_html, count=1)
+        elif "<head>" in en_html:
+            new_html = en_html.replace("<head>", f"<head>\n  {marker}", 1)
+        else:
+            raise BuildError(f"{en_path.name}: no <head> to stamp")
+        if new_html != en_html:
+            en_path.write_text(new_html, encoding="utf-8")
+            changed.append(en_path.name)
+    return changed
+
+
 def main(argv: list[str]) -> int:
-    """CLI entry point: `--write` (default), `--check`, or `--update-hashes`."""
+    """CLI: `--write` (default), `--check`, `--update-hashes`, or `--stamp`."""
     mode = argv[1] if len(argv) > 1 else "--write"
-    if mode not in ("--write", "--check", "--update-hashes"):
+    if mode not in ("--write", "--check", "--update-hashes", "--stamp"):
         # Fail loudly on typos: silently falling through to write mode would
         # rewrite en.html when the author meant e.g. `--chek`.
         print(
             f"build_i18n: unknown mode '{mode}' "
-            "(expected --write, --check or --update-hashes)",
+            "(expected --write, --check, --update-hashes or --stamp)",
             file=sys.stderr,
         )
         return 2
+
+    if mode == "--stamp":
+        try:
+            changed = stamp_legal_pages()
+        except BuildError as error:
+            print(f"build_i18n: {error}", file=sys.stderr)
+            return 1
+        if changed:
+            print("Refreshed legal stamps: " + ", ".join(changed))
+        else:
+            print("Legal stamps already up to date.")
+        return 0
 
     source = INDEX_PATH.read_text(encoding="utf-8")
     catalog = load_catalog()

--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -499,6 +499,42 @@ def check_i18n_home_generated(root: Path = ROOT) -> list[str]:
     return []
 
 
+def check_legal_freshness(root: Path = ROOT) -> list[str]:
+    """Freshness guard for the hand-maintained EN legal twins (S4, ADR-0027 D1
+    clause 5). Each `{stem}-en.html` embeds a sha1 of its FR source; a FR legal
+    edit that skips the EN re-review leaves the stamp stale — a hard failure.
+    The author reviews the EN twin, runs `build_i18n.py --stamp`, and commits.
+    Skipped for trees without the i18n toolchain (minimal test fixtures)."""
+    if not (root / "scripts" / "build_i18n.py").exists():
+        return []
+
+    try:
+        from scripts import build_i18n  # pytest / package context
+    except ImportError:  # direct `python3 scripts/quality_gate.py` run
+        # no-redef: exactly one import form runs; both bind the same module.
+        import build_i18n  # type: ignore[no-redef]
+
+    errors: list[str] = []
+    for stem in build_i18n.LEGAL_STEMS:
+        fr_path = root / f"{stem}.html"
+        en_path = root / f"{stem}-en.html"
+        if not fr_path.exists() or not en_path.exists():
+            continue
+        stamped = build_i18n.read_legal_stamp(en_path.read_text(encoding="utf-8"))
+        expected = build_i18n.sha1(fr_path.read_text(encoding="utf-8"))
+        if stamped is None:
+            errors.append(
+                f"{stem}-en.html: tampon i18n-src manquant "
+                "(lancer `python3 scripts/build_i18n.py --stamp`)"
+            )
+        elif stamped != expected:
+            errors.append(
+                f"{stem}-en.html: tampon i18n-src périmé — {stem}.html a changé "
+                "sans re-relecture EN (lancer `python3 scripts/build_i18n.py --stamp`)"
+            )
+    return errors
+
+
 def check_og_image_dimensions(root: Path = ROOT) -> list[str]:
     """Every Open Graph share image (FR + localized EN card) must be exactly
     1200×630 (the 1.91:1 ratio social platforms crop to); a wrong-sized image
@@ -582,6 +618,7 @@ def collect_errors(root: Path = ROOT) -> list[str]:
     errors.extend(check_no_stale_host(root))
     errors.extend(check_og_image_dimensions(root))
     errors.extend(check_hreflang_reciprocity(root))
+    errors.extend(check_legal_freshness(root))
     errors.extend(check_i18n_home_generated(root))
     return errors
 

--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -493,7 +493,7 @@ def check_i18n_home_generated(root: Path = ROOT) -> list[str]:
     current = output_path.read_text(encoding="utf-8") if output_path.exists() else ""
     if current != generated:
         return [
-            "en.html est périmé — lancer `python scripts/build_i18n.py` "
+            "en.html est périmé — lancer `python3 scripts/build_i18n.py` "
             "puis committer le résultat"
         ]
     return []
@@ -521,7 +521,8 @@ def check_legal_freshness(root: Path = ROOT) -> list[str]:
         if not fr_path.exists() or not en_path.exists():
             continue
         stamped = build_i18n.read_legal_stamp(en_path.read_text(encoding="utf-8"))
-        expected = build_i18n.sha1(fr_path.read_text(encoding="utf-8"))
+        # Reuse the generator's helper so the hashing policy stays single-source.
+        expected = build_i18n.fr_legal_hash(root, stem)
         if stamped is None:
             errors.append(
                 f"{stem}-en.html: tampon i18n-src manquant "

--- a/packages/website/terms-en.html
+++ b/packages/website/terms-en.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- i18n-src: sha1:8102e72f096a6fdcc1e35df1784ea382038a67d7 -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terms of Use - Brasse-Bouillon</title>

--- a/packages/website/tests/test_build_i18n.py
+++ b/packages/website/tests/test_build_i18n.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import tempfile
 import unittest
+from pathlib import Path
 
 from scripts import build_i18n
 
@@ -9,6 +11,21 @@ def _catalog(strings: dict, **extra) -> dict:
     catalog: dict = {"strings": strings}
     catalog.update(extra)
     return catalog
+
+
+def _write_legal_twins(base: Path) -> None:
+    """Minimal FR + EN legal twins (all four stems) for the stamp helper."""
+    for stem in build_i18n.LEGAL_STEMS:
+        (base / f"{stem}.html").write_text(
+            f"<!DOCTYPE html><html lang=fr><head><title>{stem} FR</title></head>"
+            "<body></body></html>",
+            encoding="utf-8",
+        )
+        (base / f"{stem}-en.html").write_text(
+            f"<!DOCTYPE html><html lang=en><head><title>{stem} EN</title></head>"
+            "<body></body></html>",
+            encoding="utf-8",
+        )
 
 
 class GenerateTests(unittest.TestCase):
@@ -211,6 +228,54 @@ class GenerateTests(unittest.TestCase):
         out = build_i18n.generate(source, catalog, check_hashes=False)
         self.assertIn('"name": "Q EN"', out)
         self.assertIn('"text": "A EN"', out)
+
+
+class LegalStampTests(unittest.TestCase):
+    def test_stamp_inserts_then_is_idempotent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            _write_legal_twins(base)
+
+            # Returned in LEGAL_STEMS order, one entry per freshly-stamped twin.
+            first = build_i18n.stamp_legal_pages(base)
+            self.assertEqual(first, [f"{s}-en.html" for s in build_i18n.LEGAL_STEMS])
+            # Every EN twin now carries the sha1 of its FR source.
+            for stem in build_i18n.LEGAL_STEMS:
+                en_html = (base / f"{stem}-en.html").read_text(encoding="utf-8")
+                self.assertEqual(
+                    build_i18n.read_legal_stamp(en_html),
+                    build_i18n.fr_legal_hash(base, stem),
+                )
+            # A second run changes nothing.
+            self.assertEqual(build_i18n.stamp_legal_pages(base), [])
+
+    def test_stamp_refreshes_only_the_changed_twin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            _write_legal_twins(base)
+            build_i18n.stamp_legal_pages(base)
+
+            fr = base / "privacy.html"
+            fr.write_text(fr.read_text(encoding="utf-8") + "<!-- edit -->", "utf-8")
+
+            changed = build_i18n.stamp_legal_pages(base)
+            self.assertEqual(changed, ["privacy-en.html"])
+            self.assertEqual(
+                build_i18n.read_legal_stamp(
+                    (base / "privacy-en.html").read_text(encoding="utf-8")
+                ),
+                build_i18n.fr_legal_hash(base, "privacy"),
+            )
+
+    def test_read_legal_stamp_none_when_absent(self) -> None:
+        self.assertIsNone(build_i18n.read_legal_stamp("<head></head>"))
+
+    def test_stamp_raises_on_missing_twin(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            base = Path(tmp_dir)
+            (base / "legal.html").write_text("<head></head>", encoding="utf-8")
+            with self.assertRaises(build_i18n.BuildError):
+                build_i18n.stamp_legal_pages(base)
 
 
 if __name__ == "__main__":

--- a/packages/website/tests/test_quality_gate.py
+++ b/packages/website/tests/test_quality_gate.py
@@ -169,12 +169,60 @@ Sitemap: https://brasse-bouillon.com/sitemap.xml
     )
 
 
+def _stampable_fixture(base: Path) -> None:
+    """Valid fixture + the build_i18n toolchain marker (so `check_legal_freshness`
+    actually runs instead of skipping) + freshly stamped EN legal twins."""
+    _create_valid_fixture(base)
+    _write_file(base, "scripts/build_i18n.py", "# marker\n")
+    build_i18n.stamp_legal_pages(base)
+
+
 class QualityGateTests(unittest.TestCase):
     def test_collect_errors_passes_on_valid_fixture(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
             _create_valid_fixture(root)
             self.assertEqual(quality_gate.collect_errors(root), [])
+
+    def test_legal_freshness_passes_when_stamped(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _stampable_fixture(root)
+            self.assertEqual(quality_gate.check_legal_freshness(root), [])
+
+    def test_legal_freshness_detects_stale_stamp(self) -> None:
+        # A FR legal edit without re-stamping the EN twin must fail the gate.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _stampable_fixture(root)
+            fr = root / "legal.html"
+            fr.write_text(fr.read_text(encoding="utf-8") + "<!-- x -->", "utf-8")
+
+            errors = quality_gate.check_legal_freshness(root)
+            self.assertTrue(any("legal-en.html" in e and "périmé" in e for e in errors))
+
+    def test_legal_freshness_detects_missing_stamp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _stampable_fixture(root)
+            en = root / "cookies-en.html"
+            en.write_text(
+                build_i18n._LEGAL_STAMP_RE.sub("", en.read_text(encoding="utf-8")),
+                encoding="utf-8",
+            )
+
+            errors = quality_gate.check_legal_freshness(root)
+            self.assertTrue(
+                any("cookies-en.html" in e and "manquant" in e for e in errors)
+            )
+
+    def test_legal_freshness_skipped_without_toolchain(self) -> None:
+        # No scripts/build_i18n.py in the tree (unstamped legal pages) -> skip,
+        # matching the home i18n check's toolchain gate.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            _create_valid_fixture(root)
+            self.assertEqual(quality_gate.check_legal_freshness(root), [])
 
     def test_detects_missing_required_file(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Closes the last slice of the website i18n epic (ADR-0027 D1 clause 5) — and the last drift hole. The generated home has had a `srcHash` guard since S1; the **hand-maintained EN legal twins had none**, so a FR legal edit that skipped its EN twin passed CI silently (the exact pain lived before #1379).

- Each EN legal twin now embeds `<!-- i18n-src: sha1:<hash of the FR twin> -->` right after `<head>`.
- New gate check `check_legal_freshness` recomputes the FR file's sha1 and fails on a **missing** or **stale** stamp, with an actionable message.
- `build_i18n.py --stamp` refreshes the four stamps (insert-then-replace, idempotent); the mode is validated like the others (unknown flag → exit 2).
- The stamp is the **re-review acknowledgment**: edit FR legal + its EN twin, run `--stamp`, commit. End-to-end verified locally: a FR edit without re-stamp turns the gate red; `--stamp` turns it green.
- **Design note**: the stamp hashes the whole FR file, not just `<body>` — the `<head>` metadata (title/description/og) is itself translatable content that must stay in sync, so hashing it *strengthens* the guard. A sitewide head sweep (cache-bust) also needs a `--stamp` re-run, but such sweeps touch the EN twin in the same PR anyway (documented in code + CLAUDE.md).
- Tests 50 → 58. Docs: package `CLAUDE.md` § Languages + the `build_i18n` module docstring.

## Verification

- gate ✅, `build_i18n.py --check` ✅, 58/58 unit tests ✅, `ruff check`/`ruff format` clean.
- End-to-end guard behavior verified (FR edit → red → `--stamp` → green).
- Pre-push review: **0 Must Have**; both Should (ruff-format the new test blocks; document the whole-file-hash tradeoff) applied.

## Checklist

- [x] Conventional Commits
- [x] `en.html` regeneration still clean (legal twins are hand-maintained, not generated)
- [x] Tests happy + sad + edge (stamp insert/idempotent/refresh/missing-twin; freshness pass/stale/missing/skip)
- [x] Pre-push review ritual passed

Refs #1075

🤖 Generated with [Claude Code](https://claude.com/claude-code)