### PR TITLE
fix(shop): drop the Academy shortcut from the shop header

### DIFF
--- a/packages/mobile-app/docs/design-system.md
+++ b/packages/mobile-app/docs/design-system.md
@@ -187,7 +187,7 @@ Main CTA button.
 
 ## 6. Pattern: Écran liste
 
-Used by: `BatchesScreen`, `RecipesScreen`, `IngredientsScreen`, `ShopCategoryScreen`
+Used by: `BatchesScreen`, `RecipesScreen`, `IngredientsScreen`, `EquipmentScreen`
 
 ```tsx
 <Screen
@@ -195,23 +195,22 @@ Used by: `BatchesScreen`, `RecipesScreen`, `IngredientsScreen`, `ShopCategoryScr
   error={error}
   onRetry={fetch}
 >
-  {/* Header */}
-  <View style={styles.header}>
-    <ListHeader title="..." subtitle="..." />
-    <Pressable
-      onPress={navigate}
-      style={styles.actionButton}
-      accessibilityRole="button"
-      accessibilityLabel="..."
-    >
-      <Ionicons
-        name="school-outline"
-        size={18}
-        color={colors.brand.secondary}
-      />
-      <Text style={styles.actionText}>Academy</Text>
-    </Pressable>
-  </View>
+  {/* Header. A header action goes in ListHeader's own `action` slot —
+      never as a sibling of ListHeader, which is unconstrained and will
+      push the action off the right screen edge. */}
+  <ListHeader
+    title="..."
+    subtitle="..."
+    action={
+      <Pressable
+        onPress={navigate}
+        accessibilityRole="button"
+        accessibilityLabel="..."
+      >
+        <Ionicons name="..." size={18} color={colors.brand.secondary} />
+      </Pressable>
+    }
+  />
 
   {/* Empty state */}
   {showEmptyState && (
@@ -263,29 +262,6 @@ Used by: `BatchesScreen`, `RecipesScreen`, `IngredientsScreen`, `ShopCategoryScr
 **Required styles:**
 
 ```ts
-header: {
-  flexDirection: "row",
-  justifyContent: "space-between",
-  alignItems: "center",
-  paddingHorizontal: spacing.sm,
-  paddingBottom: spacing.sm,
-},
-actionButton: {
-  flexDirection: "row",
-  alignItems: "center",
-  gap: spacing.xxs,
-  paddingHorizontal: spacing.sm,
-  paddingVertical: spacing.xs,
-  borderRadius: radius.lg,
-  backgroundColor: colors.brand.background,
-  borderWidth: 1,
-  borderColor: colors.brand.secondary,
-},
-actionText: {
-  color: colors.brand.secondary,
-  fontSize: typography.size.caption,
-  fontWeight: typography.weight.medium,
-},
 list: {
   paddingBottom: spacing.md,
   paddingHorizontal: spacing.sm,
@@ -444,7 +420,7 @@ badgesRow: {
 | Hops               | `leaf-outline`       | Ingredient category icon                           |
 | Yeast              | `flask-outline`      | Ingredient category icon                           |
 | Equipment          | `construct-outline`  | Equipment list item icon                           |
-| Academy            | `school-outline`     | Contextual action button (header)                  |
+| Academy            | `school-outline`     | Academy tab + Academy entry points                 |
 | Shop               | `storefront-outline` | Shop navigation                                    |
 | Navigation forward | `chevron-forward`    | All navigable list items, size: 20, color: `muted` |
 | Navigation back    | `chevron-back`       | Back navigation buttons in header actions          |

--- a/packages/mobile-app/src/features/shop/presentation/ShopScreen.tsx
+++ b/packages/mobile-app/src/features/shop/presentation/ShopScreen.tsx
@@ -1,5 +1,5 @@
 import { colors, radius, spacing, typography } from "@/core/theme";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 
 import { Card } from "@/core/ui/Card";
@@ -10,11 +10,9 @@ import {
   shopCategoryDescriptions,
 } from "@/features/shop/presentation/shop.constants";
 import { Ionicons } from "@expo/vector-icons";
-import { useRouter } from "expo-router";
 
 export function ShopScreen() {
   const bottomPadding = useNavigationFooterOffset();
-  const router = useRouter();
 
   return (
     <Screen>
@@ -23,19 +21,6 @@ export function ShopScreen() {
           title="Ma Boutique"
           subtitle="Tout pour brasser chez vous"
         />
-        <Pressable
-          onPress={() => router.push("/(app)/academy")}
-          style={styles.academyButton}
-          accessibilityRole="button"
-          accessibilityLabel="Accéder à l'Académie"
-        >
-          <Ionicons
-            name="school-outline"
-            size={18}
-            color={colors.brand.secondary}
-          />
-          <Text style={styles.academyText}>Academy</Text>
-        </Pressable>
       </View>
 
       <ScrollView
@@ -86,26 +71,7 @@ export function ShopScreen() {
 
 const styles = StyleSheet.create({
   header: {
-    flexDirection: "row",
-    justifyContent: "space-between",
-    alignItems: "center",
     paddingHorizontal: spacing.sm,
-  },
-  academyButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: spacing.xxs,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.xs,
-    borderRadius: radius.lg,
-    backgroundColor: colors.brand.background,
-    borderWidth: 1,
-    borderColor: colors.brand.secondary,
-  },
-  academyText: {
-    color: colors.brand.secondary,
-    fontSize: typography.size.caption,
-    fontWeight: typography.weight.medium,
   },
   content: {
     paddingHorizontal: spacing.sm,

--- a/packages/mobile-app/src/features/shop/presentation/__tests__/ShopScreen.test.tsx
+++ b/packages/mobile-app/src/features/shop/presentation/__tests__/ShopScreen.test.tsx
@@ -36,10 +36,9 @@ describe("ShopScreen", () => {
 
   // The header carries no Academy shortcut: the cross-link was unrelated to
   // shopping and its pill was clipped off the right screen edge on device.
-  it("exposes no interactive control in the header", () => {
+  it("offers no Academy shortcut", () => {
     render(<ShopScreen />);
 
     expect(screen.queryByLabelText("Accéder à l'Académie")).toBeNull();
-    expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/packages/mobile-app/src/features/shop/presentation/__tests__/ShopScreen.test.tsx
+++ b/packages/mobile-app/src/features/shop/presentation/__tests__/ShopScreen.test.tsx
@@ -1,9 +1,7 @@
-import { fireEvent, render, screen } from "@testing-library/react-native";
+import { render, screen } from "@testing-library/react-native";
 
 import React from "react";
 import { ShopScreen } from "@/features/shop/presentation/ShopScreen";
-
-const mockPush = jest.fn();
 
 jest.mock("@expo/vector-icons", () => {
   return {
@@ -11,23 +9,7 @@ jest.mock("@expo/vector-icons", () => {
   };
 });
 
-jest.mock("expo-router", () => {
-  const actual = jest.requireActual("expo-router");
-  return {
-    ...actual,
-    useRouter: () => ({
-      push: mockPush,
-      replace: jest.fn(),
-      back: jest.fn(),
-    }),
-  };
-});
-
 describe("ShopScreen", () => {
-  beforeEach(() => {
-    mockPush.mockClear();
-  });
-
   it("renders shop header with title and subtitle", () => {
     render(<ShopScreen />);
 
@@ -52,11 +34,12 @@ describe("ShopScreen", () => {
     expect(screen.getByText(/La boutique arrive bientôt/)).toBeTruthy();
   });
 
-  it("navigates to the Academy from the header shortcut", () => {
+  // The header carries no Academy shortcut: the cross-link was unrelated to
+  // shopping and its pill was clipped off the right screen edge on device.
+  it("exposes no interactive control in the header", () => {
     render(<ShopScreen />);
 
-    fireEvent.press(screen.getByLabelText("Accéder à l'Académie"));
-
-    expect(mockPush).toHaveBeenCalledWith("/(app)/academy");
+    expect(screen.queryByLabelText("Accéder à l'Académie")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Removes the "Academy" pill from the shop screen header, and fixes the design-system doc that still prescribed the broken pattern behind it.

- **`ShopScreen.tsx`** — deletes the Academy `Pressable`, its `academyButton` / `academyText` styles, and the now-unused `useRouter` + `Pressable` imports. `styles.header` shrinks to a padding-only wrapper.
- **`design-system.md`** — section 6 ("Pattern: Écran liste") documented *exactly* the layout this PR removes, as the required template. Now aligned with section 5 and the real code.
- **`ShopScreen.test.tsx`** — drops the Academy navigation test and its `expo-router` mock; adds a regression test.

Net -76 LOC across 3 files.

## Context

The pill had two independent problems.

**It was an unrelated cross-link.** Academy has had its own permanent slot in the bottom tab bar since #613, so a second entry point from the shop bought nothing. This was already flagged during the shop audit that produced #1444.

**Its layout was broken.** The pill sat as a *sibling* of `<ListHeader>` inside a `flexDirection: row / space-between` wrapper. `ListHeader` is unconstrained, so it claimed its intrinsic width and pushed the pill past the right screen edge — on a 1080x2400 device only the icon was visible. Verified on the emulator before and after.

The doc fix is the reason this PR is worth more than its diff. `design-system.md` is cited by `packages/mobile-app/CLAUDE.md` as the charter every screen must follow, and its section 6 still prescribed that same sibling-Pressable layout — a pattern with **zero call sites** left in the codebase once this PR lands. Meanwhile the actual house convention, `ListHeader`'s own `action` slot, is used by 10+ screens (EquipmentScreen, ScanScreen, PendingScansScreen, BatchFinishedScreen…) and was already documented in section 5. Section 6 was contradicting section 5 and teaching the bug. It also still listed `ShopCategoryScreen`, deleted in #1444.

`ListHeader`'s `action` slot remains available should the shop header ever need a real control.

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format:check)
- [x] `npm test` green — shop suite 4/4
- [x] Local pre-push review passed (0 Must Have; both Should Have items addressed in-branch)
- [x] Visual verification on Android emulator (bb_pixel, demo mode, Metro serving this branch): pill gone, title correctly aligned with the cards below, no crash
- [x] No dead import, style or variable left behind (verified per-symbol)
- [x] Conventional Commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)