### PR TITLE
docs(claude-tooling): refresh website-audit skill for Cloudflare Pages hosting

### DIFF
--- a/.claude/skills/website-audit-brasse-bouillon/SKILL.md
+++ b/.claude/skills/website-audit-brasse-bouillon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: website-audit-brasse-bouillon
-description: Brasse-Bouillon overlay for the global `website-audit` method — supplies this repo's target domain, GitHub Project ID, label vocabulary, assignee, report location (the VitePress audit-history site), and the GitHub Pages header constraint. Use when auditing brasse-bouillon.com or adding a new dated audit to docs/audit-report/.
+description: Brasse-Bouillon overlay for the global `website-audit` method — supplies this repo's target domain, GitHub Project ID, label vocabulary, assignee, report location (the VitePress audit-history site), and the Cloudflare Pages `_headers` mechanism for header findings. Use when auditing brasse-bouillon.com or adding a new dated audit to docs/audit-report/.
 ---
 
 # Brasse-Bouillon — website audit overlay
@@ -12,10 +12,14 @@ project-open constants. Keep this file to constants and deltas only.
 ## Target
 
 - Domain: `brasse-bouillon.com` (the marketing site). Source: `packages/website` (static HTML/CSS/JS).
-- **Host = GitHub Pages** → cannot set custom response headers. Header findings (CSP, X-Frame-Options,
-  nosniff, Referrer-Policy, Permissions-Policy, HSTS hardening) are fixed via a **Cloudflare edge
-  proxy** (free) or a partial `<meta http-equiv>` fallback (CSP + Referrer-Policy only). See skill
-  `website-pages-deploy` for the deploy pipeline.
+- **Host = Cloudflare Pages** (ADR-0014; project `brasse-bouillon-website`). Deploy pipeline:
+  `.github/workflows/website-deploy.yml` — `wrangler pages deploy` on push to `main`; other refs
+  produce preview deployments. (Skill `website-pages-deploy` documents the pre-ADR-0014 GitHub
+  Pages pipeline — historical only, do not follow it.)
+- **Response headers ARE settable** via `packages/website/_headers` (shipped in PR #1370). Before
+  filing a header finding, read that file's comments: some headers (nosniff, Referrer-Policy) come
+  from the Cloudflare edge, and CSP (#1032) + HSTS hardening (#1033) are deliberately deferred with
+  documented prerequisites. Always re-verify live with `curl -sSI` — edge behavior drifts.
 
 ## Issue tracking constants
 
@@ -37,7 +41,7 @@ Reference campaign: epic **#1031** (2026-05-21, 12 findings) — the template fo
 
 The report lives at **`docs/audit-report/`** (standalone VitePress 1.6.4, on-brand theme; isolated
 from `docs/ydays`, not in the npm workspaces; `node_modules`/`dist`/`cache` gitignored). Run
-`cd docs/audit-report && npm run docs:dev` (port 5183) / `docs:build`.
+`cd docs/audit-report && npm run docs:dev` (default port 5173) / `docs:build`.
 
 - **Current structure (flat, ADR-0001 "build for today"):** root `index.md` = latest audit synthèse,
   `historique.md` = audits journal, `findings.md` / `remediation.md` / `methodology.md` at root.
@@ -46,5 +50,5 @@ from `docs/ydays`, not in the npm workspaces; `node_modules`/`dist`/`cache` giti
 - **Adding the 2nd audit = migration trigger:** switch to per-audit dated folders
   `docs/audit-report/AAAA-MM-JJ/{index,findings,remediation,methodology}.md` (stable per-audit URLs),
   add a row to the history table and a `sidebar` group. Until then, keep flat.
-- Lives on branch `docs/log-website-audit`. Never keep uncommitted audit work under `/tmp` (it gets
-  wiped).
+- Tracked on `main` (the historical `docs/log-website-audit` working branch is merged and deleted).
+  Never keep uncommitted audit work under `/tmp` (it gets wiped).

--- a/.claude/skills/website-audit-brasse-bouillon/SKILL.md
+++ b/.claude/skills/website-audit-brasse-bouillon/SKILL.md
@@ -13,9 +13,10 @@ project-open constants. Keep this file to constants and deltas only.
 
 - Domain: `brasse-bouillon.com` (the marketing site). Source: `packages/website` (static HTML/CSS/JS).
 - **Host = Cloudflare Pages** (ADR-0014; project `brasse-bouillon-website`). Deploy pipeline:
-  `.github/workflows/website-deploy.yml` — `wrangler pages deploy` on push to `main`; other refs
-  produce preview deployments. (Skill `website-pages-deploy` documents the pre-ADR-0014 GitHub
-  Pages pipeline — historical only, do not follow it.)
+  `.github/workflows/website-deploy.yml` — `wrangler pages deploy`, auto-triggered on pushes to
+  `main` (production) and `staging` (the long-lived preview environment) touching
+  `packages/website/**`, plus manual `workflow_dispatch`. (Skill `website-pages-deploy` documents
+  the pre-ADR-0014 GitHub Pages pipeline — historical only, do not follow it.)
 - **Response headers ARE settable** via `packages/website/_headers` (shipped in PR #1370). Before
   filing a header finding, read that file's comments: some headers (nosniff, Referrer-Policy) come
   from the Cloudflare edge, and CSP (#1032) + HSTS hardening (#1033) are deliberately deferred with

--- a/.claude/skills/website-pages-deploy/SKILL.md
+++ b/.claude/skills/website-pages-deploy/SKILL.md
@@ -1,9 +1,15 @@
 ---
 name: website-pages-deploy
-description: Diagnostic and operating procedure for the brasse-bouillon.com GitHub Pages deployment — verify a deploy succeeded, trigger a manual rerun, recover from a CNAME / archive / certificate conflict, or onboard a new contributor to how the marketing site reaches production. Use when the site is not updating after a merge that touches `packages/website/**`, when investigating a Pages outage on the custom domain, before reproducing the 2026-05-19 Pages reclaim, or when documenting the deploy story for an ADR / soutenance.
+description: HISTORICAL — superseded by ADR-0014; brasse-bouillon.com now deploys to Cloudflare Pages via `.github/workflows/website-deploy.yml`. This runbook documents the retired GitHub Pages pipeline (2026-05-19 reclaim era). Use only when reading the historical deploy story for an ADR / soutenance — never for operating today's deployment.
 ---
 
 # Brasse-Bouillon Website — GitHub Pages deploy
+
+> **HISTORICAL — do not follow for deploys.** Since
+> [ADR-0014](../../../docs/architecture/decisions/0014-website-hosting-cloudflare-pages-dns.md)
+> the site is hosted on **Cloudflare Pages** and `.github/workflows/website-deploy.yml` deploys it
+> via `wrangler pages deploy`. Everything below describes the pre-ADR-0014 GitHub Pages pipeline
+> and is kept for the historical record (2026-05-19 reclaim, ADR / soutenance narrative) only.
 
 This skill captures the deployment story of the marketing site after the 2026-05-19 reclaim, verified end-to-end on commit `99f2208`. The procedure below is what worked in practice, not the theory.
 


### PR DESCRIPTION
## Summary

The `website-audit-brasse-bouillon` skill's Target section still claimed the site was hosted on **GitHub Pages** and that custom response headers were impossible (pointing to a Cloudflare edge-proxy workaround). Both claims are stale since [ADR-0014](docs/architecture/decisions/0014-website-hosting-cloudflare-pages-dns.md) moved hosting to **Cloudflare Pages** and PR #1370 shipped [`packages/website/_headers`](packages/website/_headers).

- **Target section rewritten**: Cloudflare Pages host (project `brasse-bouillon-website`, deployed by `.github/workflows/website-deploy.yml` via `wrangler pages deploy`); response headers ARE settable via `_headers`, with a pointer to that file's edge-emitted vs deliberately-deferred header notes (#1032 CSP, #1033 HSTS) and the re-verify-live rule.
- **Report location fixed**: `docs/audit-report/` is tracked on `main` — the old `docs/log-website-audit` working branch no longer exists.
- **VitePress dev port fixed**: default 5173, not 5183 (no port override in `.vitepress/config.mjs`).
- **`website-pages-deploy` skill marked HISTORICAL** (deprecation banner + description), so an agent loading it directly sees it was superseded by ADR-0014 instead of following the retired GitHub Pages runbook.

## Context

Pre-push review ritual ran locally (Claude pr-pre-reviewer + Codex): 0 Must Have; the 2 Should Have findings (deprecation banner on `website-pages-deploy`, commit scope aligned to the `claude-tooling` precedent) are implemented in this PR.

## Checklist

- [x] Docs-only change — no code, no tests to add
- [x] Claims cross-checked against ADR-0014, `website-deploy.yml`, `_headers`, `docs/audit-report/`
- [x] English-only artifacts (FYI comment excepted)
- [x] Conventional Commit, branch from `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)