### PR TITLE
ci(ci): bound every CI job with an explicit timeout-minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
   # ============================================================================
   changes:
     runs-on: ubuntu-latest
+    # Observed max 0.21 min. Budgets across this file are deliberately loose:
+    # the point is to turn a hung runner into a fast, legible failure instead
+    # of letting it sit on the 360-minute Actions default, not to police
+    # runtime. A job cancelled on a slow-runner day is noise that erodes trust
+    # in CI, so every value keeps a wide margin over what we actually measure.
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -63,6 +69,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.mobile-app == 'true'
     runs-on: ubuntu-latest
+    # Observed max 2.29 min.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: packages/mobile-app
@@ -100,6 +108,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
+    # Observed max 2.23 min.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: packages/api
@@ -143,6 +153,8 @@ jobs:
     needs: changes
     if: needs.changes.outputs.website == 'true'
     runs-on: ubuntu-latest
+    # Observed max 0.18 min.
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: packages/website
@@ -198,6 +210,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.beer-encyclopedia == 'true'
     runs-on: ubuntu-latest
+    # Observed max 1.95 min — but budgeted higher than the npm jobs on purpose,
+    # not aligned with them. This is the one job with no dependency cache:
+    # `setup-python` here has no `cache: pip` (unlike `cache: npm` on mobile-app
+    # and api), so `pip install -e ".[ml,dev]"` refetches ultralytics, easyocr
+    # and opencv-python — and PyTorch transitively — from PyPI on every run.
+    # That install step alone is the bulk of the job and swings widely on
+    # registry conditions, so a slow PyPI day or a missing manylinux wheel
+    # (forcing a source build) is a realistic way to overrun a tighter budget.
+    timeout-minutes: 20
     defaults:
       run:
         working-directory: packages/beer-encyclopedia
@@ -240,6 +261,18 @@ jobs:
   # ============================================================================
   security-audit:
     runs-on: ubuntu-latest
+    # Observed max 0.40 min, but `npm audit` reaches the registry over the
+    # network, which is the kind of step that hangs rather than fails — hence a
+    # 25x margin rather than a tight one.
+    #
+    # Behaviour change worth naming: this job is deliberately unfailable today
+    # (`npm audit ... || true` plus `continue-on-error: true`), so findings
+    # never turn CI red. A `timeout-minutes` cancellation is NOT swallowed by
+    # `continue-on-error`, so a registry hang can now fail this job for the
+    # first time. That is the intended trade — a job stuck for six hours is
+    # worse than an occasional red on a hung network call — but it is a real
+    # change, not a no-op.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

No job in `ci.yml` set `timeout-minutes`, so all six inherited GitHub Actions' **360-minute** default. A hung step held a runner for six hours before anyone learned anything — the failure mode was silence, not a red cross.

| Job | Observed max | Budget |
|---|---|---|
| `changes` | 0.21 min | **5** |
| `website` | 0.18 min | **10** |
| `security-audit` | 0.40 min | **10** |
| `mobile-app` | 2.36 min | **15** |
| `api` | 2.23 min | **15** |
| `beer-encyclopedia` | 1.95 min | **20** |

Margins are deliberately wide. The goal is turning a hang into a fast, legible failure, not policing runtime — a job cancelled on a slow-runner day is noise that erodes trust in CI, which costs more than the minutes it saves.

## Why beer-encyclopedia gets the largest budget despite the second-lowest time

It is the **only job with no dependency cache**. `setup-python` here has no `cache: pip` (unlike `cache: npm` on mobile-app and api), so `pip install -e ".[ml,dev]"` refetches `ultralytics`, `easyocr` and `opencv-python` — PyTorch transitively — from PyPI on **every run**. A slow registry day, or a missing manylinux wheel forcing a source build, is a realistic overrun path the npm-cached jobs simply do not have.

An earlier draft of this PR gave it 15 min "aligned with the other package jobs", on a comment claiming no successful run existed to measure. **That claim was wrong** — successful runs exist at 1.86 and 1.95 min — and the reasoning behind it was wrong too. Both are corrected here.

## Behaviour change worth naming

`security-audit` is deliberately **unfailable** today: `npm audit --audit-level=high || true` plus `continue-on-error: true`, so findings never turn CI red.

A `timeout-minutes` cancellation is **not** swallowed by `continue-on-error`. A registry hang can therefore fail that job for the first time. That is the intended trade — six hours stuck is worse than an occasional red on a hung network call — but it is a real change, not a no-op, and it is commented as such in the file.

## Scope

`ci.yml` only. The other nine workflows share the same gap and are tracked in **#1503**, including the two that matter most: `docker-build.yml` holds `packages: write` to GHCR, and the deploy workflows hold Cloudflare secrets. Scoped as a first slice rather than touching ten workflow files at once.

## Checklist

- [x] YAML parses; all six jobs resolve a `timeout-minutes` value
- [x] Diff is purely additive (33 insertions, 0 deletions)
- [x] Budgets measured from real run history via `gh run view --json jobs`, sampled over 60 runs
- [x] No untraced deferred-work comment (ADR-0001) — the follow-up is issue #1503
- [x] Pre-push review passed (Claude reviewer + Codex), Must Have resolved