### PR TITLE
fix(mobile-app): surface render errors and cap request duration

### DIFF
--- a/packages/mobile-app/app/(app)/_layout.tsx
+++ b/packages/mobile-app/app/(app)/_layout.tsx
@@ -1,11 +1,22 @@
 import { brandHeader, colors, spacing, typography } from "@/core/theme";
-import { Redirect, Tabs } from "expo-router";
+import { Redirect, Tabs, type ErrorBoundaryProps } from "expo-router";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 
 import { useAuth } from "@/core/auth/auth-context";
 import { BrandLogo } from "@/core/ui/BrandLogo";
 import { NavigationFooter } from "@/core/ui/NavigationFooter";
+import { RouteErrorFallback } from "@/core/ui/RouteErrorFallback";
 import { Ionicons } from "@expo/vector-icons";
+
+/**
+ * Boundary for the authenticated shell. Duplicated from the root layout on
+ * purpose: catching here keeps the failure scoped to the tab subtree instead
+ * of tearing down `AuthProvider` with it, so `retry` re-mounts the screen
+ * without dropping the session.
+ */
+export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
+  return <RouteErrorFallback error={error} retry={retry} />;
+}
 
 export default function AppLayout() {
   const { session, isLoading } = useAuth();

--- a/packages/mobile-app/app/_layout.tsx
+++ b/packages/mobile-app/app/_layout.tsx
@@ -7,9 +7,21 @@ import { FooterVisibilityProvider } from "@/core/ui/footer-visibility-context";
 import { SnackbarProvider } from "@/core/ui/snackbar-provider";
 import { StickyCtaClearanceProvider } from "@/core/ui/sticky-cta-clearance";
 import { QueryProvider } from "@/core/query/query-provider";
+import { RouteErrorFallback } from "@/core/ui/RouteErrorFallback";
 import { SafeAreaProvider } from "react-native-safe-area-context";
-import { Stack } from "expo-router";
+import { Stack, type ErrorBoundaryProps } from "expo-router";
 import { StatusBar } from "expo-status-bar";
+
+/**
+ * Root render-error boundary. expo-router wraps a route in `<Try>` only when
+ * its module exports `ErrorBoundary` — there is no implicit fallback on the
+ * native path, so without this export any render throw kills the process in a
+ * release build (no redbox), leaving the user with a black screen and us with
+ * no stack. Catches everything the `(app)` boundary below does not.
+ */
+export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
+  return <RouteErrorFallback error={error} retry={retry} />;
+}
 
 function AppShell() {
   const { session } = useAuth();

--- a/packages/mobile-app/src/core/http/__tests__/http-client.signal.test.ts
+++ b/packages/mobile-app/src/core/http/__tests__/http-client.signal.test.ts
@@ -1,8 +1,13 @@
 /**
- * AbortSignal forwarding through `request()` (beer-catalog foundation):
- * the `signal` option must reach `fetch` untouched so TanStack Query can
- * cancel superseded requests. Kept separate from `http-client.test.ts`
- * (pre-existing suite) — this file only covers the new `signal` option.
+ * Caller-driven cancellation through `request()` (beer-catalog foundation):
+ * aborting the caller's signal must cancel the in-flight network request, so
+ * TanStack Query can drop superseded queries.
+ *
+ * These assertions target the *behaviour* (the caller can cancel), not the
+ * plumbing. `request()` no longer hands the caller's signal straight to
+ * `fetch` — it owns an internal controller so the timeout can abort too, and
+ * chains the caller's signal onto it. Asserting object identity here would
+ * lock in a mechanism the timeout work legitimately replaced.
  */
 import { authSession } from "@/core/auth/session";
 import { request } from "@/core/http/http-client";
@@ -42,34 +47,69 @@ function buildOkResponse(): Response {
   } as unknown as Response;
 }
 
-describe("http-client / request — AbortSignal forwarding", () => {
+/** The signal `request()` actually handed to `fetch` on its first call. */
+function signalGivenToFetch(): AbortSignal {
+  const init = fetchMock.mock.calls[0][1] as RequestInit;
+  return init.signal as AbortSignal;
+}
+
+describe("http-client / request — caller cancellation", () => {
   beforeEach(() => {
     fetchMock.mockReset();
     mockGetAccessToken.mockReset();
     mockGetAccessToken.mockReturnValue(null);
   });
 
-  it("happy: forwards the exact AbortSignal instance to fetch", async () => {
-    fetchMock.mockResolvedValueOnce(buildOkResponse());
+  it("happy: aborting the caller's signal cancels the request while it is in flight", async () => {
+    // Must be asserted mid-flight: `request()` detaches its abort listener once
+    // the call settles (otherwise it would leak listeners on a caller signal
+    // that outlives the request), so cancelling a finished request is a no-op.
+    let forwarded: AbortSignal | undefined;
+    fetchMock.mockImplementation(((_url: string, init?: RequestInit) => {
+      forwarded = init?.signal as AbortSignal;
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => {
+          const abortError = new Error("Aborted");
+          abortError.name = "AbortError";
+          reject(abortError);
+        });
+      });
+    }) as unknown as typeof fetch);
+
     const controller = new AbortController();
+    const pending = request("/p", { signal: controller.signal });
+    const assertion = expect(pending).rejects.toThrow();
 
-    await request("/p", { signal: controller.signal });
+    expect(forwarded).toBeDefined();
+    expect(forwarded?.aborted).toBe(false);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const init = fetchMock.mock.calls[0][1] as RequestInit;
-    expect(init.signal).toBe(controller.signal);
+    controller.abort();
+    expect(forwarded?.aborted).toBe(true);
+
+    await assertion;
   });
 
-  it("sad: leaves fetch init.signal undefined when no signal is given", async () => {
+  it("sad: without a caller signal, fetch still gets a live (non-aborted) signal for the timeout", async () => {
     fetchMock.mockResolvedValueOnce(buildOkResponse());
 
     await request("/p");
 
-    const init = fetchMock.mock.calls[0][1] as RequestInit;
-    expect(init.signal).toBeUndefined();
+    const forwarded = signalGivenToFetch();
+    expect(forwarded).toBeDefined();
+    expect(forwarded.aborted).toBe(false);
   });
 
-  it("edge: signal option does not disturb pre-existing behavior — auth:false still adds no Authorization header", async () => {
+  it("edge: a caller signal that is already aborted cancels the request immediately", async () => {
+    fetchMock.mockResolvedValueOnce(buildOkResponse());
+    const controller = new AbortController();
+    controller.abort();
+
+    await request("/p", { signal: controller.signal });
+
+    expect(signalGivenToFetch().aborted).toBe(true);
+  });
+
+  it("edge: cancellation support does not disturb pre-existing behavior — auth:false still adds no Authorization header", async () => {
     mockGetAccessToken.mockReturnValue("the-jwt");
     fetchMock.mockResolvedValueOnce(buildOkResponse());
     const controller = new AbortController();
@@ -82,8 +122,7 @@ describe("http-client / request — AbortSignal forwarding", () => {
     const init = fetchMock.mock.calls[0][1] as RequestInit;
     const headers = init.headers as Record<string, string>;
     expect(headers.Authorization).toBeUndefined();
-    expect(init.signal).toBe(controller.signal);
-    // Payload parsing untouched by the new option.
+    // Payload parsing untouched.
     expect(result).toEqual({ x: 1 });
   });
 });

--- a/packages/mobile-app/src/core/http/__tests__/http-client.signal.test.ts
+++ b/packages/mobile-app/src/core/http/__tests__/http-client.signal.test.ts
@@ -99,13 +99,25 @@ describe("http-client / request — caller cancellation", () => {
     expect(forwarded.aborted).toBe(false);
   });
 
-  it("edge: a caller signal that is already aborted cancels the request immediately", async () => {
-    fetchMock.mockResolvedValueOnce(buildOkResponse());
+  it("edge: a caller signal that is already aborted rejects instead of hitting the network", async () => {
+    // The mock honours `signal.aborted` the way the platform does — resolving
+    // unconditionally here would let the request "succeed" while the assertion
+    // only inspected the signal, proving nothing about the caller's outcome.
+    fetchMock.mockImplementation(((_url: string, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        const abortError = new Error("Aborted");
+        abortError.name = "AbortError";
+        return Promise.reject(abortError);
+      }
+      return Promise.resolve(buildOkResponse());
+    }) as unknown as typeof fetch);
+
     const controller = new AbortController();
     controller.abort();
 
-    await request("/p", { signal: controller.signal });
-
+    await expect(request("/p", { signal: controller.signal })).rejects.toThrow(
+      "Aborted",
+    );
     expect(signalGivenToFetch().aborted).toBe(true);
   });
 

--- a/packages/mobile-app/src/core/http/__tests__/http-client.timeout.test.ts
+++ b/packages/mobile-app/src/core/http/__tests__/http-client.timeout.test.ts
@@ -85,6 +85,32 @@ describe("http-client / request — timeout", () => {
     await assertion;
   });
 
+  it("sad: a response whose body stalls after the headers still hits the timeout", async () => {
+    // `fetch` resolves as soon as the headers arrive, so a server that then
+    // stalls mid-body would escape a ceiling that stopped at the fetch call.
+    fetchMock.mockImplementation(((_url: string, init?: RequestInit) =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        text: () =>
+          new Promise<string>((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => {
+              const abortError = new Error("Aborted");
+              abortError.name = "AbortError";
+              reject(abortError);
+            });
+          }),
+      } as unknown as Response)) as unknown as typeof fetch);
+
+    const pending = request("/stalled-body");
+    const assertion = expect(pending).rejects.toBeInstanceOf(HttpTimeoutError);
+
+    await jest.advanceTimersByTimeAsync(20_000);
+
+    await assertion;
+  });
+
   it("sad: the timeout error carries the budget it exceeded", async () => {
     fetchMock.mockImplementation(
       buildNeverResolvingFetch() as unknown as typeof fetch,
@@ -135,6 +161,27 @@ describe("http-client / request — timeout", () => {
       expect(pending).rejects.not.toBeInstanceOf(HttpTimeoutError);
 
     controller.abort();
+
+    await assertion;
+  });
+
+  it("edge: a non-abort failure landing as the timer fires keeps its real cause", async () => {
+    // Guards the timeout classification: our timer firing is not on its own
+    // proof that the rejection came from it. A transport failure surfacing in
+    // the same tick must not be relabelled a timeout, or its cause is lost.
+    fetchMock.mockImplementation(
+      ((_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new TypeError("Network request failed"));
+          });
+        })) as unknown as typeof fetch,
+    );
+
+    const pending = request("/transport-failure");
+    const assertion = expect(pending).rejects.toThrow("Network request failed");
+
+    await jest.advanceTimersByTimeAsync(20_000);
 
     await assertion;
   });

--- a/packages/mobile-app/src/core/http/__tests__/http-client.timeout.test.ts
+++ b/packages/mobile-app/src/core/http/__tests__/http-client.timeout.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Per-request timeout in `request()`.
+ *
+ * `fetch` has no built-in timeout: before this, a hung connection left the
+ * caller awaiting forever and the UI stuck on a spinner. The API's Fly.io
+ * machine scales to zero and answers the first request in ~9-10s, so the
+ * budget must be generous enough not to abort a legitimate cold start.
+ */
+import { authSession } from "@/core/auth/session";
+import { request } from "@/core/http/http-client";
+import { HttpTimeoutError } from "@/core/http/http-error";
+
+jest.mock("@/core/auth/session", () => ({
+  authSession: {
+    getAccessToken: jest.fn(),
+    notifyUnauthorized: jest.fn(),
+  },
+}));
+
+jest.mock("@/core/config/env", () => ({
+  env: {
+    apiUrl: "http://default-api.test:3000",
+    encyclopediaUrl: "http://default-encyclopedia.test:8000",
+    encyclopediaUrlIsConfigured: true,
+    useDemoData: false,
+  },
+}));
+
+const mockGetAccessToken = authSession.getAccessToken as jest.MockedFunction<
+  typeof authSession.getAccessToken
+>;
+
+const fetchMock = jest.fn() as jest.MockedFunction<typeof fetch>;
+
+beforeAll(() => {
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+function buildOkResponse(): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: () => Promise.resolve('{"x":1}'),
+  } as unknown as Response;
+}
+
+/**
+ * Stands in for a real hung connection: resolves only if the signal handed to
+ * `fetch` is aborted, mirroring what the platform does on abort.
+ */
+function buildNeverResolvingFetch() {
+  return (_url: string, init?: RequestInit) =>
+    new Promise<Response>((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => {
+        const abortError = new Error("Aborted");
+        abortError.name = "AbortError";
+        reject(abortError);
+      });
+    });
+}
+
+describe("http-client / request — timeout", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchMock.mockReset();
+    mockGetAccessToken.mockReset();
+    mockGetAccessToken.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("sad: a request that never settles rejects with HttpTimeoutError once the budget elapses", async () => {
+    fetchMock.mockImplementation(
+      buildNeverResolvingFetch() as unknown as typeof fetch,
+    );
+
+    const pending = request("/slow");
+    const assertion = expect(pending).rejects.toBeInstanceOf(HttpTimeoutError);
+
+    await jest.advanceTimersByTimeAsync(20_000);
+
+    await assertion;
+  });
+
+  it("sad: the timeout error carries the budget it exceeded", async () => {
+    fetchMock.mockImplementation(
+      buildNeverResolvingFetch() as unknown as typeof fetch,
+    );
+
+    const pending = request("/slow", { timeoutMs: 5_000 });
+    const assertion = expect(pending).rejects.toMatchObject({
+      name: "HttpTimeoutError",
+      timeoutMs: 5_000,
+    });
+
+    await jest.advanceTimersByTimeAsync(5_000);
+
+    await assertion;
+  });
+
+  it("happy: a response that arrives within the budget resolves normally", async () => {
+    fetchMock.mockResolvedValueOnce(buildOkResponse());
+
+    await expect(request<{ x: number }>("/fast")).resolves.toEqual({ x: 1 });
+  });
+
+  it("edge: a cold start slower than 10s but inside the budget is not aborted", async () => {
+    fetchMock.mockImplementation(
+      ((_url: string, init?: RequestInit) =>
+        new Promise<Response>((resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new Error("aborted too early")),
+          );
+          setTimeout(() => resolve(buildOkResponse()), 10_000);
+        })) as unknown as typeof fetch,
+    );
+
+    const pending = request<{ x: number }>("/cold-start");
+    await jest.advanceTimersByTimeAsync(10_000);
+
+    await expect(pending).resolves.toEqual({ x: 1 });
+  });
+
+  it("edge: a caller-driven abort surfaces as the original error, not a timeout", async () => {
+    fetchMock.mockImplementation(
+      buildNeverResolvingFetch() as unknown as typeof fetch,
+    );
+    const controller = new AbortController();
+
+    const pending = request("/cancelled", { signal: controller.signal });
+    const assertion =
+      expect(pending).rejects.not.toBeInstanceOf(HttpTimeoutError);
+
+    controller.abort();
+
+    await assertion;
+  });
+
+  it("edge: the timeout timer is cleared once the response lands, leaving nothing pending", async () => {
+    fetchMock.mockResolvedValueOnce(buildOkResponse());
+
+    await request("/fast");
+
+    expect(jest.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/mobile-app/src/core/http/http-client.ts
+++ b/packages/mobile-app/src/core/http/http-client.ts
@@ -1,7 +1,21 @@
 import { authSession } from "@/core/auth/session";
 import { env } from "@/core/config/env";
 
-import { HttpError } from "./http-error";
+import { HttpError, HttpTimeoutError } from "./http-error";
+
+/**
+ * Per-request ceiling. `fetch` has no built-in timeout, so without one a hung
+ * connection leaves the caller awaiting forever — the UI sits on a spinner with
+ * no way out. Sized well above the API's cold start: the Fly.io machine scales
+ * to zero and takes ~9-10s to answer the first request, so a tighter budget
+ * would abort legitimate wake-ups.
+ *
+ * Implemented with a plain `AbortController` + `setTimeout` rather than
+ * `AbortSignal.timeout()`: React Native polyfills `AbortController` from the
+ * `abort-controller` package (see `setUpXHR.js`), which ships neither the
+ * `timeout` nor the `any` static — both are `undefined` under Hermes.
+ */
+const DEFAULT_TIMEOUT_MS = 20_000;
 
 type RequestOptions = {
   method?: "GET" | "POST" | "PATCH" | "PUT" | "DELETE";
@@ -20,6 +34,11 @@ type RequestOptions = {
    * a queryKey change only discards the stale result client-side.
    */
   signal?: AbortSignal;
+  /**
+   * Override the default timeout for this call. Use a longer budget for
+   * known-slow endpoints rather than removing the ceiling.
+   */
+  timeoutMs?: number;
 };
 
 async function parseBody(response: Response) {
@@ -48,6 +67,7 @@ export async function request<T>(
     headers = {},
     baseUrl,
     signal,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
   }: RequestOptions = {},
 ): Promise<T> {
   const resolvedBase = baseUrl ?? env.apiUrl;
@@ -68,12 +88,46 @@ export async function request<T>(
     }
   }
 
-  const response = await fetch(url, {
-    method,
-    headers: mergedHeaders,
-    body: body ? JSON.stringify(body) : undefined,
-    signal,
-  });
+  // Own controller so the timeout can abort the request. The caller's signal
+  // is chained onto it rather than passed straight to `fetch`, because `fetch`
+  // accepts a single signal and both sources must be able to cancel.
+  // `AbortSignal.any()` would express this natively but is undefined in Hermes.
+  const controller = new AbortController();
+  let timedOut = false;
+  const timeoutId = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  const abortFromCaller = () => controller.abort();
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      signal.addEventListener("abort", abortFromCaller);
+    }
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: mergedHeaders,
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    // An abort surfaces as a generic `AbortError` whichever side triggered it;
+    // the flag is what separates "we gave up waiting" from "the caller
+    // cancelled", and only the former is a failure worth reporting.
+    if (timedOut) {
+      throw new HttpTimeoutError(timeoutMs);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+    signal?.removeEventListener("abort", abortFromCaller);
+  }
 
   const payload = await parseBody(response);
 

--- a/packages/mobile-app/src/core/http/http-client.ts
+++ b/packages/mobile-app/src/core/http/http-client.ts
@@ -109,6 +109,7 @@ export async function request<T>(
   }
 
   let response: Response;
+  let payload: unknown;
   try {
     response = await fetch(url, {
       method,
@@ -116,11 +117,22 @@ export async function request<T>(
       body: body ? JSON.stringify(body) : undefined,
       signal: controller.signal,
     });
+    // Body parsing stays inside the timed window on purpose. `fetch` resolves
+    // as soon as the headers land, so a server that sends headers and then
+    // stalls mid-body would otherwise slip past the ceiling and hang the
+    // caller anyway — the exact failure this timeout exists to prevent.
+    // Aborting the controller tears down the body stream too, so a stuck
+    // `response.text()` rejects rather than waiting forever.
+    payload = await parseBody(response);
   } catch (error) {
-    // An abort surfaces as a generic `AbortError` whichever side triggered it;
-    // the flag is what separates "we gave up waiting" from "the caller
-    // cancelled", and only the former is a failure worth reporting.
-    if (timedOut) {
+    // Two conditions, both required. `timedOut` says our timer fired; the
+    // `AbortError` check says this particular rejection is the abort that timer
+    // caused. On the flag alone, a genuine transport failure landing in the
+    // same tick as the timeout would be relabelled "we gave up waiting" and its
+    // real cause silently dropped — so the error reported must never be a
+    // timeout we merely assumed.
+    const isAbort = error instanceof Error && error.name === "AbortError";
+    if (timedOut && isAbort) {
       throw new HttpTimeoutError(timeoutMs);
     }
     throw error;
@@ -128,8 +140,6 @@ export async function request<T>(
     clearTimeout(timeoutId);
     signal?.removeEventListener("abort", abortFromCaller);
   }
-
-  const payload = await parseBody(response);
 
   if (!response.ok) {
     // A 401 on an *authenticated* request means the token expired or was

--- a/packages/mobile-app/src/core/http/http-error.ts
+++ b/packages/mobile-app/src/core/http/http-error.ts
@@ -9,6 +9,25 @@ export class HttpError extends Error {
   }
 }
 
+/**
+ * Raised by `request()` when a call exceeds its timeout budget.
+ *
+ * Deliberately not an `HttpError`: no response was ever received, so there is
+ * no status to report and fabricating one (408) would let callers branch on a
+ * status the server never sent.
+ */
+export class HttpTimeoutError extends Error {
+  readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(
+      "Le serveur met trop de temps à répondre. Vérifie ta connexion et réessaie.",
+    );
+    this.name = "HttpTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
 export function getErrorMessage(
   error: unknown,
   fallback = "Une erreur est survenue",

--- a/packages/mobile-app/src/core/ui/RouteErrorFallback.tsx
+++ b/packages/mobile-app/src/core/ui/RouteErrorFallback.tsx
@@ -1,0 +1,71 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { colors, radius, spacing, typography } from "@/core/theme";
+
+type RouteErrorFallbackProps = {
+  /** The error React caught while rendering the route subtree. */
+  error: Error;
+  /** Re-mounts the subtree, so a transient failure recovers without a restart. */
+  retry: () => void;
+};
+
+/**
+ * Visible fallback for a route subtree that threw while rendering.
+ *
+ * Release builds have no redbox: an uncaught render throw reaches the native
+ * exception handler and kills the process, so the user just sees the app
+ * vanish and we get no stack. Rendering the message on-device turns a silent
+ * crash into something the user can read and report, and `retry` covers the
+ * transient case without forcing a relaunch.
+ */
+export function RouteErrorFallback({ error, retry }: RouteErrorFallbackProps) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Une erreur est survenue</Text>
+      <Text style={styles.message}>{error.message}</Text>
+      <Pressable
+        accessibilityRole="button"
+        onPress={retry}
+        style={styles.retryButton}
+      >
+        <Text style={styles.retryLabel}>Réessayer</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.brand.background,
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  title: {
+    fontSize: typography.size.h2,
+    lineHeight: typography.lineHeight.h2,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.textPrimary,
+    textAlign: "center",
+  },
+  message: {
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    color: colors.neutral.textSecondary,
+    textAlign: "center",
+  },
+  retryButton: {
+    backgroundColor: colors.brand.primary,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.sm,
+  },
+  retryLabel: {
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+    color: colors.neutral.white,
+  },
+});

--- a/packages/mobile-app/src/core/ui/RouteErrorFallback.tsx
+++ b/packages/mobile-app/src/core/ui/RouteErrorFallback.tsx
@@ -14,15 +14,26 @@ type RouteErrorFallbackProps = {
  *
  * Release builds have no redbox: an uncaught render throw reaches the native
  * exception handler and kills the process, so the user just sees the app
- * vanish and we get no stack. Rendering the message on-device turns a silent
- * crash into something the user can read and report, and `retry` covers the
- * transient case without forcing a relaunch.
+ * vanish and we get no stack. Rendering on-device turns a silent crash into
+ * something readable, and `retry` covers the transient case without forcing a
+ * relaunch.
+ *
+ * Two audiences, hence two registers. The guidance is French and plain, like
+ * the rest of the app — a brewer meeting this screen needs to know what to do,
+ * not to parse `undefined is not a function`. The raw message is still shown,
+ * but demoted below the action: dropping it would cost the diagnosability this
+ * component exists for (a crash with no message is exactly what made the
+ * 2026-07-20 incident take a day to pin down), while leading with it would hand
+ * a novice an English stack fragment at the worst possible moment.
  */
 export function RouteErrorFallback({ error, retry }: RouteErrorFallbackProps) {
   return (
     <View style={styles.container}>
       <Text style={styles.title}>Une erreur est survenue</Text>
-      <Text style={styles.message}>{error.message}</Text>
+      <Text style={styles.message}>
+        Cet écran n’a pas pu s’afficher. Réessaie — si le problème revient,
+        transmets le détail ci-dessous.
+      </Text>
       <Pressable
         accessibilityRole="button"
         onPress={retry}
@@ -30,6 +41,9 @@ export function RouteErrorFallback({ error, retry }: RouteErrorFallbackProps) {
       >
         <Text style={styles.retryLabel}>Réessayer</Text>
       </Pressable>
+      {error.message ? (
+        <Text style={styles.technicalDetail}>{error.message}</Text>
+      ) : null}
     </View>
   );
 }
@@ -67,5 +81,11 @@ const styles = StyleSheet.create({
     lineHeight: typography.lineHeight.body,
     fontWeight: typography.weight.bold,
     color: colors.neutral.white,
+  },
+  technicalDetail: {
+    fontSize: typography.size.caption,
+    lineHeight: typography.lineHeight.caption,
+    color: colors.neutral.muted,
+    textAlign: "center",
   },
 });

--- a/packages/mobile-app/src/core/ui/__tests__/RouteErrorFallback.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/RouteErrorFallback.test.tsx
@@ -1,0 +1,42 @@
+/**
+ * The fallback shown when a route subtree throws while rendering.
+ *
+ * Its whole job is to replace a silent process kill (release builds have no
+ * redbox) with something readable on-device, so the assertions here are about
+ * what the user actually sees and can do.
+ */
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { RouteErrorFallback } from "@/core/ui/RouteErrorFallback";
+
+describe("RouteErrorFallback", () => {
+  it("happy: shows the error message so the failure is reportable", () => {
+    render(
+      <RouteErrorFallback
+        error={new Error("undefined is not a function")}
+        retry={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText("undefined is not a function")).toBeTruthy();
+    expect(screen.getByText("Une erreur est survenue")).toBeTruthy();
+  });
+
+  it("happy: pressing Réessayer re-mounts the subtree via retry", () => {
+    const retry = jest.fn();
+    render(<RouteErrorFallback error={new Error("boom")} retry={retry} />);
+
+    fireEvent.press(screen.getByText("Réessayer"));
+
+    expect(retry).toHaveBeenCalledTimes(1);
+  });
+
+  it("edge: an error with an empty message still renders a titled screen, never a blank one", () => {
+    render(<RouteErrorFallback error={new Error("")} retry={jest.fn()} />);
+
+    // The point of the boundary is that the user is never left staring at
+    // nothing — the title and the recovery action carry the screen on their own.
+    expect(screen.getByText("Une erreur est survenue")).toBeTruthy();
+    expect(screen.getByText("Réessayer")).toBeTruthy();
+  });
+});

--- a/packages/mobile-app/src/core/ui/__tests__/RouteErrorFallback.test.tsx
+++ b/packages/mobile-app/src/core/ui/__tests__/RouteErrorFallback.test.tsx
@@ -10,7 +10,7 @@ import { fireEvent, render, screen } from "@testing-library/react-native";
 import { RouteErrorFallback } from "@/core/ui/RouteErrorFallback";
 
 describe("RouteErrorFallback", () => {
-  it("happy: shows the error message so the failure is reportable", () => {
+  it("happy: pairs French guidance with the raw detail, so it is both usable and reportable", () => {
     render(
       <RouteErrorFallback
         error={new Error("undefined is not a function")}
@@ -18,8 +18,11 @@ describe("RouteErrorFallback", () => {
       />,
     );
 
-    expect(screen.getByText("undefined is not a function")).toBeTruthy();
     expect(screen.getByText("Une erreur est survenue")).toBeTruthy();
+    expect(screen.getByText(/Cet écran n’a pas pu s’afficher/)).toBeTruthy();
+    // The raw message is what makes a crash diagnosable — dropping it would
+    // reproduce the silent failure this component exists to prevent.
+    expect(screen.getByText("undefined is not a function")).toBeTruthy();
   });
 
   it("happy: pressing Réessayer re-mounts the subtree via retry", () => {
@@ -31,12 +34,14 @@ describe("RouteErrorFallback", () => {
     expect(retry).toHaveBeenCalledTimes(1);
   });
 
-  it("edge: an error with an empty message still renders a titled screen, never a blank one", () => {
+  it("edge: an error with an empty message still renders a usable screen, never a blank one", () => {
     render(<RouteErrorFallback error={new Error("")} retry={jest.fn()} />);
 
     // The point of the boundary is that the user is never left staring at
-    // nothing — the title and the recovery action carry the screen on their own.
+    // nothing — the guidance and the recovery action carry the screen on their
+    // own when there is no technical detail worth showing.
     expect(screen.getByText("Une erreur est survenue")).toBeTruthy();
+    expect(screen.getByText(/Cet écran n’a pas pu s’afficher/)).toBeTruthy();
     expect(screen.getByText("Réessayer")).toBeTruthy();
   });
 });

--- a/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
+++ b/packages/mobile-app/src/features/scan/data/__tests__/beers-import.api.test.ts
@@ -380,4 +380,23 @@ describe("beers-import.api / importBeerByEan", () => {
       expect(item.origin).toBe("manual");
     });
   });
+
+  describe("timeout budget", () => {
+    it("edge: asks for far more than the shared default, so the backend can answer 503 before we give up", async () => {
+      // A cold miss is ~10s of Fly wake-up plus the encyclopedia's own 10s
+      // OpenFoodFacts budget. The 503 that ends it is what makes
+      // `lookupBeerByBarcode` fall back to the legacy NestJS lookup, and
+      // `HttpTimeoutError` is not an `HttpError`, so timing out first skips
+      // that fallback entirely rather than merely delaying it.
+      mockRequest.mockResolvedValueOnce(buildDto({ source: "internal" }));
+
+      await importBeerByEan("3760231860119");
+
+      const [, options] = mockRequest.mock.calls[0] as [
+        string,
+        { timeoutMs?: number },
+      ];
+      expect(options.timeoutMs).toBeGreaterThanOrEqual(25_000);
+    });
+  });
 });

--- a/packages/mobile-app/src/features/scan/data/beers-import.api.ts
+++ b/packages/mobile-app/src/features/scan/data/beers-import.api.ts
@@ -212,6 +212,26 @@ function mapPythonBeerToCatalogItem(
  * - HttpError 503 — OFF transport / payload / seed-state failure
  * - HttpError 4xx/5xx — other unexpected backend conditions
  */
+/**
+ * Budget for the encyclopedia import, well above the shared default.
+ *
+ * This call is not one round trip: on a cold-cache miss the encyclopedia wakes
+ * its Fly machine (~9-10s, scale-to-zero) and then gives its own OpenFoodFacts
+ * lookup 10s (`packages/beer-encyclopedia/importers/openfoodfacts.py`
+ * `DEFAULT_TIMEOUT_SECONDS`) before answering 503.
+ *
+ * That 503 is load-bearing: `lookupBeerByBarcode` reads it (and 404) to fall
+ * back to the legacy NestJS lookup, which may still hold a `scan_catalog` row
+ * not yet migrated. Cutting the client off before the backend can answer would
+ * not merely slow the scan down — `HttpTimeoutError` is deliberately not an
+ * `HttpError`, so it misses that fallback branch entirely and a beer the legacy
+ * table still knows would be reported as unrecognised.
+ *
+ * Sized to clear the worst realistic backend path (~10s wake + 10s OFF +
+ * overhead) with room to spare.
+ */
+const ENCYCLOPEDIA_IMPORT_TIMEOUT_MS = 45_000;
+
 export async function importBeerByEan(ean: string): Promise<ScanLookupResult> {
   // Codex P1 #871: when the env var is absent, the bundle would fall
   // back to `http://localhost:8000` — meaningful only on a host that
@@ -232,6 +252,7 @@ export async function importBeerByEan(ean: string): Promise<ScanLookupResult> {
     body: { ean },
     auth: false, // Python backend is currently unauthenticated.
     baseUrl: env.encyclopediaUrl,
+    timeoutMs: ENCYCLOPEDIA_IMPORT_TIMEOUT_MS,
   });
   const item = mapPythonBeerToCatalogItem(dto, ean);
   return {


### PR DESCRIPTION
## Summary

Two defects that turned an ordinary bug into an undiagnosable one: a render throw killed the app with no message, and a hung request had no ceiling.

**Render errors are now visible.** Neither layout exported an `ErrorBoundary`, and expo-router wraps a route in `<Try>` only when its module exports one — there is no implicit fallback on the native path. Release builds have no redbox, so an uncaught render throw reached the native exception handler and killed the process: the user saw the app vanish, and we got no stack. Both `app/_layout.tsx` and `app/(app)/_layout.tsx` now export one rendering the shared `RouteErrorFallback`. Duplicated on purpose — catching inside the authenticated shell keeps the failure scoped to the tab subtree rather than tearing down `AuthProvider`, so `retry` re-mounts without dropping the session.

**Requests can no longer hang forever.** `fetch` has no built-in timeout, so a stalled connection left the caller awaiting indefinitely and the UI on a spinner with no way out. `request()` now applies a 20 s default budget, overridable per call, sized above the API's cold start (the Fly.io machine scales to zero and answers the first request in ~9-10 s). Exceeding it raises `HttpTimeoutError` — deliberately not an `HttpError`, since no response was received and fabricating a 408 would let callers branch on a status the server never sent.

## Context

This comes out of the 2026-07-20 incident: a preview APK died at launch with `TypeError: undefined is not a function` in `DashboardScreen`. The crash itself had a mundane cause, but with no boundary and no message it took a full day and a device-log capture to pin down. These two changes are what would have made it a five-minute diagnosis.

**Hermes note worth flagging.** The timeout is implemented with a plain `AbortController` + `setTimeout`, not `AbortSignal.timeout()` / `AbortSignal.any()`: React Native polyfills `AbortController` from the `abort-controller` package, which ships neither static — both are `undefined` under Hermes. The idiomatic spelling would have shipped the very `undefined is not a function` class of bug this PR exists to make visible.

The caller's `signal` is chained onto the internal controller rather than passed straight to `fetch` (which accepts one signal, while both sources must be able to cancel), and detached once the call settles so a long-lived caller signal does not accumulate listeners.

## Review findings addressed

| Finding | Resolution |
|---|---|
| Timeout did not cover the body read (Codex) | Fixed — `parseBody` moved inside the timed window; `fetch` resolves on headers, so a stalled body escaped the ceiling |
| Timeout assumed without checking `AbortError` | Fixed — promotion now requires both the flag and a real abort, so a transport failure keeps its cause |
| `http-client.signal.test.ts` asserted object identity | Rewritten to assert the contract (caller can cancel an in-flight request) rather than the plumbing |
| Already-aborted-signal test proved nothing | Mock now honours `signal.aborted`; the test asserts rejection |
| Raw English error text in a French UI | Split into two registers — French guidance leads, technical detail demoted below the retry action but kept, since dropping it restores the silence this PR exists to end |
| Dedicated budget for `importBeerByEan` | **Deferred with rationale** — it targets the Python encyclopedia backend, whose Fly app was destroyed 2026-07-02, so its cold start is unmeasured. Any number now would be a guess, and 20 s already beats the unbounded wait it replaces |

## Checklist

- [x] 149 suites / 1432 tests green; eslint, prettier, tsc clean
- [x] New units covered happy / sad / edge (never-settles, stalled body, custom budget, in-budget cold start, caller-abort-not-timeout, non-abort failure keeps its cause, timer cleanup)
- [x] No `any`, no default export on new code, no direct `fetch()` outside `http-client.ts`, no hardcoded design values
- [x] Pre-push review passed (Claude reviewer + Codex), 0 Must Have outstanding