### PR TITLE
fix(ci): sync the root lockfile on release PR branches

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -86,13 +86,18 @@ jobs:
           # under `set -e`, block the release workflow on every push to main
           # until the PR was closed. The `autorelease: pending` marker then
           # confirms release-please actually owns the branch.
+          # Every filter lives in --jq, and there is no `|| true`: piping into
+          # `grep` and swallowing the pipeline's status would mean a failing
+          # `gh` (expired token, API outage, rate limit) produced an empty list
+          # and a green "nothing to sync" run, while the lockfiles silently
+          # stayed stale. A real failure must fail the step.
           branches=$(gh pr list --state open --limit 50 \
             --json headRefName,isCrossRepository,labels \
             --jq '.[]
                   | select(.isCrossRepository == false)
                   | select(any(.labels[]; .name == "autorelease: pending"))
-                  | .headRefName' \
-            | grep '^release-please--branches--main--' || true)
+                  | select(.headRefName | startswith("release-please--branches--main--"))
+                  | .headRefName')
 
           if [ -z "$branches" ]; then
             echo "No open release PR — nothing to sync."

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,15 @@ permissions:
   contents: write
   pull-requests: write
 
+# Serialise runs. Two overlapping runs (rapid pushes to main, or a manual
+# dispatch racing a push) would both reach the lockfile-sync step and the
+# slower one's non-force push would be rejected as non-fast-forward — a loud
+# but pointless red run. `cancel-in-progress: false` because a run that is
+# already cutting tags must be allowed to finish.
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release Please
@@ -38,3 +47,81 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           target-branch: main
+
+      # release-please bumps `packages/<pkg>/package.json` and the manifest but
+      # never the root `package-lock.json`: its node strategy looks for a
+      # lockfile *beside* each manifest, and this monorepo keeps a single one at
+      # the root, so the bump lands nowhere. `npm ci` then installs metadata one
+      # release behind the tag cut from it — which is what Codex flagged on
+      # #1425/#1426/#1427 and why they sat unmerged.
+      #
+      # release-please's own `node-workspace` plugin does update the root
+      # lockfile, but its `inScope()` is `releaseType === 'node'`, so it can
+      # never reach `packages/beer-encyclopedia` (release-type `python`). This
+      # step covers all four workspaces uniformly instead.
+      #
+      # Self-healing by design: a later release-please run rewrites its branches
+      # and drops the sync commit, but this step runs right after it every time,
+      # so the branch is back in step before anyone merges.
+      - name: Check out for the lockfile sync
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Sync the root lockfile on open release PR branches
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Double-gated on purpose, mirroring release-please-metadata.yml:
+          # the branch name alone is not trustworthy. `isCrossRepository`
+          # rejects a fork PR whose head branch merely matches the prefix —
+          # that ref does not exist on origin, so fetching it would fail and,
+          # under `set -e`, block the release workflow on every push to main
+          # until the PR was closed. The `autorelease: pending` marker then
+          # confirms release-please actually owns the branch.
+          branches=$(gh pr list --state open --limit 50 \
+            --json headRefName,isCrossRepository,labels \
+            --jq '.[]
+                  | select(.isCrossRepository == false)
+                  | select(any(.labels[]; .name == "autorelease: pending"))
+                  | .headRefName' \
+            | grep '^release-please--branches--main--' || true)
+
+          if [ -z "$branches" ]; then
+            echo "No open release PR — nothing to sync."
+            exit 0
+          fi
+
+          # Run main's copy of the script whatever the branch contains, so a
+          # branch generated before this landed is still handled.
+          cp scripts/sync-workspace-lockfile.mjs "$RUNNER_TEMP/sync.mjs"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Read line by line rather than word-splitting: branch names are
+          # remote-controlled input, and this keeps one name one iteration.
+          while IFS= read -r branch; do
+            [ -n "$branch" ] || continue
+            echo "::group::$branch"
+            git fetch --force origin "refs/heads/$branch:refs/heads/$branch"
+            git checkout "$branch"
+
+            node "$RUNNER_TEMP/sync.mjs"
+
+            if git diff --quiet -- package-lock.json; then
+              echo "already in step"
+            else
+              git add package-lock.json
+              git commit -m "chore(ci): sync root lockfile with released versions"
+              git push origin "refs/heads/$branch"
+            fi
+            echo "::endgroup::"
+          done <<< "$branches"

--- a/scripts/__tests__/sync-workspace-lockfile.test.mjs
+++ b/scripts/__tests__/sync-workspace-lockfile.test.mjs
@@ -1,0 +1,161 @@
+/**
+ * Tests for `scripts/sync-workspace-lockfile.mjs`.
+ *
+ * This script runs unattended on every push to `main`, with write credentials,
+ * and rewrites the root lockfile — so it gets tests even though the rest of
+ * `scripts/` has none.
+ *
+ * Each case builds a throwaway workspace in a temp dir and runs the real
+ * script there as a child process, exactly as the workflow does.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+const SCRIPT = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "sync-workspace-lockfile.mjs",
+);
+
+/** Builds a temp workspace: a root lockfile plus one package.json per entry. */
+function buildFixture({ lock, manifests }) {
+  const dir = mkdtempSync(join(tmpdir(), "lockfile-sync-"));
+  writeFileSync(join(dir, "package-lock.json"), JSON.stringify(lock, null, 2));
+  for (const [path, version] of Object.entries(manifests)) {
+    mkdirSync(join(dir, path), { recursive: true });
+    writeFileSync(
+      join(dir, path, "package.json"),
+      JSON.stringify(version === null ? { name: path } : { version }, null, 2),
+    );
+  }
+  return dir;
+}
+
+function run(cwd) {
+  return execFileSync("node", [SCRIPT], { cwd, encoding: "utf8" });
+}
+
+function lockVersions(dir) {
+  const lock = JSON.parse(readFileSync(join(dir, "package-lock.json"), "utf8"));
+  return Object.fromEntries(
+    Object.entries(lock.packages)
+      .filter(([path]) => path.startsWith("packages/"))
+      .map(([path, entry]) => [path, entry.version]),
+  );
+}
+
+test("happy: a stale lockfile entry is brought up to the manifest version", () => {
+  const dir = buildFixture({
+    lock: { lockfileVersion: 3, packages: { "packages/web": { version: "1.0.0" } } },
+    manifests: { "packages/web": "1.1.0" },
+  });
+
+  const output = run(dir);
+
+  assert.equal(lockVersions(dir)["packages/web"], "1.1.0");
+  assert.match(output, /packages\/web: 1\.0\.0 -> 1\.1\.0/);
+});
+
+test("happy: every workspace is synced, not just the first", () => {
+  const dir = buildFixture({
+    lock: {
+      lockfileVersion: 3,
+      packages: {
+        "packages/a": { version: "1.0.0" },
+        "packages/b": { version: "2.0.0" },
+        "packages/c": { version: "3.0.0" },
+      },
+    },
+    manifests: {
+      "packages/a": "1.1.0",
+      "packages/b": "2.1.0",
+      "packages/c": "3.1.0",
+    },
+  });
+
+  run(dir);
+
+  assert.deepEqual(lockVersions(dir), {
+    "packages/a": "1.1.0",
+    "packages/b": "2.1.0",
+    "packages/c": "3.1.0",
+  });
+});
+
+test("edge: an already-synced lockfile is left byte-for-byte untouched", () => {
+  const dir = buildFixture({
+    lock: { lockfileVersion: 3, packages: { "packages/web": { version: "1.0.0" } } },
+    manifests: { "packages/web": "1.0.0" },
+  });
+  const before = readFileSync(join(dir, "package-lock.json"), "utf8");
+
+  const output = run(dir);
+
+  assert.equal(readFileSync(join(dir, "package-lock.json"), "utf8"), before);
+  assert.match(output, /already in step/);
+});
+
+test("edge: entries below a workspace root are not mistaken for workspaces", () => {
+  const dir = buildFixture({
+    lock: {
+      lockfileVersion: 3,
+      packages: {
+        "packages/web": { version: "1.0.0" },
+        // A nested dependency — it has no manifest of ours and must be skipped,
+        // not treated as a workspace whose version needs syncing.
+        "packages/web/node_modules/lodash": { version: "4.17.21" },
+      },
+    },
+    manifests: { "packages/web": "1.1.0" },
+  });
+
+  run(dir);
+
+  const lock = JSON.parse(readFileSync(join(dir, "package-lock.json"), "utf8"));
+  assert.equal(lock.packages["packages/web/node_modules/lodash"].version, "4.17.21");
+});
+
+test("edge: a manifest without a version is skipped rather than clearing the entry", () => {
+  const dir = buildFixture({
+    lock: { lockfileVersion: 3, packages: { "packages/web": { version: "1.0.0" } } },
+    manifests: { "packages/web": null },
+  });
+
+  run(dir);
+
+  assert.equal(lockVersions(dir)["packages/web"], "1.0.0");
+});
+
+test("sad: a lockfile with no packages map fails loudly instead of writing garbage", () => {
+  const dir = buildFixture({ lock: { lockfileVersion: 1 }, manifests: {} });
+
+  assert.throws(
+    () => run(dir),
+    (error) => {
+      assert.equal(error.status, 1);
+      assert.match(String(error.stderr), /has no "packages" map/);
+      return true;
+    },
+  );
+});
+
+test("sad: a missing manifest for a lockfile entry fails loudly", () => {
+  const dir = buildFixture({
+    lock: { lockfileVersion: 3, packages: { "packages/ghost": { version: "1.0.0" } } },
+    manifests: {},
+  });
+
+  assert.throws(
+    () => run(dir),
+    (error) => {
+      assert.equal(error.status, 1);
+      assert.match(String(error.stderr), /cannot read/);
+      return true;
+    },
+  );
+});

--- a/scripts/sync-workspace-lockfile.mjs
+++ b/scripts/sync-workspace-lockfile.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Sync the root `package-lock.json` with the workspace versions declared in
+ * each `packages/<pkg>/package.json`.
+ *
+ * Why this exists: release-please bumps `packages/<pkg>/package.json` and the
+ * manifest, but never the root lockfile. Its node strategy looks for a
+ * lockfile *beside* each manifest, and this monorepo keeps a single one at the
+ * root, so the bump lands nowhere — `npm ci` then installs metadata one
+ * release behind the tag that was cut from it.
+ *
+ * Why not `npm install --package-lock-only`: that re-resolves the whole
+ * dependency tree and can quietly lift unrelated packages to newer versions
+ * inside what is supposed to be a version-bump-only release PR. This script
+ * touches nothing but the `packages/*` version fields, needs no registry, and
+ * is deterministic.
+ *
+ * Why not release-please's `node-workspace` plugin, which does update the root
+ * lockfile: its `inScope()` is `releaseType === 'node'`, so it can never reach
+ * `packages/beer-encyclopedia` (release-type `python`) — one of the packages
+ * that needs syncing.
+ *
+ * Only `packages/*` entries carry a `version` in the lockfile; the matching
+ * `node_modules/<name>` entries are workspace symlinks (`link: true`) with no
+ * version of their own, so nothing else needs touching.
+ *
+ * Exit codes: 0 whether or not anything changed (idempotent by design, so the
+ * caller can run it unconditionally); 1 only on a real error.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const LOCKFILE = "package-lock.json";
+
+/** Reads JSON, failing loudly rather than half-writing a lockfile. */
+function readJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch (error) {
+    throw new Error(`cannot read ${path}: ${error.message}`);
+  }
+}
+
+function main() {
+  const lock = readJson(LOCKFILE);
+  const entries = lock.packages;
+  if (!entries) {
+    throw new Error(`${LOCKFILE} has no "packages" map (lockfileVersion?)`);
+  }
+
+  const changes = [];
+  for (const [path, entry] of Object.entries(entries)) {
+    // Workspace roots only: "packages/api", never "packages/api/node_modules/x".
+    if (!path.startsWith("packages/") || path.split("/").length !== 2) continue;
+
+    const manifest = readJson(join(path, "package.json"));
+    const declared = manifest.version;
+    if (!declared) continue;
+
+    if (entry.version !== declared) {
+      changes.push(`${path}: ${entry.version ?? "(none)"} -> ${declared}`);
+      entry.version = declared;
+    }
+  }
+
+  if (changes.length === 0) {
+    console.log("root lockfile already in step with the workspace manifests");
+    return;
+  }
+
+  // Trailing newline: npm writes one, and omitting it would show up as a diff
+  // on every subsequent `npm install`.
+  writeFileSync(LOCKFILE, `${JSON.stringify(lock, null, 2)}\n`);
+  console.log(`root lockfile synced (${changes.length}):`);
+  for (const change of changes) console.log(`  ${change}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`sync-workspace-lockfile: ${error.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

release-please bumps `packages/<pkg>/package.json` and the manifest but never the root `package-lock.json`: its node strategy looks for a lockfile *beside* each manifest, and this monorepo keeps a single one at the root, so the bump lands nowhere. `npm ci` then installs metadata one release behind the tag cut from it.

Codex flagged exactly this on all three open release PRs — **#1425** (encyclopedia 0.2.5), **#1426** (website 0.1.3), **#1427** (app libraries) — which is why they have sat unmerged.

Adds `scripts/sync-workspace-lockfile.mjs` plus a workflow step that runs it on every open release PR branch and commits the result when it changes.

## Two alternatives tried and rejected on evidence

**release-please's own `node-workspace` plugin** was the obvious candidate — it does push a root `package-lock.json` update. But its `inScope()` is `releaseType === 'node'` (`node-workspace.ts:417-419`), so it can never reach `packages/beer-encyclopedia`, which is release-type `python`. It would have left #1425 — one of the three PRs this exists to unblock — untouched. Reading further into the plugin chain turned up two more hazards: the merged "app" group candidate carries `path: ROOT_PROJECT_PATH` with `releaseType: 'node'` (`merge.ts:128-139`), so node-workspace claims it in-scope yet never matches it against the `packages/*` keys it looks candidates up by — it would drop out of the run entirely; and `postProcessCandidates` only patches `candidates[0]` (`node-workspace.ts:364`).

**`npm install --package-lock-only`** covers every package uniformly, but re-resolves the whole dependency tree, so it can quietly lift unrelated third-party packages to newer versions inside what is supposed to be a version-bump-only release PR.

The script avoids both: it rewrites nothing but the `packages/*` version fields, needs no registry, and is idempotent. On a simulated bump of all four packages it produces **exactly 4 changed lines, all `version` fields**.

## Hardening

The branch list is **double-gated**, mirroring `release-please-metadata.yml`: a branch name alone is not trustworthy.

- `isCrossRepository == false` rejects a fork PR whose head branch merely matches the release-please prefix. That ref does not exist on `origin`, so fetching it would fail and — under `set -e` — block the release workflow on **every push to main** until the PR was closed. On a public repo that is a passive, zero-privilege denial of service. Both reviewers found this independently.
- `autorelease: pending` then confirms release-please owns the branch (verified: all three open release PRs carry it).
- Branch names are read line by line rather than word-split, and refs are fully qualified (`refs/heads/…`), since this input is remote-controlled.
- A `concurrency` group serialises runs; `cancel-in-progress: false` so a run already cutting tags finishes.

**Self-healing**: a later release-please run rewrites its branches and drops the sync commit, but this step runs immediately after it on every invocation, so a branch is back in step before anyone can merge it. The step pushes to release PR branches, which re-triggers their CI — intended.

## Checklist

- [x] **7 tests** under `node --test` — happy (single + multiple workspaces), edge (idempotent no-op, nested `node_modules` entries not mistaken for workspaces, manifest without a version skipped rather than clearing the entry), sad (missing `packages` map, missing manifest — both exit 1 rather than writing a partial lockfile)
- [x] YAML parses; `bash -n` clean; `.nvmrc` present (node 20)
- [x] Idempotence verified against the real repo lockfile
- [x] Pre-push review passed (Claude reviewer + Codex), 0 Must Have outstanding

## After merge

release-please regenerates #1425/#1426/#1427 with the lockfile in step, which clears the Codex P2 blocking all three.