### PR TITLE
refactor(api): use one SQLite driver in tests instead of two

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2357,7 +2357,8 @@
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
@@ -4285,6 +4286,7 @@
       "version": "1.1.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
@@ -4294,6 +4296,7 @@
       "version": "7.7.4",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4305,6 +4308,7 @@
       "version": "1.1.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
@@ -5671,6 +5675,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5682,6 +5687,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5869,7 +5875,8 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -5956,6 +5963,7 @@
       "version": "4.6.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -5967,6 +5975,7 @@
       "version": "3.1.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -6190,12 +6199,14 @@
     "node_modules/aproba": {
       "version": "2.1.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -6799,6 +6810,7 @@
       "version": "15.3.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
@@ -6827,6 +6839,7 @@
       "version": "7.2.3",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -6846,6 +6859,7 @@
       "version": "6.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6857,6 +6871,7 @@
       "version": "3.3.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6868,6 +6883,7 @@
       "version": "6.2.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -6884,6 +6900,7 @@
       "version": "5.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6891,7 +6908,8 @@
     "node_modules/cacache/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
@@ -7049,8 +7067,9 @@
     },
     "node_modules/chownr": {
       "version": "2.0.0",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7126,6 +7145,7 @@
       "version": "2.2.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -7281,6 +7301,7 @@
       "version": "1.1.3",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -7429,7 +7450,8 @@
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
@@ -8519,7 +8541,8 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -8681,6 +8704,7 @@
       "version": "0.1.13",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -8689,6 +8713,7 @@
       "version": "0.6.3",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -8739,6 +8764,7 @@
       "version": "2.2.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -8746,7 +8772,8 @@
     "node_modules/err-code": {
       "version": "2.0.3",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
@@ -10590,8 +10617,9 @@
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -10601,8 +10629,9 @@
     },
     "node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10612,8 +10641,9 @@
     },
     "node_modules/fs-minipass/node_modules/yallist": {
       "version": "4.0.0",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fs-monkey": {
       "version": "1.1.0",
@@ -10635,6 +10665,7 @@
       "version": "4.0.4",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.3",
@@ -10652,7 +10683,8 @@
     "node_modules/gauge/node_modules/signal-exit": {
       "version": "3.0.7",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -10920,7 +10952,8 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/hasown": {
       "version": "2.0.4",
@@ -11051,6 +11084,7 @@
       "version": "1.2.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -11170,7 +11204,8 @@
     "node_modules/infer-owner": {
       "version": "1.0.4",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -11208,6 +11243,7 @@
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -11305,7 +11341,8 @@
     "node_modules/is-lambda": {
       "version": "1.0.1",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -14485,6 +14522,7 @@
       "version": "9.1.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agentkeepalive": "^4.1.3",
         "cacache": "^15.2.0",
@@ -14511,6 +14549,7 @@
       "version": "1.1.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -14519,6 +14558,7 @@
       "version": "4.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -14532,6 +14572,7 @@
       "version": "6.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14543,6 +14584,7 @@
       "version": "3.3.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -14553,7 +14595,8 @@
     "node_modules/make-fetch-happen/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -15290,6 +15333,7 @@
       "version": "1.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -15301,6 +15345,7 @@
       "version": "3.3.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -15311,12 +15356,14 @@
     "node_modules/minipass-collect/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/minipass-fetch": {
       "version": "1.4.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
@@ -15333,6 +15380,7 @@
       "version": "3.3.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -15343,12 +15391,14 @@
     "node_modules/minipass-fetch/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/minipass-flush": {
       "version": "1.0.5",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -15360,6 +15410,7 @@
       "version": "3.3.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -15370,12 +15421,14 @@
     "node_modules/minipass-flush/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -15387,6 +15440,7 @@
       "version": "3.3.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -15397,12 +15451,14 @@
     "node_modules/minipass-pipeline/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -15414,6 +15470,7 @@
       "version": "3.3.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -15424,12 +15481,14 @@
     "node_modules/minipass-sized/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/minizlib": {
       "version": "2.1.2",
-      "devOptional": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -15440,8 +15499,9 @@
     },
     "node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -15451,8 +15511,9 @@
     },
     "node_modules/minizlib/node_modules/yallist": {
       "version": "4.0.0",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -15666,6 +15727,7 @@
       "version": "8.4.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -15698,6 +15760,7 @@
       "version": "7.2.3",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -15717,6 +15780,7 @@
       "version": "5.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15725,6 +15789,7 @@
       "version": "7.7.4",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -15736,6 +15801,7 @@
       "version": "6.2.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -15751,7 +15817,8 @@
     "node_modules/node-gyp/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -15765,6 +15832,7 @@
       "version": "5.0.0",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -15835,6 +15903,7 @@
       "version": "6.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
@@ -16014,6 +16083,7 @@
       "version": "4.0.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -16546,12 +16616,14 @@
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -17629,6 +17701,7 @@
       "version": "0.12.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -17820,7 +17893,8 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -18078,6 +18152,7 @@
       "version": "4.2.0",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -18087,6 +18162,7 @@
       "version": "2.8.7",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
         "smart-buffer": "^4.2.0"
@@ -18100,6 +18176,7 @@
       "version": "6.2.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "agent-base": "^6.0.2",
         "debug": "^4.3.3",
@@ -18168,9 +18245,10 @@
     },
     "node_modules/sqlite3": {
       "version": "5.1.7",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^7.0.0",
@@ -18191,21 +18269,24 @@
     },
     "node_modules/sqlite3/node_modules/minipass": {
       "version": "5.0.0",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/sqlite3/node_modules/node-addon-api": {
       "version": "7.1.1",
-      "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/sqlite3/node_modules/tar": {
       "version": "6.2.1",
-      "devOptional": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -18220,13 +18301,15 @@
     },
     "node_modules/sqlite3/node_modules/yallist": {
       "version": "4.0.0",
-      "devOptional": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ssri": {
       "version": "8.0.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "minipass": "^3.1.1"
       },
@@ -18238,6 +18321,7 @@
       "version": "3.3.6",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -18248,7 +18332,8 @@
     "node_modules/ssri/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/stack-generator": {
       "version": "2.0.10",
@@ -19636,6 +19721,7 @@
       "version": "1.1.1",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "unique-slug": "^2.0.0"
       }
@@ -19644,6 +19730,7 @@
       "version": "2.0.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       }
@@ -20343,6 +20430,7 @@
       "version": "1.1.5",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
@@ -20614,7 +20702,6 @@
         "jest": "^30.0.0",
         "prettier": "^3.4.2",
         "source-map-support": "^0.5.21",
-        "sqlite3": "^5.1.7",
         "supertest": "^7.0.0",
         "ts-jest": "^29.2.5",
         "ts-loader": "^9.5.2",

--- a/packages/api/AUDIT.md
+++ b/packages/api/AUDIT.md
@@ -232,7 +232,13 @@ Tests:       2 skipped, 54 passed, 56 total
 - `RolesGuard` for admin routes ✅
 
 ### Dependencies
-- `npm audit` critical vulnerabilities: ✅ clean (sqlite3 chain handled with tar override)
+- `npm audit` critical vulnerabilities: ✅ clean
+- The `sqlite3 -> node-gyp -> cacache -> tar@6` chain is **not** handled — an
+  earlier `overrides` block claimed to pin `tar` but never applied (npm only
+  reads `overrides` from the workspace root) and has been removed. The chain is
+  pinned by TypeORM's optional `sqlite3 ^5.0.3` peer and is accepted risk:
+  native-build tooling that rarely executes and never runs in the served app.
+  Tracked in #1497.
 - `high`-level vulnerabilities may still exist (policy: CI gate at `critical` only)
 
 ### Exposure and Hardening

--- a/packages/api/ROADMAP.md
+++ b/packages/api/ROADMAP.md
@@ -120,7 +120,7 @@ modern, and offline-first.
 - Brewing assistant: Batch API + auth integration
 - Brewing assistant: Fermentation + reminders API
 - JWT integration tests (auth.protected.e2e-spec.ts — valid/invalid/expired/missing token)
-- Security: npm audit pipeline hardening (critical-only gate + tar override for sqlite3 chain)
+- Security: npm audit pipeline hardening (critical-only gate)
 - DB config alignment with migrations (typeorm.config.ts + data-source.ts synchronized)
 - CI: GitHub Actions build + test + lint:check
 - CI: Security audit job (production deps, critical-only)

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -74,7 +74,6 @@
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
     "source-map-support": "^0.5.21",
-    "sqlite3": "^5.1.7",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",
     "ts-loader": "^9.5.2",
@@ -115,10 +114,5 @@
       }
     },
     "testEnvironment": "node"
-  },
-  "overrides": {
-    "sqlite3": {
-      "tar": "7.5.7"
-    }
   }
 }

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -49,7 +49,7 @@ describe('BatchService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             RecipeOrmEntity,

--- a/packages/api/src/catalog/distributor/services/__tests__/distributor-catalog.service.spec.ts
+++ b/packages/api/src/catalog/distributor/services/__tests__/distributor-catalog.service.spec.ts
@@ -20,7 +20,7 @@ describe('DistributorCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [DistributorOrmEntity],
           synchronize: true,

--- a/packages/api/src/catalog/equipment/services/__tests__/equipment-catalog.service.spec.ts
+++ b/packages/api/src/catalog/equipment/services/__tests__/equipment-catalog.service.spec.ts
@@ -25,7 +25,7 @@ describe('EquipmentCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             EquipmentTemplateOrmEntity,

--- a/packages/api/src/catalog/fermentable/services/__tests__/fermentable-catalog.service.spec.ts
+++ b/packages/api/src/catalog/fermentable/services/__tests__/fermentable-catalog.service.spec.ts
@@ -34,7 +34,7 @@ describe('FermentableCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             FermentableOrmEntity,

--- a/packages/api/src/catalog/hop/services/__tests__/hop-catalog.service.spec.ts
+++ b/packages/api/src/catalog/hop/services/__tests__/hop-catalog.service.spec.ts
@@ -36,7 +36,7 @@ describe('HopCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             HopOrmEntity,

--- a/packages/api/src/catalog/mash/services/__tests__/mash-catalog.service.spec.ts
+++ b/packages/api/src/catalog/mash/services/__tests__/mash-catalog.service.spec.ts
@@ -30,7 +30,7 @@ describe('MashCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [MashProfileOrmEntity, MashStepOrmEntity],
           synchronize: true,

--- a/packages/api/src/catalog/misc/services/__tests__/misc-catalog.service.spec.ts
+++ b/packages/api/src/catalog/misc/services/__tests__/misc-catalog.service.spec.ts
@@ -26,7 +26,7 @@ describe('MiscCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             MiscTemplateOrmEntity,

--- a/packages/api/src/catalog/producer/services/__tests__/producer-catalog.service.spec.ts
+++ b/packages/api/src/catalog/producer/services/__tests__/producer-catalog.service.spec.ts
@@ -21,7 +21,7 @@ describe('ProducerCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [ProducerOrmEntity],
           synchronize: true,

--- a/packages/api/src/catalog/style/services/__tests__/style-catalog.service.spec.ts
+++ b/packages/api/src/catalog/style/services/__tests__/style-catalog.service.spec.ts
@@ -29,7 +29,7 @@ describe('StyleCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [StyleOrmEntity],
           synchronize: true,

--- a/packages/api/src/catalog/water/services/__tests__/water-catalog.service.spec.ts
+++ b/packages/api/src/catalog/water/services/__tests__/water-catalog.service.spec.ts
@@ -26,7 +26,7 @@ describe('WaterCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [WaterOrmEntity],
           synchronize: true,

--- a/packages/api/src/catalog/yeast/services/__tests__/yeast-catalog.service.spec.ts
+++ b/packages/api/src/catalog/yeast/services/__tests__/yeast-catalog.service.spec.ts
@@ -36,7 +36,7 @@ describe('YeastCatalogService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             YeastOrmEntity,

--- a/packages/api/src/label/label.module.spec.ts
+++ b/packages/api/src/label/label.module.spec.ts
@@ -11,7 +11,7 @@ describe('LabelModule', () => {
     const moduleRef = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [LabelDraftOrmEntity],
           synchronize: true,

--- a/packages/api/src/recipe/recipe-import.service.spec.ts
+++ b/packages/api/src/recipe/recipe-import.service.spec.ts
@@ -33,7 +33,7 @@ describe('RecipeService.importFromCommunity (Issue #601)', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             RecipeOrmEntity,

--- a/packages/api/src/recipe/recipe-ingredients.service.spec.ts
+++ b/packages/api/src/recipe/recipe-ingredients.service.spec.ts
@@ -38,7 +38,7 @@ describe('RecipeIngredientsService', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             RecipeOrmEntity,

--- a/packages/api/src/recipe/recipe-steps.service.spec.ts
+++ b/packages/api/src/recipe/recipe-steps.service.spec.ts
@@ -32,7 +32,7 @@ describe('RecipeService (steps)', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             RecipeOrmEntity,

--- a/packages/api/src/recipe/recipe-testing.module.ts
+++ b/packages/api/src/recipe/recipe-testing.module.ts
@@ -32,7 +32,7 @@ export const RECIPE_ORM_ENTITIES = [
 export function buildRecipeTestingTypeOrm() {
   return [
     TypeOrmModule.forRoot({
-      type: 'sqlite' as const,
+      type: 'better-sqlite3' as const,
       database: ':memory:',
       entities: [...RECIPE_ORM_ENTITIES],
       synchronize: true,

--- a/packages/api/src/recipe/services/recipe-matching.service.spec.ts
+++ b/packages/api/src/recipe/services/recipe-matching.service.spec.ts
@@ -36,7 +36,7 @@ describe('RecipeMatchingService (matcher v2, ADR-0016)', () => {
     module = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             RecipeOrmEntity,

--- a/packages/api/src/scan/scan.module.spec.ts
+++ b/packages/api/src/scan/scan.module.spec.ts
@@ -14,7 +14,7 @@ describe('ScanModule', () => {
     const moduleRef = await Test.createTestingModule({
       imports: [
         TypeOrmModule.forRoot({
-          type: 'sqlite',
+          type: 'better-sqlite3',
           database: ':memory:',
           entities: [
             User,


### PR DESCRIPTION
## Summary

The API declared **two** SQLite drivers: `better-sqlite3` as a runtime dependency (used by `typeorm.config.ts` and two specs) and `sqlite3` as a devDependency (used by 18 test files through TypeORM's `type: 'sqlite'`). Nothing needed both.

Switches those 18 specs plus `recipe-testing.module.ts` to `type: 'better-sqlite3'` and drops the `sqlite3` devDependency, so tests exercise the driver production actually runs on.

## Not a security fix

**This is hygiene and should not be read as remediation.** Removing the devDependency does *not* remove `sqlite3` from the tree: TypeORM declares it as an optional peer (`peerDependenciesMeta.sqlite3.optional`), and `optional` only means npm will not error when the package is missing — it does not stop npm installing it. After the change, `npm ls sqlite3` still resolves `api → typeorm@0.3.29 → sqlite3@5.1.7`, so the `sqlite3 → node-gyp@8 → cacache@15 → tar@6.2.1` chain and its **6 high alerts are untouched**.

A root-level `{"tar": "^7.5.14"}` override was tried too — npm did not even record it in the lockfile. Those alerts are accepted risk, tracked in **#1497** with every avenue that was tested and ruled out.

## Also removes a dead config block

```json
"overrides": { "sqlite3": { "tar": "7.5.7" } }
```

This never did anything. npm only reads `overrides` from the workspace **root** package.json, so one declared inside a workspace package is silently ignored — the lockfile recorded no overrides at all and the nested `tar` stayed at 6.2.1 throughout. Inert since `88379e0c` (the `backend` → `api` rename).

Two docs credited it as working and are corrected here: `AUDIT.md` claimed the chain was "handled with tar override", `ROADMAP.md` listed the override as done.

## Why the driver swap is safe

Both TypeORM drivers extend the shared `AbstractSqliteDriver` / `AbstractSqliteQueryRunner` base classes, which own value coercion (boolean/date/JSON) and the whole transaction lifecycle. Only the low-level bind/execute layer differs. Production has run `better-sqlite3` all along, and two specs were already on it before this PR — this converges a pre-existing test/prod driver split rather than introducing an untested one.

## Checklist

- [x] **1018 API tests pass.** The one failing suite (`app.module.spec.ts`) fails on `Config validation error: "JWT_SECRET" is required` — a missing `.env` in the throwaway worktree, not a regression; that spec contains no sqlite reference
- [x] No remaining `type: 'sqlite'` anywhere in `packages/api`
- [x] Lockfile diff is metadata-only — no package added, removed or re-resolved; the changed `peer`/`optional`/`devOptional` flags are npm reclassifying the sqlite3 subtree now that nothing depends on it directly
- [x] `better-sqlite3` deliberately stays in `dependencies` — it is the production driver
- [x] Pre-push review passed (Claude reviewer + Codex), 0 Must Have outstanding