### PR TITLE
docs(log): record PR #1469 (ruff format for website scripts)

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -7,6 +7,12 @@ This is the operational logbook, not the release changelog (see [docs/changelog.
 
 ## 2026-07-17
 
+### PR #1469 merged (`2e04b35`) — chore(website): apply ruff format to roadmap_sync and weekly_digest scripts
+
+- Branch `chore/website-ruff-format`, 1 commit (`3619342`).
+- Formatter-only pass over the two pre-existing scripts that `ruff format --check` still flagged (line wrapping + missing trailing newline); AST-verified identical before/after. `ruff check`, the 58-test website unittest suite, and `quality_gate.py` stay green. Website CI runs no ruff step — this clears the local formatter baseline only.
+- Reviews — local pre-push: 0 Must Have (Claude reviewer + Codex CLI). On GitHub: Copilot overview only, no inline comments; Codex posted no review. CI green.
+
 ### PR #1467 merged (`eac81af`) — fix(website): close the head-level blind spot in the i18n srcHash drift guard
 
 - Branch `claude/laughing-lamport-3fe93f`, 2 commits (`5f40146`, `a2c3a52`).


### PR DESCRIPTION
## Summary

Add the PROJECT_LOG.md entry for PR #1469 (`2e04b35`) — the formatter-only `ruff format` pass on `packages/website/scripts/roadmap_sync.py` and `weekly_digest.py`.

## Checklist

- [x] Entry at the top of the existing `## 2026-07-17` section (reverse-chronological order preserved)
- [x] SHA references resolve on `main` (`2e04b35` merge commit, `3619342` branch commit); log-wide SHA sanity scan clean
- [x] Format matches neighboring entries (terse references, Reviews line, no narrative)
- [x] Local pre-push review ritual run (Claude + Codex reviewers): 0 Must Have; the 2 cosmetic notes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)