### PR TITLE
fix(mobile-app): add back controls to screens missing them

### DIFF
--- a/packages/mobile-app/src/core/navigation/__tests__/use-back-navigation.test.ts
+++ b/packages/mobile-app/src/core/navigation/__tests__/use-back-navigation.test.ts
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react-native";
+
+import { useBackNavigation } from "@/core/navigation/use-back-navigation";
+
+const mockBack = jest.fn();
+const mockReplace = jest.fn();
+let mockCanGoBack = true;
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    canGoBack: () => mockCanGoBack,
+    back: mockBack,
+    replace: mockReplace,
+  }),
+}));
+
+describe("useBackNavigation", () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+    mockReplace.mockClear();
+    mockCanGoBack = true;
+  });
+
+  it("pops the real history when a previous screen exists", () => {
+    mockCanGoBack = true;
+    const { result } = renderHook(() => useBackNavigation("/(app)/academy"));
+
+    result.current();
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the given route when there is no history to pop", () => {
+    mockCanGoBack = false;
+    const { result } = renderHook(() => useBackNavigation("/(app)/academy"));
+
+    result.current();
+
+    expect(mockReplace).toHaveBeenCalledWith("/(app)/academy");
+    expect(mockBack).not.toHaveBeenCalled();
+  });
+
+  it("uses whichever fallback route it is given", () => {
+    mockCanGoBack = false;
+    const { result } = renderHook(() => useBackNavigation("/(app)/dashboard"));
+
+    result.current();
+
+    expect(mockReplace).toHaveBeenCalledWith("/(app)/dashboard");
+  });
+});

--- a/packages/mobile-app/src/core/navigation/use-back-navigation.ts
+++ b/packages/mobile-app/src/core/navigation/use-back-navigation.ts
@@ -1,0 +1,30 @@
+import { useCallback } from "react";
+
+import { useRouter, type Href } from "expo-router";
+
+/**
+ * Shared "back" behavior for screens that render a manual back control.
+ *
+ * Prefers popping the real navigation history so the user returns to
+ * wherever they actually came from. When there is nothing to pop — a deep
+ * link, a cold start, or a screen reached via `replace` — it falls back to a
+ * known parent route instead of dead-ending (which, on iOS, would strand the
+ * user since there is no hardware back button).
+ *
+ * Generalizes the `canGoBack()` guard first introduced on the Academy screens
+ * so every screen shares one predictable back behavior.
+ *
+ * @param fallback Route to land on when there is no history to pop.
+ * @returns A stable-per-fallback handler to wire to a back control's `onPress`.
+ */
+export function useBackNavigation(fallback: Href): () => void {
+  const router = useRouter();
+
+  return useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace(fallback);
+    }
+  }, [router, fallback]);
+}

--- a/packages/mobile-app/src/core/ui/BackHeaderAction.tsx
+++ b/packages/mobile-app/src/core/ui/BackHeaderAction.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import type { Href } from "expo-router";
+
+import { useBackNavigation } from "@/core/navigation/use-back-navigation";
+import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
+
+type Props = {
+  /** Route to land on when there is no navigation history to pop. */
+  fallback: Href;
+  /** Visible label; defaults to a generic "Retour". */
+  label?: string;
+};
+
+/**
+ * Ready-to-drop back control for a screen header (e.g. the `action` slot of
+ * `ListHeader`). Wires {@link HeaderBackButton} to {@link useBackNavigation}
+ * so every screen shares one back behavior: pop the real history, or fall
+ * back to a known parent when there is none.
+ */
+export function BackHeaderAction({ fallback, label = "Retour" }: Props) {
+  const goBack = useBackNavigation(fallback);
+
+  return (
+    <HeaderBackButton
+      label={label}
+      accessibilityLabel="Retour à l'écran précédent"
+      onPress={goBack}
+    />
+  );
+}

--- a/packages/mobile-app/src/core/ui/__tests__/BackHeaderAction.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/BackHeaderAction.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
+
+const mockBack = jest.fn();
+const mockReplace = jest.fn();
+let mockCanGoBack = true;
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    canGoBack: () => mockCanGoBack,
+    back: mockBack,
+    replace: mockReplace,
+  }),
+}));
+
+const BACK_A11Y_LABEL = "Retour à l'écran précédent";
+
+describe("BackHeaderAction", () => {
+  beforeEach(() => {
+    mockBack.mockClear();
+    mockReplace.mockClear();
+    mockCanGoBack = true;
+  });
+
+  it("renders a back control with a default label", () => {
+    render(<BackHeaderAction fallback="/(app)/academy" />);
+
+    expect(screen.getByText("Retour")).toBeTruthy();
+  });
+
+  it("supports a custom label", () => {
+    render(<BackHeaderAction fallback="/(app)/academy" label="Accueil" />);
+
+    expect(screen.getByText("Accueil")).toBeTruthy();
+  });
+
+  it("pops the history when a previous screen exists", () => {
+    mockCanGoBack = true;
+    render(<BackHeaderAction fallback="/(app)/academy" />);
+
+    fireEvent.press(screen.getByLabelText(BACK_A11Y_LABEL));
+
+    expect(mockBack).toHaveBeenCalledTimes(1);
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the given route when there is no history", () => {
+    mockCanGoBack = false;
+    render(<BackHeaderAction fallback="/(app)/academy" />);
+
+    fireEvent.press(screen.getByLabelText(BACK_A11Y_LABEL));
+
+    expect(mockReplace).toHaveBeenCalledWith("/(app)/academy");
+    expect(mockBack).not.toHaveBeenCalled();
+  });
+});

--- a/packages/mobile-app/src/features/auth/presentation/ProfileScreen.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/ProfileScreen.tsx
@@ -1,5 +1,5 @@
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 import {
   Modal,
   Pressable,
@@ -9,8 +9,11 @@ import {
   View,
 } from "react-native";
 
+import { useFocusEffect, useRouter } from "expo-router";
+
 import { AboutFooter } from "@/core/ui/AboutFooter";
 import { useAuth } from "@/core/auth/auth-context";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { getErrorMessage } from "@/core/http/http-error";
 import { Card } from "@/core/ui/Card";
 import { Screen } from "@/core/ui/Screen";
@@ -18,6 +21,18 @@ import { Ionicons } from "@expo/vector-icons";
 
 export function ProfileScreen() {
   const { session, refreshProfile, logout, isLoading } = useAuth();
+  const router = useRouter();
+  const [canGoBack, setCanGoBack] = useState(false);
+
+  // Re-derive on focus: expo-router's `useRouter()` is a non-reactive
+  // singleton and this tab screen stays mounted, so a bare render-time read
+  // would keep the control hidden if Profile is first opened as a footer tab
+  // (no history) and later reached via a push (history now exists).
+  useFocusEffect(
+    useCallback(() => {
+      setCanGoBack(router.canGoBack());
+    }, [router]),
+  );
   const [localError, setLocalError] = useState<string | null>(null);
   const [localInfo, setLocalInfo] = useState<string | null>(null);
   const [isLogoutModalVisible, setIsLogoutModalVisible] = useState(false);
@@ -64,6 +79,11 @@ export function ProfileScreen() {
   return (
     <Screen>
       <ScrollView contentContainerStyle={styles.content}>
+        {canGoBack ? (
+          <View style={styles.backRow}>
+            <BackHeaderAction fallback="/(app)/dashboard" />
+          </View>
+        ) : null}
         <Card style={styles.headerCard}>
           <View style={styles.avatar}>
             <Ionicons
@@ -197,6 +217,9 @@ const styles = StyleSheet.create({
   content: {
     gap: spacing.sm,
     paddingBottom: spacing.lg,
+  },
+  backRow: {
+    alignItems: "flex-start",
   },
   headerCard: {
     alignItems: "center",

--- a/packages/mobile-app/src/features/auth/presentation/__tests__/ProfileScreen.test.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/__tests__/ProfileScreen.test.tsx
@@ -10,10 +10,38 @@ import React from "react";
 
 const mockRefreshProfile = jest.fn();
 const mockLogout = jest.fn();
+const mockCanGoBack = jest.fn(() => false);
+const mockBack = jest.fn();
+const mockReplace = jest.fn();
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
 }));
+
+// Local expo-router mock: the global one (jest.setup) omits `canGoBack`,
+// which ProfileScreen now calls at render to decide whether to show the
+// back control. Mirror the global shape and route back/replace to spies.
+jest.mock("expo-router", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const react = require("react");
+  return {
+    useRouter: () => ({
+      push: jest.fn(),
+      replace: mockReplace,
+      back: mockBack,
+      canGoBack: mockCanGoBack,
+    }),
+    // Run the focus callback via an effect so ProfileScreen re-derives
+    // `canGoBack` on (re)focus, mirroring expo-router's real behavior.
+    useFocusEffect: (callback: () => void | (() => void)) =>
+      react.useEffect(callback, [callback]),
+    useLocalSearchParams: () => ({}),
+    usePathname: () => "/",
+    Redirect: () => null,
+    Stack: ({ children }: { children: React.ReactNode }) => children,
+    Tabs: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
 
 jest.mock("@/core/auth/auth-context", () => ({
   useAuth: () => ({
@@ -40,6 +68,10 @@ describe("ProfileScreen", () => {
   beforeEach(() => {
     mockRefreshProfile.mockReset();
     mockLogout.mockReset();
+    mockCanGoBack.mockReset();
+    mockCanGoBack.mockReturnValue(false);
+    mockBack.mockReset();
+    mockReplace.mockReset();
   });
 
   it("renders profile information", () => {
@@ -120,5 +152,41 @@ describe("ProfileScreen", () => {
     await waitFor(() => {
       expect(mockLogout).toHaveBeenCalledTimes(1);
     });
+  });
+
+  // Issue back-buttons — Profil is reachable both as a footer destination
+  // (no history) and pushed from the dashboard (has history). The back
+  // control must appear only in the pushed case, so a footer-reached tab
+  // root stays consistent with the other roots (no stray back button).
+  it("shows a back control when reached as a pushed screen (has history)", () => {
+    mockCanGoBack.mockReturnValue(true);
+
+    render(<ProfileScreen />);
+
+    expect(screen.getByLabelText("Retour à l'écran précédent")).toBeTruthy();
+  });
+
+  it("hides the back control when reached as a tab root (no history)", () => {
+    mockCanGoBack.mockReturnValue(false);
+
+    render(<ProfileScreen />);
+
+    expect(screen.queryByLabelText("Retour à l'écran précédent")).toBeNull();
+  });
+
+  // Regression — the screen instance stays mounted across tab switches, so a
+  // bare render-time `canGoBack()` read would leave the control hidden after
+  // history appears. Re-deriving on focus must reveal it on the next focus.
+  it("reveals the back control after gaining history on a later focus", () => {
+    mockCanGoBack.mockReturnValue(false);
+
+    render(<ProfileScreen />);
+
+    expect(screen.queryByLabelText("Retour à l'écran précédent")).toBeNull();
+
+    mockCanGoBack.mockReturnValue(true);
+    screen.rerender(<ProfileScreen />);
+
+    expect(screen.getByLabelText("Retour à l'écran précédent")).toBeTruthy();
   });
 });

--- a/packages/mobile-app/src/features/auth/presentation/__tests__/ProfileScreen.test.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/__tests__/ProfileScreen.test.tsx
@@ -1,4 +1,5 @@
 import {
+  act,
   fireEvent,
   render,
   screen,
@@ -13,6 +14,22 @@ const mockLogout = jest.fn();
 const mockCanGoBack = jest.fn(() => false);
 const mockBack = jest.fn();
 const mockReplace = jest.fn();
+const mockPush = jest.fn();
+
+// expo-router hands back a module-level singleton from `useRouter()`, so the
+// router identity is stable across renders. The double must be stable too: a
+// fresh object per render would rebuild the focus callback on every render and
+// re-run the focus effect on any rerender — something production never does.
+const mockRouter = {
+  push: mockPush,
+  replace: mockReplace,
+  back: mockBack,
+  canGoBack: mockCanGoBack,
+};
+
+// Latest focus callback registered by the screen, so a test can fire a real
+// focus event instead of leaning on a rerender.
+const mockFocus: { run?: () => void | (() => void) } = {};
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
@@ -25,16 +42,13 @@ jest.mock("expo-router", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const react = require("react");
   return {
-    useRouter: () => ({
-      push: jest.fn(),
-      replace: mockReplace,
-      back: mockBack,
-      canGoBack: mockCanGoBack,
-    }),
-    // Run the focus callback via an effect so ProfileScreen re-derives
-    // `canGoBack` on (re)focus, mirroring expo-router's real behavior.
-    useFocusEffect: (callback: () => void | (() => void)) =>
-      react.useEffect(callback, [callback]),
+    useRouter: () => mockRouter,
+    // Mirror expo-router: run the callback on mount (first focus) and keep a
+    // handle on it so a test can replay it as a later focus event.
+    useFocusEffect: (callback: () => void | (() => void)) => {
+      mockFocus.run = callback;
+      react.useEffect(callback, [callback]);
+    },
     useLocalSearchParams: () => ({}),
     usePathname: () => "/",
     Redirect: () => null,
@@ -184,8 +198,16 @@ describe("ProfileScreen", () => {
 
     expect(screen.queryByLabelText("Retour à l'écran précédent")).toBeNull();
 
+    // The user now reaches Profile again through a push, so history exists.
     mockCanGoBack.mockReturnValue(true);
-    screen.rerender(<ProfileScreen />);
+
+    // Replay the focus callback: an actual focus event is the only thing that
+    // re-derives this in production. A rerender would NOT do — the router is a
+    // stable singleton, so the callback identity never changes and the focus
+    // effect never re-fires on a plain re-render.
+    act(() => {
+      mockFocus.run?.();
+    });
 
     expect(screen.getByLabelText("Retour à l'écran précédent")).toBeTruthy();
   });

--- a/packages/mobile-app/src/features/beer-catalog/presentation/BeerCatalogBrowseScreen.tsx
+++ b/packages/mobile-app/src/features/beer-catalog/presentation/BeerCatalogBrowseScreen.tsx
@@ -1,5 +1,11 @@
 import React, { useMemo } from "react";
-import { FlatList, Pressable, RefreshControl, StyleSheet } from "react-native";
+import {
+  FlatList,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  View,
+} from "react-native";
 
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter, type Href } from "expo-router";
@@ -7,6 +13,7 @@ import { useRouter, type Href } from "expo-router";
 import { getErrorMessage } from "@/core/http/http-error";
 import { colors, spacing } from "@/core/theme";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { Screen } from "@/core/ui/Screen";
@@ -82,21 +89,24 @@ export function BeerCatalogBrowseScreen() {
         title={BROWSE_TITLE}
         subtitle={BROWSE_SUBTITLE}
         action={
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Rechercher une bière"
-            // Href cast: the `app/(app)/beer-catalog/*` route files land
-            // with the routing slice; typed routes do not know them yet.
-            onPress={() => router.push("/(app)/beer-catalog/search" as Href)}
-            style={styles.searchAction}
-            testID="beer-catalog-search-action"
-          >
-            <Ionicons
-              name="search-outline"
-              size={22}
-              color={colors.brand.primary}
-            />
-          </Pressable>
+          <View style={styles.headerActions}>
+            <BackHeaderAction fallback="/(app)/dashboard" />
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Rechercher une bière"
+              // Href cast: the `app/(app)/beer-catalog/*` route files land
+              // with the routing slice; typed routes do not know them yet.
+              onPress={() => router.push("/(app)/beer-catalog/search" as Href)}
+              style={styles.searchAction}
+              testID="beer-catalog-search-action"
+            >
+              <Ionicons
+                name="search-outline"
+                size={22}
+                color={colors.brand.primary}
+              />
+            </Pressable>
+          </View>
         }
       />
 
@@ -143,6 +153,11 @@ export function BeerCatalogBrowseScreen() {
 }
 
 const styles = StyleSheet.create({
+  headerActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+  },
   searchAction: {
     padding: spacing.xs,
   },

--- a/packages/mobile-app/src/features/beer-catalog/presentation/BeerCatalogSearchScreen.tsx
+++ b/packages/mobile-app/src/features/beer-catalog/presentation/BeerCatalogSearchScreen.tsx
@@ -7,6 +7,7 @@ import { getErrorMessage } from "@/core/http/http-error";
 import { spacing } from "@/core/theme";
 import { BeerMugLoader } from "@/core/ui/BeerMugLoader";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { Screen } from "@/core/ui/Screen";
@@ -149,7 +150,10 @@ export function BeerCatalogSearchScreen() {
 
   return (
     <Screen error={settledError} onRetry={handleRefetch}>
-      <ListHeader title={SEARCH_TITLE} />
+      <ListHeader
+        title={SEARCH_TITLE}
+        action={<BackHeaderAction fallback="/(app)/beer-catalog" />}
+      />
       <SearchField value={term} onChangeText={setTerm} />
       {content}
     </Screen>

--- a/packages/mobile-app/src/features/beer-catalog/presentation/__tests__/BeerCatalogBrowseScreen.test.tsx
+++ b/packages/mobile-app/src/features/beer-catalog/presentation/__tests__/BeerCatalogBrowseScreen.test.tsx
@@ -274,4 +274,15 @@ describe("BeerCatalogBrowseScreen (UC1)", () => {
     getBrowseListProps().onEndReached?.({ distanceFromEnd: 0 });
     expect(mockFetchNextPage).toHaveBeenCalledTimes(1);
   });
+
+  // back-buttons: the header composes the new back control with the existing
+  // search action — adding one must not drop the other.
+  it("shows both a back control and the search action in the header", () => {
+    mockedUseBeerCatalogPagination.mockReturnValue(buildPaginationResult({}));
+
+    render(<BeerCatalogBrowseScreen />);
+
+    expect(screen.getByLabelText("Retour à l'écran précédent")).toBeTruthy();
+    expect(screen.getByLabelText("Rechercher une bière")).toBeTruthy();
+  });
 });

--- a/packages/mobile-app/src/features/beer-catalog/presentation/__tests__/BeerCatalogSearchScreen.test.tsx
+++ b/packages/mobile-app/src/features/beer-catalog/presentation/__tests__/BeerCatalogSearchScreen.test.tsx
@@ -144,6 +144,12 @@ describe("BeerCatalogSearchScreen (UC2)", () => {
     });
   });
 
+  it("renders a back control in the header", () => {
+    render(<BeerCatalogSearchScreen />);
+
+    expect(screen.getByLabelText("Retour à l'écran précédent")).toBeTruthy();
+  });
+
   // happy: the query only reaches the hook once the debounce settles —
   // an intermediate keystroke is never propagated.
   it("happy: debounces the term before it reaches the hook", () => {

--- a/packages/mobile-app/src/features/recipes/presentation/CatalogScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/CatalogScreen.tsx
@@ -3,6 +3,7 @@ import { FlatList, RefreshControl, StyleSheet } from "react-native";
 import { spacing } from "@/core/theme";
 
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import React from "react";
@@ -62,6 +63,7 @@ export function CatalogScreen() {
       <ListHeader
         title="Catalogue de recettes"
         subtitle="Découvre les recettes partagées par la communauté Brasse-Bouillon"
+        action={<BackHeaderAction fallback="/recipes" />}
       />
 
       {showEmptyState ? (

--- a/packages/mobile-app/src/features/tools/presentation/AvancesCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AvancesCalculatorScreen.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/core/brewing-calculations";
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import { Card } from "@/core/ui/Card";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 
@@ -127,6 +128,7 @@ export function AvancesCalculatorScreen() {
       <ListHeader
         title="🧪 Calculs avancés"
         subtitle="Enzymes · Diagnostic moût · Altitude"
+        action={<BackHeaderAction fallback="/(app)/academy" />}
       />
 
       <View style={styles.tabsContainer}>

--- a/packages/mobile-app/src/features/tools/presentation/CarbonatationCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/CarbonatationCalculatorScreen.tsx
@@ -18,6 +18,7 @@ import {
 } from "react-native";
 
 import { Card } from "@/core/ui/Card";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 
@@ -86,6 +87,7 @@ export function CarbonatationCalculatorScreen() {
       <ListHeader
         title="🍾 Calculs Carbonatation"
         subtitle="Priming · CO₂ résiduel · Pression fût"
+        action={<BackHeaderAction fallback="/(app)/academy" />}
       />
 
       <View style={styles.tabsContainer}>

--- a/packages/mobile-app/src/features/tools/presentation/CouleurCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/CouleurCalculatorScreen.tsx
@@ -23,6 +23,7 @@ import {
 } from "react-native";
 
 import { Card } from "@/core/ui/Card";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 import Slider from "@react-native-community/slider";
@@ -148,7 +149,11 @@ export function CouleurCalculatorScreen() {
 
   return (
     <Screen>
-      <ListHeader title="🎨 Calculs Couleur" subtitle="MCU · SRM · EBC" />
+      <ListHeader
+        title="🎨 Calculs Couleur"
+        subtitle="MCU · SRM · EBC"
+        action={<BackHeaderAction fallback="/(app)/academy" />}
+      />
 
       {/* Tabs */}
       <View style={styles.tabsContainer}>

--- a/packages/mobile-app/src/features/tools/presentation/EauCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/EauCalculatorScreen.tsx
@@ -21,6 +21,7 @@ import {
 } from "react-native";
 
 import { Card } from "@/core/ui/Card";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 import type { IonRange } from "@/features/tools/domain/water-profiles";
@@ -393,6 +394,7 @@ export function EauCalculatorScreen() {
       <ListHeader
         title="Le Puits 💧"
         subtitle="Calculs eau de brassage · profil ionique et alkalinité résiduelle"
+        action={<BackHeaderAction fallback="/(app)/academy" />}
       />
 
       {/* Tabs */}

--- a/packages/mobile-app/src/features/tools/presentation/FermentesciblesCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/FermentesciblesCalculatorScreen.tsx
@@ -25,6 +25,7 @@ import {
 } from "react-native";
 
 import { Card } from "@/core/ui/Card";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
@@ -123,6 +124,7 @@ export function FermentesciblesCalculatorScreen() {
       <ListHeader
         title="🍺 Calculs Fermentescibles"
         subtitle="Densité initiale et malts"
+        action={<BackHeaderAction fallback="/(app)/academy" />}
       />
 
       {/* Tabs */}

--- a/packages/mobile-app/src/features/tools/presentation/HoublonsCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/HoublonsCalculatorScreen.tsx
@@ -17,6 +17,7 @@ import {
 } from "react-native";
 
 import { Card } from "@/core/ui/Card";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 import {
@@ -208,6 +209,7 @@ export function HoublonsCalculatorScreen() {
       <ListHeader
         title="🌿 Calculs Houblons"
         subtitle="IBU · Tinseth · BU:GU"
+        action={<BackHeaderAction fallback="/(app)/academy" />}
       />
 
       {/* Tabs */}

--- a/packages/mobile-app/src/features/tools/presentation/LevuresCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/LevuresCalculatorScreen.tsx
@@ -22,6 +22,7 @@ import {
 } from "react-native";
 
 import { Card } from "@/core/ui/Card";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 
@@ -77,6 +78,7 @@ export function LevuresCalculatorScreen() {
       <ListHeader
         title="🧫 Calculs Levures"
         subtitle="Pitch rate · Atténuation · Sachets"
+        action={<BackHeaderAction fallback="/(app)/academy" />}
       />
 
       <View style={styles.tabsContainer}>

--- a/packages/mobile-app/src/features/tools/presentation/RendementCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/RendementCalculatorScreen.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/core/brewing-calculations";
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import { Card } from "@/core/ui/Card";
+import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
 import * as Haptics from "expo-haptics";
@@ -111,6 +112,7 @@ export function RendementCalculatorScreen() {
       <ListHeader
         title="⚙️ Calculs Rendement"
         subtitle="Efficacité · Volumes · Plan d'eau"
+        action={<BackHeaderAction fallback="/(app)/academy" />}
       />
 
       <View style={styles.tabsContainer}>

--- a/packages/mobile-app/src/features/tools/presentation/__tests__/HoublonsCalculatorScreen.test.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/__tests__/HoublonsCalculatorScreen.test.tsx
@@ -38,6 +38,12 @@ describe("HoublonsCalculatorScreen", () => {
     expect(screen.getByText("BU:GU")).toBeTruthy();
   });
 
+  it("renders a back control in the header", () => {
+    render(<HoublonsCalculatorScreen />);
+
+    expect(screen.getByLabelText("Retour à l'écran précédent")).toBeTruthy();
+  });
+
   describe("Rapide tab", () => {
     it("shows the Rapide tab content by default", () => {
       render(<HoublonsCalculatorScreen />);


### PR DESCRIPTION
## Summary

Screens reached by `router.push` previously shipped with **no back control** — a
dead-end on iOS (no hardware back button), and on the tool calculators reachable
from up to three different origins. This adds a consistent back affordance to
every such screen.

- New `useBackNavigation(fallback)` hook: pop the real history when it exists,
  otherwise fall back to a known parent route (never a dead-end). Generalizes the
  `canGoBack()` guard previously unique to the Academy screens.
- New `BackHeaderAction` component wiring that hook to the existing
  `HeaderBackButton`.
- Back control added to: the **8 tool calculators** (fallback → Academy),
  beer-catalog **browse** (composed with the existing search action, fallback →
  Dashboard) and **search** (fallback → catalog), the community **recipe
  catalog** (fallback → Recipes), and **Profile** (shown only when the screen was
  pushed, i.e. `canGoBack()` — re-derived on focus so it stays correct across tab
  switches).

This is **Lot 1** (the "no back control at all" cases) of a wider back-navigation
audit. Lot 2 (screens whose back button lands on a fixed hub instead of the real
origin: batch details, recipe details, label editor/details) will follow in a
separate PR.

## Context

Found via a full navigation audit of the mobile app (Expo Router). The app has no
global `BackHandler`, so on iOS these pushed screens had no way back except the
bottom tab bar — which switches tab via `replace`, discarding the origin. The
`canGoBack()`-guarded pattern already existed on the Academy screens; this PR
extracts and generalizes it into one shared hook.

Verified live on the Android emulator (demo mode): the calculators now render a
"‹ Retour" control and it pops the stack correctly.

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format)
- [x] `npm test` green — 1414/1415; the single red is the pre-existing flaky
  `BeerInfoCardScreen` retry-timing test (react-query timing under load, green in CI)
- [x] New units covered happy/sad/edge (`useBackNavigation`, `BackHeaderAction`),
  plus Profile conditional + focus-regression, browse composition, and
  representative per-screen smoke tests
- [x] No new forbidden patterns (no `any`, no default export, no hardcoded
  colors/spacing/fonts, no inline style objects)
- [x] Local pre-push review (Claude `pr-pre-reviewer` + Codex) run and reconciled —
  0 Must-Have; the Should-Haves (Profile reactivity, a11y label alignment, smoke
  tests) were implemented in this PR
