### PR TITLE
ci(website): add ruff lint and format checks to the website job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@
 # Quality gates (ADR-0019):
 #   - Mobile App: lint + typecheck + format + unit tests (blocking coverage ratchet)
 #   - API: lint + build + unit tests (blocking coverage ratchet) + e2e (Supertest)
-#   - Website: Python quality gate
+#   - Website: ruff lint + format check + Python quality gate + unit tests
 #   - Beer Encyclopedia: ruff lint + compile check + tests (blocking coverage ratchet)
 #   - Security: npm audit (here) + gitleaks / CodeQL / dependency-review (dedicated workflows)
 #
@@ -137,7 +137,7 @@ jobs:
           retention-days: 7
 
   # ============================================================================
-  # Website: Python quality gate (if scripts exist)
+  # Website: ruff lint + format check + Python quality gate + unit tests
   # ============================================================================
   website:
     needs: changes
@@ -153,6 +153,25 @@ jobs:
         with:
           python-version: "3.12"
 
+      # The package ships no pyproject.toml, so ruff runs on its built-in
+      # defaults (line-length 88, lint rules E4/E7/E9/F) — deliberately looser
+      # than the beer-encyclopedia ruleset, which this baseline does not meet.
+      # Pinned exactly: Dependabot only tracks npm here, so an unpinned ruff
+      # would drift silently and could redden an unrelated website PR when a
+      # release changes formatter style or default rules. Nothing bumps this
+      # pin automatically — next-review: 2027-01.
+      - name: Install lint tooling (ruff)
+        run: pip install ruff==0.15.8
+
+      # Unguarded on purpose, unlike the two steps below: scripts/ and tests/
+      # are always present here, and a guard would turn their disappearance
+      # into a silent pass instead of the failure it should be.
+      - name: Lint (ruff)
+        run: ruff check scripts tests
+
+      - name: Format check (ruff)
+        run: ruff format --check scripts tests
+
       - name: Run quality gate
         run: |
           if [ -f scripts/quality_gate.py ]; then
@@ -162,7 +181,8 @@ jobs:
           fi
 
       # The gate only checks structural invariants; the unit suites cover the
-      # i18n generator and the gate logic itself (stdlib unittest — no pip).
+      # i18n generator and the gate logic itself (stdlib unittest — the suites
+      # themselves pull no dependency; ruff above is the job's only install).
       - name: Run Python unit tests
         run: |
           if [ -d tests ]; then

--- a/packages/website/CLAUDE.md
+++ b/packages/website/CLAUDE.md
@@ -5,7 +5,7 @@
 **Name:** Brasse Bouillon — Marketing Website
 **Stack:** Static HTML/CSS/JS, no framework. Hosted on Cloudflare Pages; DNS and the custom domain (brasse-bouillon.com) are managed on Cloudflare (ADR-0014).
 **Deployment:** any push to `main` whose diff touches `packages/website/**` triggers the [`website-deploy.yml`](../../.github/workflows/website-deploy.yml) workflow, which stages the public files into `_site/` and publishes them to the `brasse-bouillon-website` Cloudflare Pages project via `wrangler pages deploy`. Can also be re-run manually from the Actions tab (`workflow_dispatch`).
-**Quality gate:** Python scripts under `scripts/` (`quality_gate.py` + the i18n generator `build_i18n.py`), tested in `tests/`, executed by the `website:` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) (gate + unit suites) on every PR that touches the package.
+**Quality gate:** Python scripts under `scripts/` (`quality_gate.py` + the i18n generator `build_i18n.py`), tested in `tests/`, executed by the `website:` job in [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) (ruff lint + format check + gate + unit suites) on every PR that touches the package.
 
 The site is a thin marketing surface — not a SaaS frontend. Persistent product UX lives in `packages/mobile-app`.
 
@@ -94,7 +94,14 @@ cd packages/website
 python3 scripts/quality_gate.py            # run the gate locally
 python3 scripts/build_i18n.py --check      # en.html regeneration is clean
 python3 -m unittest discover -s tests -v   # gate + i18n generator suites
+ruff check scripts tests                   # lint (CI-blocking)
+ruff format --check scripts tests          # format (CI-blocking)
 ```
+
+CI blocks on the two `ruff` commands as well, so run them before pushing. The
+package has no `pyproject.toml`: ruff uses its built-in defaults, and CI pins
+`ruff==0.15.8` — install that same version locally (`pip install ruff==0.15.8`)
+so a local pass means a CI pass.
 
 ## Feedback Widget
 


### PR DESCRIPTION
## Summary

The `website:` job ran `quality_gate.py` and the unit suites but **no ruff step**, unlike the `beer-encyclopedia:` job which runs `ruff check .`. This adds both checks to the website job, pinned:

```yaml
- name: Install lint tooling (ruff)
  run: pip install ruff==0.15.8
- name: Lint (ruff)
  run: ruff check scripts tests
- name: Format check (ruff)
  run: ruff format --check scripts tests
```

PR #1469 cleaned the last two files `ruff format --check` flagged, so the baseline is green and enforceable from now on.

## Context

**The baseline is green for both commands.** #1469 only ran `ruff format`, so it guaranteed nothing about `ruff check` (the linter). Verified separately: `ruff check scripts tests` also passes at this baseline, so both steps are safe to enable together.

**beer-encyclopedia's install path does not transfer.** It installs ruff via `pip install -e ".[ml,dev]"` from its own `pyproject.toml` (`ruff>=0.6`). `packages/website` ships no `pyproject.toml`, and there is no repo-root ruff config, so ruff is installed directly and runs on its **built-in defaults** (line-length 88, lint rules `E4`/`E7`/`E9`/`F`) — deliberately looser than the beer-encyclopedia ruleset.

**Aligning the two rulesets is out of scope.** Applying beer-encyclopedia's config to the website (line-length 100 + extended select) was tested: it would reformat all 8 files and raise 6 `I001` import-sorting errors, partly undoing #1469. That is a separate decision, not this PR.

**Why the pin is exact rather than floating.** `.github/dependabot.yml` configures the `npm` ecosystem only — nothing in this repo auto-bumps Python tooling. An unpinned ruff would therefore drift with no review and could redden an unrelated website PR whenever a release changes formatter style or default rules. The pin carries a `next-review: 2027-01` marker since nothing bumps it automatically.

**Ordering and guards.** ruff runs before the gate (fail-fast on the cheap checks, mirroring the beer-encyclopedia job's lint-first ordering). The ruff steps are intentionally unguarded, unlike the adjacent `if [ -f ... ]` gate/test steps: a guard would turn a missing `scripts/` into a silent pass rather than the failure a lint gate exists to produce.

`packages/website/CLAUDE.md` is updated in the same PR — CI now blocks on ruff, so the documented local repro had to list both commands and the pinned version, otherwise a local run would pass and the push would go red.

## Checklist

- [x] Verified locally with the pinned ruff 0.15.8: `ruff check` and `ruff format --check` both green
- [x] Rest of the job unaffected: quality gate, `build_i18n.py --check`, and the 69 unit tests still pass
- [x] Workflow YAML parses; step order and `working-directory` confirmed
- [x] Local pre-push review ritual run (Claude `pr-pre-reviewer` + Codex) — no Must Have outstanding
- [x] Docs updated so a local pass implies a CI pass
- [ ] CI green on this PR

## Notes for the reviewer

- No behaviour change to the site or its deploy — CI tooling only.
- This makes ruff the website job's first `pip` install; the unit suites themselves remain stdlib-only. The stale "no pip" comment was corrected.
- Follow-up (not in this PR): `packages/website/CONTRIBUTING.md`'s local-commands block is separately stale — it lists a `py_compile` step CI does not run and omits the unit suite.

Generated with [Claude Code](https://claude.com/claude-code)