### PR TITLE
docs(conception): retire the shop's duplicate catalog use case

### DIFF
--- a/docs/architecture/diagrams/equipment-shop/01-use-case.md
+++ b/docs/architecture/diagrams/equipment-shop/01-use-case.md
@@ -64,7 +64,9 @@ flowchart LR
   needs a partner + prices, which the project does not have yet.
 - **Retired UC3/UC4** (browse the shop / view a product): merged into the
   ingredients catalog's UC1–UC3. The shop's fake product catalog was deleted in
-  #1444; the Shop hub now routes into the real catalog instead of mirroring it.
+  #1444; Lot 1 will route the Shop hub into the real catalog instead of
+  mirroring it. Today the hub is still a static placeholder — the retirement is
+  a conception decision, not a shipped behaviour.
 - **UC6 cross-domain**: the shopping list is fed from a recipe's ingredients
   (recipes domain) and from a scan's "what to buy" (#777) — it is the connective
   tissue between recipe → purchase. **Suggestion**: a single shopping list,

--- a/docs/architecture/diagrams/equipment-shop/01-use-case.md
+++ b/docs/architecture/diagrams/equipment-shop/01-use-case.md
@@ -1,16 +1,26 @@
-# Use-case diagram — equipment & shop — gear, catalog & shopping list
+# Use-case diagram — equipment & shop — gear, shopping list & buying
 
-> **Feature**: equipment "L'Office" CRUD #621; shop catalog (E10, read);
-> local cart/shopping list #653; affiliate links #650.
+> **Feature**: equipment "L'Office" CRUD #621; local cart/shopping list #653;
+> affiliate links #650. Catalog browsing is **not** modelled here — see
+> [`../ingredients/01-use-case.md`](../ingredients/01-use-case.md) UC1–UC3.
 > **Refonte**: equipment + shop are reached from the Profile hub (ux-refonte).
 > **Personas**: all (need gear + ingredients); Léa (what to buy for batch 1).
 
 ## Context
 
-Who manages brewing gear and shops for ingredients/equipment, and how the
-shopping list ties the app together (a recipe's ingredients → things to buy).
-Grouped by domain. The cart is **local** (a shopping list), not a checkout —
-purchase happens at a partner (#650).
+Who manages brewing gear and buys ingredients, and how the shopping list ties
+the app together (a recipe's ingredients → things to buy). Grouped by domain.
+The cart is **local** (a shopping list), not a checkout — purchase happens at a
+partner (#650).
+
+**The Shop does not own a browse use case.** It used to declare "Browse the shop
+by category" + "View a product", which duplicated the ingredients catalog's
+UC1/UC3: the brewer's goal is *consult the ingredient catalog*, and whether the
+door is labelled "Ingrédients" or "Boutique" is information architecture, not an
+actor goal (UML 2.5 — a use case is a goal, not a screen). Those duplicated UCs
+were the reason the app shipped two catalogs, one of them fake. The Shop is now
+the **entry point** to the ingredients catalog; the goal itself stays in the
+ingredients domain. See [`03-component.md`](03-component.md) for the wiring.
 
 ## Diagram
 
@@ -24,8 +34,6 @@ flowchart LR
       UC2(("Search my equipment"))
     end
     subgraph Shop ["Shop"]
-      UC3(("Browse the shop by category"))
-      UC4(("View a product"))
       UC5(("Open a partner link to buy"))
     end
     subgraph List ["Shopping list"]
@@ -37,19 +45,26 @@ flowchart LR
 
   Brewer --> UC1
   Brewer --> UC2
-  Brewer --> UC3
-  Brewer --> UC4
   Brewer --> UC5
   Brewer --> UC6
   Brewer --> UC7
   Brewer --> UC8
 ```
 
+> UC numbering is kept stable (UC3/UC4 retired, not renumbered) so existing
+> references in issues and PRs keep resolving.
+
 ## Notes / suggestions
 
-- **Status**: shop browse/product (UC3/UC4) shipped (read); equipment is read
-  today, CRUD is #621; the **local cart concept exists in recipe detail but is
-  never visible** (#653) — UC6–UC8 surface it.
+- **Status**: nothing in this diagram is built. Equipment is read today, CRUD is
+  #621. The **local cart concept was deleted** in #1444 — it had zero non-test
+  callers and its "add to cart" buttons in recipe detail were no-ops; UC6–UC8
+  remain the target and must be built from scratch (`LocalCartItem` in
+  [`04-class.md`](04-class.md) is a *design*, no longer live code). UC5 (#650)
+  needs a partner + prices, which the project does not have yet.
+- **Retired UC3/UC4** (browse the shop / view a product): merged into the
+  ingredients catalog's UC1–UC3. The shop's fake product catalog was deleted in
+  #1444; the Shop hub now routes into the real catalog instead of mirroring it.
 - **UC6 cross-domain**: the shopping list is fed from a recipe's ingredients
   (recipes domain) and from a scan's "what to buy" (#777) — it is the connective
   tissue between recipe → purchase. **Suggestion**: a single shopping list,

--- a/docs/architecture/diagrams/equipment-shop/02-sequence-shopping-list.md
+++ b/docs/architecture/diagrams/equipment-shop/02-sequence-shopping-list.md
@@ -35,11 +35,17 @@ sequenceDiagram
 
 ## Notes / suggestions
 
+- **Status — this whole diagram is a design, not a description.** The
+  `cart.use-cases` participant was deleted in #1444: it had zero non-test callers
+  and the recipe-detail "Ajouter au panier" buttons it backed were no-ops that
+  discarded their result. #653 builds this from scratch; `Store` never existed.
 - **Local & persisted**: the list lives client-side (AsyncStorage), survives app
   restarts. No server order. **Suggestion** — one list per user, appended to from
   any recipe or scan (#777), not a per-recipe ephemeral cart.
-- **Grouping**: items group by `ShopCategory` (malts / houblons / levures / materiel / accessoires / kits)
-  so the brewer shops efficiently.
+- **Grouping**: items group by `IngredientCategory` (malt / hop / yeast today,
+  growing as rayons are wired — see [`03-component.md`](03-component.md)) so the
+  brewer shops efficiently. The retired `ShopCategory` enum is not the grouping
+  key: one taxonomy for the whole app ([`04-class.md`](04-class.md)).
 - **Share** is text today (parity with labels share) — a richer export (checklist
   PDF) is a later enhancement.
 - **Demo mode**: the list reads/writes the in-memory demo store.

--- a/docs/architecture/diagrams/equipment-shop/03-component.md
+++ b/docs/architecture/diagrams/equipment-shop/03-component.md
@@ -66,21 +66,29 @@ flowchart TD
 
 ## Notes / suggestions
 
-- **Retired, not deleted twice**: `/(app)/ingredients/index` redirects to
-  `/(app)/shop` rather than 404-ing, so any existing deep link or muscle memory
+> **Nothing below is built yet.** This diagram is the Lot 1 target; today
+> `/(app)/ingredients/index.tsx` still renders `IngredientsScreen` and the
+> dashboard still lists both doors. The dashed edges mark what Lot 1 changes.
+
+- **Retire, don't delete twice**: `/(app)/ingredients/index` **should redirect**
+  to `/(app)/shop` rather than 404, so any existing deep link or muscle memory
   still lands somewhere sensible. The dashboard's "Ingrédients" entry
-  (`DashboardScreen`, `businessRoute("ingredients", …)`) is removed — that is the
-  "one door" change.
-- **The Shop hub owns no data layer.** It calls
+  (`DashboardScreen`, `businessRoute("ingredients", …)`) **should be removed** —
+  that is the "one door" change.
+- **The Shop hub must own no data layer.** It should call
   `listIngredientCategoriesSummary()` for the live rayons' counts, exactly as the
-  retired `IngredientsScreen` did. No `features/shop/data/`, no second API
-  client, no duplicated types — the whole point of this diagram.
+  `IngredientsScreen` it replaces does today. No `features/shop/data/`, no second
+  API client, no duplicated types — the whole point of this diagram.
 - **Two-speed hub, and the split is about mobile wiring — not missing data.**
   Lot 1 makes three rayons live (Malts / Houblons / Levures) because those are
   the only catalogs the mobile app already consumes. Matériel and Accessoires
   stay inert **for now**, and Kits stays inert **for good** (no source at all).
   A placeholder tile must stay non-pressable — the shop promises nothing it
-  cannot deliver (#1444); `ShopScreen.test.tsx` guards this.
+  cannot deliver (#1444). Today that holds only structurally (the tiles are
+  plain `View`s); the assertion that pins it — "exposes no pressable affordance"
+  in `ShopScreen.test.tsx` — is open in #1453. Lot 1 must **amend** that guard
+  rather than delete it: live rayons become pressable by design, placeholders
+  must not, so the guard narrows to the placeholders instead of vanishing.
 
 - **The backend already serves ten catalogs**, which is more than this feature
   ever used:

--- a/docs/architecture/diagrams/equipment-shop/03-component.md
+++ b/docs/architecture/diagrams/equipment-shop/03-component.md
@@ -1,0 +1,118 @@
+# Component diagram — shop → ingredients catalog wiring
+
+> **Feature**: the Shop hub as the single entry point to the ingredient catalog.
+> Supersedes the shop's own (deleted) product catalog — see
+> [`01-use-case.md`](01-use-case.md) § retired UC3/UC4.
+
+## Context
+
+Where the catalog actually lives once the Shop stops mirroring it. The decision
+is **reuse, not relocation**: the Shop hub reads the existing ingredients
+use-cases, and the category/datasheet screens stay exactly where they are.
+
+That constraint is not cosmetic — `RecipeDetailsScreen` deep-links straight into
+`/(app)/ingredients/[category]/[id]` and `/(app)/ingredients/malts/[id]` when a
+brewer taps an ingredient in a recipe. Moving those routes under `/shop` would
+break the recipe → ingredient path and its tests, and buy nothing: the goal is
+one *door*, not one *directory*.
+
+So the Shop hub replaces the `/ingredients` **hub** only. Everything below the
+hub is shared.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  subgraph Entry ["Entry points"]
+    Dash["Dashboard — 'Voir plus' sheet"]
+    Recipe["RecipeDetailsScreen<br/>(tap an ingredient)"]
+  end
+
+  subgraph Presentation ["Mobile — presentation"]
+    ShopHub["ShopScreen<br/>/(app)/shop"]
+    IngHub["IngredientsScreen<br/>/(app)/ingredients — RETIRED"]
+    CatScreen["IngredientCategoryScreen<br/>/(app)/ingredients/[category]"]
+    Detail["Malt/Hop/Yeast DetailsScreen<br/>/(app)/ingredients/[category]/[id]"]
+  end
+
+  subgraph Application ["Mobile — application (unchanged)"]
+    UC1["listIngredientCategoriesSummary()"]
+    UC2["listIngredientsByCategory()"]
+    UC3["getIngredientDetails()"]
+  end
+
+  subgraph Data ["Mobile — data (unchanged)"]
+    API["malts.api / hops.api / yeasts.api"]
+  end
+
+  Backend[("Catalog backend")]
+
+  Dash -->|"'Boutique'"| ShopHub
+  Dash -.->|"'Ingrédients' entry removed"| IngHub
+  IngHub -.->|"redirect"| ShopHub
+  Recipe -->|"deep-link, unchanged"| Detail
+
+  ShopHub -->|"live rayon"| CatScreen
+  ShopHub -->|"reads counts"| UC1
+  CatScreen --> UC2
+  Detail --> UC3
+  UC1 --> API
+  UC2 --> API
+  UC3 --> API
+  API --> Backend
+
+  style IngHub stroke-dasharray: 5 5
+```
+
+## Notes / suggestions
+
+- **Retired, not deleted twice**: `/(app)/ingredients/index` redirects to
+  `/(app)/shop` rather than 404-ing, so any existing deep link or muscle memory
+  still lands somewhere sensible. The dashboard's "Ingrédients" entry
+  (`DashboardScreen`, `businessRoute("ingredients", …)`) is removed — that is the
+  "one door" change.
+- **The Shop hub owns no data layer.** It calls
+  `listIngredientCategoriesSummary()` for the live rayons' counts, exactly as the
+  retired `IngredientsScreen` did. No `features/shop/data/`, no second API
+  client, no duplicated types — the whole point of this diagram.
+- **Two-speed hub, and the split is about mobile wiring — not missing data.**
+  Lot 1 makes three rayons live (Malts / Houblons / Levures) because those are
+  the only catalogs the mobile app already consumes. Matériel and Accessoires
+  stay inert **for now**, and Kits stays inert **for good** (no source at all).
+  A placeholder tile must stay non-pressable — the shop promises nothing it
+  cannot deliver (#1444); `ShopScreen.test.tsx` guards this.
+
+- **The backend already serves ten catalogs**, which is more than this feature
+  ever used:
+
+  | Rayon | Endpoint | Mobile status |
+  |---|---|---|
+  | Malts | `/catalog/fermentables` | wired (`malts.api.ts`) |
+  | Houblons | `/catalog/hops` | wired (`hops.api.ts`) |
+  | Levures | `/catalog/yeasts` | wired (`yeasts.api.ts`) |
+  | Accessoires | `/catalog/misc-templates` | `misc.api.ts` **exists but is not wired** into the catalog use-cases |
+  | Matériel | `/catalog/equipment-templates` | nothing mobile-side |
+  | Kits | — | no source |
+
+  Also unused: `/catalog/styles`, `/catalog/waters`, `/catalog/mash-profiles`,
+  `/catalog/producers`, `/catalog/distributors`.
+
+- **Lot 2 — wire the two remaining rayons.** Accessoires is the cheaper of the
+  two (`misc.api.ts` already exists; it needs an application layer + a category
+  screen + `IngredientCategory` gaining a `misc` member). Matériel needs a full
+  data → application → screens slice. Each is its own increment.
+
+- **`/catalog/distributors` is worth a look before UC5 (#650)**: a distributor
+  catalog is closer to "a real shop" than an affiliate deep-link, and it already
+  has a controller. Nobody has scoped what it holds — do that before designing
+  the buy path.
+
+- **Equipment: two different concepts, same word.** `/equipment` (the brewer's
+  *own* gear, `/equipment-profiles`, 3Q wizard) is NOT the Matériel rayon
+  (`/catalog/equipment-templates`, purchasable models). Wiring the rayon must not
+  merge them: owning a Braumeister and browsing Braumeisters are different goals.
+
+- **Naming drift to fix**: `EquipmentScreen` is titled "L'Office 🍽️" while the
+  shop's equivalent rayon was renamed "Matériel" in #1449. Same word, two
+  concepts, two names, and the emoji is against the sobriety rule. Reconcile when
+  the Matériel rayon gets wired.

--- a/docs/architecture/diagrams/equipment-shop/03-component.md
+++ b/docs/architecture/diagrams/equipment-shop/03-component.md
@@ -16,8 +16,8 @@ brewer taps an ingredient in a recipe. Moving those routes under `/shop` would
 break the recipe → ingredient path and its tests, and buy nothing: the goal is
 one *door*, not one *directory*.
 
-So the Shop hub replaces the `/ingredients` **hub** only. Everything below the
-hub is shared.
+So the Shop hub is to replace the `/ingredients` **hub** only. Everything below
+the hub stays shared.
 
 ## Diagram
 

--- a/docs/architecture/diagrams/equipment-shop/04-class.md
+++ b/docs/architecture/diagrams/equipment-shop/04-class.md
@@ -30,11 +30,11 @@ classDiagram
   }
 
   class ShopRayon {
-    +string label
+    +String label
     +IconName icon
-    +string description
-    +IngredientCategory catalogCategory
-    +bool isLive()
+    +String description
+    +IngredientCategory~nullable~ catalogCategory
+    +isLive() bool
   }
 
   class ShoppingList {

--- a/docs/architecture/diagrams/equipment-shop/04-class.md
+++ b/docs/architecture/diagrams/equipment-shop/04-class.md
@@ -1,13 +1,20 @@
-# Class diagram — equipment & shop — gear, products, shopping list
+# Class diagram — equipment & shop — gear, rayons, shopping list
 
-> **Feature**: equipment CRUD #621; shop catalog E10; local cart #653.
-> **Source**: `features/shop/domain/shop.types.ts`, `cart.types.ts`.
+> **Feature**: equipment CRUD #621; shop hub rayons; local cart #653.
+> **Source**: `features/equipment/domain/equipment.types.ts` (live);
+> `features/shop/` (`ShopRayon` = target). `Product` / `PriceUnit` /
+> `LocalCartItem` were deleted in #1444 — see § Status.
 
 ## Context
 
-The model for owned equipment, the shop product catalog, and the local shopping
-list that links recipes/scans to purchases. Reflects the existing shop/cart types;
-`Equipment` CRUD fields are the #621 addition.
+The model for owned equipment, the Shop hub's rayons, and the local shopping
+list that links recipes/scans to purchases.
+
+**The shop owns no product model.** It used to declare `Product` + `PriceUnit`
+mirroring a catalog that the ingredients domain already owned — the class-level
+face of the duplicated UC3/UC4 ([`01-use-case.md`](01-use-case.md)). The catalog
+entity is `Ingredient` (see [`../ingredients/04-class.md`](../ingredients/04-class.md));
+the shop only models **how its hub presents rayons** and routes into that catalog.
 
 ## Diagram
 
@@ -21,13 +28,15 @@ classDiagram
     +float volumeL
     +string notes
   }
-  class Product {
-    +UUID id
-    +string name
-    +float price
-    +PriceUnit priceUnit
-    +ShopCategory category
+
+  class ShopRayon {
+    +string label
+    +IconName icon
+    +string description
+    +IngredientCategory catalogCategory
+    +bool isLive()
   }
+
   class ShoppingList {
     +UUID ownerId
     +LocalCartItem[] items
@@ -37,30 +46,20 @@ classDiagram
     +LocalCartItemSource source
     +string refId
     +string name
-    +ShopCategory category
+    +IngredientCategory category
     +int quantity
     +string unit
   }
 
+  ShopRayon "0..*" ..> "0..1" IngredientCategory : routes to
   ShoppingList "1" o-- "0..*" LocalCartItem
-  LocalCartItem "0..*" ..> "0..1" Product : may reference
   LocalCartItem "0..*" ..> "0..1" Equipment : may reference
 
-  class ShopCategory {
+  class IngredientCategory {
     <<enumeration>>
-    malts
-    houblons
-    levures
-    materiel
-    accessoires
-    kits
-  }
-  class PriceUnit {
-    <<enumeration>>
-    eurPerKg
-    eurPer100g
-    eurPerSachet
-    eurPerPiece
+    malt
+    hop
+    yeast
   }
   class LocalCartItemSource {
     <<enumeration>>
@@ -71,17 +70,32 @@ classDiagram
 
 ## Notes / suggestions
 
-- **Existing & real values**: `ShopCategory` = `malts / houblons / levures /
-  materiel / accessoires / kits` (French, `shop.types.ts`); `PriceUnit` literals
-  are `"€/kg" | "€/100g" | "€/sachet" | "€/pièce"` (shown as `eurPerKg`… in the
-  enum — Mermaid avoids `€` and `/`). `LocalCartItem` = `key/source/refId/name/
-  category/quantity/unit` (`cart.types.ts`). `Equipment` fields + `EquipmentType`
-  are the #621 CRUD addition (today equipment is read-only demo).
-- **`ShoppingList` is local** (the "cart" that was never surfaced, #653) — not a
-  server order. **Suggestion**: persist it per user (so it survives reinstall)
-  and let any recipe/scan append to the *same* list.
-- **Item → catalog link is optional**: a custom ingredient (Strategy B) added to
-  the list may not map to a `Product` — keep `refId` generic so off-catalog items
-  are listable (name + quantity).
+- **Status — what is live vs designed.** `Equipment` is live (read; CRUD is
+  #621). `ShopRayon` is the **target** for the hub rework. `ShoppingList` /
+  `LocalCartItem` are **design only**: the real `cart.types.ts` was deleted in
+  #1444 (zero non-test callers), so #653 builds them from scratch. `Product`,
+  `PriceUnit` and the `ShopCategory` enum are **gone** and are not coming back —
+  prices do not exist for this project today.
+- **`ShopRayon.catalogCategory` is nullable, and that nullability *is* the
+  two-speed hub**: a rayon with a category is live and pressable (routes to
+  `/(app)/ingredients/[category]`); a rayon without one is an inert "bientôt"
+  placeholder. `isLive()` is exactly `catalogCategory != null`. Modelling the
+  placeholder as an absent link (rather than a status flag) means an unsourced
+  rayon *cannot* be made pressable by accident.
+- **Lot 1 wires three rayons; two more are waiting on mobile plumbing, not on
+  data.** Malts → `malt`, Houblons → `hop`, Levures → `yeast`. Accessoires
+  (`/catalog/misc-templates`) and Matériel (`/catalog/equipment-templates`) are
+  served by the backend already but unconsumed mobile-side — Lot 2 adds them, and
+  `IngredientCategory` grows a `misc` member for Accessoires. Kits alone has no
+  source anywhere. See [`03-component.md`](03-component.md) for the endpoint map.
+- **`IngredientCategory` is the shared taxonomy and it will grow.** It is
+  `malt | hop | yeast` today; the API's catalog module is wider (fermentable /
+  hop / yeast / misc / equipment / style / water / mash / producer / distributor).
+  Growing this enum is how a rayon goes live — not by adding a shop-side type.
+- **`LocalCartItem.category` is now `IngredientCategory`**, not the retired
+  `ShopCategory` — one taxonomy for the whole app.
+- **Item → catalog link is optional**: a custom ingredient (Strategy B, #915)
+  added to the list may not map to a catalog entry — keep `refId` generic so
+  off-catalog items are listable (name + quantity).
 - **No payment/order entity**: purchase is a partner deep-link (#650) — out of
-  the model on purpose.
+  the model on purpose, and blocked on having a partner and prices at all.

--- a/docs/architecture/diagrams/ingredients/01-use-case.md
+++ b/docs/architecture/diagrams/ingredients/01-use-case.md
@@ -63,3 +63,13 @@ flowchart LR
   brewer's authoring.
 - **Categories** today: malt / hop / yeast (mobile); the API also has
   fermentable / water / misc / style / equipment catalogs (component/class view).
+- **This domain owns catalog browsing, and it is the only one that does.**
+  `equipment-shop` used to declare its own "Browse the shop by category" +
+  "View a product" — the same actor goal, modelled twice, which is why the app
+  shipped two catalogs (one of them fake, deleted in #1444). Those UCs are
+  retired: the Shop is now the **entry point** into UC1–UC3, and the retired
+  `/(app)/ingredients` hub redirects to it. Naming a door is information
+  architecture, not an actor goal. See
+  [`../equipment-shop/03-component.md`](../equipment-shop/03-component.md).
+- **UC7 hands off to a shopping list that does not exist yet**: the local cart
+  was deleted in #1444 (zero non-test callers); #653 rebuilds it.

--- a/docs/architecture/diagrams/ingredients/01-use-case.md
+++ b/docs/architecture/diagrams/ingredients/01-use-case.md
@@ -67,9 +67,10 @@ flowchart LR
   `equipment-shop` used to declare its own "Browse the shop by category" +
   "View a product" — the same actor goal, modelled twice, which is why the app
   shipped two catalogs (one of them fake, deleted in #1444). Those UCs are
-  retired: the Shop is now the **entry point** into UC1–UC3, and the retired
-  `/(app)/ingredients` hub redirects to it. Naming a door is information
-  architecture, not an actor goal. See
-  [`../equipment-shop/03-component.md`](../equipment-shop/03-component.md).
+  retired: the Shop becomes the **entry point** into UC1–UC3. Naming a door is
+  information architecture, not an actor goal. **Target, not current state**: the
+  `/(app)/ingredients` hub should redirect to `/(app)/shop` in Lot 1 — today it
+  still renders `IngredientsScreen` and both doors are listed on the dashboard.
+  See [`../equipment-shop/03-component.md`](../equipment-shop/03-component.md).
 - **UC7 hands off to a shopping list that does not exist yet**: the local cart
   was deleted in #1444 (zero non-test callers); #653 rebuilds it.


### PR DESCRIPTION
## Summary

Conception-only PR — no code. Resolves the modelling contradiction that made the app ship **two ingredient catalogs**, and corrects three documents that described deleted code as shipped.

| File | Change |
|---|---|
| `equipment-shop/01-use-case.md` | Retires UC3 "Browse the shop by category" + UC4 "View a product" (duplicates of ingredients UC1–UC3). Fixes the false "shipped (read)" status. |
| `equipment-shop/03-component.md` | **New** — the shop → catalog wiring, the map of the ten backend catalogs, the two-speed rayon model. |
| `equipment-shop/04-class.md` | Purges `Product` / `PriceUnit` / `ShopCategory` (deleted in #1444). Adds `ShopRayon`. `LocalCartItem.category` → `IngredientCategory`. |
| `equipment-shop/02-sequence-shopping-list.md` | Marked as design, not description — its `cart.use-cases` participant no longer exists. Grouping key corrected. |
| `ingredients/01-use-case.md` | Documents that this domain owns catalog browsing, and that the Shop is its entry point. |

## Context

**The duplication was designed before it was coded.** `ingredients/` declared UC1–UC3 (browse / filter / datasheet). `equipment-shop/` declared UC3 "Browse the shop by category" + UC4 "View a product". Same actor goal, modelled twice — so the code faithfully built both: a real catalog under `/ingredients` and a fake one under `/shop`. Deleting the fake catalog in #1444 fixed the symptom and left the cause standing; this PR removes the cause.

A use case is an actor goal, not a screen (UML 2.5). Consulting the catalog is **one** goal; whether the door reads "Ingrédients" or "Boutique" is information architecture. `ingredients/` keeps the goal, the Shop becomes its entry point, and the `/ingredients` hub redirects to it. UC numbering is deliberately **not** renumbered so existing issue/PR references keep resolving.

**Reuse, not relocation.** `RecipeDetailsScreen` deep-links straight into `/(app)/ingredients/[category]/[id]` and `/(app)/ingredients/malts/[id]`. Moving those routes under `/shop` would break the recipe → ingredient path and its tests, and buy nothing: the goal is one *door*, not one *directory*. Only the `/ingredients` **hub** is retired.

**Two findings worth flagging:**

- **The backend already serves ten catalogs** — including `/catalog/equipment-templates` and `/catalog/misc-templates`, both unconsumed mobile-side. So the Matériel and Accessoires rayons are waiting on **mobile plumbing, not on data**; only Kits has no source at all. (I had previously concluded no equipment catalog existed, having looked only at `/equipment-profiles` — the brewer's *own* gear, a different concept sharing the word.)
- **`/catalog/distributors` exists**, with a controller, unscoped by anyone. A distributor catalog may be closer to "a real shop" than the affiliate deep-link modelled in UC5 (#650) — worth scoping before that path is designed.

**Modelling note:** `ShopRayon.catalogCategory` is nullable, and that nullability *is* the two-speed hub — a rayon without a category cannot be made pressable by accident. Preferred over a status flag for exactly that reason.

## Follow-up (not in this PR)

- **Lot 1** — the Shop hub becomes the catalog door for the three wired rayons; `/ingredients` hub retired.
- **Lot 2** — wire `misc-templates` (Accessoires) then `equipment-templates` (Matériel).
- Naming drift: `EquipmentScreen` is still titled "L'Office 🍽️" while the shop rayon was renamed "Matériel" in #1449 — same word, two concepts.

## Checklist

- [x] Mermaid blocks balanced and syntactically valid in all four diagrams
- [x] No stale reference to a deleted type left (`Product`, `PriceUnit`, `ShopCategory` appear only in "this is gone" notes)
- [x] UML 2.5 conformant — use cases are actor goals, not screens; the Mobile/API split lives in the component view
- [x] Cross-links between the two conception folders resolve
- [x] Docs only — no code, no test, nothing for CI to run beyond the doc gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)