### PR TITLE
docs(review): align AI-reviewer docs with GitHub reality

### DIFF
--- a/.claude/skills/pr-create-brasse-bouillon/SKILL.md
+++ b/.claude/skills/pr-create-brasse-bouillon/SKILL.md
@@ -59,9 +59,9 @@ gh api graphql -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{pro
 
 ## Step 4 — Reviewers
 
-Codex reviews **every PR automatically** on GitHub but **posts a comment
-only when it has findings** — a clean PR gets no Codex comment; never wait
-for one. CodeRabbit was removed 2026-06-24. Do **not** call
+Codex auto-triggers when the PR is **opened** (not on push). Its verdict is
+either a **review** (it has findings) or a **👍 reaction on the PR body**
+(clean) — never silence. CodeRabbit was removed 2026-06-24. Do **not** call
 `requested_reviewers` for `Codex` or `Copilot` (the API returns 422 for
 GitHub App bot accounts).
 
@@ -132,6 +132,6 @@ gh api repos/benoit-bremaud/brasse-bouillon/issues/$PR/comments \
 2. Open the PR (step 1).
 3. Apply labels + assignee + project + milestone (steps 2–5) — these can run in parallel.
 4. Post the French FYI comment (step 6).
-5. Check the posted bot reviews before any merge, per the global `pr-review-procedure` skill (loaded from `~/.claude/skills/pr-review-procedure/SKILL.md`, user-scoped — invoke by name, no in-repo link possible). Codex posts only when it has findings — a clean PR gets nothing, so never block waiting for it. Copilot posts only if `needs-copilot` was added in step 4. Address whatever comments are actually there. The substantive review is the local pre-push ritual (Claude + Codex) run before pushing.
+5. Wait for Codex's verdict on the head commit before any merge, per the global `pr-review-procedure` skill (loaded from `~/.claude/skills/pr-review-procedure/SKILL.md`, user-scoped — invoke by name, no in-repo link possible). The verdict is a **review** (findings) or a **👍 on the PR body** (clean); an empty `pulls/$PR/reviews` proves nothing on its own — poll both channels for up to ~10 min, and if nothing lands, record "no Codex verdict" instead of assuming clean. Copilot posts only if `needs-copilot` was added in step 4. Full protocol + commands: CONTRIBUTING.md § AI reviewers. The substantive review is the local pre-push ritual (Claude + Codex) run before pushing.
 
 Never auto-merge. Never use `--auto` or `--admin`. Per the global merge gate, present a readiness summary in English and wait for explicit textual approval.

--- a/.claude/skills/pr-create-brasse-bouillon/SKILL.md
+++ b/.claude/skills/pr-create-brasse-bouillon/SKILL.md
@@ -59,9 +59,11 @@ gh api graphql -f query='mutation($p:ID!,$c:ID!){addProjectV2ItemById(input:{pro
 
 ## Step 4 — Reviewers
 
-Codex reviews **every PR automatically** on GitHub; CodeRabbit was removed
-2026-06-24. Do **not** call `requested_reviewers` for `Codex` or `Copilot`
-(the API returns 422 for GitHub App bot accounts).
+Codex reviews **every PR automatically** on GitHub but **posts a comment
+only when it has findings** — a clean PR gets no Codex comment; never wait
+for one. CodeRabbit was removed 2026-06-24. Do **not** call
+`requested_reviewers` for `Codex` or `Copilot` (the API returns 422 for
+GitHub App bot accounts).
 
 Copilot is **manual** (it bills premium requests; ×13 per review since
 2026-06-01). Do **not** request it by default. Only when a deliberate Copilot
@@ -71,7 +73,12 @@ review is wanted, add the `needs-copilot` label:
 gh pr edit "$PR" --add-label "needs-copilot"
 ```
 
-The `Copilot Review` workflow then posts `@copilot please review`. See
+The `Copilot Review` workflow then posts `@copilot please review`. Gotcha:
+automatic Copilot review is governed by a **repository ruleset**, not by
+that workflow — after the workflow went label-only (2026-06-05), the
+`copilot_code_review` ruleset rule silently kept auto-reviewing every
+non-draft PR until it was removed on 2026-07-17. If unlabeled PRs get
+Copilot reviews again, fix it in *Settings → Rules → Rulesets*. See
 CONTRIBUTING.md § AI reviewers.
 
 ## Step 5 — Milestone
@@ -125,6 +132,6 @@ gh api repos/benoit-bremaud/brasse-bouillon/issues/$PR/comments \
 2. Open the PR (step 1).
 3. Apply labels + assignee + project + milestone (steps 2–5) — these can run in parallel.
 4. Post the French FYI comment (step 6).
-5. Wait for the automatic Codex review (and Copilot, if `needs-copilot` was added in step 4) to be **posted** per the global `pr-review-procedure` skill (loaded from `~/.claude/skills/pr-review-procedure/SKILL.md`, user-scoped — invoke by name, no in-repo link possible) before any merge. The substantive review is the local pre-push ritual (Claude + Codex) run before pushing.
+5. Check the posted bot reviews before any merge, per the global `pr-review-procedure` skill (loaded from `~/.claude/skills/pr-review-procedure/SKILL.md`, user-scoped — invoke by name, no in-repo link possible). Codex posts only when it has findings — a clean PR gets nothing, so never block waiting for it. Copilot posts only if `needs-copilot` was added in step 4. Address whatever comments are actually there. The substantive review is the local pre-push ritual (Claude + Codex) run before pushing.
 
 Never auto-merge. Never use `--auto` or `--admin`. Per the global merge gate, present a readiness summary in English and wait for explicit textual approval.

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -4,8 +4,9 @@ name: Copilot Review
 # Rationale: each Copilot review consumes a GitHub Copilot premium request
 # (13 per review since 2026-06-01 under the AI-credits model), so we reserve it
 # for deliberate, complementary reviews. The default review path is the local
-# pre-push ritual (Claude + Codex) plus CodeRabbit post-push.
-# See CONTRIBUTING.md § AI reviewers.
+# pre-push ritual (Claude + Codex) plus the Codex GitHub bot post-push.
+# NOTE: automatic Copilot review is governed by a repository RULESET, not by
+# this workflow — see CONTRIBUTING.md § AI reviewers (rule removed 2026-07-17).
 #
 # To trigger Copilot on a PR: add the `needs-copilot` label.
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -488,9 +488,14 @@ What this means in practice:
   rather than "Codex clean".
 - **A verdict covers only the commit Codex read, and pushing does not
   re-trigger it.** After pushing to an open PR, comment `@codex review` to get
-  a fresh pass. GitHub allows one reaction per user, so a re-triggered clean
-  pass cannot add a second 👍 — after a re-trigger, "no new review within the
-  bounded wait" is the clean signal.
+  a fresh pass, and check the new verdict names the current head SHA.
+- **On a PR that already carries a 👍, a clean re-pass has no signal left to
+  send** — GitHub allows one reaction per user, so Codex cannot 👍 twice. "No
+  new review" is then indistinguishable from "the re-run never happened", and
+  inferring clean from it is the same silence-as-authorization mistake this
+  section exists to prevent. That head has **no Codex verdict**: merge on the
+  local pre-push review + CI and log it as such. (A PR whose verdicts so far
+  were all reviews can still be cleared with a 👍 — the reaction is unused.)
 - **Do not** call `gh api ... requested_reviewers -X POST` for `Codex` or
   `Copilot` — the call fails with 422 for GitHub App bot accounts (not all
   `[bot]` users). Codex auto-triggers; Copilot is triggered via the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,11 +413,11 @@ RGPD. Aucun impact sur l'application mobile ni sur le serveur backend.
 
 The list of people to mention should be suggested based on the PR context (scope labels, area labels) and confirmed by the author before posting.
 
-### 7. Check reviews
+### 7. Wait for review
 
 - CI must pass (GitHub Actions runs automatically)
+- **Codex has returned a verdict** on the current head commit — a review (findings) or a 👍 (clean). Neither means it has not finished; see § AI reviewers below for how to read and wait for it
 - Every posted review comment is addressed — bot reviewers (Codex, and Copilot on demand) only comment, and `main` has no required-approval or status-check rule (its ruleset only blocks deletion and force-push, see § AI reviewers below), so a GitHub approval is **not** required; the local pre-push review (all Must-Have items resolved) is the gate
-- Address review comments before merging
 
 #### AI reviewers — defence-in-depth pipeline
 
@@ -438,10 +438,10 @@ gates the push on all Must Have items resolved.
 
 **2. Post-push (GitHub) — Codex (automatic) + Copilot (on-demand):**
 
-| Reviewer | Bot account | Trigger | Status |
+| Reviewer | Bot account | Trigger | Verdict |
 |---|---|---|---|
-| Codex | `chatgpt-codex-connector[bot]` | Automatic on every PR — **posts only when it has findings** | Comments only — never approves |
-| Copilot | `copilot-pull-request-reviewer[bot]` | **Manual** — add the `needs-copilot` label | On-demand only (premium-request quota) |
+| Codex | `chatgpt-codex-connector[bot]` | Automatic when a PR is **opened**, a draft is **marked ready**, or someone comments `@codex review` — **never on push** | Review if it has findings, **👍 reaction on the PR body if clean** — never approves |
+| Copilot | `copilot-pull-request-reviewer[bot]` | **Manual** — add the `needs-copilot` label | Review comments only (premium-request quota) — never approves |
 
 Codex also runs in the **local pre-push** ritual (`scripts/codex-review.sh`).
 No GitHub bot reviewer can *approve* — they only post comments.
@@ -460,16 +460,41 @@ What this means in practice:
   protects `main` against deletion and force-push. If Copilot ever starts
   reviewing unlabeled PRs again, check *Settings → Rules → Rulesets* —
   editing `copilot-review.yml` will not turn it off.
-- **Codex posts nothing on a clean PR.** Do not block a merge waiting for a
-  Codex comment that may never come — check the posted reviews and address
-  what is actually there.
+- **Codex signals "clean" with a 👍, not with silence.** Its own doc block
+  states the contract: *"If Codex has suggestions, it will comment; otherwise
+  it will react with 👍."* So its verdict is exactly one of two things:
+  **findings** → a review whose body names the commit it read
+  (`**Reviewed commit:** <sha>`); **clean** → a `+1` reaction on the PR body.
+  **Neither present = no verdict yet** — it is still running, or it never ran.
+  Never read that as clean.
+- **Poll both channels — the review list alone cannot tell you.**
+  `pulls/$PR/reviews` returns `[]` both when Codex cleared the PR and when it
+  has not started; those are different states with the same shape:
+
+  ```bash
+  # clean verdict (the channel that is easy to miss)
+  gh api repos/benoit-bremaud/brasse-bouillon/issues/$PR/reactions \
+    --jq '[.[] | select(.user.login=="chatgpt-codex-connector[bot]" and .content=="+1") | .created_at] | last // "no clean verdict"'
+  # findings verdict, and the SHA it was made against
+  gh api repos/benoit-bremaud/brasse-bouillon/pulls/$PR/reviews \
+    --jq '.[] | select(.user.login=="chatgpt-codex-connector[bot]") | .submitted_at'
+  ```
+
+- **Bounded wait, then report what actually happened.** Poll for up to ~10
+  minutes after the trigger (observed: 👍 in ~2 min, reviews in 2–7 min).
+  If no verdict lands, Codex did not run — it was down for all of 2026-07-16
+  and #1442–#1459 merged with no Codex pass. That is **not** a clean verdict:
+  merge on the local pre-push review + green CI, and log "no Codex verdict"
+  rather than "Codex clean".
+- **A verdict covers only the commit Codex read, and pushing does not
+  re-trigger it.** After pushing to an open PR, comment `@codex review` to get
+  a fresh pass. GitHub allows one reaction per user, so a re-triggered clean
+  pass cannot add a second 👍 — after a re-trigger, "no new review within the
+  bounded wait" is the clean signal.
 - **Do not** call `gh api ... requested_reviewers -X POST` for `Codex` or
   `Copilot` — the call fails with 422 for GitHub App bot accounts (not all
-  `[bot]` users). Codex reviews automatically; Copilot is triggered via the
+  `[bot]` users). Codex auto-triggers; Copilot is triggered via the
   `needs-copilot` label above.
-- **Do** check the posted reviews before considering the PR ready, per the
-  PR review procedure in global `~/.claude/CLAUDE.md`. Verify with:
-  `gh api repos/OWNER/REPO/pulls/PR/reviews --jq '.[].state'`.
 - **Do** address every inline comment per the Must Have / Should
   Have / Nice to Have / Disagree taxonomy, exactly the same way as
   for a human reviewer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -413,10 +413,10 @@ RGPD. Aucun impact sur l'application mobile ni sur le serveur backend.
 
 The list of people to mention should be suggested based on the PR context (scope labels, area labels) and confirmed by the author before posting.
 
-### 7. Wait for review
+### 7. Check reviews
 
 - CI must pass (GitHub Actions runs automatically)
-- Every posted review comment is addressed — bot reviewers (Codex, and Copilot on demand) only comment, and `main` is not branch-protected, so a GitHub approval is **not** required; the local pre-push review (all Must-Have items resolved) is the gate
+- Every posted review comment is addressed — bot reviewers (Codex, and Copilot on demand) only comment, and `main` has no required-approval or status-check rule (its ruleset only blocks deletion and force-push, see § AI reviewers below), so a GitHub approval is **not** required; the local pre-push review (all Must-Have items resolved) is the gate
 - Address review comments before merging
 
 #### AI reviewers — defence-in-depth pipeline
@@ -440,7 +440,7 @@ gates the push on all Must Have items resolved.
 
 | Reviewer | Bot account | Trigger | Status |
 |---|---|---|---|
-| Codex | `chatgpt-codex-connector[bot]` | Automatic on every PR | Comments only — never approves |
+| Codex | `chatgpt-codex-connector[bot]` | Automatic on every PR — **posts only when it has findings** | Comments only — never approves |
 | Copilot | `copilot-pull-request-reviewer[bot]` | **Manual** — add the `needs-copilot` label | On-demand only (premium-request quota) |
 
 Codex also runs in the **local pre-push** ritual (`scripts/codex-review.sh`).
@@ -452,13 +452,23 @@ What this means in practice:
   review on a PR, add the **`needs-copilot`** label — the `Copilot Review`
   workflow then posts `@copilot please review`. Use it sparingly (premium
   requests, ×13 per review).
+- **Automatic Copilot review is controlled by a repository ruleset, not by
+  the workflow.** From 2026-06-05 to 2026-07-17 an active ruleset rule
+  (`copilot_code_review`) kept auto-requesting Copilot on every non-draft
+  PR despite the documented manual-only policy; the rule was removed on
+  2026-07-17. The ruleset, renamed *Protect default branch*, now only
+  protects `main` against deletion and force-push. If Copilot ever starts
+  reviewing unlabeled PRs again, check *Settings → Rules → Rulesets* —
+  editing `copilot-review.yml` will not turn it off.
+- **Codex posts nothing on a clean PR.** Do not block a merge waiting for a
+  Codex comment that may never come — check the posted reviews and address
+  what is actually there.
 - **Do not** call `gh api ... requested_reviewers -X POST` for `Codex` or
   `Copilot` — the call fails with 422 for GitHub App bot accounts (not all
   `[bot]` users). Codex reviews automatically; Copilot is triggered via the
   `needs-copilot` label above.
-- **Do** wait for each review to be **posted** (not just "requested")
-  before considering the PR ready, per the PR review procedure in
-  global `~/.claude/CLAUDE.md`. Verify with:
+- **Do** check the posted reviews before considering the PR ready, per the
+  PR review procedure in global `~/.claude/CLAUDE.md`. Verify with:
   `gh api repos/OWNER/REPO/pulls/PR/reviews --jq '.[].state'`.
 - **Do** address every inline comment per the Must Have / Should
   Have / Nice to Have / Disagree taxonomy, exactly the same way as

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. Quick summary:
 - Use Conventional Commits: `type(scope): description`.
 - Run `make lint-all && make test-all` before pushing.
 - Open a PR with a clear description and checklist.
-- Wait for CI green and at least one review before merging.
+- Wait for CI green and for Codex's verdict — a review (findings) or a 👍 on the PR body (clean) — before merging. See [CONTRIBUTING.md](CONTRIBUTING.md) § AI reviewers.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Copilot**: the 2026-06-06 "manual-only" switch never took effect — only the workflow was label-gated, while the active repository ruleset rule `copilot_code_review` kept auto-requesting Copilot on every non-draft PR (verified from ≥2026-06-05 through 2026-07-17, observed on #1461/#1463/#1464/#1467). The rule was removed on 2026-07-17 (ruleset renamed *Protect default branch*, keeping the deletion/force-push protections on `main`). Docs now state where the real switch lives (*Settings → Rules → Rulesets*), since editing `copilot-review.yml` cannot turn it off.
- **Codex GitHub**: not retired — it reviews every PR but posts a comment **only when it has findings** (posted on #1437 and #1460, silent on the clean PRs above). Docs no longer instruct to wait for a Codex post before merge.
- Applied from the pre-push review reconciliation: reworded the now-contradictory "`main` is not branch-protected" line, renamed CONTRIBUTING §7 to *Check reviews*, fixed the stale CodeRabbit mention in the `copilot-review.yml` header (comment-only, no behavior change).
- The local pre-push ritual (`pre-push-review` skill, local Codex CLI) is deliberately unchanged.

## Context

Observed on 2026-07-17: `copilot-pull-request-reviewer[bot]` reviewed every PR without the `needs-copilot` label while `chatgpt-codex-connector[bot]` posted nothing. Fact-check against the ruleset version history confirmed the rule predated the 2026-06-06 decision and silently survived it. Both resolutions (truly disable Copilot auto-review; document Codex silent-when-clean) were explicitly confirmed by @benoit-bremaud before this change.

## Checklist

- [x] Docs-only + one comment-line in a workflow header (no behavior change)
- [x] Local pre-push review ritual run (Claude pr-pre-reviewer + Codex CLI + independent fact-check agent): 0 Must Have; all retained Should Haves implemented
- [x] `npm run ci:all` green locally
- [x] Conventional Commits (`docs(review)`, matching repo precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)