### PR TITLE
fix(mobile-app): return to real origin from detail/editor back buttons

### DIFF
--- a/packages/mobile-app/app/(app)/dashboard/labels/_layout.tsx
+++ b/packages/mobile-app/app/(app)/dashboard/labels/_layout.tsx
@@ -1,0 +1,14 @@
+import { Stack } from "expo-router";
+
+/**
+ * Navigation stack for the labels subtree (home / [id] / create/select-batch /
+ * create/editor). Without it these routes had no back-stack of their own, so
+ * `router.back()` from the fiche or the editor fell through to the Tabs
+ * navigator instead of returning to the screen the user came from (fiche ↔
+ * editor round-trips). The stack makes back pop to the actual origin, which
+ * the back controls now rely on via useBackNavigation. Screens render their
+ * own header, so the stack header stays hidden (mirrors batches / academy).
+ */
+export default function LabelsLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/packages/mobile-app/app/(app)/recipes/_layout.tsx
+++ b/packages/mobile-app/app/(app)/recipes/_layout.tsx
@@ -1,0 +1,15 @@
+import { Stack } from "expo-router";
+
+/**
+ * Navigation stack for the recipes tab. Without it the nested routes (hub /
+ * catalog / [id] / prepare) had no in-tab back-stack, so `router.back()` from
+ * a recipe detail fell through to the Tabs navigator and landed on the
+ * previously focused tab (observed live: catalog → detail → back ended on
+ * the batches list). The stack makes back pop to the actual origin (catalog,
+ * hub, …), which the back controls now rely on via useBackNavigation.
+ * Screens render their own header, so the stack header stays hidden
+ * (mirrors batches / beer-catalog / academy).
+ */
+export default function RecipesLayout() {
+  return <Stack screenOptions={{ headerShown: false }} />;
+}

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -47,6 +47,8 @@ import { demoRecipes } from "@/mocks/demo-data";
 import { getErrorMessage } from "@/core/http/http-error";
 import { useRouter } from "expo-router";
 
+import { useBackNavigation } from "@/core/navigation/use-back-navigation";
+
 const DEMO_FERMENTATION_TARGET_DAYS = 14;
 // Pinned so the demo fermentation always reads exactly "J+5 / J+14" — the
 // state the marketing site showcases. Deriving the day count from a fixed
@@ -161,6 +163,7 @@ function useFermentationTrackerInfo(batch: Batch | null) {
 export function BatchDetailsScreen({ batchId }: Props) {
   const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
+  const handleGoBack = useBackNavigation("/batches");
   const confirm = useConfirm();
   const queryClient = useQueryClient();
   const [mutationError, setMutationError] = React.useState<string | null>(null);
@@ -346,10 +349,6 @@ export function BatchDetailsScreen({ batchId }: Props) {
     // done the physical prep. No confirm — starting is low-stakes.
     setMutationError(null);
     mutateStartCurrentStep();
-  };
-
-  const handleGoBack = () => {
-    router.replace("/batches");
   };
 
   const handleDelete = async () => {

--- a/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/__tests__/BatchDetailsScreen.test.tsx
@@ -29,6 +29,8 @@ const TS = "2026-05-01T08:00:00.000Z";
 
 const mockReplace = jest.fn();
 const mockPush = jest.fn();
+const mockBack = jest.fn();
+let mockCanGoBack = true;
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
@@ -41,7 +43,8 @@ jest.mock("expo-router", () => {
     useRouter: () => ({
       push: mockPush,
       replace: mockReplace,
-      back: jest.fn(),
+      back: mockBack,
+      canGoBack: () => mockCanGoBack,
     }),
   };
 });
@@ -148,6 +151,8 @@ async function pressDialogButton(label: string) {
 describe("BatchDetailsScreen", () => {
   beforeEach(() => {
     mockReplace.mockReset();
+    mockBack.mockReset();
+    mockCanGoBack = true;
     dataSource.useDemoData = false;
     (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
       viewModel(mashBatch, "Ma recette test"),
@@ -581,7 +586,24 @@ describe("BatchDetailsScreen", () => {
 
     fireEvent.press(screen.getByLabelText("Retour à la liste des brassins"));
 
+    // Now pops the real history when it exists (returns to the true origin),
+    // falling back to the batches list only when there is none — see
+    // useBackNavigation. The batches Stack keeps the list beneath, so this
+    // still lands on the list in-app.
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it("falls back to the batches list when there is no history to pop", async () => {
+    mockCanGoBack = false;
+
+    renderBatchDetailsScreen();
+
+    expect(await screen.findByText("Ma recette test")).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText("Retour à la liste des brassins"));
+
     expect(mockReplace).toHaveBeenCalledWith("/batches");
+    expect(mockBack).not.toHaveBeenCalled();
   });
 });
 
@@ -636,6 +658,8 @@ describe("BatchDetailsScreen — demo-mode fermentation tracker", () => {
 
   beforeEach(() => {
     mockReplace.mockReset();
+    mockBack.mockReset();
+    mockCanGoBack = true;
     dataSource.useDemoData = true;
     (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
       viewModel(fermentationInProgressBatch, "La Première du dimanche"),
@@ -753,6 +777,8 @@ describe("BatchDetailsScreen — brewing step timer + pedagogical tip (#781)", (
 
   beforeEach(() => {
     mockReplace.mockReset();
+    mockBack.mockReset();
+    mockCanGoBack = true;
     dataSource.useDemoData = true;
     (getBatchDetailsViewModel as jest.Mock).mockResolvedValue(
       viewModel(guidedMashBatch, "La Première du dimanche"),
@@ -1018,6 +1044,8 @@ describe("BatchDetailsScreen — B3 bottling routing + closure view", () => {
   beforeEach(() => {
     mockPush.mockReset();
     mockReplace.mockReset();
+    mockBack.mockReset();
+    mockCanGoBack = true;
     dataSource.useDemoData = false;
     (listBatchMeasurements as jest.Mock).mockResolvedValue([]);
     (getTasting as jest.Mock).mockResolvedValue(null);

--- a/packages/mobile-app/src/features/labels/presentation/LabelDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelDetailsScreen.tsx
@@ -23,6 +23,8 @@ import { LabelDraft } from "@/features/labels/domain/label.types";
 import { buildLabelShareMessage } from "@/features/labels/presentation/label-share";
 import { useRouter } from "expo-router";
 
+import { useBackNavigation } from "@/core/navigation/use-back-navigation";
+
 type LabelDetailsScreenProps = {
   draftIdParam?: string | string[];
 };
@@ -41,6 +43,7 @@ function buildLabelEditorRoute(draftId: string) {
 
 export function LabelDetailsScreen({ draftIdParam }: LabelDetailsScreenProps) {
   const router = useRouter();
+  const goBack = useBackNavigation(LABELS_HOME_ROUTE);
   const normalizedDraftId = normalizeRouteParam(draftIdParam) ?? "";
 
   const [draft, setDraft] = useState<LabelDraft | null>(null);
@@ -139,7 +142,7 @@ export function LabelDetailsScreen({ draftIdParam }: LabelDetailsScreenProps) {
             <HeaderBackButton
               label="Étiquettes"
               accessibilityLabel="Retour à mes étiquettes"
-              onPress={() => router.replace(LABELS_HOME_ROUTE)}
+              onPress={goBack}
             />
           }
         />
@@ -164,7 +167,7 @@ export function LabelDetailsScreen({ draftIdParam }: LabelDetailsScreenProps) {
           <HeaderBackButton
             label="Étiquettes"
             accessibilityLabel="Retour à mes étiquettes"
-            onPress={() => router.replace(LABELS_HOME_ROUTE)}
+            onPress={goBack}
           />
         }
       />

--- a/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
@@ -23,6 +23,7 @@ import {
   LABEL_TEMPLATE_OPTIONS,
 } from "@/features/labels/presentation/label-template.constants";
 import { Href, useRouter } from "expo-router";
+
 import React, { useCallback, useMemo, useState } from "react";
 import {
   Pressable,
@@ -35,6 +36,7 @@ import {
 
 import { getErrorMessage } from "@/core/http/http-error";
 import { normalizeRouteParam } from "@/core/navigation/route-params";
+import { useBackNavigation } from "@/core/navigation/use-back-navigation";
 import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
@@ -59,6 +61,7 @@ function toButtonLabel(isSaving: boolean): string {
 
 export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
   const router = useRouter();
+  const goBack = useBackNavigation(LABELS_HOME_ROUTE);
   const navigationFooterOffset = useNavigationFooterOffset();
   const normalizedDraftId = normalizeRouteParam(draftIdParam) ?? "";
 
@@ -186,7 +189,7 @@ export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
             <HeaderBackButton
               label="Étiquettes"
               accessibilityLabel="Retour à mes étiquettes"
-              onPress={() => router.replace(LABELS_HOME_ROUTE)}
+              onPress={goBack}
             />
           }
         />
@@ -211,7 +214,7 @@ export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
           <HeaderBackButton
             label="Étiquettes"
             accessibilityLabel="Retour à mes étiquettes"
-            onPress={() => router.replace(LABELS_HOME_ROUTE)}
+            onPress={goBack}
           />
         }
       />

--- a/packages/mobile-app/src/features/labels/presentation/__tests__/LabelDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/__tests__/LabelDetailsScreen.test.tsx
@@ -16,6 +16,8 @@ import React from "react";
 
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
+const mockBack = jest.fn();
+let mockCanGoBack = true;
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
@@ -29,7 +31,8 @@ jest.mock("expo-router", () => {
     useRouter: () => ({
       push: mockPush,
       replace: mockReplace,
-      back: jest.fn(),
+      back: mockBack,
+      canGoBack: () => mockCanGoBack,
     }),
   };
 });
@@ -50,6 +53,8 @@ describe("LabelDetailsScreen", () => {
   beforeEach(() => {
     mockPush.mockReset();
     mockReplace.mockReset();
+    mockBack.mockReset();
+    mockCanGoBack = true;
     mockedGetLabelDraftById.mockReset();
     mockedRemoveLabelDraft.mockReset();
   });
@@ -152,5 +157,34 @@ describe("LabelDetailsScreen", () => {
     });
 
     expect(mockReplace).toHaveBeenCalledWith("/(app)/dashboard/labels");
+  });
+
+  it("navigates back from the header action (pops history, else labels home)", async () => {
+    mockedGetLabelDraftById.mockResolvedValue(buildLabelDraft());
+
+    render(<LabelDetailsScreen draftIdParam="draft-1" />);
+
+    expect(await screen.findByText("Saison")).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText("Retour à mes étiquettes"));
+
+    // The labels Stack (app/(app)/dashboard/labels/_layout.tsx) makes this
+    // pop to the true origin (e.g. the editor when reached via « Voir la
+    // fiche »); labels home is only the fallback — see useBackNavigation.
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it("falls back to labels home when there is no history to pop", async () => {
+    mockCanGoBack = false;
+    mockedGetLabelDraftById.mockResolvedValue(buildLabelDraft());
+
+    render(<LabelDetailsScreen draftIdParam="draft-1" />);
+
+    expect(await screen.findByText("Saison")).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText("Retour à mes étiquettes"));
+
+    expect(mockReplace).toHaveBeenCalledWith("/(app)/dashboard/labels");
+    expect(mockBack).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile-app/src/features/labels/presentation/__tests__/LabelEditorScreen.test.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/__tests__/LabelEditorScreen.test.tsx
@@ -16,6 +16,8 @@ import React from "react";
 
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
+const mockBack = jest.fn();
+let mockCanGoBack = true;
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
@@ -29,7 +31,8 @@ jest.mock("expo-router", () => {
     useRouter: () => ({
       push: mockPush,
       replace: mockReplace,
-      back: jest.fn(),
+      back: mockBack,
+      canGoBack: () => mockCanGoBack,
     }),
   };
 });
@@ -50,6 +53,8 @@ describe("LabelEditorScreen", () => {
   beforeEach(() => {
     mockPush.mockReset();
     mockReplace.mockReset();
+    mockBack.mockReset();
+    mockCanGoBack = true;
     mockedGetLabelDraftById.mockReset();
     mockedUpdateLabelDraft.mockReset();
   });
@@ -128,6 +133,23 @@ describe("LabelEditorScreen", () => {
 
     fireEvent.press(screen.getByLabelText("Retour à mes étiquettes"));
 
+    // The labels Stack (app/(app)/dashboard/labels/_layout.tsx) makes this
+    // pop to the true origin (e.g. the label fiche when reached via
+    // « Modifier »); labels home is only the fallback — see useBackNavigation.
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it("falls back to labels home when there is no history to pop", async () => {
+    mockCanGoBack = false;
+    mockedGetLabelDraftById.mockResolvedValue(buildLabelDraft());
+
+    render(<LabelEditorScreen draftIdParam="draft-1" />);
+
+    expect(await screen.findByDisplayValue("Saison")).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText("Retour à mes étiquettes"));
+
     expect(mockReplace).toHaveBeenCalledWith("/(app)/dashboard/labels");
+    expect(mockBack).not.toHaveBeenCalled();
   });
 });

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -4,6 +4,8 @@ import { Ionicons } from "@expo/vector-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 
+import { useBackNavigation } from "@/core/navigation/use-back-navigation";
+
 import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
@@ -112,6 +114,7 @@ function isRecipeReferencedByBatch(
  */
 export function RecipeDetailsScreen({ recipeId }: Props) {
   const router = useRouter();
+  const handleGoBack = useBackNavigation("/recipes");
   const confirm = useConfirm();
   const snackbar = useSnackbar();
   const bottomPadding = useNavigationFooterOffset();
@@ -331,10 +334,6 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
       pathname: "/(app)/recipes/[id]/prepare",
       params: { id: recipeId },
     });
-  };
-
-  const handleGoBack = () => {
-    router.replace("/recipes");
   };
 
   const handleRetry = () => {

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeDetailsScreen.test.tsx
@@ -20,6 +20,8 @@ import {
 
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
+const mockBack = jest.fn();
+let mockCanGoBack = true;
 
 jest.mock("@expo/vector-icons", () => ({
   Ionicons: () => null,
@@ -63,7 +65,8 @@ jest.mock("expo-router", () => {
     useRouter: () => ({
       push: mockPush,
       replace: mockReplace,
-      back: jest.fn(),
+      back: mockBack,
+      canGoBack: () => mockCanGoBack,
     }),
   };
 });
@@ -185,6 +188,8 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
   beforeEach(() => {
     mockPush.mockReset();
     mockReplace.mockReset();
+    mockBack.mockReset();
+    mockCanGoBack = true;
     (getRecipeDetailsViewModel as jest.Mock).mockReset();
     (getRecipeDetailsViewModel as jest.Mock).mockResolvedValue(baseViewModel);
     (importRecipeFromCommunity as jest.Mock).mockReset();
@@ -685,7 +690,23 @@ describe("RecipeDetailsScreen — 5-tab redesigned layout (Issue #740 v2)", () =
 
     fireEvent.press(screen.getByLabelText("Retour à mes recettes"));
 
+    // The recipes Stack (app/(app)/recipes/_layout.tsx) makes this pop to the
+    // true origin (catalog, hub, …); the Recipes hub is only the fallback
+    // when there is nothing to pop — see useBackNavigation.
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it("falls back to the Recipes hub when there is no history to pop", async () => {
+    mockCanGoBack = false;
+
+    renderRecipeDetails();
+
+    await screen.findByTestId("recipe-overview-tab");
+
+    fireEvent.press(screen.getByLabelText("Retour à mes recettes"));
+
     expect(mockReplace).toHaveBeenCalledWith("/recipes");
+    expect(mockBack).not.toHaveBeenCalled();
   });
 
   it("shows the not-found state when recipeId is missing", async () => {


### PR DESCRIPTION
## Summary

**Lot 2** of the back-navigation audit (stacked on #1442 / Lot 1 — merge that one
first; this PR then retargets `main`).

Detail screens' back buttons previously forced `router.replace("/hub")`,
discarding the user's real origin: a recipe opened from the community catalog
went "back" to the Recipes hub, a label fiche opened from the editor went
"back" to the labels home. This PR makes those back controls return to the
actual origin:

- Swap the back handlers of **batch details**, **recipe details**, and the
  **label editor + fiche** to the shared `useBackNavigation` hook (from Lot 1):
  pop the real history; the hub is only the empty-stack fallback.
- Add the missing **nested Stack layouts** — `app/(app)/recipes/_layout.tsx`
  and `app/(app)/dashboard/labels/_layout.tsx`. Without them these routes sit
  directly on the Tabs navigator, where `back()` falls through to the
  previously focused tab (observed live: catalog → detail → back landed on the
  **batches list**). Same pattern as the existing `batches/` and
  `beer-catalog/` stacks, whose layout comment describes this exact bug.
- Post-action redirects (delete / cancel / archive → list) are intentionally
  unchanged: the detail no longer exists there, so the list is correct.

**Live-verified on the Android emulator**: catalog → German Pilsner → back now
lands on the catalog (before: the hub — and, without the Stack fix, even the
batches tab).

## Context

The Lot 1 static analysis assumed hoisted tab routes would pop chronologically;
live testing disproved that (Tabs `backBehavior` ≠ stack pop). This PR is the
course-correction: hook + nested Stacks together deliver the "return to real
origin" behavior. A true cross-tab `returnTo` for batch details (Dashboard
origin) is deferred — its nested stack keeps the list beneath, so behavior is
unchanged there (honest "Mes brassins" label).

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format)
- [x] `npm test` green — 1419/1420; the single red is the pre-existing flaky
  `BeerInfoCardScreen` retry-timing test (green in CI)
- [x] Tests updated to the new contract (back pops history) + per-screen
  edge tests asserting each screen's exact empty-stack fallback route
- [x] Local pre-push review (Claude `pr-pre-reviewer` + Codex) run and
  reconciled — 0 Must-Have; both Should-Haves (import grouping, fallback edge
  tests) implemented; batches cross-tab `returnTo` deferral endorsed by review
- [x] No new forbidden patterns
