### PR TITLE
chore(mobile-app): make the nav-clearance rule enforceable, not memorable

### DIFF
--- a/docs/architecture/decisions/0029-footer-nav-scroll-away.md
+++ b/docs/architecture/decisions/0029-footer-nav-scroll-away.md
@@ -191,10 +191,39 @@ failure mode this redesign eliminates.
 
 ## Verification
 
-- `pr-pre-reviewer` checklist additions: no `useNavigationFooterOffset` references remain (the
-  hook is deleted); no screen-level `paddingBottom` derived from nav-bar arithmetic; the bar
-  height is read from `NAV_BAR_HEIGHT` only (grep for `48` / hardcoded `96` around the footer
-  and sticky CTAs).
+- **Enforced mechanically in CI** (added 2026-07-16, after #1457): the `@typescript-eslint/no-restricted-imports` rule in
+  `packages/mobile-app/eslint.config.js` restricts importing the raw-scroller family from
+  `react-native` inside `src/features/**/presentation/**/*Screen.tsx`, so a new screen cannot
+  reintroduce a raw scroller with hand-rolled padding. `ci:check` runs lint, so the mistake
+  cannot be merged.
+
+  This clause first read *"`pr-pre-reviewer` checklist additions"*. That protection had **the
+  same weakness as the defect it guards**: it relied on someone remembering to run the reviewer
+  and to notice. Remembering is exactly what failed — 36 screens opted in, 5 never did, and
+  nobody saw it for months (#1457). A rule that runs on every push needs no memory.
+
+  Legitimate exceptions disable the rule **on the offending line, with their reason** rather
+  than in an allowlist file: an allowlist rots out of sight, whereas a disable is visible in the
+  diff and has to be justified to a reviewer. Three exist today — `LoginScreen` (no bar under `(auth)`),
+  `AcademyHubScreen` (horizontal carousel) and `LabelSelectBatchScreen` (its list scrolls, but
+  its viewport is bounded above a CTA that carries the footprint, so nothing reaches the bar;
+  the bar knowingly does not hide on that screen — tracked). Type-only imports need no exception:
+  `allowTypeImports` lets them through, since a type renders nothing.
+
+  The rule covers the whole raw-scroller family — `ScrollView`, `FlatList`, `SectionList`,
+  `VirtualizedList`, `VirtualizedSectionList` — not just the two in use today. The unused ones
+  are the dangerous ones: a screen reaching for `SectionList` next year would reproduce the
+  defect with CI green, which is precisely how the 5 occluded screens stayed invisible.
+
+  Known limits, stated rather than glossed. Namespace imports (`import * as RN from
+  "react-native"`) **are** caught — ESLint rejects the whole `*` import when named restrictions
+  apply, verified with a probe. What the rule does not see: a local re-export of the raw
+  component, a scrollable screen whose file is not named `*Screen.tsx`, a screen that reserves
+  nothing while using the right container, and a bottom-anchored control outside any scroller.
+  It is a floor that makes the easy mistake impossible, not a proof of correctness.
+- `pr-pre-reviewer` checklist (still useful for what the rule cannot see): no
+  `useNavigationFooterOffset` references remain (the hook is deleted); the bar height is read
+  from `NAV_BAR_HEIGHT` only (grep for `48` / hardcoded `96` around the footer and sticky CTAs).
 - Tests pin the state machine (threshold, near-top guard, forced reveals), `Screen`'s reserved
   clearance, and that Snackbar/sticky-CTA track `FooterVisibilityContext`.
 - The existing `NavigationFooter.test.tsx` contract (six items, longest-prefix active match)

--- a/packages/mobile-app/eslint.config.js
+++ b/packages/mobile-app/eslint.config.js
@@ -36,4 +36,64 @@ module.exports = [
       ...tsPlugin.configs.recommended.rules,
     },
   },
+  {
+    // ADR-0029 guard. The bar overlays content, so a screen's scroller must
+    // reserve its footprint. That used to be a per-screen opt-in: 36 screens
+    // remembered, 5 never did, and their controls sat under the bar unnoticed
+    // for months (#1457). The shared containers removed the need to remember —
+    // this rule removes the ability to forget, mechanically, in CI.
+    //
+    // Scoped to *Screen.tsx: the defect is a screen's own vertical scroller.
+    // Nested scrollers, tabs, modal content and components are not screens and
+    // are covered by whatever container their screen already uses.
+    //
+    // Legitimate exceptions disable this rule ON THE LINE, with their reason —
+    // deliberately not an allowlist file, which would rot out of sight. A
+    // disable is visible in the diff and has to be justified to a reviewer.
+    // `**/*Screen.tsx`, not `*Screen.tsx`: the tail must cross directory
+    // boundaries or a screen nested one level deeper (presentation/wizard/…)
+    // slips through — the same latent shape as the unused list components above.
+    files: ["src/features/**/presentation/**/*Screen.tsx"],
+    // The plugin must be re-declared here: a flat-config block can only use
+    // rules from plugins IT loads, and the broader ts/tsx block above is a
+    // separate object. Without this, ESLint exits 2 on an unknown rule key —
+    // and a crashed lint reports no violations, which looks exactly like a
+    // clean one. Verify this guard by exit code, never by grepping output.
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+    },
+    rules: {
+      // The @typescript-eslint variant, for `allowTypeImports`: a type-only
+      // import renders nothing, so it cannot occlude anything and must not need
+      // a documented exception.
+      "no-restricted-imports": "off",
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "react-native",
+              // Per-path, not top-level: the rule's schema rejects the option
+              // anywhere else. A type-only import renders nothing, so it cannot
+              // occlude anything and must not need a documented exception.
+              allowTypeImports: true,
+              // The whole raw-scroller family, not just the two in use today:
+              // SectionList / VirtualizedList are the same class of defect and
+              // would sail through green if listed later, which is exactly how
+              // the 5 occluded screens stayed invisible.
+              importNames: [
+                "ScrollView",
+                "FlatList",
+                "SectionList",
+                "VirtualizedList",
+                "VirtualizedSectionList",
+              ],
+              message:
+                "Use ScreenScrollView / ScreenFlatList from @/core/ui instead: they reserve the navigation bar's footprint and wire scroll tracking (ADR-0029 clause 4). A raw scroller silently hides bottom controls under the bar. No shared container exists for SectionList/VirtualizedList yet — add one rather than reaching for the raw component. If this scroller is horizontal, nested inside an already-reserved container, inside a Modal, on a screen with no bar, or imported for its type only, disable this rule on the import line and say which.",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
+++ b/packages/mobile-app/src/features/auth/presentation/LoginScreen.tsx
@@ -5,6 +5,7 @@ import {
   KeyboardAvoidingView,
   Platform,
   Pressable,
+  // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- ADR-0029: no nav bar is mounted under (auth), so there is no footprint to reserve.
   ScrollView,
   StyleSheet,
   Text,

--- a/packages/mobile-app/src/features/labels/presentation/LabelSelectBatchScreen.tsx
+++ b/packages/mobile-app/src/features/labels/presentation/LabelSelectBatchScreen.tsx
@@ -13,6 +13,7 @@ import {
   LABEL_TEMPLATE_OPTIONS,
 } from "@/features/labels/presentation/label-template.constants";
 import React, { useCallback, useState } from "react";
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports -- ADR-0029: this list DOES scroll (RN gives ScrollView flexGrow:1), but its viewport is bounded above the CTA below it, which carries the footprint as its own margin — so no content ever reaches the bar. Swapping in ScreenFlatList would pad the content by a footprint the viewport already clears. Known gap, tracked: scroll events never reach useScrollDirection, so the bar does not hide here; fixing that means making the CTA absolute like RecipeStickyCta, not suppressing this line.
 import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
 
 import { getErrorMessage } from "@/core/http/http-error";

--- a/packages/mobile-app/src/features/tools/presentation/AcademyHubScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyHubScreen.tsx
@@ -1,6 +1,7 @@
 import { colors, radius, spacing, typography } from "@/core/theme";
 import {
   Pressable,
+  // eslint-disable-next-line @typescript-eslint/no-restricted-imports -- ADR-0029: horizontal filter carousel nested in the page; it must not inherit a vertical clearance, and the screen's own scroller already reserves it.
   ScrollView,
   StyleSheet,
   Text,

--- a/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/tools/presentation/AcademyTopicDetailsScreen.tsx
@@ -3,7 +3,7 @@ import {
   Image,
   LayoutChangeEvent,
   Pressable,
-  ScrollView,
+  type ScrollView,
   StyleSheet,
   Text,
   View,


### PR DESCRIPTION
## Summary

ADR-0029 removed the per-screen clearance opt-in that hid controls under the bottom bar. **Nothing stopped it from coming back**: a new screen with a raw `ScrollView` and a hand-rolled `paddingBottom` compiles, passes its tests, goes green in CI — and silently occludes its own buttons. That is exactly how 5 screens stayed broken for months (#1457), unnoticed until a user complained.

This adds the guard **ADR-0029's own Verification section already promised** — but promised only as a *`pr-pre-reviewer` checklist item*, i.e. a protection that relies on someone remembering to run the reviewer and to notice. **Remembering is precisely what failed.** A rule that runs on every push needs no memory.

An ESLint rule scoped to `src/features/**/presentation/**/*Screen.tsx` restricts the raw-scroller family from `react-native`. `ci:check` runs lint → the mistake cannot be merged.

## Why a lint rule and not a CI grep

- **It reads the AST.** A grep trips on `useRef<ScrollView>` — a type position, not a component. That false positive burned two of my own greps during the #1457 investigation.
- **Exceptions live on the offending line, with their reason** — not in an allowlist file. An allowlist rots out of sight; a `disable` is visible in the diff and has to be justified to a reviewer.

## Verified by construction, not by reading

Three probe screens were written to make the guard fail, then deleted:

| Probe | Result |
| --- | --- |
| raw `ScrollView` on a screen | `ci:check` **red** |
| raw `SectionList` on a screen | `ci:check` **red** |
| screen nested in a subdirectory | `ci:check` **red** |
| the real codebase | **green** |

## Two latent holes closed during review — both the same shape

Both reviewers found a gap, and neither was reachable from today's code. **That is the point**: the thing nobody uses today is the thing that bites later, silently, exactly as the 5 screens did.

- **Codex**: the rule covered only `ScrollView`/`FlatList` — the two in use. `SectionList` appears nowhere in the tree, so nobody would have seen it coming; a screen reaching for it next year would have reproduced the defect with CI green. Now the whole family is restricted (`SectionList`, `VirtualizedList`, `VirtualizedSectionList`).
- **Local reviewer**: the glob's tail `*Screen.tsx` does not cross directory boundaries — `presentation/wizard/StepOneScreen.tsx` slipped through entirely (proved with a probe). Now `**/*Screen.tsx`.

## A rationale I had wrong, corrected

The reviewer disproved my justification for `LabelSelectBatchScreen`'s exemption. I claimed *"its CTA is the last flex child and reserves the footprint itself"*. It does not: the list has no height constraint and its ancestor `Screen` is a plain `flex:1` `View`, so **there is no scroll boundary at all** — nothing scrolls, which is why nothing goes under the bar.

That matters beyond the comment: the ADR cited the false reason as precedent, and a future author could have applied it to a screen whose list *does* scroll — where the reasoning collapses and the bug returns. Corrected in the comment and the ADR, with an explicit warning that it is not a pattern to copy.

I had also **invented a limit**: the ADR claimed namespace imports (`import * as RN`) bypass the rule. Testing disproved it — ESLint rejects the whole `*` import when named restrictions apply. Removed.

## Honest limits (in the ADR, not glossed)

The rule guards the **import**. It does not see: a local re-export of the raw component, a scrollable screen whose file isn't named `*Screen.tsx`, a screen that reserves nothing while using the right container, or a bottom-anchored control outside any scroller. **It is a floor that makes the easy mistake impossible, not a proof of correctness.**

## Checklist

- [x] Local pre-push review (Claude `pr-pre-reviewer` + Codex CLI) — **0 Must Have** from both; every Should Have applied
- [x] `eslint.config.js` is on the "do not modify without explicit user request" list — this PR **is** that request
- [x] Flat-config block ordering verified empirically: it merges with the earlier `**/*.{ts,tsx}` block rather than clobbering it (a probe triggered rules from both)
- [x] lint 0 errors, typecheck clean, prettier clean — re-run on the exact commit being pushed (the branch moved during review)
- [ ] No fixture-based meta-test asserting the rule still fires — noted as a follow-up; `eslint.config.js` churns rarely, but a future edit could silently drop the guard
- [ ] PROJECT_LOG entry — separate post-merge `docs(log)` commit, per this repo's precedent
