### PR TITLE
feat(website): SEO/GEO optimization (keyword-first titles, WebSite schema, llms.txt, pages.dev noindex)

### DIFF
--- a/.claude/skills/seo-geo-brasse-bouillon/SKILL.md
+++ b/.claude/skills/seo-geo-brasse-bouillon/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: seo-geo-brasse-bouillon
+description: Brasse-Bouillon overlay for SEO and GEO (generative engine optimization) work on brasse-bouillon.com — supplies this repo's policy pointers, quality-gate invariants, i18n metadata pipeline rules, the Cloudflare edge robots/AI-crawler caveat, the AI-bot taxonomy, verification commands, and the standing action plan. Use when optimizing, auditing, or reviewing anything SEO/GEO-related in packages/website (titles, metas, JSON-LD, sitemap, robots, hreflang, AI-crawler access, llms.txt).
+---
+
+# Brasse-Bouillon — SEO / GEO overlay
+
+Wraps the global `seo-audit` skill (the universal audit method). Load that for the
+method; this file holds the **repo-specific constants, invariants, and live state**.
+Policy source of truth: [packages/website/docs/SEO_RUNBOOK.md](../../../packages/website/docs/SEO_RUNBOOK.md)
+— when this file and the runbook disagree, the runbook wins; fix this file.
+
+## Target & architecture
+
+- Domain `brasse-bouillon.com`, static site in `packages/website/`, hosted on
+  **Cloudflare Pages** (ADR-0014), deployed by `.github/workflows/website-deploy.yml`
+  which **whitelists** staged files (globs `*.html|css|js|png|svg|webp` + explicit
+  list `favicon.ico sitemap.xml robots.txt _headers _redirects`). A new public
+  non-matching file (e.g. `llms.txt`) ships ONLY if added to that explicit list.
+- Bilingual FR+EN (ADR-0027): `index.html` = authored FR source; `en.html` =
+  **generated** (`python3 scripts/build_i18n.py`) — never hand-edit; EN strings +
+  head metas live in `i18n/home.en.json` (`head` block: title, description, og/twitter,
+  orgDescription, keywords, knowsAbout). Legal pages = hand-maintained twins with
+  `i18n-src: sha1` stamps (`build_i18n.py --stamp`).
+
+## Gate-enforced SEO invariants (never fight these — change the gate WITH the policy)
+
+`scripts/quality_gate.py`, run by CI on every website PR:
+
+- **Sitemap exact-set**: `sitemap.xml` lists exactly `/`, `/en`, `/legal`, `/privacy`,
+  `/cookies`, `/terms`. EN legal twins deliberately out (indexable, reachable via hreflang).
+- **hreflang reciprocity** on all 5 FR/EN pairs (`fr`, `en`, `x-default`→FR).
+- Canonical presence gate-enforced on **both homes**; any canonical/hreflang link
+  on ANY page must use the **clean URL** (no `.html`) — legal-page canonical
+  presence is convention, not gate.
+- `noindex` on any EN page = gate failure (S2 switch must not regress).
+- OG image dimensions checked (1200×630); required-meta tables exist for
+  index/en/404 (other pages: convention); `404.html` must stay `noindex`;
+  `llms.txt` in `REQUIRED_FILES`.
+
+## The edge caveat (single most important SEO/GEO gotcha)
+
+**The live robots.txt is NOT the repo file** — two mutable Cloudflare zone
+mechanisms sit in front of the repo (full detail + dated snapshots: runbook §1.1):
+*managed robots.txt* prepends Content Signals + a Cloudflare-curated `Disallow`
+list, and *AI Crawl Control* 403-blocks crawlers **per-crawler** (dashboard
+toggles, not a fixed class). GEO access decisions live in the **Cloudflare
+dashboard**, never in this repo. Always verify live, and **probe with the bot's
+real, full user-agent string** — bare tokens (`-A "GPTBot"`) miss the edge rules
+and return false 200s:
+
+```bash
+curl -s https://brasse-bouillon.com/robots.txt   # what crawlers actually see
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -A "Mozilla/5.0 (compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot)" \
+  https://brasse-bouillon.com/                   # 403 = blocked, 200 = not UA-blocked
+```
+
+## AI-bot taxonomy (for GEO decisions)
+
+Independent levers — allowing citations does NOT require allowing training:
+
+- **Answer/citation bots (allow for GEO)**: `OAI-SearchBot` (ChatGPT Search),
+  `PerplexityBot`/`Perplexity-User`, `Claude-SearchBot`; user-triggered fetchers
+  `ChatGPT-User`, `Claude-User`. Google AI Overviews use regular `Googlebot`
+  (unaffected by Google-Extended).
+- **Training bots (rights stance, blockable without GEO cost)**: `GPTBot`, `ClaudeBot`,
+  `CCBot`, `Google-Extended` (Gemini training/grounding), `Bytespider`,
+  `meta-externalagent`, `Applebot-Extended`, `Amazonbot`.
+- This taxonomy is a **snapshot** (vendor bot rosters and semantics drift) —
+  re-verify against vendor docs + the runbook §1.1 probes before acting on it.
+
+## Verification ritual (every SEO PR)
+
+```bash
+cd packages/website
+python3 scripts/quality_gate.py
+python3 scripts/build_i18n.py --check     # en.html regen clean
+python3 -m unittest discover -s tests
+```
+
+Plus the runbook §2 checklist. After any live/dashboard change: the curl checks above,
+and spot-check `https://brasse-bouillon.com/{,en,legal,doesnotexist-xyz}` status codes
+(expect 200/200/200/404; `.html` forms 308 to clean URLs).
+
+## House rules that constrain SEO copy
+
+- Simple hyphens only in site copy (no em-dashes — sweep #1421); code comments
+  and internal docs exempt.
+- `<title>` policy: keyword-first, brand last (pre-launch brand); `og:title`/
+  `twitter:title` stay brand-first (social cards) — intentional split. The
+  brand's SERP visibility is carried by the language-neutral **WebSite** JSON-LD
+  (Google site-name feature) — never remove it while titles are brand-last.
+- **Every present-tense marketing claim is fact-checked against code/roadmap before
+  publishing** (durable rule from the Reddit playbook work). The app is pre-launch;
+  the waitlist (+ feedback questionnaire) is the only CTA; never claim shipped
+  features that aren't.
+- No SoftwareApplication JSON-LD until a real app page exists (runbook §1).
+- FR is primary (`x-default`→FR); never auto-redirect by language.
+
+## Standing action plan (state as of 2026-07-17 — check PROJECT_LOG for drift)
+
+- **A (USER, Cloudflare dashboard)**: unblock answer/citation bots (403→200), adjust
+  managed robots.txt; optional `www`→apex 301. Blocking prerequisite for all GEO.
+- **B (USER)**: Google Search Console (runbook §3) + Bing Webmaster Tools (feeds
+  ChatGPT Search/Copilot).
+- **C (code)**: implemented on branch `claude/brasse-bouillon-seo-geo-audit-ed89eb`
+  (keyword-first titles, Ko-fi `sameAs`, WebSite JSON-LD, og:site_name,
+  max-image-preview, llms.txt, runbook §1.1, pages.dev noindex) — flip this line
+  to "shipped" with the merge SHA once on `main` and verified live.
+- **D (USER)**: execute the frozen Reddit playbook
+  (`packages/website/docs/EN_LAUNCH_PLAYBOOK.md`) — Reddit is the top citation
+  source for answer engines.
+- **E (epic, conception-first)**: informational content (Académie guides, extended FAQ)
+  targeting novice queries; FAQPage JSON-LD derives from the same i18n keys.
+- **F (optional)**: cookieless analytics (Cloudflare Web Analytics) to measure AI
+  referrals — **blocked until** runbook §4 (which currently forbids any measurement
+  snippet) AND the privacy/cookies pages' no-analytics promise are amended first.
+- Accepted/no-action: og-image slightly over 100KB (byte-identical og-card pipeline
+  outweighs the small gain), EN legal twins out of sitemap.
+
+## Issue/PR constants
+
+Same as `website-audit-brasse-bouillon`: repo `benoit-bremaud/brasse-bouillon`,
+Project `PVT_kwHOB8rwIc4AuVew`, labels `scope:website` + `type:*` + `priority:*`,
+assignee `benoit-bremaud`, artifacts in English. The FR FYI comment rule lives in
+the repo `CLAUDE.md` + skill `pr-create-brasse-bouillon`.

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -64,7 +64,7 @@ jobs:
           # matched by the glob copies above and must be staged explicitly
           # (Cloudflare Pages reads them from the deployment root to set
           # response headers and URL redirects — ADR-0027 D2).
-          for required in favicon.ico sitemap.xml robots.txt _headers _redirects; do
+          for required in favicon.ico sitemap.xml robots.txt llms.txt _headers _redirects; do
             cp "$src/$required" _site/
           done
 

--- a/packages/website/_headers
+++ b/packages/website/_headers
@@ -30,3 +30,14 @@
 # cache them for a year.
 /fonts/*
   Cache-Control: public, max-age=31536000, immutable
+
+# The pages.dev aliases serve the same content as brasse-bouillon.com; keep
+# them out of search indexes (self-canonicals are a hint, this is a directive).
+# `:project` / `:version` are Cloudflare Pages host placeholders — the
+# documented pattern from "Prevent your pages.dev deployment from being
+# indexed" (developers.cloudflare.com/pages/how-to/add-custom-http-headers/).
+https://:project.pages.dev/*
+  X-Robots-Tag: noindex
+
+https://:version.:project.pages.dev/*
+  X-Robots-Tag: noindex

--- a/packages/website/docs/SEO_RUNBOOK.md
+++ b/packages/website/docs/SEO_RUNBOOK.md
@@ -28,22 +28,56 @@ while the product is still in pre-launch.
   (`og-image-en.png` — the FR card has a French tagline baked in).
 - A `noindex` on any EN page is a **gate failure** since S2 (the switch must
   not silently regress).
-- `robots.txt` is minimal and points to the sitemap.
-  **Caveat — the live robots.txt is NOT the repo file alone.** Cloudflare's
-  "managed robots.txt" zone setting prepends a managed block (Content Signals
-  `ai-train=no` + `Disallow` for GPTBot, ClaudeBot, CCBot, Google-Extended, …),
-  and AI Crawl Control additionally 403-blocks AI user agents at the network
-  level — including search/user-triggered agents such as `OAI-SearchBot`,
-  `Claude-User` and `PerplexityBot` (verified 2026-07-17). Any GEO decision
-  (letting AI answer engines read or cite the site) must be made in the
-  Cloudflare dashboard (AI Crawl Control → Crawlers tab + the managed
-  robots.txt toggle), not in this repo. After changing it, verify with
-  `curl -s -o /dev/null -w "%{http_code}" -A "<bot UA>" https://brasse-bouillon.com/`.
-  Cloudflare references: [managed robots.txt](https://developers.cloudflare.com/bots/additional-configurations/managed-robots-txt/)
-  · [AI Crawl Control](https://developers.cloudflare.com/ai-crawl-control/).
-- Structured data: **Organization** + **FAQPage** on both homes (FAQPage is
-  rebuilt from the same i18n catalog keys as the visible FAQ — no
-  SoftwareApplication entity until `app.html` exists).
+- The **repo** `robots.txt` (`packages/website/robots.txt`) is minimal and
+  points to the sitemap. The **live** file is edge-modified — see §1.1.
+- Structured data: **WebSite** + **Organization** + **FAQPage** on both homes
+  (FAQPage is rebuilt from the same i18n catalog keys as the visible FAQ; the
+  WebSite block is language-neutral — brand + apex URL — and copied verbatim
+  to `en.html`; it feeds Google's site-name feature, which matters because the
+  `<title>` is keyword-first/brand-last. No SoftwareApplication entity until
+  `app.html` exists).
+
+### 1.1) Edge overlay — Cloudflare managed robots.txt & AI Crawl Control
+
+The live `https://brasse-bouillon.com/robots.txt` is **not** the repo file
+alone, and AI crawlers can be 403-blocked before they ever read it. Two
+zone-level Cloudflare mechanisms sit in front of this repo. Both are
+**dashboard state** — mutable outside git; the values below are dated
+snapshots, never trust them without re-running the probes:
+
+- **Managed robots.txt** prepends a Cloudflare-maintained block: a
+  `Content-Signal` line (snapshot 2026-07-17: `search=yes,ai-train=no,use=reference`
+  — note `ai-input` is deliberately unset) plus `Disallow: /` for a
+  Cloudflare-curated crawler list (snapshot: GPTBot, ClaudeBot, CCBot,
+  Google-Extended, Amazonbot, Applebot-Extended, Bytespider,
+  meta-externalagent, CloudflareBrowserRenderingCrawler — Cloudflare updates
+  this list over time). The repo file is appended after the managed block.
+- **AI Crawl Control** returns 403 at the network level for each crawler set
+  to "Block" in the dashboard — a **per-crawler toggle**, not a fixed class
+  (snapshot 2026-07-17: every probed AI agent was blocked, including the
+  search/citation agents `OAI-SearchBot`, `ChatGPT-User`, `Claude-SearchBot`,
+  `Claude-User`, `PerplexityBot`).
+
+Any GEO decision (letting AI answer engines read or cite the site) is made in
+the Cloudflare dashboard (AI Crawl Control section; the references below carry
+the current navigation), never in this repo. Re-verify live state before and
+after any change:
+
+```bash
+curl -s https://brasse-bouillon.com/robots.txt   # the managed block, as crawlers see it
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -A "Mozilla/5.0 (compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot)" \
+  https://brasse-bouillon.com/                   # 403 = blocked, 200 = not UA-blocked
+```
+
+**Probe with the bot's real, full user-agent string** (as documented by each
+vendor). Bare tokens (`-A "GPTBot"`) do not match the edge rules and return
+**false 200s** (observed 2026-07-17). A 200 only proves the absence of a
+UA-level block for that exact string — verified-bot rules may still treat the
+real crawler differently.
+
+Cloudflare references: [managed robots.txt](https://developers.cloudflare.com/bots/additional-configurations/managed-robots-txt/)
+· [AI Crawl Control](https://developers.cloudflare.com/ai-crawl-control/).
 
 ## 2) Release checklist (every SEO PR)
 
@@ -57,15 +91,25 @@ while the product is still in pre-launch.
    - `Allow: /`
    - `Sitemap: https://brasse-bouillon.com/sitemap.xml`
 
-   The repo file is not the whole story — the edge rewrites it (see the
-   caveat in §1). For any robots/GEO-adjacent change, also run the
-   live `curl -A "<bot UA>"` check described there.
+   The repo file is not the whole story — Cloudflare prepends a managed block
+   and can 403 AI crawlers before they ever fetch it (§1.1). Verify the live
+   file with `curl -s https://brasse-bouillon.com/robots.txt`; if the change
+   concerns AI-crawler access, also run the full-UA status probe from §1.1.
 5. Run local quality checks:
 
 ```bash
 python3 scripts/quality_gate.py
 python3 -m unittest discover -s tests
 ```
+
+6. If `_headers` changed, verify after deploy that the pages.dev alias stays
+   out of search indexes:
+   `curl -sI https://brasse-bouillon-website.pages.dev/ | grep -i x-robots-tag`
+   (expect `noindex`; the custom domain must NOT carry that header).
+7. `llms.txt` is gate-required in the repo but ships only if staged by
+   `website-deploy.yml` (explicit whitelist). After any deploy-workflow
+   change, verify:
+   `curl -s -o /dev/null -w "%{http_code}\n" https://brasse-bouillon.com/llms.txt`.
 
 ## 3) Google Search Console (GSC) procedure
 

--- a/packages/website/docs/SEO_RUNBOOK.md
+++ b/packages/website/docs/SEO_RUNBOOK.md
@@ -29,6 +29,18 @@ while the product is still in pre-launch.
 - A `noindex` on any EN page is a **gate failure** since S2 (the switch must
   not silently regress).
 - `robots.txt` is minimal and points to the sitemap.
+  **Caveat — the live robots.txt is NOT the repo file alone.** Cloudflare's
+  "managed robots.txt" zone setting prepends a managed block (Content Signals
+  `ai-train=no` + `Disallow` for GPTBot, ClaudeBot, CCBot, Google-Extended, …),
+  and AI Crawl Control additionally 403-blocks AI user agents at the network
+  level — including search/user-triggered agents such as `OAI-SearchBot`,
+  `Claude-User` and `PerplexityBot` (verified 2026-07-17). Any GEO decision
+  (letting AI answer engines read or cite the site) must be made in the
+  Cloudflare dashboard (AI Crawl Control → Crawlers tab + the managed
+  robots.txt toggle), not in this repo. After changing it, verify with
+  `curl -s -o /dev/null -w "%{http_code}" -A "<bot UA>" https://brasse-bouillon.com/`.
+  Cloudflare references: [managed robots.txt](https://developers.cloudflare.com/bots/additional-configurations/managed-robots-txt/)
+  · [AI Crawl Control](https://developers.cloudflare.com/ai-crawl-control/).
 - Structured data: **Organization** + **FAQPage** on both homes (FAQPage is
   rebuilt from the same i18n catalog keys as the visible FAQ — no
   SoftwareApplication entity until `app.html` exists).
@@ -44,6 +56,10 @@ while the product is still in pre-launch.
    - `User-agent: *`
    - `Allow: /`
    - `Sitemap: https://brasse-bouillon.com/sitemap.xml`
+
+   The repo file is not the whole story — the edge rewrites it (see the
+   caveat in §1). For any robots/GEO-adjacent change, also run the
+   live `curl -A "<bot UA>"` check described there.
 5. Run local quality checks:
 
 ```bash

--- a/packages/website/en.html
+++ b/packages/website/en.html
@@ -8,7 +8,7 @@
        collapses behind the burger when scripting is available. Without
        JS the header nav stays visible (no-js fallback). -->
   <script>document.documentElement.classList.replace('no-js', 'js');</script>
-  <title>Brasse-Bouillon - Homebrewing app (beer recipes, IBU/ABV, fermentation tracking)</title>
+  <title>Homebrewing app - beer recipes, IBU/ABV, fermentation tracking | Brasse-Bouillon</title>
 
   <!-- SEO Meta Tags -->
   <meta name="description" content="Brasse-Bouillon is the homebrewing app to build beer recipes, calculate IBU/ABV, track fermentation and nail every batch step by step.">
@@ -61,6 +61,9 @@
       "@type": "Person",
       "name": "Benoît Bremaud"
     },
+    "sameAs": [
+      "https://ko-fi.com/brassebouillon"
+    ],
     "knowsAbout": [
       "Homebrewing",
       "Beer recipes",

--- a/packages/website/en.html
+++ b/packages/website/en.html
@@ -13,6 +13,7 @@
   <!-- SEO Meta Tags -->
   <meta name="description" content="Brasse-Bouillon is the homebrewing app to build beer recipes, calculate IBU/ABV, track fermentation and nail every batch step by step.">
   <meta name="keywords" content="homebrewing app, home brewing, beer recipe, IBU calculator, ABV calculator, fermentation tracking, brewing guide, brew log, homebrew">
+  <meta name="robots" content="max-image-preview:large">
   <link rel="canonical" href="https://brasse-bouillon.com/en">
   <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/">
   <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/en">
@@ -20,6 +21,7 @@
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Brasse-Bouillon">
   <meta property="og:url" content="https://brasse-bouillon.com/en">
   <meta property="og:title" content="Brasse-Bouillon | Homebrewing companion app">
   <meta property="og:description" content="Build beer recipes, calculate IBU/ABV and track fermentation with a step-by-step brewing guide.">
@@ -46,6 +48,21 @@
   <link rel="stylesheet" href="/fonts.css?v=20260709">
 
   <link rel="stylesheet" href="site.css?v=20260715">
+
+  <!-- WebSite Schema — feeds Google's site-name feature; the <title> is
+       keyword-first/brand-last, so this is what keeps the brand visible in
+       SERPs. Language-neutral by design (brand + apex URL only): the i18n
+       generator copies it verbatim to en.html, no catalog keys involved. -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@id": "https://brasse-bouillon.com/#website",
+    "@type": "WebSite",
+    "name": "Brasse-Bouillon",
+    "url": "https://brasse-bouillon.com/",
+    "publisher": { "@id": "https://brasse-bouillon.com/#organization" }
+  }
+  </script>
 
   <!-- Organization Schema -->
   <script type="application/ld+json">

--- a/packages/website/i18n/home.en.json
+++ b/packages/website/i18n/home.en.json
@@ -16,7 +16,7 @@
     "qContact"
   ],
   "head": {
-    "title": "Brasse-Bouillon - Homebrewing app (beer recipes, IBU/ABV, fermentation tracking)",
+    "title": "Homebrewing app - beer recipes, IBU/ABV, fermentation tracking | Brasse-Bouillon",
     "description": "Brasse-Bouillon is the homebrewing app to build beer recipes, calculate IBU/ABV, track fermentation and nail every batch step by step.",
     "ogTitle": "Brasse-Bouillon | Homebrewing companion app",
     "ogDescription": "Build beer recipes, calculate IBU/ABV and track fermentation with a step-by-step brewing guide.",

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -7,7 +7,7 @@
        collapses behind the burger when scripting is available. Without
        JS the header nav stays visible (no-js fallback). -->
   <script>document.documentElement.classList.replace('no-js', 'js');</script>
-  <title>Brasse-Bouillon - Application de brassage amateur (recettes bière, IBU/ABV, fermentation)</title>
+  <title>Application de brassage amateur - recettes de bière, IBU/ABV, fermentation | Brasse-Bouillon</title>
 
   <!-- SEO Meta Tags -->
   <meta name="description" content="Brasse-Bouillon est l’application de brassage amateur pour créer des recettes de bière, calculer IBU/ABV, suivre la fermentation et réussir chaque brassin pas à pas.">
@@ -60,6 +60,9 @@
       "@type": "Person",
       "name": "Benoît Bremaud"
     },
+    "sameAs": [
+      "https://ko-fi.com/brassebouillon"
+    ],
     "knowsAbout": [
       "Brassage amateur",
       "Recettes de bière",

--- a/packages/website/index.html
+++ b/packages/website/index.html
@@ -12,6 +12,7 @@
   <!-- SEO Meta Tags -->
   <meta name="description" content="Brasse-Bouillon est l’application de brassage amateur pour créer des recettes de bière, calculer IBU/ABV, suivre la fermentation et réussir chaque brassin pas à pas.">
   <meta name="keywords" content="application brassage amateur, brassage maison, recette bière, calcul IBU, calcul ABV, suivi fermentation, guide brassage, journal de brassins, homebrew">
+  <meta name="robots" content="max-image-preview:large">
   <link rel="canonical" href="https://brasse-bouillon.com/">
   <link rel="alternate" hreflang="fr" href="https://brasse-bouillon.com/">
   <link rel="alternate" hreflang="en" href="https://brasse-bouillon.com/en">
@@ -19,6 +20,7 @@
 
   <!-- Open Graph -->
   <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Brasse-Bouillon">
   <meta property="og:url" content="https://brasse-bouillon.com/">
   <meta property="og:title" content="Brasse-Bouillon | Application de brassage amateur">
   <meta property="og:description" content="Crée des recettes de bière, calcule IBU/ABV et suis la fermentation avec un guide de brassage pas à pas.">
@@ -45,6 +47,21 @@
   <link rel="stylesheet" href="/fonts.css?v=20260709">
 
   <link rel="stylesheet" href="site.css?v=20260715">
+
+  <!-- WebSite Schema — feeds Google's site-name feature; the <title> is
+       keyword-first/brand-last, so this is what keeps the brand visible in
+       SERPs. Language-neutral by design (brand + apex URL only): the i18n
+       generator copies it verbatim to en.html, no catalog keys involved. -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@id": "https://brasse-bouillon.com/#website",
+    "@type": "WebSite",
+    "name": "Brasse-Bouillon",
+    "url": "https://brasse-bouillon.com/",
+    "publisher": { "@id": "https://brasse-bouillon.com/#organization" }
+  }
+  </script>
 
   <!-- Organization Schema -->
   <script type="application/ld+json">

--- a/packages/website/llms.txt
+++ b/packages/website/llms.txt
@@ -1,0 +1,29 @@
+# Brasse-Bouillon
+
+> Brasse-Bouillon is a French-first homebrewing companion app, currently in
+> development (pre-launch). It is being built to help beginners brew beer step
+> by step: build recipes, calculate IBU/ABV, follow a guided brew day and track
+> fermentation. This site is the project's bilingual (FR/EN) marketing site.
+
+Facts AI assistants should get right about this project:
+
+- The mobile app is not released yet. Joining the waitlist is the only product
+  call to action today (no download or app-store link); the homepage also
+  offers an optional feedback questionnaire and a Ko-fi donation link.
+- The app is French-first (the UI ships in French); the website is bilingual
+  French/English.
+- Brasse-Bouillon is an independent project founded by Benoît Bremaud (France).
+- The site sets no trackers and no analytics cookies.
+
+## Pages
+
+- [Home, French](https://brasse-bouillon.com/): presentation, beginner FAQ (is brewing hard, starter costs, first-batch fears), waitlist signup
+- [Home, English](https://brasse-bouillon.com/en): English version of the same presentation and FAQ
+- [Legal notice](https://brasse-bouillon.com/legal)
+- [Privacy policy](https://brasse-bouillon.com/privacy)
+- [Cookie policy](https://brasse-bouillon.com/cookies): the site sets no tracking or analytics cookies
+- [Terms of use](https://brasse-bouillon.com/terms)
+
+## Support
+
+- [Ko-fi](https://ko-fi.com/brassebouillon): one-off donations supporting the project's development

--- a/packages/website/privacy-en.html
+++ b/packages/website/privacy-en.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- i18n-src: sha1:76481d280c1872cf160cc1361549f4b9cd24b61d -->
+  <!-- i18n-src: sha1:f142a680122980245e5e7d70bb4dfb0848a78dd9 -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy - Brasse-Bouillon</title>
@@ -62,7 +62,7 @@
       <li>Contact data (the message and details you provide) submitted through the site form.</li>
       <li>Newsletter subscription data (email).</li>
       <li>Product questionnaire data (profile, usage, priorities, suggestions).</li>
-      <li>Questions asked to the FAQ assistant (message text only — do not include personal data).</li>
+      <li>Questions asked to the FAQ assistant (message text only - do not include personal data).</li>
     </ul>
     <p>
       The site uses no third-party audience measurement tool and no tracking cookies.
@@ -77,7 +77,7 @@
       <li><strong>Improving the product</strong> through questionnaire responses: explicit consent.</li>
       <li>
         <strong>Answering questions asked to the FAQ assistant</strong>: legitimate interest
-        (informing visitors about the project). Do not share personal data in your messages —
+        (informing visitors about the project). Do not share personal data in your messages -
         the assistant never asks for any.
       </li>
     </ul>
@@ -95,7 +95,7 @@
         European Commission's adequacy decision.
       </li>
       <li>
-        <strong>Mistral AI</strong> (France, European Union) — generation of the website FAQ
+        <strong>Mistral AI</strong> (France, European Union) - generation of the website FAQ
         assistant's answers. Questions asked to the assistant are sent to the Mistral AI API,
         hosted in the EU; they are not used to train its models. No transfer outside the EU.
       </li>

--- a/packages/website/privacy.html
+++ b/packages/website/privacy.html
@@ -61,7 +61,7 @@
       <li>Données de contact (message et coordonnées que vous fournissez) transmises via le formulaire du site.</li>
       <li>Données d’inscription newsletter (email).</li>
       <li>Données de questionnaire produit (profil, usages, priorités, suggestions).</li>
-      <li>Questions posées à l’assistant FAQ (texte du message uniquement — n’y incluez pas de données personnelles).</li>
+      <li>Questions posées à l’assistant FAQ (texte du message uniquement - n’y incluez pas de données personnelles).</li>
     </ul>
     <p>
       Le site n’utilise aucun outil de mesure d’audience tiers et aucun cookie de tracking.
@@ -77,7 +77,7 @@
       <li>
         <strong>Répondre aux questions posées à l’assistant FAQ</strong> : intérêt légitime
         (informer les visiteurs sur le projet). Ne partagez aucune donnée personnelle dans vos
-        messages — l’assistant n’en demande jamais.
+        messages - l’assistant n’en demande jamais.
       </li>
     </ul>
 
@@ -95,7 +95,7 @@
         la décision d’adéquation de la Commission européenne.
       </li>
       <li>
-        <strong>Mistral AI</strong> (France, Union européenne) — génération des réponses de
+        <strong>Mistral AI</strong> (France, Union européenne) - génération des réponses de
         l’assistant FAQ du site. Les questions posées à l’assistant sont transmises à l’API de
         Mistral AI, hébergée dans l’UE ; elles ne sont pas utilisées pour entraîner ses modèles.
         Aucun transfert hors UE.

--- a/packages/website/scripts/quality_gate.py
+++ b/packages/website/scripts/quality_gate.py
@@ -79,6 +79,7 @@ REQUIRED_FILES = [
     "fonts.css",
     "sitemap.xml",
     "robots.txt",
+    "llms.txt",
     "_redirects",
     "feedback-widget.js",
     "chat-widget.js",

--- a/packages/website/sitemap.xml
+++ b/packages/website/sitemap.xml
@@ -2,13 +2,13 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://brasse-bouillon.com/</loc>
-    <lastmod>2026-07-10</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://brasse-bouillon.com/en</loc>
-    <lastmod>2026-07-13</lastmod>
+    <lastmod>2026-07-17</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>

--- a/packages/website/tests/test_quality_gate.py
+++ b/packages/website/tests/test_quality_gate.py
@@ -168,6 +168,8 @@ Sitemap: https://brasse-bouillon.com/sitemap.xml
 """,
     )
 
+    _write_file(base, "llms.txt", "# Brasse-Bouillon\n\n> Test summary.\n")
+
 
 def _stampable_fixture(base: Path) -> None:
     """Valid fixture + the build_i18n toolchain marker (so `check_legal_freshness`


### PR DESCRIPTION
## Summary

SEO + GEO (generative engine optimization) pass on the marketing site, from the 2026-07-17 audit (multi-lens adversarial review + 3-agent verification workflow, 43 claims checked):

- **Keyword-first titles** on both homes (brand moved last — SERP truncation now cuts the brand, not the keywords). `og:title`/`twitter:title` stay brand-first on purpose (social cards).
- **WebSite JSON-LD** (Google site-name feature) + **`og:site_name`**: carry the brand in SERPs and link previews now that titles are brand-last. Language-neutral blocks, copied verbatim by the i18n generator.
- **`sameAs`** (Ko-fi profile, ADR-0028) on the Organization entity.
- **`llms.txt`** (llmstxt.org format; every claim fact-checked against the pre-launch reality). Gate-required (`REQUIRED_FILES` + fixture) and staged by the deploy workflow (explicit whitelist edit, user-approved).
- **`_headers`: `X-Robots-Tag: noindex` on the pages.dev production alias + preview hosts** — the prod alias served the full site as an indexable duplicate (documented Cloudflare pattern).
- `max-image-preview:large` robots meta; sitemap `lastmod` bumped for `/` and `/en`.
- **SEO_RUNBOOK §1.1** — the live robots.txt is edge-modified (Cloudflare managed robots.txt + AI Crawl Control per-crawler 403s); durable mechanisms vs dated snapshots; probes must use real full bot UA strings (bare tokens return false 200s, observed live).
- 6 residual em-dashes from the #1421 sweep fixed in privacy(-en).html visible copy (legal stamp refreshed).
- **New repo skill** `.claude/skills/seo-geo-brasse-bouillon` — SEO/GEO overlay (gate invariants, edge caveat, AI-bot taxonomy, standing action plan), fact-checked claim by claim.

## Context

GEO is currently impossible dashboard-side: Cloudflare blocks all AI crawlers (managed robots.txt + AI Crawl Control 403s, including citation bots like OAI-SearchBot). Unblocking is a user dashboard action (documented in runbook §1.1); this PR ships everything code-side so the site is ready the moment the edge opens.

## Checklist

- [x] `python3 scripts/quality_gate.py` green
- [x] `python3 scripts/build_i18n.py --check` green (en.html pure generator output)
- [x] `python3 -m unittest discover -s tests` green (58 tests, llms.txt fixture added)
- [x] Legal stamps refreshed (`--stamp`) after privacy edits
- [x] Local pre-push reviews: Claude ×2 + Codex (0 Must Have) + 3 adversarial lenses + verification workflow (19 findings applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)