### PR TITLE
fix(mobile-app): cover the 5 screens that never opted into the nav clearance

### DIFF
--- a/docs/architecture/decisions/0029-footer-nav-scroll-away.md
+++ b/docs/architecture/decisions/0029-footer-nav-scroll-away.md
@@ -151,9 +151,11 @@ failure mode this redesign eliminates.
 
 ### Positive
 
-- The root cause of "hidden buttons" is removed structurally: clearance is owned by `Screen`,
-  36 manual paddings and the offset hook disappear, and clause 6 makes occlusion impossible at
-  rest by construction.
+- The root cause of "hidden buttons" is removed structurally: the clearance is owned by the
+  shared scroll containers (clause 4), the 36 manual paddings and the offset hook disappear,
+  the 5 screens that had never opted in are brought in, and clause 6 makes occlusion impossible
+  at rest by construction. Crucially the opt-in itself is gone: a screen can no longer be
+  forgotten, which is what let those 5 slip through every earlier count.
 - One `NAV_BAR_HEIGHT` source of truth ends the magic-number drift (M2/M3).
 - Snackbar and sticky CTAs follow the same visibility boolean as the bar — the current
   hand-synced clearance stack shrinks.
@@ -162,7 +164,8 @@ failure mode this redesign eliminates.
 ### Negative
 
 - **Migration surface: 41 screens** (plus the Snackbar and sticky CTAs) must swap their manual
-  padding for the `Screen`-owned clearance and wire `onScroll` into the shared hook.
+  padding for the container-owned clearance; the containers wire `onScroll` themselves, so the
+  swap is the whole migration.
 - Scroll-away needs real tuning (threshold value, spring feel) and new plumbing
   (`useScrollDirection`, `FooterVisibilityContext`) that a static bar would not.
 - The dual-nav mount (M4) is consciously kept.

--- a/docs/architecture/decisions/0029-footer-nav-scroll-away.md
+++ b/docs/architecture/decisions/0029-footer-nav-scroll-away.md
@@ -23,6 +23,19 @@ the very bottom"* and *"it hides buttons"* — to structural causes, not styling
   `useNavigationFooterOffset()` and wires the value as `paddingBottom` on the right container.
   Any missed screen, wrong container, or bottom-anchored control outside the ScrollView is
   silently covered by the pill.
+
+  **Corrected 2026-07-16 (post-#1452).** Those 36 were the screens that **opted in** — not the
+  screens the bar covers. This ADR counted the opt-ins and mistook them for the population,
+  which is precisely the failure mode an opt-in model produces, and #1452's migration inherited
+  the blind spot. A sweep of every raw vertical scroller under `(app)` found **5 more**, none of
+  which had ever called the hook: `ScanScreen`, `ScanResultScreen`, `PendingScansScreen`
+  (reserving `spacing.xl` = 32) and `ProfileScreen` (`spacing.lg` = 24) — all short of the
+  footprint (`NAV_BAR_HEIGHT` 64 + `insets.bottom`, so 64 at minimum and more on any device
+  with a gesture bar) — plus `BeerInfoCardScreen`, which over-reserved with a hand-tuned
+  `spacing.xxl * 3` = 120. The real population is **41 screens**. Two raw scrollers remain by
+  design: `LabelSelectBatchScreen`'s list (its CTA is a sibling below it and anchors itself) and
+  `LoginScreen` (under `(auth)`, where no bar is mounted); nested scrollers inside an already
+  reserved container (the recipe tabs) and modal scrollers are out of scope by construction.
 - **B2 — zero-gap geometry.** The offset the hook returns —
   `(insets.bottom > 0 ? insets.bottom : spacing.md) + spacing.xs + 48 + spacing.md`, i.e. 88 px
   with no bottom inset — lands exactly on the pill's top edge, so the hook reserves **no
@@ -63,7 +76,8 @@ on scroll-down, reappears on scroll-up. The conception study lives in
    `ScreenScrollView` / `ScreenFlatList` (`core/ui`) — which every scrollable screen uses in
    place of a raw `ScrollView` / `FlatList`. They apply the footprint to the scrolled
    **content** and wire `onScroll` (clause 5) in one swap. `useNavigationFooterOffset` and
-   the **36 per-screen `paddingBottom` call sites are deleted**. `NAV_BAR_HEIGHT`
+   the **36 per-screen `paddingBottom` call sites are deleted**, and the 5 screens that never
+   opted in are brought in, so all **41** screens under the bar are covered by construction. `NAV_BAR_HEIGHT`
    (`core/theme/layout.ts`) is the bar's base **visual** height; the effective footprint is
    computed at runtime by `useNavigationBarFootprint()` as `NAV_BAR_HEIGHT + insets.bottom`
    and shared by the containers (reserved clearance), the bar (its own height *and* hide
@@ -147,7 +161,7 @@ failure mode this redesign eliminates.
 
 ### Negative
 
-- **Migration surface: 36 screens** (plus the Snackbar and sticky CTAs) must swap their manual
+- **Migration surface: 41 screens** (plus the Snackbar and sticky CTAs) must swap their manual
   padding for the `Screen`-owned clearance and wire `onScroll` into the shared hook.
 - Scroll-away needs real tuning (threshold value, spring feel) and new plumbing
   (`useScrollDirection`, `FooterVisibilityContext`) that a static bar would not.
@@ -155,7 +169,7 @@ failure mode this redesign eliminates.
 
 ### Mitigations
 
-- The build PR enumerates all 36 screens as a tracked checklist; the invariant (clause 6) keeps
+- The build PR enumerates all 41 screens as a tracked checklist; the invariant (clause 6) keeps
   every intermediate state safe during migration.
 - Threshold and guards live in **one** hook — tuning is a one-file change.
 - Fallback path documented: pin `visible = true` and C degrades to the static bar B.

--- a/packages/mobile-app/src/features/auth/presentation/ProfileScreen.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/ProfileScreen.tsx
@@ -1,13 +1,6 @@
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import React, { useCallback, useState } from "react";
-import {
-  Modal,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
 
 import { useFocusEffect, useRouter } from "expo-router";
 
@@ -17,6 +10,7 @@ import { BackHeaderAction } from "@/core/ui/BackHeaderAction";
 import { getErrorMessage } from "@/core/http/http-error";
 import { Card } from "@/core/ui/Card";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { Ionicons } from "@expo/vector-icons";
 
 export function ProfileScreen() {
@@ -78,7 +72,7 @@ export function ProfileScreen() {
 
   return (
     <Screen>
-      <ScrollView contentContainerStyle={styles.content}>
+      <ScreenScrollView contentContainerStyle={styles.content}>
         {canGoBack ? (
           <View style={styles.backRow}>
             <BackHeaderAction fallback="/(app)/dashboard" />
@@ -149,7 +143,7 @@ export function ProfileScreen() {
         </Pressable>
 
         <AboutFooter />
-      </ScrollView>
+      </ScreenScrollView>
 
       <Modal
         transparent
@@ -216,7 +210,6 @@ export function ProfileScreen() {
 const styles = StyleSheet.create({
   content: {
     gap: spacing.sm,
-    paddingBottom: spacing.lg,
   },
   backRow: {
     alignItems: "flex-start",

--- a/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/BeerInfoCardScreen.tsx
@@ -3,7 +3,6 @@ import {
   Alert,
   Linking,
   Pressable,
-  ScrollView,
   StyleSheet,
   Text,
   View,
@@ -14,6 +13,7 @@ import { Card } from "@/core/ui/Card";
 import { HeaderBackButton } from "@/core/ui/HeaderBackButton";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { useConfirm } from "@/core/ui/confirm-provider";
 
 import {
@@ -282,10 +282,7 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
 
   return (
     <Screen>
-      <ScrollView
-        contentContainerStyle={styles.scrollContent}
-        showsVerticalScrollIndicator={false}
-      >
+      <ScreenScrollView showsVerticalScrollIndicator={false}>
         <ListHeader
           title="Bière reconnue"
           subtitle={subtitleForSource(status.result.source)}
@@ -325,7 +322,7 @@ export function BeerInfoCardScreen({ barcodeParam }: BeerInfoCardScreenProps) {
             <BreweryStory brewery={status.result.item.brewery} />
           )}
         />
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }
@@ -803,9 +800,6 @@ function BreweryStory({ brewery }: { brewery: string }) {
 }
 
 const styles = StyleSheet.create({
-  scrollContent: {
-    paddingBottom: spacing.xxl * 3,
-  },
   glanceCard: {
     marginBottom: spacing.md,
     padding: spacing.md,

--- a/packages/mobile-app/src/features/scan/presentation/PendingScansScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/PendingScansScreen.tsx
@@ -1,4 +1,4 @@
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 import React, { useCallback, useMemo, useState } from "react";
 import { colors, radius, spacing, typography } from "@/core/theme";
 import {
@@ -13,6 +13,7 @@ import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import type { ScanPendingCapture } from "@/features/scan/domain/scan.types";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { getErrorMessage } from "@/core/http/http-error";
 import { useRouter } from "expo-router";
 
@@ -114,7 +115,7 @@ export function PendingScansScreen() {
         void loadPendingCaptures();
       }}
     >
-      <ScrollView contentContainerStyle={styles.content}>
+      <ScreenScrollView contentContainerStyle={styles.content}>
         <ListHeader
           title="Pending scans"
           subtitle="Stored locally for later product analysis"
@@ -203,14 +204,13 @@ export function PendingScansScreen() {
             ) : null}
           </Card>
         )}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }
 
 const styles = StyleSheet.create({
   content: {
-    paddingBottom: spacing.xl,
     gap: spacing.sm,
   },
   topCard: {

--- a/packages/mobile-app/src/features/scan/presentation/ScanResultScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/ScanResultScreen.tsx
@@ -1,4 +1,4 @@
-import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 import React, { useCallback, useMemo, useState } from "react";
 import { colors, radius, spacing, typography } from "@/core/theme";
 
@@ -9,6 +9,7 @@ import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import type { ScanResultDetailsViewModel } from "@/features/scan/domain/scan.types";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { getErrorMessage } from "@/core/http/http-error";
 import { getScanResultDetails } from "@/features/scan/application/scan.use-cases";
 import { useRouter } from "expo-router";
@@ -116,7 +117,7 @@ export function ScanResultScreen({ scanIdParam }: ScanResultScreenProps) {
       error={error}
       onRetry={() => void loadDetails()}
     >
-      <ScrollView contentContainerStyle={styles.content}>
+      <ScreenScrollView>
         <ListHeader
           title="Scan result"
           subtitle="Product match and recipe equivalents"
@@ -249,15 +250,12 @@ export function ScanResultScreen({ scanIdParam }: ScanResultScreenProps) {
             ) : null}
           </Card>
         ) : null}
-      </ScrollView>
+      </ScreenScrollView>
     </Screen>
   );
 }
 
 const styles = StyleSheet.create({
-  content: {
-    paddingBottom: spacing.xl,
-  },
   cardSpacing: {
     marginBottom: spacing.sm,
   },

--- a/packages/mobile-app/src/features/scan/presentation/ScanScreen.tsx
+++ b/packages/mobile-app/src/features/scan/presentation/ScanScreen.tsx
@@ -19,20 +19,14 @@ import React, {
   useRef,
   useState,
 } from "react";
-import {
-  Modal,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
 
 import { getErrorMessage } from "@/core/http/http-error";
 import { Card } from "@/core/ui/Card";
 import { ListHeader } from "@/core/ui/ListHeader";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
 import { Screen } from "@/core/ui/Screen";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
 import { BarcodeVerificationProgress } from "@/features/scan/presentation/components/BarcodeVerificationProgress";
 import { DemoOverrideMenu } from "@/features/scan/presentation/components/DemoOverrideMenu";
 import { useRouter } from "expo-router";
@@ -546,7 +540,7 @@ export function ScanScreen() {
         void loadConsentSettings();
       }}
     >
-      <ScrollView contentContainerStyle={styles.content}>
+      <ScreenScrollView contentContainerStyle={styles.content}>
         <ListHeader
           title="Guided scan flow"
           subtitle="Scan barcode first, then complete bottle capture only when needed."
@@ -867,7 +861,7 @@ export function ScanScreen() {
           style={styles.primaryActionButton}
           onPress={() => setIsResetModalVisible(true)}
         />
-      </ScrollView>
+      </ScreenScrollView>
 
       <Modal
         transparent
@@ -1019,7 +1013,6 @@ export function ScanScreen() {
 
 const styles = StyleSheet.create({
   content: {
-    paddingBottom: spacing.xl,
     gap: spacing.sm,
   },
   sectionCard: {


### PR DESCRIPTION
## Summary

ADR-0029's *"36 screens"* inventory counted the screens that **opted into** the old `useNavigationFooterOffset` hook — **not the screens the bar covers**. #1452 migrated those 36 faithfully and inherited the blind spot from the ADR. A sweep of every raw vertical scroller under `(app)` found **5 more that never called the hook at all**.

This matters more *after* #1452 than before it: with the scroll-away live, the bar now hides and reveals over content that reserves nothing for it.

| Screen | Reserved | Verdict |
| --- | --- | --- |
| `ScanScreen`, `ScanResultScreen`, `PendingScansScreen` | `spacing.xl` = 32 | **occluded** — live defect |
| `ProfileScreen` | `spacing.lg` = 24 | **latent** — short of the footprint, but its content is too short to scroll today (emulator-verified) |
| `BeerInfoCardScreen` | `spacing.xxl * 3` = 120 | **not occluded** — over-reserved via a hand-tuned magic number |

Footprint for comparison: `NAV_BAR_HEIGHT` (64) + `insets.bottom`.

All 5 now use `ScreenScrollView`, so they also inherit the scroll tracking for free. **Real population: 41 screens.** The ADR context is corrected in the same commit — including *why* the count was wrong, since that is the reusable lesson.

## Context

This is the one finding that survived from #1454, which I closed as redundant: a parallel session built the same ADR and landed it first as #1452 (a better implementation — it pins `height: footprint` explicitly and wires `useScrollDirection` inside the container). Only this blind spot was left.

**Honest correction:** my closing comment on #1454 claimed `BeerInfoCardScreen` reserved 40px and was occluded. It reserves **120px** and was not — my grep dropped the ` * 3`. Three screens were the real bug, not five. All five are still worth migrating (three fix a live defect, one closes a latent one, one replaces a magic number), but the claim needed correcting.

## Out of scope — verified, not assumed

- **Recipe tabs** (`BrewingTab`, `WaterTab`, `IngredientsTab`): nested inside `RecipeDetailsScreen`'s already-reserved `ScreenScrollView`, so the outer container reserves for them. Their same-orientation nested `ScrollView` is a real RN smell (unbounded height, never scrolls independently) but is **pre-existing** and untouched here — worth a backlog item.
- **Modal scrollers** (`DemoOverrideMenu`, `DifficultyExplainModal`): modals render over the bar.
- **`LoginScreen`**: under `(auth)`, no bar mounted.
- **`LabelSelectBatchScreen`**: its CTA is a sibling below the list and anchors itself. Its inline `style={{ marginBottom: footprint }}` (from #1452) is a forbidden-pattern nit worth a follow-up — flagged, not fixed here.

## Checklist

- [x] Local pre-push review (Claude `pr-pre-reviewer` + Codex CLI) — **0 Must Have** from both; Codex returned clean
- [x] Reviewer's Should-Haves applied: commit scope `mobile/ui` → `mobile-app` (matches `CONTRIBUTING.md` + the `#1442`/`#1448` precedent); the ADR's "~88px" corrected (it was the *old* pill-era hook's figure, not the new footprint); `ScanResultScreen`'s now-empty `content: {}` style dropped
- [x] `npm run ci:check` green; the 5 touched screens' suites **267/267**
- [x] `BeerInfoCardScreen` verified **36/36 in isolation** after modifying it — the full-suite red on that file is the documented timing flake, not this diff. A second flake (`ScanScreen.test.tsx`) also surfaced under local parallel load; **CI is the arbiter here, not my loaded machine**
- [ ] Not emulator-verified — the 5 screens sit deep in the scan flow; the change is a mechanical swap onto an already-tested shared container
- [ ] PROJECT_LOG entry — separate post-merge `docs(log)` commit, per this repo's precedent

## Follow-ups worth filing (not in this PR)

- A **regression guard** — ADR-0029's own Verification section already prescribes it: a CI grep so no future screen can reintroduce a raw `ScrollView` + hand-rolled `paddingBottom`. That is precisely the failure mode this PR exists to clean up, and nothing prevents it from recurring.
- The nested-`ScrollView` smell in the recipe tabs; the inline style in `LabelSelectBatchScreen`.
