### PR TITLE
feat(mobile-app): flush scroll-away bottom bar with centralized clearance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ Currently accepted ADRs (see each file for the `Status` line and full rationale)
 - [ADR-0026 — Equipment capacity fit-check: advisory pre-batch readiness, backend-computed](docs/architecture/decisions/0026-equipment-capacity-fit-check.md)
 - [ADR-0027 — Website internationalization strategy (bilingual FR+EN marketing site)](docs/architecture/decisions/0027-website-i18n-strategy.md)
 - [ADR-0028 — Website donation link: Ko-fi one-off, plain outbound link only](docs/architecture/decisions/0028-website-donation-link-kofi.md)
+- [ADR-0029 — Bottom navigation: flush edge-to-edge scroll-away bar, centralized bottom clearance](docs/architecture/decisions/0029-footer-nav-scroll-away.md)
 
 When a new ADR is accepted, add its file link here (no dates, no per-ADR summaries — open the file for the live status and content). When reviewing a PR, flag any diff that violates these ADRs and cite the ADR number and clause in the review comment.
 

--- a/docs/architecture/decisions/0029-footer-nav-scroll-away.md
+++ b/docs/architecture/decisions/0029-footer-nav-scroll-away.md
@@ -1,6 +1,6 @@
 # ADR-0029 — Bottom navigation: flush edge-to-edge scroll-away bar, centralized bottom clearance
 
-**Status**  Proposed
+**Status**  Accepted
 **Date**    2026-07-16 (audit + decisions D1/D2 taken 2026-07-15, branch `claude/mobile-footer-audit-fef293`)
 **Owners**  @benoit-bremaud
 
@@ -59,13 +59,28 @@ on scroll-down, reappears on scroll-up. The conception study lives in
    while the content's bottom clearance stays **constant**. Animating the padding itself
    (reclaiming the residual end-of-list gap) is **rejected**: it reflows content on every
    toggle (jank) and reintroduces a dynamic offset (bug surface).
-4. **Centralized bottom clearance.** The `Screen` primitive reserves the bar's footprint,
-   exactly as it already owns the top clearance. `useNavigationFooterOffset` and the
-   **36 per-screen `paddingBottom` call sites are deleted**. `NAV_BAR_HEIGHT`
+4. **Centralized bottom clearance.** The clearance is owned by shared scroll containers —
+   `ScreenScrollView` / `ScreenFlatList` (`core/ui`) — which every scrollable screen uses in
+   place of a raw `ScrollView` / `FlatList`. They apply the footprint to the scrolled
+   **content** and wire `onScroll` (clause 5) in one swap. `useNavigationFooterOffset` and
+   the **36 per-screen `paddingBottom` call sites are deleted**. `NAV_BAR_HEIGHT`
    (`core/theme/layout.ts`) is the bar's base **visual** height; the effective footprint is
-   computed at runtime as `NAV_BAR_HEIGHT + insets.bottom` and shared by `Screen` (reserved
-   clearance), the bar (hide translate distance) and its followers — a bare constant cannot
-   serve devices with a non-zero bottom safe-area inset.
+   computed at runtime by `useNavigationBarFootprint()` as `NAV_BAR_HEIGHT + insets.bottom`
+   and shared by the containers (reserved clearance), the bar (its own height *and* hide
+   translate distance) and its followers — a bare constant cannot serve devices with a
+   non-zero bottom safe-area inset.
+
+   > **Amended at build time (2026-07-16).** This clause first read "the `Screen` primitive
+   > reserves the bar's footprint". That is not implementable as written without losing D2:
+   > `Screen` wraps a screen, so it can only pad its own container, which stops content from
+   > scrolling *under* the bar — the full-screen feel of B1 — and turns the residual gap into
+   > a permanent one. That is option **A (space always reserved)** of the second matrix,
+   > which this ADR rejected. The clearance must live on the scrolled content's
+   > `contentContainerStyle` (as `02-state` already specified), and only the scroll container
+   > itself can put it there. Shared containers keep the intent — one source, zero per-screen
+   > arithmetic, no opt-in to forget — and shrink the migration to a single swap per screen.
+   > `Screen` keeps the top clearance; the bottom is not symmetric with it because the top
+   > has no scroll-under requirement.
 5. **Single visibility source.** One shared `useScrollDirection` hook (anti-flicker threshold +
    near-top guard, defined once) feeds a `FooterVisibilityContext`. The bar, the app-level
    `Snackbar`, and sticky CTAs all follow that one boolean — they can no longer desync.

--- a/docs/architecture/diagrams/footer-nav-redesign/01-component.md
+++ b/docs/architecture/diagrams/footer-nav-redesign/01-component.md
@@ -2,12 +2,12 @@
 
 > **Feature**: mobile bottom-nav footer redesign — flush edge-to-edge bar + Revolut scroll-away.
 > **Source**: audit 2026-07-15 (branch `claude/mobile-footer-audit-fef293`).
-> **Related ADRs**: ADR-0029 (Proposed) — flush edge-to-edge scroll-away bar, centralized bottom clearance.
+> **Related ADRs**: ADR-0029 (Accepted) — flush edge-to-edge scroll-away bar, centralized bottom clearance.
 > **Decisions captured**: ADR-0029 clauses 1–5 (D1 scroll-away, D2 recover space via translate-only).
 
 ## Context
 
-Shows the **target** structure that replaces today's floating-pill + per-screen offset. It makes explicit the single new seam — a shared scroll-direction contract feeding one footer-visibility source — and the fact that the bottom clearance moves **out of the 36 screens** into the `Screen` primitive. It does NOT show the runtime timing (see `03-sequence`) nor the visibility lifecycle (see `02-state`).
+Shows the **target** structure that replaces today's floating-pill + per-screen offset. It makes explicit the single new seam — a shared scroll-direction contract feeding one footer-visibility source — and the fact that the bottom clearance moves **out of the 36 screens** into the shared scroll containers. It does NOT show the runtime timing (see `03-sequence`) nor the visibility lifecycle (see `02-state`).
 
 Today's coupling this removes: 36 screens (plus the app-level Snackbar — 37 consumers in total) each call `useNavigationFooterOffset()` and wire their own `paddingBottom` (audit findings M1/M2); much of the `sticky-cta-clearance` provider exists to work around the floating pill's offset arithmetic.
 
@@ -20,7 +20,8 @@ flowchart TD
   end
 
   subgraph core ["src/core/ui + core/theme"]
-    Screen["Screen (reserves constant bottom footprint — replaces 36 manual paddings)"]
+    Screen["Screen (owns the TOP clearance, unchanged)"]
+    Containers["ScreenScrollView / ScreenFlatList (reserve constant bottom footprint on scrolled content — replace 36 manual paddings)"]
     UseScroll["useScrollDirection (threshold + anti-flicker)"]
     VisCtx["FooterVisibilityContext (single visible source)"]
     Footer["NavigationFooter (flush, translateY 0 to +height)"]
@@ -36,19 +37,20 @@ flowchart TD
   Layout --> VisCtx
   Layout --> Footer
   ScreenN -->|"wraps content in"| Screen
-  ScreenN -->|"onScroll(offsetY)"| UseScroll
+  ScreenN -->|"scrolls with"| Containers
+  Containers -->|"onScroll(offsetY)"| UseScroll
   UseScroll -->|"setVisible(direction)"| VisCtx
   VisCtx -->|"visible"| Footer
   VisCtx -->|"visible"| Snack
   VisCtx -->|"visible"| Cta
   Footer -->|"reads height"| Tokens
-  Screen -->|"reserves height"| Tokens
+  Containers -->|"reserve height"| Tokens
 ```
 
 ## Notes
 
 - **Single source of truth for the bar height** (`NAV_BAR_HEIGHT` in `theme/layout` = base visual height; effective footprint = `NAV_BAR_HEIGHT + insets.bottom`, computed at runtime): both `Screen` (reserved clearance) and `NavigationFooter` (translate distance) derive from the same pair. Kills audit finding **M2** (offset was a hand-rebuilt magic number `48 + spacing.md`) and **M3** (the hardcoded `+96` in `RecipeDetailsScreen`). A bare constant alone would break on devices with a non-zero bottom safe-area inset (ADR-0029 clause 4).
-- **`Screen` owns the bottom clearance** now (it already owns the top clearance via `brandHeader.contentClearance`) — removes the 36-screen opt-in that is the root cause of "it hides buttons" (**M1/B1**). `useNavigationFooterOffset` is deleted.
+- **The shared scroll containers own the bottom clearance** (`ScreenScrollView` / `ScreenFlatList`) — removing the 36-screen opt-in that is the root cause of "it hides buttons" (**M1/B1**). `useNavigationFooterOffset` is deleted. `Screen` keeps only the TOP clearance (`brandHeader.contentClearance`): the two are not symmetric, because the bottom one must sit on the scrolled **content** for content to pass under the bar (D2/B1). Padding `Screen`'s own container instead would stop that and turn the residual gap into a permanent one — the rejected option A. See ADR-0029 clause 4 and its build-time amendment.
 - **D2 (recover space when hidden)** is realized via **B1 (translate-only)**: the reserved bottom padding stays **constant**; the full-screen feel comes from the bar sliding off-screen, not from re-laying-out content. B2 (animate padding to 0 to reclaim the end-of-list gap) is **rejected** — ADR-0029, second matrix (jank + dynamic offset risk).
 - **Custom bar kept** (native expo-router `Tabs` bar has no scroll-away) — settled by ADR-0029 clause 9; M4 unification stays out of scope.
 - **Follow-up**: `sticky-cta-clearance` provider shrinks to just the visibility-follow concern once the floating pill is gone.

--- a/docs/architecture/diagrams/footer-nav-redesign/02-state-footer-visibility.md
+++ b/docs/architecture/diagrams/footer-nav-redesign/02-state-footer-visibility.md
@@ -1,12 +1,12 @@
 # State diagram — footer-nav-redesign — footer visibility lifecycle
 
 > **Feature**: mobile bottom-nav footer redesign — flush edge-to-edge bar + Revolut scroll-away.
-> **Related ADRs**: ADR-0029 (Proposed) — this machine realizes clauses 2–3 and 6–8.
+> **Related ADRs**: ADR-0029 (Accepted) — this machine realizes clauses 2–3 and 6–8.
 > **Decisions captured**: D1 (scroll-away), D2 (recover space when hidden — B1 translate-only).
 
 ## Context
 
-The `stm` for the shared footer visibility held in `FooterVisibilityContext`. It drives the bar's `translateY` (and the Snackbar / sticky-CTA follow). It deliberately models **visibility only**: the content clearance has no state dimension here — it is **constant across both states** and owned by the `Screen` primitive. That absence is the point, and it is exactly what makes the clause-6 invariant below hold.
+The `stm` for the shared footer visibility held in `FooterVisibilityContext`. It drives the bar's `translateY` (and the Snackbar / sticky-CTA follow). It deliberately models **visibility only**: the content clearance has no state dimension here — it is **constant across both states** and owned by the shared scroll containers (`ScreenScrollView` / `ScreenFlatList`), which apply it to the scrolled content — see ADR-0029 clause 4 and its amendment. That absence is the point, and it is exactly what makes the clause-6 invariant below hold.
 
 Two states only. `Revealed` = bar flush at the bottom (`translateY = 0`). `Hidden` = bar slid off the bottom edge (`translateY = +footprint`, where footprint = `NAV_BAR_HEIGHT + insets.bottom` — ADR-0029 clause 4).
 

--- a/docs/architecture/diagrams/footer-nav-redesign/03-sequence-scroll-hide-reveal.md
+++ b/docs/architecture/diagrams/footer-nav-redesign/03-sequence-scroll-hide-reveal.md
@@ -1,7 +1,7 @@
 # Sequence diagram — footer-nav-redesign — scroll hide/reveal
 
 > **Feature**: mobile bottom-nav footer redesign — flush edge-to-edge bar + Revolut scroll-away.
-> **Related ADRs**: ADR-0029 (Proposed) — this scenario realizes clauses 2, 5 and 6.
+> **Related ADRs**: ADR-0029 (Accepted) — this scenario realizes clauses 2, 5 and 6.
 > **Decisions captured**: D1 (scroll-away), D2 (recover space when hidden — B1 translate-only).
 
 ## Context
@@ -49,7 +49,7 @@ sequenceDiagram
 
 ## Notes
 
-- **Single boolean, no desync**: the bar, Snackbar and sticky CTA all subscribe to `FooterVisibilityContext.visible`. There is no per-screen offset in this path — the reserved clearance is static in `Screen` and untouched by scroll.
+- **Single boolean, no desync**: the bar, Snackbar and sticky CTA all subscribe to `FooterVisibilityContext.visible`. There is no per-screen offset in this path — the reserved clearance is static in the shared scroll containers and untouched by scroll.
 - **Threshold lives in `useScrollDirection`**, once, not per screen — the anti-flicker rule is defined in one place and every screen inherits it by wiring `onScroll`.
 - **The threshold gates BOTH directions symmetrically** (hide *and* reveal): an un-gated reveal would re-introduce the flicker the threshold exists to prevent, since a hidden bar would pop back on the tiniest upward jitter or bounce. The only reveals that bypass it are the **forced** ones (list top/end, pull-to-refresh, programmatic) — they are state changes, not scroll deltas. Matches `02-state` (`scroll up past threshold` vs the separate forced-reveal transitions).
 - **Wiring cost**: each of the 36 scrollable screens must pass its scroll handler to `useScrollDirection` (one line + the shared `onScroll`). This is the real migration surface — enumerate and track it in the build PR.

--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -3,6 +3,7 @@ import "react-native-reanimated";
 import { AuthProvider, useAuth } from "@/core/auth/auth-context";
 
 import { ConfirmProvider } from "@/core/ui/confirm-provider";
+import { FooterVisibilityProvider } from "@/core/ui/footer-visibility-context";
 import { SnackbarProvider } from "@/core/ui/snackbar-provider";
 import { StickyCtaClearanceProvider } from "@/core/ui/sticky-cta-clearance";
 import { QueryProvider } from "@/core/query/query-provider";
@@ -17,12 +18,20 @@ function AppShell() {
   return (
     <QueryProvider key={queryScopeKey}>
       <ConfirmProvider>
-        <StickyCtaClearanceProvider>
-          <SnackbarProvider>
-            <Stack screenOptions={{ headerShown: false }} />
-            <StatusBar style="auto" />
-          </SnackbarProvider>
-        </StickyCtaClearanceProvider>
+        {/*
+          Above the Snackbar on purpose: the Snackbar is mounted here at the
+          root, outside `(app)/_layout`, so a provider scoped to the tab layout
+          would leave it reading the default `visible: true` and never
+          following the bar — silently breaking ADR-0029 clause 5.
+        */}
+        <FooterVisibilityProvider>
+          <StickyCtaClearanceProvider>
+            <SnackbarProvider>
+              <Stack screenOptions={{ headerShown: false }} />
+              <StatusBar style="auto" />
+            </SnackbarProvider>
+          </StickyCtaClearanceProvider>
+        </FooterVisibilityProvider>
       </ConfirmProvider>
     </QueryProvider>
   );

--- a/packages/mobile-app/src/core/theme/index.ts
+++ b/packages/mobile-app/src/core/theme/index.ts
@@ -1,4 +1,4 @@
-export { brandHeader } from "./layout";
+export { brandHeader, NAV_BAR_HEIGHT } from "./layout";
 export { colors } from "./colors";
 export { radius } from "./radius";
 export { shadows } from "./shadows";

--- a/packages/mobile-app/src/core/theme/layout.ts
+++ b/packages/mobile-app/src/core/theme/layout.ts
@@ -25,3 +25,21 @@ export const brandHeader = {
    */
   contentClearance: 72 - spacing.xs,
 } as const;
+
+/**
+ * Bottom navigation bar — base **visual** height of the flush edge-to-edge bar
+ * (`NavigationFooter`): the 48 px item touch target plus the bar's own vertical
+ * padding. ADR-0029 clause 4.
+ *
+ * This is deliberately NOT the full footprint. The bar absorbs the bottom
+ * safe-area inset inside itself, so the space it actually occupies — and the
+ * clearance content must reserve, and the distance it translates when hiding —
+ * is `NAV_BAR_HEIGHT + insets.bottom`, computed at runtime via
+ * `useNavigationBarFootprint()`. A bare constant cannot serve devices with a
+ * non-zero bottom inset.
+ *
+ * Single source of truth: the bar (height + translate distance) and the shared
+ * scroll containers (reserved clearance) both derive from this one value, which
+ * ends the magic-number drift the previous hand-rebuilt offset suffered from.
+ */
+export const NAV_BAR_HEIGHT = 48 + spacing.xs * 2;

--- a/packages/mobile-app/src/core/ui/NavigationFooter.tsx
+++ b/packages/mobile-app/src/core/ui/NavigationFooter.tsx
@@ -1,8 +1,9 @@
 import { Href, usePathname, useRouter } from "expo-router";
-import { Pressable, StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet } from "react-native";
 import React, { useEffect, useState } from "react";
 import Animated, {
   useAnimatedStyle,
+  useReducedMotion,
   useSharedValue,
   withSpring,
 } from "react-native-reanimated";
@@ -11,15 +12,8 @@ import { colors, spacing } from "@/core/theme";
 import { Ionicons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-export function useNavigationFooterOffset() {
-  const insets = useSafeAreaInsets();
-  return (
-    (insets.bottom > 0 ? insets.bottom : spacing.md) +
-    spacing.xs +
-    48 +
-    spacing.md
-  );
-}
+import { useFooterVisibility } from "@/core/ui/footer-visibility-context";
+import { useNavigationBarFootprint } from "@/core/ui/use-navigation-bar-footprint";
 
 type NavItem = {
   label: string;
@@ -110,10 +104,29 @@ export function NavigationFooter() {
   const hasActiveItem = activeIndex >= 0;
   const safeActiveIndex = hasActiveItem ? activeIndex : 0;
 
+  const { visible } = useFooterVisibility();
+  const footprint = useNavigationBarFootprint();
+  const prefersReducedMotion = useReducedMotion();
+
   const [containerWidth, setContainerWidth] = useState(0);
   const itemWidth = containerWidth / navItems.length;
 
   const translateX = useSharedValue(0);
+  const translateY = useSharedValue(0);
+
+  // Hide by sliding the bar off the bottom edge; the content's reserved
+  // clearance never changes, so nothing reflows and the clause-6 invariant
+  // holds regardless of where the animation is (ADR-0029 clause 3).
+  useEffect(() => {
+    const target = visible ? 0 : footprint;
+    translateY.value = prefersReducedMotion
+      ? target
+      : withSpring(target, { mass: 1, damping: 18, stiffness: 140 });
+  }, [visible, footprint, prefersReducedMotion, translateY]);
+
+  const animatedBarStyle = useAnimatedStyle(() => {
+    return { transform: [{ translateY: translateY.value }] };
+  });
 
   useEffect(() => {
     if (itemWidth > 0) {
@@ -133,12 +146,19 @@ export function NavigationFooter() {
   });
 
   return (
-    <View
+    <Animated.View
       style={[
         styles.container,
-        {
-          bottom: (insets.bottom > 0 ? insets.bottom : spacing.md) + spacing.xs,
-        },
+        // Height is DERIVED from the shared footprint rather than emerging
+        // from padding + item height: that is what makes `NAV_BAR_HEIGHT` a
+        // real single source (ADR-0029 clause 4). The bar, the clearance the
+        // scroll containers reserve, and the distance it translates by are
+        // then provably the same number — they cannot drift apart, which is
+        // the magic-number bug this redesign exists to end.
+        // The inset is absorbed inside the bar so it sits flush on the edge
+        // while its items stay above the home indicator.
+        { height: footprint, paddingBottom: insets.bottom },
+        animatedBarStyle,
       ]}
       onLayout={(e) => {
         // We calculate available width by removing padding horizontally
@@ -181,26 +201,29 @@ export function NavigationFooter() {
           </Pressable>
         );
       })}
-    </View>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
+  // Flush edge-to-edge: anchored on all three edges, no lift, no rounding —
+  // the floating pill this replaces was inset 24px per side and lifted off the
+  // bottom, which is what put it over the content (ADR-0029 clause 1).
   container: {
     position: "absolute",
-    left: spacing.lg,
-    right: spacing.lg,
+    left: 0,
+    right: 0,
+    bottom: 0,
     flexDirection: "row",
     backgroundColor: colors.neutral.white,
-    borderRadius: 100,
-    borderWidth: 1,
-    borderColor: colors.neutral.border,
+    borderTopWidth: 1,
+    borderTopColor: colors.neutral.border,
     paddingHorizontal: spacing.xs,
-    paddingVertical: spacing.xs,
+    paddingTop: spacing.xs,
     shadowColor: colors.neutral.shadow,
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.15,
-    shadowRadius: 12,
+    shadowOffset: { width: 0, height: -2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 8,
     elevation: 8,
   },
   item: {

--- a/packages/mobile-app/src/core/ui/ScreenFlatList.tsx
+++ b/packages/mobile-app/src/core/ui/ScreenFlatList.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { FlatList, type FlatListProps } from "react-native";
+
+import { useNavigationBarFootprint } from "@/core/ui/use-navigation-bar-footprint";
+import { useScrollDirection } from "@/core/ui/use-scroll-direction";
+
+/**
+ * `FlatList` counterpart of {@link ScreenScrollView}: clears the bottom
+ * navigation bar and drives its scroll-away, so list screens never do either
+ * by hand (ADR-0029 clauses 4–5).
+ *
+ * See `ScreenScrollView` for why the clearance lives on the scrolled content
+ * rather than on a wrapper.
+ */
+type ScreenFlatListProps<ItemT> = FlatListProps<ItemT> & {
+  /**
+   * Extra clearance stacked on top of the nav bar footprint, for a screen that
+   * pins something else above the bar (e.g. `STICKY_CTA_BAR_HEIGHT`). Mirrors
+   * `ScreenScrollView`: these two advertise the same contract, so their APIs
+   * must not drift apart.
+   */
+  extraBottomClearance?: number;
+};
+
+export function ScreenFlatList<ItemT>({
+  contentContainerStyle,
+  onScroll,
+  extraBottomClearance = 0,
+  ...props
+}: ScreenFlatListProps<ItemT>) {
+  const footprint = useNavigationBarFootprint();
+  const { onScroll: trackScroll } = useScrollDirection();
+
+  return (
+    <FlatList<ItemT>
+      {...props}
+      contentContainerStyle={[
+        contentContainerStyle,
+        { paddingBottom: footprint + extraBottomClearance },
+      ]}
+      onScroll={(event) => {
+        trackScroll(event);
+        onScroll?.(event);
+      }}
+      scrollEventThrottle={16}
+    />
+  );
+}

--- a/packages/mobile-app/src/core/ui/ScreenScrollView.tsx
+++ b/packages/mobile-app/src/core/ui/ScreenScrollView.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { ScrollView, type ScrollViewProps } from "react-native";
+
+import { useNavigationBarFootprint } from "@/core/ui/use-navigation-bar-footprint";
+import { useScrollDirection } from "@/core/ui/use-scroll-direction";
+
+/**
+ * `ScrollView` that clears the bottom navigation bar and drives its
+ * scroll-away, so screens never do either by hand (ADR-0029 clauses 4–5).
+ *
+ * Replaces the old per-screen `useNavigationFooterOffset()` +
+ * `paddingBottom` opt-in: a screen that forgot it — or wired it to the wrong
+ * container — was silently covered by the bar. Here the clearance is applied
+ * to the scrolled content itself, which is what lets content pass *under* the
+ * bar mid-scroll (the full-screen feel of ADR-0029 D2/B1) while still landing
+ * clear of it at rest.
+ *
+ * The reserved clearance is constant across Revealed and Hidden — hiding only
+ * translates the bar, it never reflows content (clause 6).
+ *
+ * Pass `contentContainerStyle` as usual; the bottom clearance is merged in
+ * last so a screen cannot accidentally cancel it.
+ */
+type ScreenScrollViewProps = ScrollViewProps & {
+  /**
+   * Forwarded to the underlying `ScrollView` (React 19 treats `ref` as a
+   * regular prop, so no `forwardRef` needed). Screens that scroll
+   * programmatically — e.g. Academy articles jumping to a glossary term —
+   * need the real handle.
+   */
+  ref?: React.Ref<ScrollView>;
+  /**
+   * Extra clearance stacked on top of the nav bar footprint, for a screen that
+   * pins something else above the bar — today only `STICKY_CTA_BAR_HEIGHT` on
+   * the three CTA screens.
+   *
+   * Passed explicitly rather than read from `useStickyCtaClearance()`: that
+   * context is app-level, and tab screens stay mounted, so a CTA mounted on a
+   * background screen would silently inflate an unrelated screen's padding.
+   */
+  extraBottomClearance?: number;
+};
+
+export function ScreenScrollView({
+  contentContainerStyle,
+  onScroll,
+  ref,
+  extraBottomClearance = 0,
+  ...props
+}: ScreenScrollViewProps) {
+  const footprint = useNavigationBarFootprint();
+  const { onScroll: trackScroll } = useScrollDirection();
+
+  return (
+    <ScrollView
+      {...props}
+      ref={ref}
+      contentContainerStyle={[
+        contentContainerStyle,
+        { paddingBottom: footprint + extraBottomClearance },
+      ]}
+      onScroll={(event) => {
+        trackScroll(event);
+        onScroll?.(event);
+      }}
+      scrollEventThrottle={16}
+    />
+  );
+}

--- a/packages/mobile-app/src/core/ui/Snackbar.tsx
+++ b/packages/mobile-app/src/core/ui/Snackbar.tsx
@@ -1,8 +1,15 @@
 import React from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withSpring,
+} from "react-native-reanimated";
 
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { useFooterVisibility } from "@/core/ui/footer-visibility-context";
+import { useNavigationBarFootprint } from "@/core/ui/use-navigation-bar-footprint";
 import { useStickyCtaClearance } from "@/core/ui/sticky-cta-clearance";
 
 export type SnackbarProps = Readonly<{
@@ -16,8 +23,12 @@ export type SnackbarProps = Readonly<{
 /**
  * Branded transient snackbar — a bottom bar with an optional single action.
  * App-level, one at a time, driven imperatively through `useSnackbar()` (see
- * `snackbar-provider`). Sits above the floating nav footer so it never hides
- * the primary navigation, and lets touches through everywhere but the bar.
+ * `snackbar-provider`). Sits above the nav bar so it never hides the primary
+ * navigation, and lets touches through everywhere but the bar.
+ *
+ * Follows `FooterVisibilityContext` rather than tracking the nav bar by hand:
+ * it slides down with the bar and stays anchored just above it (ADR-0029
+ * clause 5). One boolean drives both, so they can no longer desync.
  */
 export function Snackbar({
   visible,
@@ -25,16 +36,37 @@ export function Snackbar({
   actionLabel,
   onAction,
 }: SnackbarProps) {
-  const footerOffset = useNavigationFooterOffset();
+  const footprint = useNavigationBarFootprint();
   // Float above a sticky CTA when one is mounted, instead of overlapping it.
   const ctaClearance = useStickyCtaClearance();
+  const { visible: isFooterVisible } = useFooterVisibility();
+  const prefersReducedMotion = useReducedMotion();
+  const translateY = useSharedValue(0);
+
+  React.useEffect(() => {
+    // When the bar slides away, its footprint is free — follow it down so the
+    // snackbar keeps hugging the bar instead of leaving a gap.
+    const target = isFooterVisible ? 0 : footprint;
+    translateY.value = prefersReducedMotion
+      ? target
+      : withSpring(target, { mass: 1, damping: 18, stiffness: 140 });
+  }, [isFooterVisible, footprint, prefersReducedMotion, translateY]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return { transform: [{ translateY: translateY.value }] };
+  });
+
   if (!visible) {
     return null;
   }
   return (
-    <View
+    <Animated.View
       testID="snackbar-overlay"
-      style={[styles.overlay, { paddingBottom: footerOffset + ctaClearance }]}
+      style={[
+        styles.overlay,
+        { paddingBottom: footprint + ctaClearance },
+        animatedStyle,
+      ]}
       pointerEvents="box-none"
     >
       <View style={styles.bar} accessibilityRole="alert">
@@ -52,7 +84,7 @@ export function Snackbar({
           </Pressable>
         ) : null}
       </View>
-    </View>
+    </Animated.View>
   );
 }
 

--- a/packages/mobile-app/src/core/ui/Snackbar.tsx
+++ b/packages/mobile-app/src/core/ui/Snackbar.tsx
@@ -7,7 +7,14 @@ import Animated, {
   withSpring,
 } from "react-native-reanimated";
 
-import { colors, radius, shadows, spacing, typography } from "@/core/theme";
+import {
+  colors,
+  NAV_BAR_HEIGHT,
+  radius,
+  shadows,
+  spacing,
+  typography,
+} from "@/core/theme";
 import { useFooterVisibility } from "@/core/ui/footer-visibility-context";
 import { useNavigationBarFootprint } from "@/core/ui/use-navigation-bar-footprint";
 import { useStickyCtaClearance } from "@/core/ui/sticky-cta-clearance";
@@ -44,9 +51,11 @@ export function Snackbar({
   const translateY = useSharedValue(0);
 
   React.useEffect(() => {
-    // When the bar slides away, its footprint is free — follow it down so the
-    // snackbar keeps hugging the bar instead of leaving a gap.
-    const target = isFooterVisible ? 0 : footprint;
+    // Follow the bar down so the snackbar keeps hugging it instead of leaving a
+    // gap — but reclaim only the bar's VISUAL height, never the safe-area inset.
+    // Translating by the full footprint would eat `insets.bottom` too and drop
+    // the snackbar into the home-indicator area once the bar is hidden.
+    const target = isFooterVisible ? 0 : NAV_BAR_HEIGHT;
     translateY.value = prefersReducedMotion
       ? target
       : withSpring(target, { mass: 1, damping: 18, stiffness: 140 });

--- a/packages/mobile-app/src/core/ui/__tests__/ScreenFlatList.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/ScreenFlatList.test.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { FlatList, StyleSheet, Text } from "react-native";
+import { act, render, screen } from "@testing-library/react-native";
+
+import { NAV_BAR_HEIGHT } from "@/core/theme";
+import {
+  FooterVisibilityProvider,
+  useFooterVisibility,
+} from "@/core/ui/footer-visibility-context";
+import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
+
+const BOTTOM_INSET = 24;
+
+jest.mock("expo-router", () => ({
+  usePathname: () => "/dashboard",
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({
+    top: 0,
+    right: 0,
+    bottom: BOTTOM_INSET,
+    left: 0,
+  }),
+}));
+
+function flattenedPaddingBottom(): number | undefined {
+  const style = StyleSheet.flatten(
+    screen.UNSAFE_getByType(FlatList).props.contentContainerStyle,
+  );
+
+  return style?.paddingBottom as number | undefined;
+}
+
+let setFooterVisible: (visible: boolean) => void = () => {};
+
+function VisibilityHandle() {
+  const { setVisible } = useFooterVisibility();
+  setFooterVisible = setVisible;
+  return null;
+}
+
+function renderFlatList(props: {
+  contentContainerStyle?: object;
+  extraBottomClearance?: number;
+}) {
+  return render(
+    <FooterVisibilityProvider>
+      <VisibilityHandle />
+      <ScreenFlatList
+        data={["a", "b"]}
+        keyExtractor={(item) => item}
+        renderItem={({ item }) => <Text>{item}</Text>}
+        {...props}
+      />
+    </FooterVisibilityProvider>,
+  );
+}
+
+describe("ScreenFlatList", () => {
+  it("reserves the bar footprint so rows clear it — inset included", () => {
+    renderFlatList({});
+
+    expect(flattenedPaddingBottom()).toBe(NAV_BAR_HEIGHT + BOTTOM_INSET);
+  });
+
+  // The clearance must win over whatever the screen passes: the old per-screen
+  // opt-in let a screen silently cancel it, which is the bug this replaces.
+  it("cannot be cancelled by the screen's own contentContainerStyle", () => {
+    renderFlatList({ contentContainerStyle: { paddingBottom: 0 } });
+
+    expect(flattenedPaddingBottom()).toBe(NAV_BAR_HEIGHT + BOTTOM_INSET);
+  });
+
+  it("keeps the screen's other content styles", () => {
+    renderFlatList({ contentContainerStyle: { paddingHorizontal: 12 } });
+
+    const style = StyleSheet.flatten(
+      screen.UNSAFE_getByType(FlatList).props.contentContainerStyle,
+    );
+
+    expect(style?.paddingHorizontal).toBe(12);
+  });
+
+  it("stacks extra clearance on top of the footprint", () => {
+    renderFlatList({ extraBottomClearance: 40 });
+
+    expect(flattenedPaddingBottom()).toBe(NAV_BAR_HEIGHT + BOTTOM_INSET + 40);
+  });
+
+  // ADR-0029 clause 6 — THE invariant. Hiding the bar only translates it; the
+  // reserved clearance never changes, so a bottom row can never be covered when
+  // the user stops scrolling. Correctness must not depend on the animation.
+  it("reserves the same clearance whether the bar is revealed or hidden", () => {
+    renderFlatList({});
+
+    const whenRevealed = flattenedPaddingBottom();
+
+    act(() => {
+      setFooterVisible(false);
+    });
+
+    expect(flattenedPaddingBottom()).toBe(whenRevealed);
+  });
+});

--- a/packages/mobile-app/src/core/ui/__tests__/ScreenScrollView.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/ScreenScrollView.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { ScrollView, StyleSheet, Text } from "react-native";
+import { act, render, screen } from "@testing-library/react-native";
+
+import { NAV_BAR_HEIGHT } from "@/core/theme";
+import {
+  FooterVisibilityProvider,
+  useFooterVisibility,
+} from "@/core/ui/footer-visibility-context";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
+
+const BOTTOM_INSET = 24;
+
+jest.mock("expo-router", () => ({
+  usePathname: () => "/dashboard",
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({
+    top: 0,
+    right: 0,
+    bottom: BOTTOM_INSET,
+    left: 0,
+  }),
+}));
+
+function flattenedPaddingBottom(): number | undefined {
+  const style = StyleSheet.flatten(
+    screen.UNSAFE_getByType(ScrollView).props.contentContainerStyle,
+  );
+
+  return style?.paddingBottom as number | undefined;
+}
+
+let setFooterVisible: (visible: boolean) => void = () => {};
+
+function VisibilityHandle() {
+  const { setVisible } = useFooterVisibility();
+  setFooterVisible = setVisible;
+  return null;
+}
+
+function renderScrollView(contentContainerStyle?: object) {
+  return render(
+    <FooterVisibilityProvider>
+      <VisibilityHandle />
+      <ScreenScrollView contentContainerStyle={contentContainerStyle}>
+        <Text>content</Text>
+      </ScreenScrollView>
+    </FooterVisibilityProvider>,
+  );
+}
+
+describe("ScreenScrollView", () => {
+  it("reserves the bar footprint so content clears it — inset included", () => {
+    renderScrollView();
+
+    expect(flattenedPaddingBottom()).toBe(NAV_BAR_HEIGHT + BOTTOM_INSET);
+  });
+
+  // The clearance must win over whatever the screen passes: the old per-screen
+  // opt-in let a screen silently cancel it, which is the bug this replaces.
+  it("cannot be cancelled by the screen's own contentContainerStyle", () => {
+    renderScrollView({ paddingBottom: 0 });
+
+    expect(flattenedPaddingBottom()).toBe(NAV_BAR_HEIGHT + BOTTOM_INSET);
+  });
+
+  it("keeps the screen's other content styles", () => {
+    renderScrollView({ gap: 12 });
+
+    const style = StyleSheet.flatten(
+      screen.UNSAFE_getByType(ScrollView).props.contentContainerStyle,
+    );
+
+    expect(style?.gap).toBe(12);
+  });
+
+  // ADR-0029 clause 6 — THE invariant. Hiding the bar only translates it; the
+  // reserved clearance never changes, so a bottom control can never be covered
+  // when the user stops scrolling. Correctness must not depend on the animation.
+  it("reserves the same clearance whether the bar is revealed or hidden", () => {
+    renderScrollView();
+
+    const whenRevealed = flattenedPaddingBottom();
+
+    act(() => {
+      setFooterVisible(false);
+    });
+
+    expect(flattenedPaddingBottom()).toBe(whenRevealed);
+  });
+});

--- a/packages/mobile-app/src/core/ui/__tests__/Snackbar.footer-follow.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/Snackbar.footer-follow.test.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import { render, screen } from "@testing-library/react-native";
+
+import { NAV_BAR_HEIGHT } from "@/core/theme";
+import { FooterVisibilityProvider } from "@/core/ui/footer-visibility-context";
+import { Snackbar } from "@/core/ui/Snackbar";
+
+const BOTTOM_INSET = 24;
+
+jest.mock("expo-router", () => ({
+  usePathname: () => "/dashboard",
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({
+    top: 0,
+    right: 0,
+    bottom: BOTTOM_INSET,
+    left: 0,
+  }),
+}));
+
+function renderSnackbar() {
+  return render(
+    <FooterVisibilityProvider>
+      <Snackbar visible message="Brouillon enregistré." />
+    </FooterVisibilityProvider>,
+  );
+}
+
+describe("Snackbar — nav bar clearance", () => {
+  // Single source of truth (ADR-0029 clause 5): the snackbar must anchor off
+  // the shared footprint, not off its own copy of the bar arithmetic. Before
+  // this, it consumed a per-screen offset that had to be hand-kept in sync.
+  it("anchors on the shared bar footprint, inset included", () => {
+    renderSnackbar();
+
+    const style = StyleSheet.flatten(
+      screen.getByTestId("snackbar-overlay").props.style,
+    );
+
+    expect(style?.paddingBottom).toBe(NAV_BAR_HEIGHT + BOTTOM_INSET);
+  });
+});

--- a/packages/mobile-app/src/core/ui/__tests__/use-scroll-direction.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/use-scroll-direction.test.tsx
@@ -1,0 +1,162 @@
+import React from "react";
+import { Text } from "react-native";
+import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+import { act, render } from "@testing-library/react-native";
+
+import {
+  FooterVisibilityProvider,
+  useFooterVisibility,
+} from "@/core/ui/footer-visibility-context";
+import { useScrollDirection } from "@/core/ui/use-scroll-direction";
+
+jest.mock("expo-router", () => ({
+  usePathname: () => "/dashboard",
+}));
+
+/**
+ * Builds a scroll event. Defaults describe a long list scrolled well away from
+ * both ends, so a test only states the axis it actually exercises.
+ */
+function scrollEvent(
+  offsetY: number,
+  overrides: Partial<NativeScrollEvent> = {},
+) {
+  return {
+    nativeEvent: {
+      contentOffset: { x: 0, y: offsetY },
+      contentSize: { width: 400, height: 5000 },
+      layoutMeasurement: { width: 400, height: 800 },
+      ...overrides,
+    },
+  } as NativeSyntheticEvent<NativeScrollEvent>;
+}
+
+type Harness = {
+  scroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  forceReveal: () => void;
+};
+
+const harness: Harness = { scroll: () => {}, forceReveal: () => {} };
+
+function Probe() {
+  const { visible } = useFooterVisibility();
+  const { onScroll, forceReveal } = useScrollDirection();
+
+  harness.scroll = onScroll;
+  harness.forceReveal = forceReveal;
+
+  return <Text>{visible ? "visible" : "hidden"}</Text>;
+}
+
+function renderProbe() {
+  return render(
+    <FooterVisibilityProvider>
+      <Probe />
+    </FooterVisibilityProvider>,
+  );
+}
+
+function scroll(offsetY: number, overrides?: Partial<NativeScrollEvent>) {
+  act(() => {
+    harness.scroll(scrollEvent(offsetY, overrides));
+  });
+}
+
+describe("useScrollDirection", () => {
+  it("starts revealed", () => {
+    const { getByText } = renderProbe();
+
+    expect(getByText("visible")).toBeTruthy();
+  });
+
+  it("hides on a sustained scroll down", () => {
+    const { getByText } = renderProbe();
+
+    scroll(200);
+
+    expect(getByText("hidden")).toBeTruthy();
+  });
+
+  it("reveals again on a sustained scroll up", () => {
+    const { getByText } = renderProbe();
+
+    scroll(400);
+    expect(getByText("hidden")).toBeTruthy();
+
+    scroll(300);
+
+    expect(getByText("visible")).toBeTruthy();
+  });
+
+  // The threshold gates BOTH directions: an ungated reveal would pop the bar
+  // back on the tiniest upward jitter — the flicker it exists to prevent.
+  it("ignores movements below the threshold in both directions", () => {
+    const { getByText } = renderProbe();
+
+    scroll(400);
+    expect(getByText("hidden")).toBeTruthy();
+
+    scroll(396); // 4px up — below threshold
+    expect(getByText("hidden")).toBeTruthy();
+
+    scroll(404); // 4px down from the anchor — still below threshold
+    expect(getByText("hidden")).toBeTruthy();
+  });
+
+  // Small movements must accumulate: the anchor only moves when the state flips,
+  // so a slow sustained scroll still toggles rather than being ignored forever.
+  it("accumulates small movements into a sustained delta", () => {
+    const { getByText } = renderProbe();
+
+    scroll(400);
+    scroll(396);
+    scroll(392);
+    scroll(388); // 12px up from the 400 anchor — threshold reached
+
+    expect(getByText("visible")).toBeTruthy();
+  });
+
+  it("stays revealed near the top even on a downward flick", () => {
+    const { getByText } = renderProbe();
+
+    scroll(20);
+
+    expect(getByText("visible")).toBeTruthy();
+  });
+
+  it("stays revealed on iOS bounce (negative offset)", () => {
+    const { getByText } = renderProbe();
+
+    scroll(400);
+    expect(getByText("hidden")).toBeTruthy();
+
+    scroll(-30);
+
+    expect(getByText("visible")).toBeTruthy();
+  });
+
+  it("forces a reveal at the end of the list", () => {
+    const { getByText } = renderProbe();
+
+    scroll(400);
+    expect(getByText("hidden")).toBeTruthy();
+
+    // Scrolled down, but the viewport bottom now sits on the content end.
+    scroll(4200);
+
+    expect(getByText("visible")).toBeTruthy();
+  });
+
+  it("forceReveal bypasses the threshold", () => {
+    const { getByText } = renderProbe();
+
+    scroll(400);
+    expect(getByText("hidden")).toBeTruthy();
+
+    act(() => {
+      harness.forceReveal();
+    });
+
+    expect(getByText("visible")).toBeTruthy();
+  });
+});

--- a/packages/mobile-app/src/core/ui/footer-visibility-context.tsx
+++ b/packages/mobile-app/src/core/ui/footer-visibility-context.tsx
@@ -1,0 +1,75 @@
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { Keyboard } from "react-native";
+
+import { usePathname } from "expo-router";
+
+type FooterVisibilityValue = {
+  /** `true` when the bottom bar is at rest, flush at the bottom edge. */
+  visible: boolean;
+  /** Set by the shared scroll containers via `useScrollDirection`. */
+  setVisible: (visible: boolean) => void;
+};
+
+const FooterVisibilityContext = createContext<FooterVisibilityValue>({
+  visible: true,
+  setVisible: () => {},
+});
+
+/**
+ * Single source of truth for whether the bottom navigation bar is revealed
+ * (ADR-0029 clause 5).
+ *
+ * The bar, the app-level Snackbar and sticky CTAs all read this one boolean,
+ * so they can no longer desync — before this, each anchored off a per-screen
+ * offset that had to be hand-kept in sync.
+ *
+ * Defaults to `visible: true`: a screen that never scrolls never emits a
+ * scroll event, so the bar stays pinned (ADR-0029 clause 8).
+ *
+ * Forced reveals that are state changes rather than scroll deltas live here
+ * (ADR-0029 clause 2). Navigation is the load-bearing one: the provider
+ * outlives the screens, so without it a bar hidden on a long list would stay
+ * hidden on the next screen — which, if that screen never scrolls, would leave
+ * it hidden for good. The other forced reveals (list top/end, pull-to-refresh)
+ * fall out of `useScrollDirection`'s near-top and end-of-list guards, since
+ * both only happen at a scroll position those guards already cover.
+ */
+export function FooterVisibilityProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [visible, setVisible] = useState(true);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    setVisible(true);
+  }, [pathname]);
+
+  useEffect(() => {
+    const subscription = Keyboard.addListener("keyboardDidShow", () =>
+      setVisible(true),
+    );
+
+    return () => subscription.remove();
+  }, []);
+
+  const value = useMemo(() => ({ visible, setVisible }), [visible]);
+
+  return (
+    <FooterVisibilityContext.Provider value={value}>
+      {children}
+    </FooterVisibilityContext.Provider>
+  );
+}
+
+/** Read the shared bar visibility. Safe outside the provider (returns `true`). */
+export function useFooterVisibility(): FooterVisibilityValue {
+  return useContext(FooterVisibilityContext);
+}

--- a/packages/mobile-app/src/core/ui/use-navigation-bar-footprint.ts
+++ b/packages/mobile-app/src/core/ui/use-navigation-bar-footprint.ts
@@ -1,0 +1,24 @@
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+
+import { NAV_BAR_HEIGHT } from "@/core/theme";
+
+/**
+ * Space the flush bottom navigation bar actually occupies, in px.
+ *
+ * The bar is anchored to the very bottom edge and absorbs the bottom
+ * safe-area inset inside itself, so its footprint is its base visual height
+ * plus that inset (ADR-0029 clause 4). `NAV_BAR_HEIGHT` alone would sit too
+ * short on a device with a home indicator.
+ *
+ * The same number serves three consumers, which is why it lives in one hook:
+ * the shared scroll containers reserve it as bottom clearance, the bar
+ * translates by it when hiding, and the Snackbar / sticky CTAs anchor above
+ * it. Keeping it constant across Revealed and Hidden is what makes the
+ * clause-6 invariant hold — content clears the bar at rest no matter what the
+ * animation is doing.
+ */
+export function useNavigationBarFootprint(): number {
+  const insets = useSafeAreaInsets();
+
+  return NAV_BAR_HEIGHT + insets.bottom;
+}

--- a/packages/mobile-app/src/core/ui/use-scroll-direction.ts
+++ b/packages/mobile-app/src/core/ui/use-scroll-direction.ts
@@ -1,0 +1,83 @@
+import { useCallback, useRef } from "react";
+
+import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+
+import { useFooterVisibility } from "@/core/ui/footer-visibility-context";
+
+/**
+ * Sustained scroll distance, in px, needed to flip the bar's visibility.
+ * Gates BOTH directions: an ungated reveal would pop the bar back on the
+ * tiniest upward jitter, re-introducing the flicker this threshold exists to
+ * prevent (ADR-0029 clause 5, `03-sequence` notes).
+ */
+const TOGGLE_THRESHOLD = 12;
+
+/**
+ * Distance from the top, in px, inside which the bar stays revealed even on a
+ * downward flick — so short lists never hide the nav. Also absorbs iOS bounce,
+ * where the offset goes negative.
+ */
+const NEAR_TOP_GUARD = 32;
+
+/** Distance from the end, in px, at which reaching the list end forces a reveal. */
+const END_OF_LIST_GUARD = 24;
+
+/**
+ * Shared scroll-direction contract feeding {@link useFooterVisibility}
+ * (ADR-0029 clause 5).
+ *
+ * Wired once by the shared scroll containers, so every screen inherits the
+ * same anti-flicker rule and tuning stays a one-file change. Returns an
+ * `onScroll` handler plus `forceReveal` for state changes that are not scroll
+ * deltas (pull-to-refresh, navigation, keyboard) — those bypass the threshold
+ * by design.
+ */
+export function useScrollDirection() {
+  const { setVisible } = useFooterVisibility();
+  // Anchor the delta is measured from. Deliberately NOT updated on
+  // below-threshold events: that lets small movements accumulate into a
+  // sustained delta instead of being individually discarded.
+  const anchorOffsetY = useRef(0);
+
+  const forceReveal = useCallback(() => {
+    anchorOffsetY.current = 0;
+    setVisible(true);
+  }, [setVisible]);
+
+  const onScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      const offsetY = contentOffset.y;
+
+      // Near the top: pinned revealed, and re-anchor so leaving the top needs a
+      // full sustained delta rather than inheriting a stale anchor.
+      if (offsetY <= NEAR_TOP_GUARD) {
+        anchorOffsetY.current = offsetY;
+        setVisible(true);
+        return;
+      }
+
+      // At the very end of the list, reveal so the last controls are reachable
+      // without scrolling back up.
+      const distanceToEnd =
+        contentSize.height - (offsetY + layoutMeasurement.height);
+      if (distanceToEnd <= END_OF_LIST_GUARD) {
+        anchorOffsetY.current = offsetY;
+        setVisible(true);
+        return;
+      }
+
+      const delta = offsetY - anchorOffsetY.current;
+      if (Math.abs(delta) < TOGGLE_THRESHOLD) {
+        return;
+      }
+
+      anchorOffsetY.current = offsetY;
+      setVisible(delta < 0);
+    },
+    [setVisible],
+  );
+
+  return { onScroll, forceReveal };
+}

--- a/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchDetailsScreen.tsx
@@ -1,12 +1,6 @@
-import {
-  Modal,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
+import { STICKY_CTA_BAR_HEIGHT } from "@/core/ui/sticky-cta-clearance";
 import { BrewStepTimer } from "@/features/batches/presentation/BrewStepTimer";
 import { colors, radius, spacing, typography } from "@/core/theme";
 import {
@@ -161,7 +155,6 @@ function useFermentationTrackerInfo(batch: Batch | null) {
 }
 
 export function BatchDetailsScreen({ batchId }: Props) {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const handleGoBack = useBackNavigation("/batches");
   const confirm = useConfirm();
@@ -569,12 +562,12 @@ export function BatchDetailsScreen({ batchId }: Props) {
         }
       />
       <View style={styles.body}>
-        <ScrollView
-          contentContainerStyle={[
-            styles.content,
-            { paddingBottom: bottomPadding },
-          ]}
+        <ScreenScrollView
+          contentContainerStyle={styles.content}
           showsVerticalScrollIndicator={false}
+          // This screen pins a sticky CTA above the nav bar; the content must
+          // clear both.
+          extraBottomClearance={STICKY_CTA_BAR_HEIGHT}
         >
           {batch ? (
             <Card style={styles.headerCard}>
@@ -838,7 +831,7 @@ export function BatchDetailsScreen({ batchId }: Props) {
               </Text>
             </Pressable>
           ) : null}
-        </ScrollView>
+        </ScreenScrollView>
       </View>
 
       {primaryCta ? (
@@ -846,7 +839,6 @@ export function BatchDetailsScreen({ batchId }: Props) {
           label={primaryCta.label}
           onPress={primaryCta.onPress}
           disabled={primaryCta.disabled}
-          bottomOffset={bottomPadding}
         />
       ) : null}
 

--- a/packages/mobile-app/src/features/batches/presentation/BatchFinishedScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchFinishedScreen.tsx
@@ -1,4 +1,4 @@
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
@@ -7,7 +7,7 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 const HERO_BEER = {
   name: "La Première du dimanche",
@@ -32,7 +32,6 @@ const TIMELINE: ReadonlyArray<{ date: string; label: string }> = [
 ];
 
 export function BatchFinishedScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
 
   const handleGoBack = () => {
@@ -53,10 +52,7 @@ export function BatchFinishedScreen() {
         }
       />
 
-      <ScrollView
-        contentContainerStyle={{ paddingBottom: bottomPadding }}
-        showsVerticalScrollIndicator={false}
-      >
+      <ScreenScrollView showsVerticalScrollIndicator={false}>
         <View style={styles.kicker}>
           <Text style={styles.kickerEmoji} accessible={false}>
             🍻
@@ -112,7 +108,7 @@ export function BatchFinishedScreen() {
             Partage ton brassin avec la communauté depuis l’onglet Communauté.
           </Text>
         </View>
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/batches/presentation/BatchesScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchesScreen.tsx
@@ -1,10 +1,8 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import {
   BatchStatus,
   BatchSummary,
 } from "@/features/batches/domain/batch.types";
 import {
-  FlatList,
   Pressable,
   RefreshControl,
   StyleSheet,
@@ -22,6 +20,7 @@ import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import React from "react";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
 import { dataSource } from "@/core/data/data-source";
 import { demoRecipes } from "@/mocks/demo-data";
 import { getErrorMessage } from "@/core/http/http-error";
@@ -65,7 +64,6 @@ const getStatusVariant = (status: BatchStatus): "success" | "info" => {
 };
 
 export function BatchesScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const {
     data: batches = [],
@@ -115,10 +113,10 @@ export function BatchesScreen() {
         />
       ) : null}
 
-      <FlatList
+      <ScreenFlatList
         data={activeBatches}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
+        contentContainerStyle={styles.list}
         refreshControl={
           <RefreshControl refreshing={isFetching} onRefresh={handleRefetch} />
         }

--- a/packages/mobile-app/src/features/batches/presentation/BottlingScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BottlingScreen.tsx
@@ -2,7 +2,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import React from "react";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import { dataSource } from "@/core/data/data-source";
 import { getErrorMessage } from "@/core/http/http-error";
@@ -10,9 +10,9 @@ import { colors, spacing, typography } from "@/core/theme";
 import { Card } from "@/core/ui/Card";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import {
   closeBottling,
   getBottlingInfo,
@@ -60,7 +60,6 @@ const BOTTLING_STEPS: ReadonlyArray<string> = [
  * @param props - The identifier of the batch being bottled.
  */
 export function BottlingScreen({ batchId }: Props) {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const queryClient = useQueryClient();
   const missingBatchId = !batchId;
@@ -125,10 +124,7 @@ export function BottlingScreen({ batchId }: Props) {
         }
       />
 
-      <ScrollView
-        contentContainerStyle={{ paddingBottom: bottomPadding }}
-        showsVerticalScrollIndicator={false}
-      >
+      <ScreenScrollView showsVerticalScrollIndicator={false}>
         <Card style={styles.card}>
           <Text style={styles.cardTitle}>Dose de sucre de réamorçage</Text>
           {isLoadingPriming ? (
@@ -226,7 +222,7 @@ export function BottlingScreen({ batchId }: Props) {
             Mode démo : la clôture est simulée.
           </Text>
         ) : null}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/beer-catalog/presentation/BeerCatalogBrowseScreen.tsx
+++ b/packages/mobile-app/src/features/beer-catalog/presentation/BeerCatalogBrowseScreen.tsx
@@ -1,11 +1,5 @@
 import React, { useMemo } from "react";
-import {
-  FlatList,
-  Pressable,
-  RefreshControl,
-  StyleSheet,
-  View,
-} from "react-native";
+import { Pressable, RefreshControl, StyleSheet, View } from "react-native";
 
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter, type Href } from "expo-router";
@@ -15,7 +9,7 @@ import { colors, spacing } from "@/core/theme";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
 import { Screen } from "@/core/ui/Screen";
 
 import { toBeerListItemVM } from "@/features/beer-catalog/application/beer-catalog.view-model";
@@ -37,7 +31,6 @@ import { CatalogListFooter } from "@/features/beer-catalog/presentation/componen
  * All states are derived from the TanStack flags — no hand-written FSM.
  */
 export function BeerCatalogBrowseScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const {
     data,
@@ -117,7 +110,7 @@ export function BeerCatalogBrowseScreen() {
         />
       ) : null}
 
-      <FlatList
+      <ScreenFlatList
         testID="beer-catalog-browse-list"
         data={rows}
         keyExtractor={(item) => item.id}
@@ -146,7 +139,7 @@ export function BeerCatalogBrowseScreen() {
             onRefresh={handleRefetch}
           />
         }
-        contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
+        contentContainerStyle={styles.list}
       />
     </Screen>
   );

--- a/packages/mobile-app/src/features/beer-catalog/presentation/BeerCatalogSearchScreen.tsx
+++ b/packages/mobile-app/src/features/beer-catalog/presentation/BeerCatalogSearchScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { FlatList, RefreshControl, StyleSheet, View } from "react-native";
+import { RefreshControl, StyleSheet, View } from "react-native";
 
 import { useRouter, type Href } from "expo-router";
 
@@ -9,8 +9,8 @@ import { BeerMugLoader } from "@/core/ui/BeerMugLoader";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
 
 import { toBeerListItemVM } from "@/features/beer-catalog/application/beer-catalog.view-model";
 import {
@@ -38,7 +38,6 @@ import { SearchField } from "@/features/beer-catalog/presentation/components/Sea
  * (`mobile-catalog/07-state-list-screen.md`).
  */
 export function BeerCatalogSearchScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const [term, setTerm] = useState("");
   const debounced = useDebouncedValue(term);
@@ -111,7 +110,7 @@ export function BeerCatalogSearchScreen() {
     );
   } else {
     content = (
-      <FlatList
+      <ScreenFlatList
         testID="beer-catalog-search-list"
         data={rows}
         keyExtractor={(item) => item.id}
@@ -142,7 +141,7 @@ export function BeerCatalogSearchScreen() {
             onRefresh={handleRefetch}
           />
         }
-        contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
+        contentContainerStyle={styles.list}
         keyboardShouldPersistTaps="handled"
       />
     );

--- a/packages/mobile-app/src/features/beer-catalog/presentation/BeerDetailScreen.tsx
+++ b/packages/mobile-app/src/features/beer-catalog/presentation/BeerDetailScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import { Ionicons } from "@expo/vector-icons";
 import { useRouter, type Href } from "expo-router";
@@ -10,8 +10,8 @@ import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 import {
   toBeerDetailVM,
@@ -60,7 +60,6 @@ interface LegalRow {
  */
 export function BeerDetailScreen({ beerId }: Props) {
   const router = useRouter();
-  const bottomPadding = useNavigationFooterOffset();
   const {
     data,
     isLoading,
@@ -119,11 +118,8 @@ export function BeerDetailScreen({ beerId }: Props) {
       error={screenError}
       onRetry={handleRetry}
     >
-      <ScrollView
-        contentContainerStyle={[
-          styles.scrollContent,
-          { paddingBottom: bottomPadding },
-        ]}
+      <ScreenScrollView
+        contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.backRow}>
@@ -140,7 +136,7 @@ export function BeerDetailScreen({ beerId }: Props) {
             onNavigate={handleTapRoute}
           />
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/beer-catalog/presentation/BreweryDetailScreen.tsx
+++ b/packages/mobile-app/src/features/beer-catalog/presentation/BreweryDetailScreen.tsx
@@ -1,12 +1,5 @@
 import React, { useCallback } from "react";
-import {
-  Linking,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { Linking, Pressable, StyleSheet, Text, View } from "react-native";
 
 import { useRouter } from "expo-router";
 
@@ -16,8 +9,8 @@ import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 import {
   toBreweryFicheVM,
@@ -53,7 +46,6 @@ interface FicheRowData {
  */
 export function BreweryDetailScreen({ breweryId }: Props) {
   const router = useRouter();
-  const bottomPadding = useNavigationFooterOffset();
   const { data, isLoading, isError, error, isFetching, refetch } =
     useBrewery(breweryId);
 
@@ -94,11 +86,8 @@ export function BreweryDetailScreen({ breweryId }: Props) {
       error={screenError}
       onRetry={handleRetry}
     >
-      <ScrollView
-        contentContainerStyle={[
-          styles.scrollContent,
-          { paddingBottom: bottomPadding },
-        ]}
+      <ScreenScrollView
+        contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.backRow}>
@@ -109,7 +98,7 @@ export function BreweryDetailScreen({ breweryId }: Props) {
           />
         </View>
         {vm === null ? null : <BreweryFiche vm={vm} />}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/beer-catalog/presentation/StyleDetailScreen.tsx
+++ b/packages/mobile-app/src/features/beer-catalog/presentation/StyleDetailScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { ScrollView, StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 
 import { useRouter } from "expo-router";
 
@@ -9,8 +9,8 @@ import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 import {
   toStyleFicheVM,
@@ -47,7 +47,6 @@ interface FicheRowData {
  */
 export function StyleDetailScreen({ styleId }: Props) {
   const router = useRouter();
-  const bottomPadding = useNavigationFooterOffset();
   const { data, isLoading, isError, error, isFetching, refetch } =
     useStyle(styleId);
 
@@ -90,11 +89,8 @@ export function StyleDetailScreen({ styleId }: Props) {
       error={screenError}
       onRetry={handleRetry}
     >
-      <ScrollView
-        contentContainerStyle={[
-          styles.scrollContent,
-          { paddingBottom: bottomPadding },
-        ]}
+      <ScreenScrollView
+        contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.backRow}>
@@ -120,7 +116,7 @@ export function StyleDetailScreen({ styleId }: Props) {
             ) : null}
           </>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
+++ b/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
@@ -1,21 +1,14 @@
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { Href, useRouter } from "expo-router";
 import React, { useCallback, useMemo, useState } from "react";
-import {
-  Modal,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
 
 import { useAuth } from "@/core/auth/auth-context";
 import { dataSource } from "@/core/data/data-source";
 import { getErrorMessage } from "@/core/http/http-error";
 import { Card } from "@/core/ui/Card";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { listBatches } from "@/features/batches/application/batches.use-cases";
 import { BatchSummary } from "@/features/batches/domain/batch.types";
 import { Ionicons } from "@expo/vector-icons";
@@ -344,7 +337,6 @@ function getStatusColors(status: string): {
 }
 
 export function DashboardScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const { session } = useAuth();
 
@@ -600,11 +592,8 @@ export function DashboardScreen() {
 
   return (
     <Screen isLoading={isLoading} error={error} onRetry={handleRetry}>
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
+      <ScreenScrollView
+        contentContainerStyle={styles.content}
         showsVerticalScrollIndicator={false}
       >
         <View style={styles.headerCard}>
@@ -1052,7 +1041,7 @@ export function DashboardScreen() {
             </View>
           )}
         </Card>
-      </ScrollView>
+      </ScreenScrollView>
 
       <Modal
         transparent

--- a/packages/mobile-app/src/features/equipment/presentation/EquipmentScreen.tsx
+++ b/packages/mobile-app/src/features/equipment/presentation/EquipmentScreen.tsx
@@ -1,4 +1,4 @@
-import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import { colors, radius, spacing, typography } from "@/core/theme";
 import { getErrorMessage } from "@/core/http/http-error";
@@ -9,7 +9,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
 import { listEquipmentProfiles } from "@/features/equipment/application/equipment.use-cases";
 import { EQUIPMENT_SYSTEM_OPTIONS } from "@/features/equipment/domain/equipment-system-options";
 import {
@@ -35,7 +35,6 @@ function systemTypeLabel(systemType: EquipmentSystemType): string {
 
 export function EquipmentScreen() {
   const router = useRouter();
-  const bottomPadding = useNavigationFooterOffset();
 
   const {
     data: profiles,
@@ -73,13 +72,10 @@ export function EquipmentScreen() {
             onPress={goToWizard}
             style={styles.cta}
           />
-          <FlatList
+          <ScreenFlatList
             data={profiles}
             keyExtractor={(item) => item.id}
-            contentContainerStyle={[
-              styles.list,
-              { paddingBottom: bottomPadding },
-            ]}
+            contentContainerStyle={styles.list}
             renderItem={({ item }) => (
               <EquipmentCard
                 profile={item}

--- a/packages/mobile-app/src/features/ingredients/presentation/HopDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/HopDetailsScreen.tsx
@@ -9,8 +9,8 @@ import {
   buildRecipeBackNavigationTarget,
   normalizeIngredientReturnContextParams,
 } from "@/features/ingredients/presentation/ingredient-navigation-context";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 import { getErrorMessage } from "@/core/http/http-error";
 import { normalizeRouteParam } from "@/core/navigation/route-params";
@@ -85,7 +85,6 @@ export function HopDetailsScreen({
   returnAttenuationMinParam,
 }: Props) {
   const router = useRouter();
-  const bottomPadding = useNavigationFooterOffset();
   const normalizedHopId = normalizeRouteParam(hopIdParam);
   const normalizedReturnContext = normalizeIngredientReturnContextParams({
     returnToParam,
@@ -212,13 +211,10 @@ export function HopDetailsScreen({
       }}
     >
       {hop ? (
-        <ScrollView
+        <ScreenScrollView
           testID="hop-details-scroll"
           style={styles.scroll}
-          contentContainerStyle={[
-            styles.content,
-            { paddingBottom: bottomPadding },
-          ]}
+          contentContainerStyle={styles.content}
         >
           <ListHeader
             title={hop.name}
@@ -282,7 +278,7 @@ export function HopDetailsScreen({
           ) : null}
 
           <PrimaryButton label="Go back" onPress={handleGoBack} />
-        </ScrollView>
+        </ScreenScrollView>
       ) : null}
     </Screen>
   );

--- a/packages/mobile-app/src/features/ingredients/presentation/IngredientCategoryScreen.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/IngredientCategoryScreen.tsx
@@ -1,11 +1,4 @@
-import {
-  FlatList,
-  Pressable,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import {
   Ingredient,
   IngredientCategory,
@@ -33,7 +26,7 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { Ionicons } from "@expo/vector-icons";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
 import { getErrorMessage } from "@/core/http/http-error";
 import { isIngredientCategory } from "@/features/ingredients/presentation/ingredient-category.constants";
 import { listIngredientsByCategory } from "@/features/ingredients/application/ingredients.use-cases";
@@ -109,7 +102,6 @@ export function IngredientCategoryScreen({
   alphaMinParam,
   attenuationMinParam,
 }: Props) {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const normalizedCategory = normalizeRouteParam(categoryParam) ?? "";
   const initialFilters = buildIngredientCategoryInitialFilters({
@@ -372,10 +364,10 @@ export function IngredientCategoryScreen({
         />
       ) : null}
 
-      <FlatList
+      <ScreenFlatList
         data={ingredients}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
+        contentContainerStyle={styles.list}
         renderItem={({ item }) => (
           <Pressable
             accessibilityRole="button"

--- a/packages/mobile-app/src/features/ingredients/presentation/IngredientsScreen.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/IngredientsScreen.tsx
@@ -1,5 +1,4 @@
-import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 import { colors, radius, spacing, typography } from "@/core/theme";
 import {
   getIngredientCategoryPageTitle,
@@ -15,6 +14,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { ListHeader } from "@/core/ui/ListHeader";
 import React from "react";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
 import { getErrorMessage } from "@/core/http/http-error";
 import { ingredientCategoryLabels } from "@/features/ingredients/presentation/ingredient-category.constants";
 import { listIngredientCategoriesSummary } from "@/features/ingredients/application/ingredients.use-cases";
@@ -22,7 +22,6 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 
 export function IngredientsScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const {
     data: categories = [],
@@ -75,10 +74,10 @@ export function IngredientsScreen() {
         />
       ) : null}
 
-      <FlatList
+      <ScreenFlatList
         data={categories}
         keyExtractor={(item) => item.category}
-        contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
+        contentContainerStyle={styles.list}
         renderItem={({ item }) => {
           const presentation =
             ingredientCategoryPresentationById[item.category];

--- a/packages/mobile-app/src/features/ingredients/presentation/MaltDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/MaltDetailsScreen.tsx
@@ -1,4 +1,3 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { colors, spacing, typography } from "@/core/theme";
 import {
   getMaltDetails,
@@ -10,7 +9,7 @@ import {
   buildRecipeBackNavigationTarget,
   normalizeIngredientReturnContextParams,
 } from "@/features/ingredients/presentation/ingredient-navigation-context";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import { getErrorMessage } from "@/core/http/http-error";
 import { normalizeRouteParam } from "@/core/navigation/route-params";
@@ -19,6 +18,7 @@ import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { MaltProduct } from "@/features/ingredients/domain/malt.types";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
@@ -85,7 +85,6 @@ export function MaltDetailsScreen({
   returnAttenuationMinParam,
 }: Props) {
   const router = useRouter();
-  const bottomPadding = useNavigationFooterOffset();
   const normalizedMaltId = normalizeRouteParam(maltIdParam);
   const normalizedReturnContext = normalizeIngredientReturnContextParams({
     returnToParam,
@@ -208,13 +207,10 @@ export function MaltDetailsScreen({
       }}
     >
       {malt ? (
-        <ScrollView
+        <ScreenScrollView
           testID="malt-details-scroll"
           style={styles.scroll}
-          contentContainerStyle={[
-            styles.content,
-            { paddingBottom: bottomPadding },
-          ]}
+          contentContainerStyle={styles.content}
         >
           <ListHeader
             title={malt.name}
@@ -278,7 +274,7 @@ export function MaltDetailsScreen({
           ) : null}
 
           <PrimaryButton label="Go back" onPress={handleGoBack} />
-        </ScrollView>
+        </ScreenScrollView>
       ) : null}
     </Screen>
   );

--- a/packages/mobile-app/src/features/ingredients/presentation/YeastDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/YeastDetailsScreen.tsx
@@ -9,8 +9,8 @@ import {
   buildRecipeBackNavigationTarget,
   normalizeIngredientReturnContextParams,
 } from "@/features/ingredients/presentation/ingredient-navigation-context";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 import { getErrorMessage } from "@/core/http/http-error";
 import { normalizeRouteParam } from "@/core/navigation/route-params";
@@ -85,7 +85,6 @@ export function YeastDetailsScreen({
   returnAttenuationMinParam,
 }: Props) {
   const router = useRouter();
-  const bottomPadding = useNavigationFooterOffset();
   const normalizedYeastId = normalizeRouteParam(yeastIdParam);
   const normalizedReturnContext = normalizeIngredientReturnContextParams({
     returnToParam,
@@ -212,13 +211,10 @@ export function YeastDetailsScreen({
       }}
     >
       {yeast ? (
-        <ScrollView
+        <ScreenScrollView
           testID="yeast-details-scroll"
           style={styles.scroll}
-          contentContainerStyle={[
-            styles.content,
-            { paddingBottom: bottomPadding },
-          ]}
+          contentContainerStyle={styles.content}
         >
           <ListHeader
             title={yeast.name}
@@ -282,7 +278,7 @@ export function YeastDetailsScreen({
           ) : null}
 
           <PrimaryButton label="Go back" onPress={handleGoBack} />
-        </ScrollView>
+        </ScreenScrollView>
       ) : null}
     </Screen>
   );

--- a/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelEditorScreen.tsx
@@ -25,14 +25,7 @@ import {
 import { Href, useRouter } from "expo-router";
 
 import React, { useCallback, useMemo, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 import { getErrorMessage } from "@/core/http/http-error";
 import { normalizeRouteParam } from "@/core/navigation/route-params";
@@ -41,9 +34,9 @@ import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 type LabelEditorScreenProps = {
   draftIdParam?: string | string[];
@@ -62,7 +55,6 @@ function toButtonLabel(isSaving: boolean): string {
 export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
   const router = useRouter();
   const goBack = useBackNavigation(LABELS_HOME_ROUTE);
-  const navigationFooterOffset = useNavigationFooterOffset();
   const normalizedDraftId = normalizeRouteParam(draftIdParam) ?? "";
 
   const [draft, setDraft] = useState<LabelDraft | null>(null);
@@ -219,12 +211,9 @@ export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
         }
       />
 
-      <ScrollView
+      <ScreenScrollView
         style={styles.scrollContainer}
-        contentContainerStyle={[
-          styles.scrollContent,
-          { paddingBottom: navigationFooterOffset },
-        ]}
+        contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
       >
@@ -431,7 +420,7 @@ export function LabelEditorScreen({ draftIdParam }: LabelEditorScreenProps) {
             <Text style={styles.secondaryButtonText}>Voir la fiche</Text>
           </Pressable>
         </View>
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/labels/presentation/LabelSelectBatchScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelSelectBatchScreen.tsx
@@ -20,9 +20,9 @@ import { Card } from "@/core/ui/Card";
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { useNavigationBarFootprint } from "@/core/ui/use-navigation-bar-footprint";
 import { useRouter } from "expo-router";
 
 const LABELS_HOME_ROUTE = "/(app)/dashboard/labels" as const;
@@ -52,7 +52,10 @@ export function resolveSelectedBatchId(
 
 export function LabelSelectBatchScreen() {
   const router = useRouter();
-  const navigationFooterOffset = useNavigationFooterOffset();
+  // Only for the CTA below the list: it is a sibling of the scroll area, not
+  // scrolled content, so it anchors above the flush nav bar itself (ADR-0029
+  // clause 4, same as the Snackbar) rather than via a shared scroll container.
+  const footprint = useNavigationBarFootprint();
   const [candidates, setCandidates] = useState<LabelBatchCandidate[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
@@ -233,7 +236,7 @@ export function LabelSelectBatchScreen() {
         />
       )}
 
-      <View style={{ marginBottom: navigationFooterOffset }}>
+      <View style={{ marginBottom: footprint }}>
         <PrimaryButton
           accessibilityLabel="Créer un brouillon d’étiquette"
           label={isCreating ? "Création..." : "Créer le brouillon"}

--- a/packages/mobile-app/src/features/labels/presentation/LabelsScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelsScreen.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/features/labels/presentation/label-palette.constants";
 import { Href, useRouter } from "expo-router";
 import React, { useCallback, useMemo, useState } from "react";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import { getErrorMessage } from "@/core/http/http-error";
 import { Card } from "@/core/ui/Card";
@@ -22,7 +22,7 @@ import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 interface LabelInspirationExample {
   id: string;
@@ -130,7 +130,6 @@ function buildLabelDraftRoute(draftId: string): Href {
 
 export function LabelsScreen() {
   const router = useRouter();
-  const bottomPadding = useNavigationFooterOffset();
   const [drafts, setDrafts] = useState<LabelDraft[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [hasFetched, setHasFetched] = useState(false);
@@ -218,11 +217,8 @@ export function LabelsScreen() {
         subtitle="Conçois et sauvegarde tes étiquettes avant impression"
       />
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.scrollContent,
-          { paddingBottom: bottomPadding },
-        ]}
+      <ScreenScrollView
+        contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
       >
         <Card style={styles.summaryCard}>
@@ -380,7 +376,7 @@ export function LabelsScreen() {
               );
             })
           : null}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/BrewPrepScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useState } from "react";
-import { Alert, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Alert, StyleSheet, Text, View } from "react-native";
 
 import { useRouter } from "expo-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -14,8 +14,9 @@ import { CapacityFitPanel } from "@/features/recipes/presentation/components/Cap
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
+import { STICKY_CTA_BAR_HEIGHT } from "@/core/ui/sticky-cta-clearance";
 import {
   getRecipeDetailsViewModel,
   type RecipeDetailsViewModel,
@@ -57,7 +58,6 @@ export function BrewPrepScreen({ recipeId }: Props) {
   const router = useRouter();
   const confirm = useConfirm();
   const queryClient = useQueryClient();
-  const footerOffset = useNavigationFooterOffset();
   const hasRecipeId = recipeId.trim().length > 0;
 
   const {
@@ -268,9 +268,12 @@ export function BrewPrepScreen({ recipeId }: Props) {
       />
 
       <View style={styles.body}>
-        <ScrollView
+        <ScreenScrollView
           contentContainerStyle={styles.content}
           showsVerticalScrollIndicator={false}
+          // This screen pins a sticky CTA above the nav bar; the content must
+          // clear both.
+          extraBottomClearance={STICKY_CTA_BAR_HEIGHT}
         >
           <ListHeader
             title="Préparer mon brassin"
@@ -329,7 +332,7 @@ export function BrewPrepScreen({ recipeId }: Props) {
               )}
             </Card>
           ) : null}
-        </ScrollView>
+        </ScreenScrollView>
       </View>
 
       <RecipeStickyCta
@@ -339,7 +342,6 @@ export function BrewPrepScreen({ recipeId }: Props) {
         disabled={
           !complete || isStarting || isSavingChecklist || !viewModel || !draft
         }
-        bottomOffset={footerOffset}
       />
     </Screen>
   );

--- a/packages/mobile-app/src/features/recipes/presentation/CatalogScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/CatalogScreen.tsx
@@ -1,5 +1,4 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
-import { FlatList, RefreshControl, StyleSheet } from "react-native";
+import { RefreshControl, StyleSheet } from "react-native";
 import { spacing } from "@/core/theme";
 
 import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
@@ -10,6 +9,7 @@ import React from "react";
 import { Recipe } from "@/features/recipes/domain/recipe.types";
 import { RecipeCard } from "@/features/recipes/presentation/RecipeCard";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
 import { getErrorMessage } from "@/core/http/http-error";
 import { listPublicRecipes } from "@/features/recipes/application/recipes.use-cases";
 import { useQuery } from "@tanstack/react-query";
@@ -28,7 +28,6 @@ import { useRouter } from "expo-router";
  * RecipeDetailsScreen.
  */
 export function CatalogScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const {
     data: recipes = [],
@@ -74,10 +73,10 @@ export function CatalogScreen() {
         />
       ) : null}
 
-      <FlatList
+      <ScreenFlatList
         data={recipes}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={[styles.list, { paddingBottom: bottomPadding }]}
+        contentContainerStyle={styles.list}
         refreshControl={
           <RefreshControl refreshing={isFetching} onRefresh={handleRefetch} />
         }

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeDetailsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Alert, Pressable, ScrollView, StyleSheet, View } from "react-native";
+import { Alert, Pressable, StyleSheet, View } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
@@ -11,9 +11,10 @@ import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
+import { STICKY_CTA_BAR_HEIGHT } from "@/core/ui/sticky-cta-clearance";
 import { colors, spacing } from "@/core/theme";
 import { getErrorMessage, HttpError } from "@/core/http/http-error";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { useConfirm } from "@/core/ui/confirm-provider";
 import { useSnackbar } from "@/core/ui/snackbar-provider";
 
@@ -114,7 +115,6 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
   const handleGoBack = useBackNavigation("/recipes");
   const confirm = useConfirm();
   const snackbar = useSnackbar();
-  const bottomPadding = useNavigationFooterOffset();
   const queryClient = useQueryClient();
 
   const hasRecipeId = recipeId.trim().length > 0;
@@ -500,12 +500,12 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
         <RecipeDetailSideRail activeTab={activeTab} onChange={setActiveTab} />
 
         <View style={styles.tabContent}>
-          <ScrollView
-            contentContainerStyle={[
-              styles.scrollContent,
-              { paddingBottom: bottomPadding + (showStickyCta ? 96 : 0) },
-            ]}
+          <ScreenScrollView
+            contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
+            // This screen pins a sticky CTA above the nav bar; the content must
+            // clear both.
+            extraBottomClearance={STICKY_CTA_BAR_HEIGHT}
           >
             {recipe ? (
               <>
@@ -570,7 +570,7 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
             ) : (
               <Card style={styles.placeholderCard} />
             )}
-          </ScrollView>
+          </ScreenScrollView>
         </View>
       </View>
 
@@ -582,14 +582,12 @@ export function RecipeDetailsScreen({ recipeId }: Props) {
             label="Ajouter à mon carnet"
             onPress={() => importMutation.mutate()}
             disabled={importMutation.isPending || !recipe}
-            bottomOffset={bottomPadding}
           />
         ) : (
           <RecipeStickyCta
             label={ctaLabel}
             onPress={handlePrepare}
             disabled={ctaDisabled}
-            bottomOffset={bottomPadding}
           />
         )
       ) : null}

--- a/packages/mobile-app/src/features/recipes/presentation/RecipesScreen.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipesScreen.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import { FlatList, RefreshControl, StyleSheet } from "react-native";
+import { RefreshControl, StyleSheet } from "react-native";
 
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
 import { spacing } from "@/core/theme";
 import {
   listPublicRecipes,
   listRecipes,
 } from "@/features/recipes/application/recipes.use-cases";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 
@@ -40,7 +40,6 @@ import type { Recipe } from "@/features/recipes/domain/recipe.types";
  * `ListFooterComponent`.
  */
 export function RecipesScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
 
   const myRecipesQuery = useQuery<Recipe[]>({
@@ -101,14 +100,11 @@ export function RecipesScreen() {
         subtitle="Mon carnet et les recettes de la communauté"
       />
 
-      <FlatList
+      <ScreenFlatList
         testID="recipes-hub-list"
         data={myRecipes}
         keyExtractor={(item) => item.id}
-        contentContainerStyle={[
-          styles.listContent,
-          { paddingBottom: bottomPadding },
-        ]}
+        contentContainerStyle={styles.listContent}
         refreshControl={
           <RefreshControl refreshing={isFetching} onRefresh={handleRefetch} />
         }

--- a/packages/mobile-app/src/features/recipes/presentation/components/RecipeStickyCta.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/RecipeStickyCta.tsx
@@ -7,7 +7,13 @@ import Animated, {
   withSpring,
 } from "react-native-reanimated";
 
-import { colors, shadows, spacing, typography } from "@/core/theme";
+import {
+  colors,
+  NAV_BAR_HEIGHT,
+  shadows,
+  spacing,
+  typography,
+} from "@/core/theme";
 import { useFooterVisibility } from "@/core/ui/footer-visibility-context";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { useMarkStickyCtaPresent } from "@/core/ui/sticky-cta-clearance";
@@ -44,10 +50,12 @@ export function RecipeStickyCta({
   const translateY = useSharedValue(0);
 
   React.useEffect(() => {
-    // Slide down into the space the bar frees. Without this the reserved
+    // Slide down into the space the bar frees — without this the reserved
     // footprint stays as a dead white block under the button once the bar is
-    // hidden (seen on device).
-    const target = visible ? 0 : footprint;
+    // hidden (seen on device). Reclaim only the bar's VISUAL height: the
+    // safe-area inset does not go away with the bar, so translating by the full
+    // footprint would push the button into the home-indicator area.
+    const target = visible ? 0 : NAV_BAR_HEIGHT;
     translateY.value = prefersReducedMotion
       ? target
       : withSpring(target, { mass: 1, damping: 18, stiffness: 140 });

--- a/packages/mobile-app/src/features/recipes/presentation/components/RecipeStickyCta.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/components/RecipeStickyCta.tsx
@@ -1,16 +1,23 @@
 import React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { StyleSheet, Text } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useReducedMotion,
+  useSharedValue,
+  withSpring,
+} from "react-native-reanimated";
 
 import { colors, shadows, spacing, typography } from "@/core/theme";
+import { useFooterVisibility } from "@/core/ui/footer-visibility-context";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { useMarkStickyCtaPresent } from "@/core/ui/sticky-cta-clearance";
+import { useNavigationBarFootprint } from "@/core/ui/use-navigation-bar-footprint";
 
 type RecipeStickyCtaProps = {
   label: string;
   onPress: () => void;
   disabled?: boolean;
   helperText?: string | null;
-  bottomOffset?: number;
 };
 
 /**
@@ -25,14 +32,41 @@ export function RecipeStickyCta({
   onPress,
   disabled = false,
   helperText = null,
-  bottomOffset = 0,
 }: RecipeStickyCtaProps) {
   // Declare this bar mounted so app-level floating UI (Snackbar) clears it.
   useMarkStickyCtaPresent();
+  // Owns its nav clearance rather than taking it as a prop: the caller cannot
+  // get it wrong, and the CTA follows the bar like every other follower
+  // (ADR-0029 clause 5).
+  const footprint = useNavigationBarFootprint();
+  const { visible } = useFooterVisibility();
+  const prefersReducedMotion = useReducedMotion();
+  const translateY = useSharedValue(0);
+
+  React.useEffect(() => {
+    // Slide down into the space the bar frees. Without this the reserved
+    // footprint stays as a dead white block under the button once the bar is
+    // hidden (seen on device).
+    const target = visible ? 0 : footprint;
+    translateY.value = prefersReducedMotion
+      ? target
+      : withSpring(target, { mass: 1, damping: 18, stiffness: 140 });
+  }, [visible, footprint, prefersReducedMotion, translateY]);
+
+  const animatedStyle = useAnimatedStyle(() => {
+    return { transform: [{ translateY: translateY.value }] };
+  });
+
   return (
-    <View
+    <Animated.View
       testID="recipe-sticky-cta"
-      style={[styles.container, { paddingBottom: spacing.sm + bottomOffset }]}
+      style={[
+        styles.container,
+        // Constant across revealed/hidden — the clause-6 invariant: the button
+        // always clears the bar at rest, whatever the animation is doing.
+        { paddingBottom: spacing.sm + footprint },
+        animatedStyle,
+      ]}
     >
       {helperText ? <Text style={styles.helper}>{helperText}</Text> : null}
       <PrimaryButton
@@ -41,12 +75,21 @@ export function RecipeStickyCta({
         disabled={disabled}
         accessibilityLabel={label}
       />
-    </View>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
+  // Absolute, like the Snackbar it sits under. In the layout flow, translating
+  // the bar to follow the nav bar dragged its whole box down and opened a gap
+  // above it (seen on device); pinned to the bottom edge instead, content
+  // scrolls underneath and only the bar moves. Screens reserve its height via
+  // `ScreenScrollView`'s `extraBottomClearance`.
   container: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    bottom: 0,
     paddingHorizontal: spacing.md,
     paddingTop: spacing.sm,
     backgroundColor: colors.neutral.white,

--- a/packages/mobile-app/src/features/shop/presentation/ShopScreen.tsx
+++ b/packages/mobile-app/src/features/shop/presentation/ShopScreen.tsx
@@ -1,10 +1,10 @@
 import { colors, radius, spacing, typography } from "@/core/theme";
-import { ScrollView, StyleSheet, Text, View } from "react-native";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { StyleSheet, Text, View } from "react-native";
 
 import { Card } from "@/core/ui/Card";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import {
   SHOP_CATEGORIES,
   shopCategoryDescriptions,
@@ -12,8 +12,6 @@ import {
 import { Ionicons } from "@expo/vector-icons";
 
 export function ShopScreen() {
-  const bottomPadding = useNavigationFooterOffset();
-
   return (
     <Screen>
       <View style={styles.header}>
@@ -23,12 +21,7 @@ export function ShopScreen() {
         />
       </View>
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         <Card style={styles.infoCard}>
           <View style={styles.infoRow}>
             <Ionicons
@@ -64,7 +57,7 @@ export function ShopScreen() {
             </View>
           ))}
         </View>
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/AcademyHubScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyHubScreen.tsx
@@ -7,12 +7,12 @@ import {
   TextInput,
   View,
 } from "react-native";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 
 import { Badge } from "@/core/ui/Badge";
 import { Card } from "@/core/ui/Card";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { listPublishedAcademyArticlesUseCase } from "@/features/academy/application";
 import { generatedAcademyRepository } from "@/features/academy/data";
 import {
@@ -41,7 +41,6 @@ const ACADEMY_ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {
 };
 
 export function AcademyHubScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
   const [searchQuery, setSearchQuery] = React.useState("");
   const [selectedFocus, setSelectedFocus] = React.useState<string | null>(null);
@@ -72,11 +71,8 @@ export function AcademyHubScreen() {
         subtitle="Base pédagogique, scientifique et historique du brassage"
       />
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
+      <ScreenScrollView
+        contentContainerStyle={styles.content}
         keyboardShouldPersistTaps="handled"
       >
         <Card style={styles.summaryCard} variant="subtle">
@@ -252,7 +248,7 @@ export function AcademyHubScreen() {
             </Pressable>
           );
         })}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
@@ -1,4 +1,3 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { colors, radius, spacing, typography } from "@/core/theme";
 import {
   Image,
@@ -35,6 +34,7 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import {
   academyTopics,
   getAcademyTopicBySlug,
@@ -52,8 +52,6 @@ type Props = {
 export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
   const router = useRouter();
   const [glossaryQuery, setGlossaryQuery] = React.useState("");
-  const bottomPadding = useNavigationFooterOffset();
-  const screenBottomPadding = bottomPadding + spacing.xl;
   const scrollViewRef = React.useRef<ScrollView>(null);
   const articleTopOffsetRef = React.useRef(0);
   const sectionOffsetsRef = React.useRef<Record<string, number>>({});
@@ -193,13 +191,10 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
           }
         />
 
-        <ScrollView
+        <ScreenScrollView
           key={`${normalizedSlug ?? "unknown"}:${normalizedTermSlug ?? ""}`}
           ref={scrollViewRef}
-          contentContainerStyle={[
-            styles.content,
-            { paddingBottom: screenBottomPadding },
-          ]}
+          contentContainerStyle={styles.content}
         >
           {calculatorSlug ? (
             <Card style={styles.sectionCard}>
@@ -270,7 +265,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
               })
             }
           />
-        </ScrollView>
+        </ScreenScrollView>
       </Screen>
     );
   }
@@ -293,12 +288,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
         }
       />
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: screenBottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         <Card style={styles.heroCard}>
           <View style={styles.heroTopRow}>
             <Image
@@ -350,7 +340,7 @@ export function AcademyTopicDetailsScreen({ slugParam, termSlugParam }: Props) {
             style={styles.secondaryButtonSpacing}
           />
         ) : null}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicPlaceholderScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicPlaceholderScreen.tsx
@@ -1,6 +1,5 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import { colors, spacing, typography } from "@/core/theme";
-import { Image, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Image, StyleSheet, Text, View } from "react-native";
 
 import { normalizeRouteParam } from "@/core/navigation/route-params";
 import { Badge } from "@/core/ui/Badge";
@@ -10,6 +9,7 @@ import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { getDisplayableAcademyTopicBySlug } from "@/features/tools/data";
 import { useRouter } from "expo-router";
 import React from "react";
@@ -22,7 +22,6 @@ type Props = {
 
 export function AcademyTopicPlaceholderScreen({ slugParam, mode }: Props) {
   const router = useRouter();
-  const bottomPadding = useNavigationFooterOffset();
   const normalizedSlug = normalizeRouteParam(slugParam);
   const topic = getDisplayableAcademyTopicBySlug(normalizedSlug);
   const goBackOrAcademyHome = React.useCallback(() => {
@@ -82,12 +81,7 @@ export function AcademyTopicPlaceholderScreen({ slugParam, mode }: Props) {
         }
       />
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         <Card style={styles.heroCard}>
           <View style={styles.heroRow}>
             <Image
@@ -126,7 +120,7 @@ export function AcademyTopicPlaceholderScreen({ slugParam, mode }: Props) {
           }
           style={styles.backButton}
         />
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/AvancesCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AvancesCalculatorScreen.tsx
@@ -1,14 +1,6 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import * as Haptics from "expo-haptics";
 import React, { useCallback, useMemo, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 import {
   calculateAltitudeAdjustedIbuTarget,
@@ -27,6 +19,7 @@ import { Card } from "@/core/ui/Card";
 import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 type TabName = "enzymes" | "mout" | "altitude";
 
@@ -50,7 +43,6 @@ function getConversionReadinessLabel(averagePowerWkPerKg: number) {
 }
 
 export function AvancesCalculatorScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const [activeTab, setActiveTab] = useState<TabName>("enzymes");
   const [malts, setMalts] = useState<MaltLine[]>([
     { id: "1", name: "Pilsner", weightKg: 4, diastaticPowerWk: 250 },
@@ -175,12 +167,7 @@ export function AvancesCalculatorScreen() {
         </Pressable>
       </View>
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {activeTab === "enzymes" && (
           <>
             <Card style={styles.card}>
@@ -405,7 +392,7 @@ export function AvancesCalculatorScreen() {
             </Card>
           </>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/CarbonatationCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/CarbonatationCalculatorScreen.tsx
@@ -1,4 +1,3 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import * as Haptics from "expo-haptics";
 
 import {
@@ -8,19 +7,13 @@ import {
 } from "@/core/brewing-calculations";
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import React, { useCallback, useMemo, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 import { Card } from "@/core/ui/Card";
 import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 type TabName = "priming" | "pression" | "styles";
 type SugarType = "dextrose" | "sucrose";
@@ -39,7 +32,6 @@ const styleRanges: StyleCo2Range[] = [
 ];
 
 export function CarbonatationCalculatorScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const [activeTab, setActiveTab] = useState<TabName>("priming");
   const [sugarType, setSugarType] = useState<SugarType>("dextrose");
 
@@ -134,12 +126,7 @@ export function CarbonatationCalculatorScreen() {
         </Pressable>
       </View>
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {activeTab === "priming" && (
           <>
             <Card style={styles.card}>
@@ -324,7 +311,7 @@ export function CarbonatationCalculatorScreen() {
             </Card>
           </>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/CouleurCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/CouleurCalculatorScreen.tsx
@@ -1,4 +1,3 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import {
   calculateMCU,
   calculateRequiredMaltForTargetSRM,
@@ -13,19 +12,13 @@ import {
   getSrmStyleLabel,
 } from "@/features/tools/data/catalogs/srm";
 import React, { useCallback, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 import { Card } from "@/core/ui/Card";
 import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import Slider from "@react-native-community/slider";
 import * as Haptics from "expo-haptics";
 
@@ -50,7 +43,6 @@ function getSrmTextColor(srm: number): string {
 }
 
 export function CouleurCalculatorScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const [activeTab, setActiveTab] = useState<TabName>("rapide");
 
   // Rapide tab state
@@ -198,12 +190,7 @@ export function CouleurCalculatorScreen() {
         </Pressable>
       </View>
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {activeTab === "rapide" && (
           <>
             {/* Volume */}
@@ -462,7 +449,7 @@ export function CouleurCalculatorScreen() {
             </View>
           </Card>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/EauCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/EauCalculatorScreen.tsx
@@ -1,4 +1,3 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import * as Haptics from "expo-haptics";
 
 import {
@@ -11,19 +10,13 @@ import {
   WATER_STYLE_PRESETS,
 } from "@/features/tools/data/water-profiles.data";
 import { useCallback, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 import { Card } from "@/core/ui/Card";
 import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import type { IonRange } from "@/features/tools/domain/water-profiles";
 
 type TabName = "profil" | "style" | "sels";
@@ -283,7 +276,6 @@ function calculateSaltCorrections(
 }
 
 export function EauCalculatorScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const [activeTab, setActiveTab] = useState<TabName>("profil");
 
   // Ion values (in ppm)
@@ -440,12 +432,7 @@ export function EauCalculatorScreen() {
         </Pressable>
       </View>
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {/* ── TAB PROFIL ── */}
         {activeTab === "profil" && (
           <>
@@ -805,7 +792,7 @@ export function EauCalculatorScreen() {
             ))}
           </>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/FermentesciblesCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/FermentesciblesCalculatorScreen.tsx
@@ -1,4 +1,3 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import {
   calculateOgFromFermentables,
   calculateRequiredMaltKgForTargetOg,
@@ -17,7 +16,6 @@ import React, { useCallback, useState } from "react";
 import {
   Alert,
   Pressable,
-  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -29,6 +27,7 @@ import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import Slider from "@react-native-community/slider";
 import * as Haptics from "expo-haptics";
 
@@ -41,7 +40,6 @@ type RecipeMalt = {
 };
 
 export function FermentesciblesCalculatorScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const [activeTab, setActiveTab] = useState<TabName>("rapide");
   const [recipeMalts, setRecipeMalts] = useState<RecipeMalt[]>([
     { id: "1", malt: fermentableMaltCatalog[0], weightKg: 4 },
@@ -170,12 +168,7 @@ export function FermentesciblesCalculatorScreen() {
         </Pressable>
       </View>
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {activeTab === "rapide" && (
           <>
             {/* Paramètres de base */}
@@ -427,7 +420,7 @@ export function FermentesciblesCalculatorScreen() {
             </Card>
           </>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/HoublonsCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/HoublonsCalculatorScreen.tsx
@@ -1,4 +1,3 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import {
   calculateIbuTinseth,
   calculateRequiredHopGramsForTargetIbu,
@@ -7,19 +6,13 @@ import {
 } from "@/core/brewing-calculations";
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import React, { useCallback, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 import { Card } from "@/core/ui/Card";
 import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import {
   getHopDefaultAa,
   hopCatalog,
@@ -84,7 +77,6 @@ function getBuGuRating(ratio: number): BuGuRating {
 }
 
 export function HoublonsCalculatorScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const [activeTab, setActiveTab] = useState<TabName>("rapide");
 
   // Rapide tab state
@@ -255,12 +247,7 @@ export function HoublonsCalculatorScreen() {
         </Pressable>
       </View>
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {/* ─── Onglet Rapide ────────────────────────────────────────── */}
         {activeTab === "rapide" && (
           <>
@@ -611,7 +598,7 @@ export function HoublonsCalculatorScreen() {
             </Card>
           </>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/LevuresCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/LevuresCalculatorScreen.tsx
@@ -1,4 +1,3 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import * as Haptics from "expo-haptics";
 
 import {
@@ -12,25 +11,18 @@ import {
 } from "@/core/brewing-calculations";
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import React, { useCallback, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 import { Card } from "@/core/ui/Card";
 import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 
 type TabName = "pitch" | "attenuation" | "packs";
 type FermentationType = "ale" | "lager";
 
 export function LevuresCalculatorScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const [activeTab, setActiveTab] = useState<TabName>("pitch");
   const [fermentationType, setFermentationType] =
     useState<FermentationType>("ale");
@@ -125,12 +117,7 @@ export function LevuresCalculatorScreen() {
         </Pressable>
       </View>
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {activeTab === "pitch" && (
           <>
             <Card style={styles.card}>
@@ -323,7 +310,7 @@ export function LevuresCalculatorScreen() {
             </Card>
           </>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/RendementCalculatorScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/RendementCalculatorScreen.tsx
@@ -1,4 +1,3 @@
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
 import {
   calculateBrewhouseEfficiencyPercent,
   calculateTargetPreBoilVolumeLiters,
@@ -11,16 +10,10 @@ import { Card } from "@/core/ui/Card";
 import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import * as Haptics from "expo-haptics";
 import React, { useCallback, useMemo, useState } from "react";
-import {
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-} from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 type TabName = "rendement" | "volumes" | "eau";
 
@@ -32,7 +25,6 @@ type GrainLine = {
 };
 
 export function RendementCalculatorScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const [activeTab, setActiveTab] = useState<TabName>("rendement");
 
   const [actualOg, setActualOg] = useState(1.06);
@@ -159,12 +151,7 @@ export function RendementCalculatorScreen() {
         </Pressable>
       </View>
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {activeTab === "rendement" && (
           <>
             <Card style={styles.card}>
@@ -402,7 +389,7 @@ export function RendementCalculatorScreen() {
             </Card>
           </>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }

--- a/packages/mobile-app/src/features/tools/presentation/ToolsHubScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/ToolsHubScreen.tsx
@@ -1,10 +1,10 @@
 import { colors, radius, spacing, typography } from "@/core/theme";
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
-import { useNavigationFooterOffset } from "@/core/ui/NavigationFooter";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import { Card } from "@/core/ui/Card";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { getAcademyArticleBySlug } from "@/features/academy/application";
 import { generatedAcademyRepository } from "@/features/academy/data";
 import { academyTopics } from "@/features/tools/data";
@@ -24,7 +24,6 @@ const CALCULATOR_ICONS: Record<string, keyof typeof Ionicons.glyphMap> = {
 };
 
 export function ToolsHubScreen() {
-  const bottomPadding = useNavigationFooterOffset();
   const router = useRouter();
 
   const calculatorTopics = academyTopics
@@ -57,12 +56,7 @@ export function ToolsHubScreen() {
         subtitle="Tes outils de calcul brassicoles"
       />
 
-      <ScrollView
-        contentContainerStyle={[
-          styles.content,
-          { paddingBottom: bottomPadding },
-        ]}
-      >
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {calculatorCards.map((card) => (
           <Pressable
             key={card.slug}
@@ -101,7 +95,7 @@ export function ToolsHubScreen() {
             </Card>
           </Pressable>
         ))}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }


### PR DESCRIPTION
## Summary

Build PR for **ADR-0029** (conception merged in #1443). The bottom nav was a
floating pill outside the layout flow: it overlaid content, and non-occlusion
relied on a manual opt-in repeated in **36 screens**, each rebuilding the offset
by hand — any screen that forgot it, or wired it to the wrong container, was
silently covered.

- **Flush edge-to-edge bar** anchored on the bottom edge, absorbing the
  safe-area inset itself. Hides on sustained scroll-down, reveals on scroll-up,
  instantly under reduced-motion.
- **One source of truth**: `NAV_BAR_HEIGHT` (`theme/layout`) +
  `useNavigationBarFootprint()` = `NAV_BAR_HEIGHT + insets.bottom`. The bar's own
  height, its hide-translate distance and the reserved clearance all derive from
  that one number, so they cannot drift apart (kills audit findings M2/M3).
- **`ScreenScrollView` / `ScreenFlatList`** own the bottom clearance and wire the
  shared `useScrollDirection` in a single swap. The 36 per-screen paddings and
  `useNavigationFooterOffset` are **deleted**. The clearance merges **last**, so a
  screen can no longer cancel it — the old failure mode is now impossible by
  construction, and tested.
- **One `FooterVisibilityContext`** drives the bar, the Snackbar and the sticky
  CTA. Mounted at the **root** layout, not the tab layout: the Snackbar lives
  above `(app)/_layout` and would otherwise never follow the bar.
- **Clause 6 invariant**: clearance is constant across revealed/hidden. Hiding
  only translates the bar, never reflows content — a control can never be covered
  at rest, whatever the animation is doing.

## Two conception corrections this PR makes (both caught on device)

**1. ADR-0029 clause 4 amended — it was not implementable as written.** It said
`Screen` reserves the footprint. But `Screen` wraps a screen, so it can only pad
its own container, which stops content from scrolling *under* the bar and turns
D2's residual gap into a permanent one — i.e. option **A**, which the ADR itself
rejected. The clearance has to sit on the scrolled content (as `02-state` already
specified), so the shared scroll containers own it. The amendment is recorded
in-place with its reasoning; the diagrams and their prose follow. Status
**Proposed → Accepted**, added to the root `CLAUDE.md`.

**2. The sticky CTA had to become absolute.** In the layout flow it could not
honour clause 5: static, it left a dead white block under the button once the bar
hid; translated, it dragged its whole box down and opened a gap above it — both
observed on the emulator. Pinned to the bottom edge like the Snackbar it
translates cleanly and content scrolls underneath. Its three screens reserve its
height via a new `extraBottomClearance` prop, passed **explicitly** rather than
read from the app-level sticky-CTA context — that context would inflate the
padding of any other tab screen that stays mounted.

## Deliberate behavioural losses

Both are exactly the hand-tuned per-screen clearance this ADR centralizes, and
neither can be re-added per screen now (the containers merge the clearance last).
If either is wanted back, it belongs in the shared containers:

- `AcademyTopicDetailsScreen` drops a `+ spacing.xl` of extra bottom room.
- The CTA screens drop the hardcoded `+ 96` — the ADR audit's own finding **M3**.

## Verified live on an Android emulator (demo mode)

Bar flush at the bottom · hides mid-list with content taking the full height ·
reveals on scroll-up **and** at list end · **the last row now clears the bar
instead of being clipped by the pill** (the original "it hides buttons"
complaint) · the sticky CTA sits flush once the bar is away.

## Checklist

- [x] `npm run ci:check` green (lint + typecheck + format)
- [x] `npm test` — **1418/1419**; the single red is the pre-existing flaky
  `BeerInfoCardScreen` retry-timing test (green in CI, scan untouched here)
- [x] Tests pin the ADR's Verification section: state machine (threshold both
  directions, near-top guard, forced reveals), the clause-6 invariant on both
  containers, Snackbar anchored on the shared footprint. The existing
  `NavigationFooter.test.tsx` contract (6 items, longest-prefix) survives
  **unchanged**.
- [x] Zero `useNavigationFooterOffset` references remain; no magic `48`/`96`
  around the bar or the CTA.
- [x] Local pre-push review (Claude `pr-pre-reviewer` + Codex) run and
  reconciled — both Must Haves fixed (sticky CTA following, `ScreenFlatList`
  coverage), doc inconsistencies corrected.

## Known follow-ups (not in scope)

- `LabelSelectBatchScreen` keeps a raw `FlatList`: its CTA sits outside the list,
  so it clears the bar directly and the screen does not drive scroll-away (bar
  stays pinned — the ADR's documented fallback B, locally).
- `RecipeStickyCta` is generic despite its name; promoting it to `core/ui` is a
  sensible follow-up.
- M4 (dual nav mount) stays deliberately out of scope per ADR-0029 clause 9.
