### PR TITLE
chore(deps): bump three NestJS packages to clear transitive CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2356,6 +2356,7 @@
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -3989,12 +3990,14 @@
       }
     },
     "node_modules/@nestjs/config": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@nestjs/config/-/config-4.0.4.tgz",
+      "integrity": "sha512-CJPjNitr0bAufSEnRe2N+JbnVmMmDoo6hvKCPzXgZoGwJSmp/dZPk9f/RMbuD/+Q1ZJPjwsRpq0vxna++Knwow==",
       "license": "MIT",
       "dependencies": {
-        "dotenv": "17.2.3",
+        "dotenv": "17.4.1",
         "dotenv-expand": "12.0.3",
-        "lodash": "4.17.23"
+        "lodash": "4.18.1"
       },
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
@@ -4042,16 +4045,6 @@
         }
       }
     },
-    "node_modules/@nestjs/core/node_modules/path-to-regexp": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
-      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@nestjs/jwt": {
       "version": "11.0.2",
       "license": "MIT",
@@ -4064,12 +4057,14 @@
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.1.0",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
         "reflect-metadata": "^0.1.12 || ^0.2.0"
       },
       "peerDependenciesMeta": {
@@ -4090,13 +4085,15 @@
       }
     },
     "node_modules/@nestjs/platform-express": {
-      "version": "11.1.17",
+      "version": "11.1.28",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.28.tgz",
+      "integrity": "sha512-hU+9Sz4m+onHrR5AmelI59QKmY/Re546bPnygnpqqeQdHDiJpBgjWbL4t6Jr73CBpS60cpyng7WzjgphNB9iwA==",
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
-        "multer": "2.1.1",
-        "path-to-regexp": "8.3.0",
+        "multer": "2.2.0",
+        "path-to-regexp": "8.4.2",
         "tslib": "2.8.1"
       },
       "funding": {
@@ -4195,18 +4192,20 @@
       }
     },
     "node_modules/@nestjs/swagger": {
-      "version": "11.2.6",
+      "version": "11.4.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.4.6.tgz",
+      "integrity": "sha512-Le136h2WC7HGsd70+WyK1qrm+Zq7kFxBLkYC1JgAVqNRCt8kNh7bMF7Qkn65D5j2t/aks0+VbWmUVlYIwPrs3A==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",
-        "@nestjs/mapped-types": "2.1.0",
-        "js-yaml": "4.1.1",
-        "lodash": "4.17.23",
-        "path-to-regexp": "8.3.0",
-        "swagger-ui-dist": "5.31.0"
+        "@nestjs/mapped-types": "2.1.1",
+        "js-yaml": "5.2.1",
+        "lodash": "4.18.1",
+        "path-to-regexp": "8.4.2",
+        "swagger-ui-dist": "5.32.8"
       },
       "peerDependencies": {
-        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@fastify/static": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "@nestjs/common": "^11.0.1",
         "@nestjs/core": "^11.0.1",
         "class-transformer": "*",
@@ -4223,6 +4222,28 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/js-yaml": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/@nestjs/testing": {
@@ -4284,6 +4305,7 @@
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -4294,6 +4316,7 @@
     },
     "node_modules/@npmcli/fs/node_modules/semver": {
       "version": "7.7.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -4306,6 +4329,7 @@
     },
     "node_modules/@npmcli/move-file": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -5874,6 +5898,7 @@
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -5950,7 +5975,7 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -5961,6 +5986,7 @@
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -5973,6 +5999,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -6194,16 +6221,20 @@
     },
     "node_modules/append-field": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
     "node_modules/aproba": {
       "version": "2.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -6792,6 +6823,8 @@
     },
     "node_modules/busboy": {
       "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -6808,6 +6841,7 @@
     },
     "node_modules/cacache": {
       "version": "15.3.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -6837,6 +6871,7 @@
     },
     "node_modules/cacache/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -6857,6 +6892,7 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -6869,6 +6905,7 @@
     },
     "node_modules/cacache/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -6881,6 +6918,7 @@
     },
     "node_modules/cacache/node_modules/tar": {
       "version": "6.2.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -6898,6 +6936,7 @@
     },
     "node_modules/cacache/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -6907,6 +6946,7 @@
     },
     "node_modules/cacache/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -7143,6 +7183,7 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -7299,6 +7340,7 @@
     },
     "node_modules/color-support": {
       "version": "1.1.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -7405,6 +7447,8 @@
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
       "engines": [
         "node >= 6.0"
       ],
@@ -7449,6 +7493,7 @@
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -8540,6 +8585,7 @@
     },
     "node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -8615,7 +8661,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.3",
+      "version": "17.4.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
+      "integrity": "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -8762,6 +8810,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -8771,6 +8820,7 @@
     },
     "node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -10663,6 +10713,7 @@
     },
     "node_modules/gauge": {
       "version": "4.0.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -10682,6 +10733,7 @@
     },
     "node_modules/gauge/node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -10951,6 +11003,7 @@
     },
     "node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -11014,7 +11067,7 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
@@ -11062,7 +11115,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -11082,6 +11135,7 @@
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -11203,6 +11257,7 @@
     },
     "node_modules/infer-owner": {
       "version": "1.0.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -11241,6 +11296,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -11340,6 +11396,7 @@
     },
     "node_modules/is-lambda": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true
@@ -14371,7 +14428,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -14520,6 +14579,7 @@
     },
     "node_modules/make-fetch-happen": {
       "version": "9.1.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -14547,6 +14607,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/@tootallnate/once": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -14556,6 +14617,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -14570,6 +14632,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -14582,6 +14645,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -14594,6 +14658,7 @@
     },
     "node_modules/make-fetch-happen/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -15331,6 +15396,7 @@
     },
     "node_modules/minipass-collect": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15343,6 +15409,7 @@
     },
     "node_modules/minipass-collect/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15355,12 +15422,14 @@
     },
     "node_modules/minipass-collect/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
     },
     "node_modules/minipass-fetch": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -15378,6 +15447,7 @@
     },
     "node_modules/minipass-fetch/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15390,12 +15460,14 @@
     },
     "node_modules/minipass-fetch/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
     },
     "node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15408,6 +15480,7 @@
     },
     "node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15420,12 +15493,14 @@
     },
     "node_modules/minipass-flush/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
     },
     "node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15438,6 +15513,7 @@
     },
     "node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15450,12 +15526,14 @@
     },
     "node_modules/minipass-pipeline/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
     },
     "node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15468,6 +15546,7 @@
     },
     "node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15480,6 +15559,7 @@
     },
     "node_modules/minipass-sized/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -15534,7 +15614,9 @@
       "license": "MIT"
     },
     "node_modules/multer": {
-      "version": "2.1.1",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -15552,6 +15634,8 @@
     },
     "node_modules/multer/node_modules/media-typer": {
       "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -15559,6 +15643,8 @@
     },
     "node_modules/multer/node_modules/type-is": {
       "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -15725,6 +15811,7 @@
     },
     "node_modules/node-gyp": {
       "version": "8.4.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -15758,6 +15845,7 @@
     },
     "node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15778,6 +15866,7 @@
     },
     "node_modules/node-gyp/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15787,6 +15876,7 @@
     },
     "node_modules/node-gyp/node_modules/semver": {
       "version": "7.7.4",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15799,6 +15889,7 @@
     },
     "node_modules/node-gyp/node_modules/tar": {
       "version": "6.2.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15816,6 +15907,7 @@
     },
     "node_modules/node-gyp/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -15830,6 +15922,7 @@
     },
     "node_modules/nopt": {
       "version": "5.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -15901,6 +15994,7 @@
     },
     "node_modules/npmlog": {
       "version": "6.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -16081,6 +16175,7 @@
     },
     "node_modules/p-map": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -16247,7 +16342,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -16615,12 +16712,14 @@
     },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -17699,6 +17798,7 @@
     },
     "node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -17892,6 +17992,7 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -18150,6 +18251,7 @@
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -18160,6 +18262,7 @@
     },
     "node_modules/socks": {
       "version": "2.8.7",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -18174,6 +18277,7 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "6.2.1",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -18307,6 +18411,7 @@
     },
     "node_modules/ssri": {
       "version": "8.0.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -18319,6 +18424,7 @@
     },
     "node_modules/ssri/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -18331,6 +18437,7 @@
     },
     "node_modules/ssri/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true
@@ -18424,6 +18531,8 @@
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -18659,7 +18768,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.31.0",
+      "version": "5.32.8",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.8.tgz",
+      "integrity": "sha512-dgMdWXIgnI4zX4OPhKEdWnlDODbgm8W3AX0Ivn/BBqcUh6xZsBxhZMnvk6DJyRz1BTrj8dPxtarmEGgkz30oyA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
@@ -19390,6 +19501,8 @@
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "license": "MIT"
     },
     "node_modules/typeorm": {
@@ -19719,6 +19832,7 @@
     },
     "node_modules/unique-filename": {
       "version": "1.1.1",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -19728,6 +19842,7 @@
     },
     "node_modules/unique-slug": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,
@@ -20428,6 +20543,7 @@
     },
     "node_modules/wide-align": {
       "version": "1.1.5",
+      "dev": true,
       "license": "ISC",
       "optional": true,
       "peer": true,


### PR DESCRIPTION
## Summary

Clears the **last three high-severity Dependabot alerts** fixable from this repo, plus their three medium siblings:

| Package | Before | After | Alerts closed |
|---|---|---|---|
| `path-to-regexp` | 8.3.0 | **8.4.2** | 1 high + 1 medium |
| `multer` | 2.1.1 | **2.2.0** | 1 high + 1 medium |
| `lodash` | 4.17.23 | **4.18.1** | 1 high + 1 medium |

**No `package.json` changes.** The declared ranges (`@nestjs/platform-express ^11.0.1`, `@nestjs/config ^4.0.2`, `@nestjs/swagger ^11.2.1`) already allowed the fixed versions — the lockfile was simply stale.

## Why it took three passes

NestJS pins these transitives to **exact** versions rather than ranges, so `npm update <transitive>` does nothing. The parents had to move:

```
@nestjs/platform-express  11.1.17 → 11.1.28   pins path-to-regexp 8.4.2, multer 2.2.0
@nestjs/config            4.0.3   → 4.0.4     pins lodash 4.18.1
@nestjs/swagger           11.2.6  → 11.4.6    pins path-to-regexp 8.4.2, lodash 4.18.1
```

`@nestjs/swagger` was the last holdout — it pinned both `path-to-regexp 8.3.0` and `lodash 4.17.23` exactly, which kept vulnerable copies hoisted at the root even after the other two moved. Bumping it also collapsed the nested duplicates, so each package now resolves to a **single patched copy**.

## One thing carried along, worth naming

`@nestjs/swagger@11.4.6` brings a nested **`js-yaml` 4.1.1 → 5.2.1 — a major bump**.

Safe here: `swagger-module` only calls `jsyaml.dump()` on the app's own already-built OpenAPI document, never `load()`/`safeLoad()` on untrusted input, which is where js-yaml's historical CVEs live. `main.ts` uses plain `DocumentBuilder` + `SwaggerModule.setup` with no custom YAML handling. The version is an exact pin owned by the `@nestjs/swagger` maintainers, not chosen here.

## Reading the diff

The bulk of +149/-33 is **npm's own dependency-graph bookkeeping**, not new packages. Exactly 9 package versions changed, 1 was added (the nested js-yaml above), 1 removed (a `path-to-regexp` duplicate, deduped). The rest is npm recomputing reachability flags (`dev`/`devOptional`) and backfilling `resolved`/`integrity` on entries that previously had none — which slightly improves lockfile integrity coverage.

## What this does *not* fix

Not to be conflated with "all alerts cleared":

- A separate **moderate `js-yaml` advisory on the ROOT `js-yaml@4.1.1`** is untouched and stays open.
- The **7 `tar` alerts** remain, pinned by TypeORM's optional `sqlite3` peer — accepted risk, documented in **#1497**.
- The **8 `vite`/`esbuild` alerts** on the two docs microsites remain: they need `vite ≥ 6.4.3`, but `vitepress@1.6.4` (latest stable) pins `vite ^5.4.14`. Only the `2.0.0-alpha` line moves to vite 8 — not something to put on two deployed sites.

After this, open alerts go **31 → 25**, and no remaining high-severity alert is fixable from this repository.

## Checklist

- [x] Verified with the package's own CI commands: `npm run build` clean, `npm run lint:check` 0 errors (3 pre-existing warnings), `npm run test:cov` **112 suites / 1019 tests passing, zero failures**
- [x] All three vulnerable copies gone, including nested duplicates under `@nestjs/*/node_modules/`
- [x] Declared ranges permit the resolved versions — lockfile and manifests stay consistent
- [x] Scope is `deps` not `api`: the only changed file is the root lockfile, outside `packages/**`, so release-please produces no version bump — matching every prior lockfile-only commit here
- [x] Pre-push review passed (Claude reviewer + Codex), 0 Must Have outstanding