### PR TITLE
fix(ci): drop linked-versions so app releases can be tagged again

### DIFF
--- a/.github/tag-protection.md
+++ b/.github/tag-protection.md
@@ -6,13 +6,17 @@ ruleset scoped to every tag pattern used by release-please.
 
 ## Tag patterns protected
 
-Per the hybrid monorepo release strategy (see [CONTRIBUTING.md](../CONTRIBUTING.md#release-workflow)):
+Every package versions independently (see [CONTRIBUTING.md](../CONTRIBUTING.md#release-workflow)):
 
-- `mobile-app-v*` — lockstep with `api-v*` (group "app")
-- `api-v*` — lockstep with `mobile-app-v*`
+- `mobile-app-v*` — independent
+- `api-v*` — independent
 - `website-v*` — independent
 - `encyclopedia-v*` — independent
 - `v*` — reserved for repo-wide anchors (audit snapshots, milestones)
+
+`mobile-app-v*` and `api-v*` were kept in lockstep until 2026-07-20, when the
+`linked-versions` group was removed because it prevented release-please from
+tagging app releases at all. The protected patterns themselves are unchanged.
 
 ## Ruleset policy (current, active)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,15 +81,23 @@ Conventional scopes for this monorepo:
 
 | Scope                                                                                                                | Typical path touched            | Effect                                                                                                      |
 | -------------------------------------------------------------------------------------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `mobile-app`, `scan`, `auth`, `recipes`, `batches`, `ingredients`, `labels`, `shop`, `tools`, `academy`, `dashboard`, `beer-catalog` | `packages/mobile-app/**`        | Bumps `mobile-app` (and `api` via lockstep group "app" if the commit also touches `packages/api/**`)        |
-| `api`                                                                                                                | `packages/api/**`               | Bumps `api` (and `mobile-app` via lockstep group "app" if the commit also touches `packages/mobile-app/**`) |
+| `mobile-app`, `scan`, `auth`, `recipes`, `batches`, `ingredients`, `labels`, `shop`, `tools`, `academy`, `dashboard`, `beer-catalog` | `packages/mobile-app/**`        | Bumps `mobile-app` independently                                                                            |
+| `api`                                                                                                                | `packages/api/**`               | Bumps `api` independently                                                                                   |
 | `website`                                                                                                            | `packages/website/**`           | Bumps `website` independently                                                                               |
 | `encyclopedia`                                                                                                       | `packages/beer-encyclopedia/**` | Bumps `encyclopedia` independently                                                                          |
 | `ydays`, `root`, `ci`, `monorepo`                                                                                    | anything outside `packages/**`  | No package bump — doc / infra commits only                                                                  |
 
-**Lockstep group "app"**: a single commit that touches files in both
-`packages/mobile-app` and `packages/api` will bump both packages to the
-same version under a linked release PR.
+**No lockstep**: every package versions on its own. A commit touching
+both `packages/mobile-app` and `packages/api` opens two release PRs, one
+per package, and their version numbers may diverge over time.
+
+The `linked-versions` group that used to bind `mobile-app` and `api` was
+removed on 2026-07-20: the plugin hardcodes a group PR title carrying no
+version (`linked-versions.ts:182`), so release-please could not parse a
+version back after merge and silently stopped tagging app releases from
+April onwards — three releases were lost that way. Nothing required the
+two packages to share a version: neither depends on the other, and both
+are private.
 
 Bump semantics (release-please computes automatically):
 
@@ -114,14 +122,17 @@ defined in `.github/workflows/release-please.yml` with the config
 in `release-please-config.json` and manifest in
 `.release-please-manifest.json`.
 
-### Monorepo grouping (hybrid)
+### Monorepo versioning (all packages independent)
 
-- **Group "app"** (lockstep): `packages/mobile-app` + `packages/api`
-  share a single `vX.Y.Z`. A commit touching either package bumps
-  both together, tag format `mobile-app-vX.Y.Z` + `api-vX.Y.Z`.
-- **Independent**: `packages/website` (tag `website-vX.Y.Z`),
-  `packages/beer-encyclopedia` (tag `encyclopedia-vX.Y.Z`). Each
-  evolves at its own rhythm.
+Every package versions and tags on its own rhythm, one release PR each:
+
+- `packages/mobile-app` → tag `mobile-app-vX.Y.Z`
+- `packages/api` → tag `api-vX.Y.Z`
+- `packages/website` → tag `website-vX.Y.Z`
+- `packages/beer-encyclopedia` → tag `encyclopedia-vX.Y.Z`
+
+`mobile-app` and `api` were grouped in lockstep until 2026-07-20; see
+the "No lockstep" note above for why that group was removed.
 
 ### Day-to-day flow
 
@@ -204,7 +215,8 @@ triptych as a regular PR:
   - `*--components--website` → `scope:website`
   - `*--components--mobile-app` → `scope:frontend`
   - `*--components--api` → `scope:backend`
-  - `*--groups--app` (lockstep) → `scope:monorepo`
+  - `*--groups--app` → `scope:monorepo` (legacy; the "app" group was
+    removed on 2026-07-20, so no new branch matches this)
 - **Project** — Brasse-Bouillon (`PVT_kwHOB8rwIc4AuVew`). Projects v2
   is user-scoped and cannot be reached from the default `GITHUB_TOKEN`
   at all. A PAT with the `project` scope (classic PAT) or Projects

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -56,12 +56,5 @@
       ]
     }
   },
-  "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "app",
-      "components": ["mobile-app", "api"]
-    }
-  ],
-  "group-pull-request-title-pattern": "chore${scope}: release ${component} ${version}"
+  "plugins": []
 }


### PR DESCRIPTION
## Summary

The `mobile-app`/`api` lockstep group has not produced a tag since April. Three consecutive group releases were merged and never tagged — **#769** (0.1.12-alpha1), **#1197** (0.1.13-alpha1), **#1427** (0.1.14-alpha1). The manifest claimed `0.1.14-alpha1` while the newest real tag was `0.1.11-alpha1`.

Removes the `linked-versions` plugin so `mobile-app` and `api` release per-component, like `website` and `beer-encyclopedia` already do.

## Root cause — upstream, not configuration

```ts
// release-please/src/plugins/linked-versions.ts:182
pullRequestTitlePattern:
  'chore${scope}: release ' + this.groupName + ' libraries',
```

The plugin **hardcodes its own PR title** and ignores this repo's `group-pull-request-title-pattern`. That title carries neither `${component}` nor `${version}` — release-please logs both as missing on every run — so once the group PR is merged it cannot parse a version back out of the title and aborts with `There are untagged, merged release PRs outstanding`.

Since it aborts **because of** the untagged PR, it can never tag it. A closed loop, which is why the documented `workflow_dispatch` escape hatch never cleared it.

## Why removal rather than a config fix

There is no config fix: the pattern cannot be overridden for a `linked-versions` group.

Removing the plugin puts both packages on the per-component path that `website` and `beer-encyclopedia` already use — with `separate-pull-requests: true`, each gets its own PR whose title carries component and version, exactly what release-please needs to tag. Not theoretical: **both other components were released and tagged successfully today** under that path.

`group-pull-request-title-pattern` goes with it; with no group left it configures nothing.

## Cost, accepted deliberately

`mobile-app` and `api` versions may now drift apart. Nothing requires them to match — neither package depends on the other (checked across dependencies, devDependencies and peerDependencies), both are `private`, the API Dockerfile builds only from `packages/api/**`, and `eas.json` uses `appVersionSource: remote` (EAS's own counter, decoupled from semver). The lockstep was a convention, and it was costing three months of silently unpublished releases.

## Remediation already applied on `main`

- `mobile-app-v0.1.14-alpha1` and `api-v0.1.14-alpha1` tagged manually on `5099ddac` (full GitHub prereleases, matching what release-please would have produced), so the pending marker could be cleared and release-please stops aborting.
- `0.1.12-alpha1` and `0.1.13-alpha1` **deliberately not backfilled** — alpha prereleases of private packages that nothing consumed.
- #769 and #1197 had their `autorelease: pending` marker removed and were left **without** an autorelease label rather than mislabelled `tagged`, with a comment recording that no tag exists for them.

## Docs

`CONTRIBUTING.md` described the lockstep in three places and `.github/tag-protection.md` declared the two tag patterns locked to each other. All now describe independent versioning, each keeping a dated note so the history stays readable. The `lockstep` mention in ADR-0005 is about the mobile app evolving across migration steps, not versioning, and was left alone.

## Checklist

- [x] Config validates against release-please's published schema; `"plugins": []` is valid and equivalent to omitting the key
- [x] `group-pull-request-title-pattern` verified inert outside the group (both consumers traced in release-please source)
- [x] Manual 0.1.14 tags verified consistent with the manifest, so the next run computes forward from a coherent baseline
- [x] Pre-push review passed (Claude reviewer + Codex), 0 Must Have outstanding