### PR TITLE
test(mobile-app): stop async assertions failing on machine load

### DIFF
--- a/packages/mobile-app/jest.setup.ts
+++ b/packages/mobile-app/jest.setup.ts
@@ -1,6 +1,46 @@
 import "@testing-library/jest-native/extend-expect";
 
 import React from "react";
+import { configure } from "@testing-library/react-native";
+
+/**
+ * Async-assertion budgets. Edited with Benoît's explicit approval (2026-07-20),
+ * as this file is on the package's do-not-modify list; `asyncUtilTimeout` has
+ * no `jest.config.js` key and can only be set at runtime via `configure()`.
+ *
+ * `waitFor` / `findBy*` default to 1000 ms, which is a wall-clock race rather
+ * than a correctness bound: they await a real loading → loaded transition while
+ * jest spreads suites across every core, so a heavy screen's first render can
+ * miss the deadline even though the code is correct. Repro on `main` 392e3a6e:
+ * green run alone, but two concurrent suites failed every time — and on
+ * different tests (`DashboardScreen`, then `BeerInfoCardScreen`), which is why
+ * this belongs here and not in one spec file.
+ *
+ * Both budgets move together and their ORDER is the point: jest's own per-test
+ * timeout also defaults to 5 s, so lifting `asyncUtilTimeout` alone to 5 s made
+ * things worse — the assertion burned the whole test budget and jest killed it
+ * with an opaque "Exceeded timeout of 5000 ms" instead of the query's own
+ * "Unable to find an element". `asyncUtilTimeout` must stay clear of
+ * `jest.setTimeout` so the async helper loses first and says what it awaited.
+ *
+ * 10 s absorbs contention; 15 s keeps 5 s of headroom (teardown costs
+ * milliseconds, not seconds) while capping what one genuinely stuck test costs
+ * CI. Per-assertion overrides remain available.
+ *
+ * Measured idle, so the budget is not a blind bump. `DashboardScreen`'s first
+ * test runs in ~235 ms — 4x clear of the old 1000 ms, so purely
+ * contention-sensitive. `BeerInfoCardScreen`'s "shows the loading state while a
+ * retry is in flight" is the outlier at ~700-810 ms (~1.4x margin), but the
+ * cost is the harness, not the app: instrumenting the screen shows it leaves
+ * the error state ~3 ms after `refetch()`, once three React flush cycles have
+ * run. Pumping `act()` by hand clears it in 3 flushes / 3 ms and drops that
+ * test to 180 ms, whereas `waitFor`'s wall-clock polling takes ~600 ms to
+ * deliver the same flushes. So the scan retry path has no user-visible delay —
+ * only a test sitting near the old ceiling for reasons unrelated to
+ * correctness, which is exactly what a wall-clock budget should absorb.
+ */
+jest.setTimeout(15_000);
+configure({ asyncUtilTimeout: 10_000 });
 
 jest.mock("react-native-safe-area-context", () => {
   const actual = jest.requireActual("react-native-safe-area-context");


### PR DESCRIPTION
## Summary

Raises the two budgets that govern async assertions in the mobile-app suite, in `packages/mobile-app/jest.setup.ts`:

```ts
jest.setTimeout(15_000);
configure({ asyncUtilTimeout: 10_000 });
```

`waitFor` / `findBy*` default to 1000 ms. That is a wall-clock race, not a correctness bound: they await a real loading → loaded transition while jest spreads suites across every core, so a heavy screen's first render can miss the deadline even though the code is correct. The suite then goes red on a machine-load lottery rather than on a regression.

## Context

Reproduced on pristine `main` (392e3a6e): the suite is green run alone (6/6), but **two concurrent suites failed every time (2/2)** — and not on the same test. `DashboardScreen` in one run, `BeerInfoCardScreen` in another. One cause, several symptoms, so the fix belongs in the shared setup rather than in any single test file.

**The order of the two budgets is the point.** Jest's own per-test timeout also defaults to 5 s, so lifting `asyncUtilTimeout` alone to 5 s makes things *worse*: the assertion burns the whole test budget and jest kills it with an opaque `Exceeded timeout of 5000 ms` instead of the query's own `Unable to find an element` — 14 such failures measured while calibrating. `asyncUtilTimeout` (10 s) therefore stays clear of `jest.setTimeout` (15 s) so the async helper loses the race first and reports what it awaited.

15 s rather than a rounder 30 s: teardown costs milliseconds, so 5 s of headroom is ample, and it halves what a genuinely stuck test costs CI.

### Measured, not guessed

| Test | Idle duration | Margin under the old 1000 ms |
|---|---|---|
| `DashboardScreen` — first test | ~235 ms | 4x — purely contention-sensitive |
| `BeerInfoCardScreen` — retry in flight | ~700-810 ms | ~1.4x |

The second was investigated further: the screen leaves its error state **~3 ms** after `refetch()`, once three React flush cycles have run. Pumping `act()` by hand clears it in 3 flushes and drops that test to 180 ms, while `waitFor`'s wall-clock polling takes ~600 ms to deliver the same flushes. **No user-visible delay on the scan retry path** — just a test sitting near the old ceiling for reasons unrelated to correctness.

## Checklist

- [x] Verified: 6 full-suite runs under the exact two-concurrent-suite contention that previously failed 2/2, plus uncontended runs — 1420/1420 green throughout
- [x] eslint, prettier, tsc clean
- [x] `jest.setup.ts` is on the package's do-not-modify list; explicit approval obtained and recorded in the commit and the file comment
- [x] Pre-push review passed (Claude reviewer + Codex), 0 Must Have outstanding

## Follow-ups filed separately

- `timeout-minutes` on CI jobs (touches CI, needs its own approval)
- The pre-existing "worker process failed to exit gracefully" warning — present before and after this change, `--detectOpenHandles` reports nothing in single-worker mode