### PR TITLE
chore(website): apply ruff format to roadmap_sync and weekly_digest scripts

### DIFF
--- a/packages/website/scripts/roadmap_sync.py
+++ b/packages/website/scripts/roadmap_sync.py
@@ -60,13 +60,17 @@ class RoadmapPayload:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Sync roadmap feed and markdown table from dispatch payload")
+    parser = argparse.ArgumentParser(
+        description="Sync roadmap feed and markdown table from dispatch payload"
+    )
     parser.add_argument(
         "--event-path",
         default="",
         help="Path to a GitHub event JSON file (defaults to $GITHUB_EVENT_PATH when omitted)",
     )
-    parser.add_argument("--payload-file", default="", help="Path to a payload JSON file")
+    parser.add_argument(
+        "--payload-file", default="", help="Path to a payload JSON file"
+    )
     parser.add_argument("--payload-json", default="", help="Raw payload JSON string")
     return parser.parse_args()
 
@@ -81,7 +85,12 @@ def normalize_iso_datetime(raw: str) -> str:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
 
-    return dt.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return (
+        dt.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
 
 
 def parse_evidence_links(raw: Any) -> list[str]:
@@ -118,7 +127,9 @@ def parse_payload(raw: dict[str, Any]) -> RoadmapPayload:
         "summary_en",
     ]
 
-    missing = [field for field in required_fields if not str(raw.get(field, "")).strip()]
+    missing = [
+        field for field in required_fields if not str(raw.get(field, "")).strip()
+    ]
     if missing:
         raise ValueError(f"Missing required payload field(s): {', '.join(missing)}")
 
@@ -149,7 +160,9 @@ def load_raw_payload(args: argparse.Namespace) -> dict[str, Any]:
     else:
         event_path = args.event_path or os_environ("GITHUB_EVENT_PATH")
         if not event_path:
-            raise ValueError("No payload source provided. Use --event-path, --payload-file, or --payload-json.")
+            raise ValueError(
+                "No payload source provided. Use --event-path, --payload-file, or --payload-json."
+            )
         data = json.loads(Path(event_path).read_text(encoding="utf-8"))
 
     if not isinstance(data, dict):
@@ -217,7 +230,9 @@ def upsert_entry(feed: dict[str, Any], entry: dict[str, Any]) -> None:
 
 def save_feed(feed: dict[str, Any], path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(feed, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(feed, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
 
 
 def markdown_link(label: str, url: str) -> str:
@@ -240,7 +255,11 @@ def reference_label(url: str, index: int) -> str:
 
 def build_references(entry: dict[str, Any]) -> str:
     source_repo = str(entry.get("source_repo", "")).strip()
-    repo_name = source_repo.split("/")[-1].replace("brasse-bouillon-", "") if source_repo else "source"
+    repo_name = (
+        source_repo.split("/")[-1].replace("brasse-bouillon-", "")
+        if source_repo
+        else "source"
+    )
     pr_number = entry.get("pr_number")
     pr_url = str(entry.get("pr_url", "")).strip()
 
@@ -277,7 +296,9 @@ def render_done_table(entries: list[dict[str, Any]]) -> str:
     for entry in entries:
         date = sanitize_cell(entry.get("date", ""))
         domain = sanitize_cell(entry.get("domain", ""))
-        summary = sanitize_cell(entry.get("summary_en") or entry.get("pr_title") or "Update")
+        summary = sanitize_cell(
+            entry.get("summary_en") or entry.get("pr_title") or "Update"
+        )
         references = sanitize_cell(build_references(entry))
         lines.append(f"| {date} | {domain} | {summary} | {references} |")
 

--- a/packages/website/scripts/weekly_digest.py
+++ b/packages/website/scripts/weekly_digest.py
@@ -143,8 +143,11 @@ def normalize_iso_datetime(value: str) -> str:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
 
-    return dt.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace(
-        "+00:00", "Z"
+    return (
+        dt.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
     )
 
 
@@ -188,10 +191,7 @@ def ensure_allowed_api_url(url: str) -> None:
     if parsed.scheme != "https":
         raise ValueError(f"Unsupported URL scheme for GitHub API call: {parsed.scheme}")
     if parsed.netloc not in ALLOWED_GITHUB_API_HOSTS:
-        raise ValueError(
-            "Unexpected GitHub API host in URL: "
-            f"{parsed.netloc}"
-        )
+        raise ValueError(f"Unexpected GitHub API host in URL: {parsed.netloc}")
     if not parsed.path.startswith("/"):
         raise ValueError("Invalid GitHub API URL path")
 
@@ -210,15 +210,11 @@ def github_get_json(url: str, token: str) -> tuple[Any, dict[str, str]]:
     try:
         with request.urlopen(req, timeout=30) as response:
             payload = json.loads(response.read().decode("utf-8"))
-            response_headers = {
-                key: value for key, value in response.headers.items()
-            }
+            response_headers = {key: value for key, value in response.headers.items()}
             return payload, response_headers
     except error.HTTPError as exc:  # pragma: no cover - network error path
         detail = exc.read().decode("utf-8", errors="replace")
-        raise RuntimeError(
-            f"GitHub API error {exc.code} for {url}: {detail}"
-        ) from exc
+        raise RuntimeError(f"GitHub API error {exc.code} for {url}: {detail}") from exc
 
 
 def paginated_get(url: str, token: str) -> list[Any]:
@@ -227,7 +223,9 @@ def paginated_get(url: str, token: str) -> list[Any]:
     while next_url:
         payload, headers = github_get_json(next_url, token)
         if not isinstance(payload, list):
-            raise ValueError(f"Expected list payload from GitHub API, got {type(payload)}")
+            raise ValueError(
+                f"Expected list payload from GitHub API, got {type(payload)}"
+            )
         items.extend(payload)
         links = parse_link_header(headers.get("Link", ""))
         next_url = links.get("next", "")
@@ -341,9 +339,13 @@ def collect_pr_records(
 ) -> list[PullRequestRecord]:
     records: list[PullRequestRecord] = []
     for repo in repos:
-        merged_prs = fetch_merged_prs(repo=repo, since_iso=since_iso, token=token, max_prs=max_prs)
+        merged_prs = fetch_merged_prs(
+            repo=repo, since_iso=since_iso, token=token, max_prs=max_prs
+        )
         for merged_pr in merged_prs:
-            files = fetch_pr_files(repo=repo, pr_number=merged_pr["number"], token=token)
+            files = fetch_pr_files(
+                repo=repo, pr_number=merged_pr["number"], token=token
+            )
             user_facing, reason = classify_pr(
                 repo=repo,
                 title=merged_pr["title"],
@@ -424,7 +426,9 @@ def select_highlights(user_facing_prs: list[PullRequestRecord]) -> list[str]:
         )
 
     if not highlights:
-        highlights.append("Multiple user-facing improvements were merged and are ready to communicate.")
+        highlights.append(
+            "Multiple user-facing improvements were merged and are ready to communicate."
+        )
 
     return highlights[:5]
 
@@ -560,9 +564,7 @@ def render_social_drafts_markdown(
             "Plusieurs améliorations user-facing ont été livrées cette semaine."
         ]
     if user_facing and not en_bullets:
-        en_bullets = [
-            "Multiple user-facing improvements were delivered this week"
-        ]
+        en_bullets = ["Multiple user-facing improvements were delivered this week"]
 
     if not user_facing:
         fr_bullets = [
@@ -681,8 +683,16 @@ def main() -> int:
         feed_path = Path(args.feed_path)
         output_dir = Path(args.output_dir)
 
-        since_iso = normalize_iso_datetime(args.since) if args.since else infer_since_from_feed(feed_path)
-        token = args.token or os.environ.get("GH_TOKEN", "") or os.environ.get("GITHUB_TOKEN", "")
+        since_iso = (
+            normalize_iso_datetime(args.since)
+            if args.since
+            else infer_since_from_feed(feed_path)
+        )
+        token = (
+            args.token
+            or os.environ.get("GH_TOKEN", "")
+            or os.environ.get("GITHUB_TOKEN", "")
+        )
         repos = args.repos if args.repos else DEFAULT_REPOS
 
         generated_at = now_iso()


### PR DESCRIPTION
## Summary

Apply `ruff format` to the two pre-existing Python scripts in `packages/website` that `ruff format --check scripts tests` flagged as needing reformatting:

- `scripts/roadmap_sync.py`
- `scripts/weekly_digest.py`

The diff is purely cosmetic: line wrapping to fit the line-length limit, plus a missing trailing newline at the end of `roadmap_sync.py`. No semantic change — verified at the AST level (old and new versions of both files parse to identical ASTs).

## Context

Both files predate current work (last touched in c0939553 / 8f495d66) and are not gated red by CI today — the website CI job runs the quality gate and the unittest suite but no ruff step. This chore clears the local `ruff format --check` noise so future website PRs start from a clean formatter baseline.

## Checklist

- [x] `ruff format --check scripts tests` — green (8 files, all formatted)
- [x] `ruff check scripts tests` — green
- [x] `python3 -m unittest discover -s tests` — 58 tests OK
- [x] `python3 scripts/quality_gate.py` — passed
- [x] AST-identical before/after (zero semantic drift)
- [x] Local pre-push review ritual run (Claude + Codex reviewers): no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)