### PR TITLE
feat(shop): wire the Accessoires rayon to the misc catalog

### DIFF
--- a/packages/mobile-app/src/features/ingredients/application/__tests__/ingredients.use-cases.test.ts
+++ b/packages/mobile-app/src/features/ingredients/application/__tests__/ingredients.use-cases.test.ts
@@ -15,6 +15,10 @@ import {
   getYeastDetails,
   listYeasts,
 } from "@/features/ingredients/application/yeasts.use-cases";
+import {
+  listMiscApi,
+  type MiscProduct,
+} from "@/features/ingredients/data/misc.api";
 
 import { HopProduct } from "@/features/ingredients/domain/hop.types";
 import { MaltProduct } from "@/features/ingredients/domain/malt.types";
@@ -43,6 +47,17 @@ jest.mock("@/features/ingredients/application/yeasts.use-cases", () => ({
   getYeastDetails: jest.fn(),
 }));
 
+// Misc dispatches straight to the api rather than through a per-type
+// use-case (it has no demo-only path or filters of its own), so the boundary
+// mocked here is the data module.
+jest.mock("@/features/ingredients/data/misc.api", () => ({
+  listMiscApi: jest.fn(),
+  getMiscDetailsApi: jest.fn(),
+}));
+
+const mockedListMiscApi = listMiscApi as jest.MockedFunction<
+  typeof listMiscApi
+>;
 const mockedListMalts = listMalts as jest.MockedFunction<typeof listMalts>;
 const mockedGetMaltDetails = getMaltDetails as jest.MockedFunction<
   typeof getMaltDetails
@@ -125,6 +140,19 @@ function buildYeastProduct(
   };
 }
 
+function buildMiscProduct(overrides: Partial<MiscProduct> = {}): MiscProduct {
+  return {
+    id: "misc-whirlfloc-uuid",
+    slug: "whirlfloc",
+    name: "Whirlfloc",
+    miscType: "fining",
+    useAt: "boil",
+    useFor: "Clarté",
+    timeMin: 15,
+    ...overrides,
+  };
+}
+
 describe("ingredients use-cases", () => {
   beforeEach(() => {
     dataSource.useDemoData = true;
@@ -134,6 +162,8 @@ describe("ingredients use-cases", () => {
     mockedGetHopDetails.mockReset();
     mockedListYeasts.mockReset();
     mockedGetYeastDetails.mockReset();
+    mockedListMiscApi.mockReset();
+    mockedListMiscApi.mockResolvedValue([]);
   });
 
   describe("listIngredientCategoriesSummary", () => {
@@ -150,6 +180,7 @@ describe("ingredients use-cases", () => {
         hop: demoIngredients.filter((item) => item.category === "hop").length,
         yeast: demoIngredients.filter((item) => item.category === "yeast")
           .length,
+        misc: demoIngredients.filter((item) => item.category === "misc").length,
       });
 
       expect(mockedListMalts).not.toHaveBeenCalled();
@@ -169,13 +200,15 @@ describe("ingredients use-cases", () => {
       );
     });
 
-    // Edge case — always returns the 3 expected categories.
-    it("always includes all three categories (malt, hop, yeast)", async () => {
+    // Edge case — every rayon the shop can open must get a count, so the hub
+    // never renders a live rayon with a missing badge.
+    it("always includes every catalog category (malt, hop, yeast, misc)", async () => {
       const summary = await listIngredientCategoriesSummary();
 
       expect(summary.map((item) => item.category).sort()).toEqual([
         "hop",
         "malt",
+        "misc",
         "yeast",
       ]);
     });
@@ -242,16 +275,19 @@ describe("ingredients use-cases", () => {
       ]);
       mockedListHops.mockResolvedValue([buildHopProduct()]);
       mockedListYeasts.mockResolvedValue([buildYeastProduct()]);
+      mockedListMiscApi.mockResolvedValue([buildMiscProduct()]);
 
       const summary = await listIngredientCategoriesSummary();
 
       expect(mockedListMalts).toHaveBeenCalledTimes(1);
       expect(mockedListHops).toHaveBeenCalledTimes(1);
       expect(mockedListYeasts).toHaveBeenCalledTimes(1);
+      expect(mockedListMiscApi).toHaveBeenCalledTimes(1);
       expect(summary).toEqual([
         { category: "malt", count: 2 },
         { category: "hop", count: 1 },
         { category: "yeast", count: 1 },
+        { category: "misc", count: 1 },
       ]);
     });
 

--- a/packages/mobile-app/src/features/ingredients/application/__tests__/ingredients.use-cases.test.ts
+++ b/packages/mobile-app/src/features/ingredients/application/__tests__/ingredients.use-cases.test.ts
@@ -16,6 +16,7 @@ import {
   listYeasts,
 } from "@/features/ingredients/application/yeasts.use-cases";
 import {
+  getMiscDetailsApi,
   listMiscApi,
   type MiscProduct,
 } from "@/features/ingredients/data/misc.api";
@@ -57,6 +58,9 @@ jest.mock("@/features/ingredients/data/misc.api", () => ({
 
 const mockedListMiscApi = listMiscApi as jest.MockedFunction<
   typeof listMiscApi
+>;
+const mockedGetMiscDetailsApi = getMiscDetailsApi as jest.MockedFunction<
+  typeof getMiscDetailsApi
 >;
 const mockedListMalts = listMalts as jest.MockedFunction<typeof listMalts>;
 const mockedGetMaltDetails = getMaltDetails as jest.MockedFunction<
@@ -164,6 +168,7 @@ describe("ingredients use-cases", () => {
     mockedGetYeastDetails.mockReset();
     mockedListMiscApi.mockReset();
     mockedListMiscApi.mockResolvedValue([]);
+    mockedGetMiscDetailsApi.mockReset();
   });
 
   describe("listIngredientCategoriesSummary", () => {
@@ -377,6 +382,88 @@ describe("ingredients use-cases", () => {
 
       expect(details).toBeNull();
       expect(mockedGetYeastDetails).not.toHaveBeenCalled();
+    });
+
+    // Misc dispatches straight to `listMiscApi` (no per-type use-case, see
+    // `listLiveIngredientsByCategory`'s `case "misc"`), so the delegation
+    // guard here mirrors the hop/yeast ones above but against the api mock.
+    it("delegates the misc list to listMiscApi + maps MiscProduct to Ingredient", async () => {
+      dataSource.useDemoData = false;
+      mockedListMiscApi.mockResolvedValue([
+        buildMiscProduct({
+          id: "misc-whirlfloc-uuid",
+          name: "Whirlfloc",
+          miscType: "fining",
+          useAt: "boil",
+          useFor: "Clarté",
+          timeMin: 15,
+          description: "Clarifiant utilisé en fin d'ébullition.",
+        }),
+      ]);
+
+      const results = await listIngredientsByCategory("misc");
+
+      expect(mockedListMiscApi).toHaveBeenCalledTimes(1);
+      expect(results).toHaveLength(1);
+      // Full-shape assertion (not just toMatchObject) — miscToIngredient is
+      // the flattest mapper (no specGroups to parse), so every field is a
+      // straight passthrough worth pinning, including the
+      // description → notes rename.
+      expect(results[0]).toEqual({
+        id: "misc-whirlfloc-uuid",
+        name: "Whirlfloc",
+        category: "misc",
+        miscType: "fining",
+        useAt: "boil",
+        useFor: "Clarté",
+        timeMin: 15,
+        notes: "Clarifiant utilisé en fin d'ébullition.",
+      });
+    });
+
+    // Edge case — an empty catalog page must not surface as an error or a
+    // stale list; the Accessoires rayon should just render empty.
+    it("returns an empty list when the misc catalog is empty", async () => {
+      dataSource.useDemoData = false;
+      mockedListMiscApi.mockResolvedValue([]);
+
+      const results = await listIngredientsByCategory("misc");
+
+      expect(mockedListMiscApi).toHaveBeenCalledTimes(1);
+      expect(results).toEqual([]);
+    });
+
+    it("delegates misc details to getMiscDetailsApi + maps to Ingredient", async () => {
+      dataSource.useDemoData = false;
+      mockedGetMiscDetailsApi.mockResolvedValue(
+        buildMiscProduct({
+          id: "misc-whirlfloc-uuid",
+          name: "Whirlfloc",
+        }),
+      );
+
+      const details = await getIngredientDetails("misc", "misc-whirlfloc-uuid");
+
+      expect(mockedGetMiscDetailsApi).toHaveBeenCalledWith(
+        "misc-whirlfloc-uuid",
+      );
+      expect(details).toMatchObject({
+        id: "misc-whirlfloc-uuid",
+        name: "Whirlfloc",
+        category: "misc",
+      });
+    });
+
+    // Sad path — a missing id resolves to null rather than throwing, same
+    // contract as getMaltDetails/getHopDetails/getYeastDetails on a 404.
+    it("returns null when the misc id does not resolve to a catalog product", async () => {
+      dataSource.useDemoData = false;
+      mockedGetMiscDetailsApi.mockResolvedValue(null);
+
+      const details = await getIngredientDetails("misc", "misc-unknown-uuid");
+
+      expect(mockedGetMiscDetailsApi).toHaveBeenCalledWith("misc-unknown-uuid");
+      expect(details).toBeNull();
     });
   });
 

--- a/packages/mobile-app/src/features/ingredients/application/ingredients.use-cases.ts
+++ b/packages/mobile-app/src/features/ingredients/application/ingredients.use-cases.ts
@@ -18,6 +18,11 @@ import {
 } from "@/features/ingredients/domain/yeast.types";
 
 import { dataSource } from "@/core/data/data-source";
+import {
+  getMiscDetailsApi,
+  listMiscApi,
+  type MiscProduct,
+} from "@/features/ingredients/data/misc.api";
 import { demoIngredients, demoMalts } from "@/mocks/demo-data";
 import {
   getHopDetails,
@@ -55,8 +60,20 @@ import {
  * English (codebase stays EN until i18n work begins).
  */
 
+/**
+ * Twin of the guard in `presentation/ingredient-category.constants.ts`, which
+ * this layer must not import (application never depends on presentation) while
+ * `domain/` is types-only by convention. Both lists must grow together: a stale
+ * copy here is invisible to `tsc` — a shorter `readonly IngredientCategory[]`
+ * is still a valid one — so it fails silently, not loudly.
+ */
 function isIngredientCategory(value: string): value is IngredientCategory {
-  const categories: readonly IngredientCategory[] = ["malt", "hop", "yeast"];
+  const categories: readonly IngredientCategory[] = [
+    "malt",
+    "hop",
+    "yeast",
+    "misc",
+  ];
   return categories.includes(value as IngredientCategory);
 }
 
@@ -269,6 +286,23 @@ function yeastToIngredient(yeast: YeastProduct): Ingredient {
   };
 }
 
+/**
+ * Misc is the flattest catalog: no `specGroups` to parse and every field
+ * nullable, so this mapper carries values across rather than deriving them.
+ */
+function miscToIngredient(misc: MiscProduct): Ingredient {
+  return {
+    id: misc.id,
+    name: misc.name,
+    category: "misc",
+    miscType: misc.miscType,
+    useAt: misc.useAt,
+    useFor: misc.useFor,
+    timeMin: misc.timeMin,
+    notes: misc.description,
+  };
+}
+
 function applyFilters(
   items: Ingredient[],
   category: IngredientCategory,
@@ -318,35 +352,58 @@ function getDemoIngredientsByCategory(
   return demoIngredients.filter((item) => item.category === category);
 }
 
+// Both dispatchers below switch exhaustively rather than letting the last
+// category fall out of an implicit `else`. They used to end on yeast, so
+// adding `misc` to IngredientCategory would silently have served yeasts to
+// the Accessoires rayon — green types, wrong data.
 async function listLiveIngredientsByCategory(
   category: IngredientCategory,
 ): Promise<Ingredient[]> {
-  if (category === "malt") {
-    const malts = await listMalts();
-    return malts.map(maltToIngredient);
+  switch (category) {
+    case "malt": {
+      const malts = await listMalts();
+      return malts.map(maltToIngredient);
+    }
+    case "hop": {
+      const hops = await listHops();
+      return hops.map(hopToIngredient);
+    }
+    case "yeast": {
+      const yeasts = await listYeasts();
+      return yeasts.map(yeastToIngredient);
+    }
+    case "misc": {
+      // Straight to the api: misc has no per-type use-case because it has no
+      // dedicated filters and no demo-only path of its own — a pass-through
+      // module would be indirection for its own sake.
+      const miscs = await listMiscApi();
+      return miscs.map(miscToIngredient);
+    }
   }
-  if (category === "hop") {
-    const hops = await listHops();
-    return hops.map(hopToIngredient);
-  }
-  const yeasts = await listYeasts();
-  return yeasts.map(yeastToIngredient);
 }
 
 async function getLiveIngredientDetails(
   category: IngredientCategory,
   ingredientId: string,
 ): Promise<Ingredient | null> {
-  if (category === "malt") {
-    const malt = await getMaltDetails(ingredientId);
-    return malt ? maltToIngredient(malt) : null;
+  switch (category) {
+    case "malt": {
+      const malt = await getMaltDetails(ingredientId);
+      return malt ? maltToIngredient(malt) : null;
+    }
+    case "hop": {
+      const hop = await getHopDetails(ingredientId);
+      return hop ? hopToIngredient(hop) : null;
+    }
+    case "yeast": {
+      const yeast = await getYeastDetails(ingredientId);
+      return yeast ? yeastToIngredient(yeast) : null;
+    }
+    case "misc": {
+      const misc = await getMiscDetailsApi(ingredientId);
+      return misc ? miscToIngredient(misc) : null;
+    }
   }
-  if (category === "hop") {
-    const hop = await getHopDetails(ingredientId);
-    return hop ? hopToIngredient(hop) : null;
-  }
-  const yeast = await getYeastDetails(ingredientId);
-  return yeast ? yeastToIngredient(yeast) : null;
 }
 
 export async function listIngredientCategoriesSummary(): Promise<
@@ -370,6 +427,11 @@ export async function listIngredientCategoriesSummary(): Promise<
         count: demoIngredients.filter((item) => item.category === "yeast")
           .length,
       },
+      {
+        category: "misc",
+        count: demoIngredients.filter((item) => item.category === "misc")
+          .length,
+      },
     ];
   }
 
@@ -377,15 +439,17 @@ export async function listIngredientCategoriesSummary(): Promise<
   // (the same source `listIngredientsByCategory` consumes below),
   // so the Ingredients home counter stays in sync with the list
   // screens.
-  const [malts, hops, yeasts] = await Promise.all([
+  const [malts, hops, yeasts, miscs] = await Promise.all([
     listMalts(),
     listHops(),
     listYeasts(),
+    listMiscApi(),
   ]);
   return [
     { category: "malt", count: malts.length },
     { category: "hop", count: hops.length },
     { category: "yeast", count: yeasts.length },
+    { category: "misc", count: miscs.length },
   ];
 }
 

--- a/packages/mobile-app/src/features/ingredients/domain/ingredient.types.ts
+++ b/packages/mobile-app/src/features/ingredients/domain/ingredient.types.ts
@@ -1,4 +1,4 @@
-export type IngredientCategory = "malt" | "hop" | "yeast";
+export type IngredientCategory = "malt" | "hop" | "yeast" | "misc";
 
 type IngredientBase = {
   id: string;
@@ -35,7 +35,30 @@ export type YeastIngredient = IngredientBase & {
   fermentationMaxC: number;
 };
 
-export type Ingredient = MaltIngredient | HopIngredient | YeastIngredient;
+/**
+ * BeerXML 1.0 `<MISC>`: spices, finings, water agents, herbs, flavour
+ * adjuncts — the "Accessoires" rayon.
+ *
+ * Every spec is optional, unlike the other variants, because the catalog
+ * columns are genuinely nullable: a fining has no `useFor`, a spice has no
+ * `timeMin`. Requiring them would force the mapper to invent values.
+ * `miscType` stays a plain string rather than a literal union, mirroring
+ * `MiscProduct`: the API serves it free-form and nothing validates it, so a
+ * union here would claim a guarantee we do not enforce.
+ */
+export type MiscIngredient = IngredientBase & {
+  category: "misc";
+  miscType?: string;
+  useAt?: string;
+  useFor?: string;
+  timeMin?: number;
+};
+
+export type Ingredient =
+  | MaltIngredient
+  | HopIngredient
+  | YeastIngredient
+  | MiscIngredient;
 
 export type IngredientFilters = {
   search?: string;

--- a/packages/mobile-app/src/features/ingredients/presentation/IngredientCategoryScreen.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/IngredientCategoryScreen.tsx
@@ -29,6 +29,10 @@ import { Screen } from "@/core/ui/Screen";
 import { ScreenFlatList } from "@/core/ui/ScreenFlatList";
 import { getErrorMessage } from "@/core/http/http-error";
 import { isIngredientCategory } from "@/features/ingredients/presentation/ingredient-category.constants";
+import {
+  getMiscTypeLabel,
+  getMiscUseLabel,
+} from "@/features/ingredients/presentation/misc.presentation";
 import { listIngredientsByCategory } from "@/features/ingredients/application/ingredients.use-cases";
 import { listMalts } from "@/features/ingredients/application/malts.use-cases";
 import { normalizeRouteParam } from "@/core/navigation/route-params";
@@ -91,7 +95,17 @@ function getIngredientMeta(item: IngredientListItem): string {
   if (item.category === "hop") {
     return `Usage: ${item.hopUse} • Alpha: ${item.alphaAcid}%`;
   }
-  return `Type: ${item.yeastType} • Atténuation: ${item.attenuationMin}-${item.attenuationMax}%`;
+  if (item.category === "yeast") {
+    return `Type: ${item.yeastType} • Atténuation: ${item.attenuationMin}-${item.attenuationMax}%`;
+  }
+  // Misc specs are all nullable in the catalog, so build from what is there
+  // rather than printing "undefined • undefined" for a fining with no usage.
+  const miscMeta = [
+    getMiscTypeLabel(item.miscType),
+    getMiscUseLabel(item.useAt),
+    item.useFor,
+  ].filter((part): part is string => Boolean(part));
+  return miscMeta.length > 0 ? miscMeta.join(" • ") : "Adjuvant de brassage";
 }
 
 export function IngredientCategoryScreen({

--- a/packages/mobile-app/src/features/ingredients/presentation/IngredientDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/IngredientDetailsScreen.tsx
@@ -3,6 +3,7 @@ import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
 import { Screen } from "@/core/ui/Screen";
 import { HopDetailsScreen } from "@/features/ingredients/presentation/HopDetailsScreen";
 import { MaltDetailsScreen } from "@/features/ingredients/presentation/MaltDetailsScreen";
+import { MiscDetailsScreen } from "@/features/ingredients/presentation/MiscDetailsScreen";
 import { YeastDetailsScreen } from "@/features/ingredients/presentation/YeastDetailsScreen";
 import React from "react";
 
@@ -38,6 +39,8 @@ export function IngredientDetailsScreen({
     normalizedCategory === "hop" || normalizedCategory === "hops";
   const isYeastCategory =
     normalizedCategory === "yeast" || normalizedCategory === "yeasts";
+  const isMiscCategory =
+    normalizedCategory === "misc" || normalizedCategory === "miscs";
 
   if (isMaltCategory) {
     return (
@@ -75,6 +78,22 @@ export function IngredientDetailsScreen({
     return (
       <YeastDetailsScreen
         yeastIdParam={ingredientIdParam}
+        returnToParam={returnToParam}
+        returnRecipeIdParam={returnRecipeIdParam}
+        returnCategoryParam={returnCategoryParam}
+        returnSearchParam={returnSearchParam}
+        returnEbcMinParam={returnEbcMinParam}
+        returnEbcMaxParam={returnEbcMaxParam}
+        returnAlphaMinParam={returnAlphaMinParam}
+        returnAttenuationMinParam={returnAttenuationMinParam}
+      />
+    );
+  }
+
+  if (isMiscCategory) {
+    return (
+      <MiscDetailsScreen
+        miscIdParam={ingredientIdParam}
         returnToParam={returnToParam}
         returnRecipeIdParam={returnRecipeIdParam}
         returnCategoryParam={returnCategoryParam}

--- a/packages/mobile-app/src/features/ingredients/presentation/MiscDetailsScreen.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/MiscDetailsScreen.tsx
@@ -1,0 +1,216 @@
+import { colors, spacing, typography } from "@/core/theme";
+import { getIngredientDetails } from "@/features/ingredients/application/ingredients.use-cases";
+import {
+  getMiscTypeLabel,
+  getMiscUseLabel,
+} from "@/features/ingredients/presentation/misc.presentation";
+import {
+  buildIngredientCategoryBackNavigationParams,
+  buildRecipeBackNavigationTarget,
+  normalizeIngredientReturnContextParams,
+} from "@/features/ingredients/presentation/ingredient-navigation-context";
+import { StyleSheet, Text, View } from "react-native";
+import { ScreenScrollView } from "@/core/ui/ScreenScrollView";
+
+import { getErrorMessage } from "@/core/http/http-error";
+import { normalizeRouteParam } from "@/core/navigation/route-params";
+import { Card } from "@/core/ui/Card";
+import { EmptyStateCard } from "@/core/ui/EmptyStateCard";
+import { ListHeader } from "@/core/ui/ListHeader";
+import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { Screen } from "@/core/ui/Screen";
+import type { Ingredient } from "@/features/ingredients/domain/ingredient.types";
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "expo-router";
+import React from "react";
+
+type Props = {
+  miscIdParam?: string | string[];
+  returnToParam?: string | string[];
+  returnRecipeIdParam?: string | string[];
+  returnCategoryParam?: string | string[];
+  returnSearchParam?: string | string[];
+  returnEbcMinParam?: string | string[];
+  returnEbcMaxParam?: string | string[];
+  returnAlphaMinParam?: string | string[];
+  returnAttenuationMinParam?: string | string[];
+};
+
+/**
+ * Datasheet for a misc ingredient — the Accessoires rayon's fiche.
+ *
+ * Deliberately lighter than its malt/hop/yeast siblings: misc carries no
+ * `specGroups` to parse and no "alternatives" notion (nothing substitutes for
+ * a water salt), so the screen is a spec list plus the brewer-facing
+ * description — the one thing the list row cannot show.
+ */
+export function MiscDetailsScreen({
+  miscIdParam,
+  returnToParam,
+  returnRecipeIdParam,
+  returnCategoryParam,
+  returnSearchParam,
+  returnEbcMinParam,
+  returnEbcMaxParam,
+  returnAlphaMinParam,
+  returnAttenuationMinParam,
+}: Props) {
+  const router = useRouter();
+  const miscId = normalizeRouteParam(miscIdParam) ?? "";
+
+  const normalizedReturnContext = normalizeIngredientReturnContextParams({
+    returnToParam,
+    returnRecipeIdParam,
+    returnCategoryParam,
+    returnSearchParam,
+    returnEbcMinParam,
+    returnEbcMaxParam,
+    returnAlphaMinParam,
+    returnAttenuationMinParam,
+  });
+
+  const {
+    data: misc = null,
+    isLoading,
+    isFetching,
+    error: queryError,
+    refetch,
+  } = useQuery<Ingredient | null>({
+    queryKey: ["ingredients", "misc", miscId],
+    queryFn: () => getIngredientDetails("misc", miscId),
+    enabled: miscId.length > 0,
+  });
+
+  const error = queryError
+    ? isFetching
+      ? null
+      : getErrorMessage(queryError, "Impossible de charger l'accessoire")
+    : null;
+  const isRetryingWithError = isFetching && Boolean(queryError);
+
+  const handleGoBack = () => {
+    const recipeBackNavigationTarget = buildRecipeBackNavigationTarget(
+      normalizedReturnContext,
+    );
+    if (recipeBackNavigationTarget) {
+      router.push(recipeBackNavigationTarget as never);
+      return;
+    }
+
+    const ingredientCategoryBackNavigationTarget =
+      buildIngredientCategoryBackNavigationParams(normalizedReturnContext);
+    if (ingredientCategoryBackNavigationTarget) {
+      router.push(ingredientCategoryBackNavigationTarget as never);
+      return;
+    }
+
+    if (normalizedReturnContext.returnTo) {
+      router.push(normalizedReturnContext.returnTo as never);
+      return;
+    }
+
+    router.push("/(app)/shop");
+  };
+
+  const specs =
+    misc && misc.category === "misc"
+      ? [
+          { label: "Type", value: getMiscTypeLabel(misc.miscType) },
+          { label: "Ajout", value: getMiscUseLabel(misc.useAt) },
+          { label: "Rôle", value: misc.useFor ?? null },
+          {
+            label: "Durée",
+            value: misc.timeMin === undefined ? null : `${misc.timeMin} min`,
+          },
+        ].filter((spec): spec is { label: string; value: string } =>
+          Boolean(spec.value),
+        )
+      : [];
+
+  return (
+    <Screen
+      isLoading={(isLoading && !misc) || isRetryingWithError}
+      error={error}
+      onRetry={() => {
+        void refetch();
+      }}
+    >
+      {!misc && !isLoading && !error ? (
+        <EmptyStateCard
+          title="Accessoire introuvable"
+          description="Cet accessoire n'existe pas ou n'est plus au catalogue."
+          action={<PrimaryButton label="Retour" onPress={handleGoBack} />}
+        />
+      ) : null}
+
+      {misc && misc.category === "misc" ? (
+        <ScreenScrollView contentContainerStyle={styles.content}>
+          <ListHeader title={misc.name} subtitle="Accessoire de brassage" />
+
+          {specs.length > 0 ? (
+            <Card style={styles.card}>
+              {specs.map((spec) => (
+                <View key={spec.label} style={styles.specRow}>
+                  <Text style={styles.specLabel}>{spec.label}</Text>
+                  <Text style={styles.specValue}>{spec.value}</Text>
+                </View>
+              ))}
+            </Card>
+          ) : null}
+
+          {misc.notes ? (
+            <Card style={styles.card}>
+              <Text style={styles.sectionTitle}>À quoi ça sert</Text>
+              <Text style={styles.description}>{misc.notes}</Text>
+            </Card>
+          ) : null}
+
+          {/* "Retour", not the "Go back" its malt/hop/yeast siblings still
+              show: the app ships in French. Those three are left alone here —
+              their tests pin the English label, so aligning them is its own
+              change, not a rider on this one. */}
+          <PrimaryButton label="Retour" onPress={handleGoBack} />
+        </ScreenScrollView>
+      ) : null}
+    </Screen>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    paddingHorizontal: spacing.sm,
+  },
+  card: {
+    marginBottom: spacing.sm,
+    padding: spacing.md,
+  },
+  specRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: spacing.xs,
+  },
+  specLabel: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+  specValue: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+    fontWeight: typography.weight.medium,
+  },
+  sectionTitle: {
+    color: colors.neutral.textPrimary,
+    fontSize: typography.size.body,
+    lineHeight: typography.lineHeight.body,
+    fontWeight: typography.weight.bold,
+    marginBottom: spacing.xs,
+  },
+  description: {
+    color: colors.neutral.textSecondary,
+    fontSize: typography.size.label,
+    lineHeight: typography.lineHeight.label,
+  },
+});

--- a/packages/mobile-app/src/features/ingredients/presentation/__tests__/IngredientDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/__tests__/IngredientDetailsScreen.test.tsx
@@ -41,6 +41,18 @@ jest.mock("@/features/ingredients/presentation/YeastDetailsScreen", () => ({
   },
 }));
 
+jest.mock("@/features/ingredients/presentation/MiscDetailsScreen", () => ({
+  MiscDetailsScreen: ({ miscIdParam }: { miscIdParam?: string }) => {
+    const React = require("react");
+    const { View, Text } = require("react-native");
+    return React.createElement(
+      View,
+      { testID: "misc-details-screen" },
+      React.createElement(Text, {}, `Misc Details: ${miscIdParam || ""}`),
+    );
+  },
+}));
+
 describe("IngredientDetailsScreen", () => {
   it("delegates to HopDetailsScreen for hops category", () => {
     render(
@@ -76,6 +88,18 @@ describe("IngredientDetailsScreen", () => {
 
     expect(screen.getByTestId("malt-details-screen")).toBeTruthy();
     expect(screen.getByText("Malt Details: malt-1")).toBeTruthy();
+  });
+
+  it("delegates to MiscDetailsScreen for miscs category", () => {
+    render(
+      <IngredientDetailsScreen
+        categoryParam="miscs"
+        ingredientIdParam="misc-1"
+      />,
+    );
+
+    expect(screen.getByTestId("misc-details-screen")).toBeTruthy();
+    expect(screen.getByText("Misc Details: misc-1")).toBeTruthy();
   });
 
   it("renders unsupported state for unknown categories", () => {

--- a/packages/mobile-app/src/features/ingredients/presentation/__tests__/MiscDetailsScreen.test.tsx
+++ b/packages/mobile-app/src/features/ingredients/presentation/__tests__/MiscDetailsScreen.test.tsx
@@ -1,0 +1,194 @@
+import { getIngredientDetails } from "@/features/ingredients/application/ingredients.use-cases";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react-native";
+
+import { MiscDetailsScreen } from "@/features/ingredients/presentation/MiscDetailsScreen";
+import type { Ingredient } from "@/features/ingredients/domain/ingredient.types";
+import React from "react";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => {
+  const actual = jest.requireActual("expo-router");
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: mockPush,
+      replace: jest.fn(),
+      back: jest.fn(),
+    }),
+  };
+});
+
+jest.mock("@/features/ingredients/application/ingredients.use-cases", () => ({
+  getIngredientDetails: jest.fn(),
+}));
+
+const mockedGetIngredientDetails = getIngredientDetails as jest.MockedFunction<
+  typeof getIngredientDetails
+>;
+
+type RenderMiscDetailsScreenOptions = {
+  miscIdParam?: string | string[];
+  returnToParam?: string | string[];
+  returnRecipeIdParam?: string | string[];
+  returnCategoryParam?: string | string[];
+  returnSearchParam?: string | string[];
+};
+
+function buildMiscIngredient(overrides: Partial<Ingredient> = {}): Ingredient {
+  return {
+    id: "misc-whirlfloc-uuid",
+    name: "Whirlfloc",
+    category: "misc",
+    miscType: "fining",
+    useAt: "boil",
+    useFor: "Clarté",
+    timeMin: 15,
+    notes: "Clarifiant utilisé en fin d'ébullition.",
+    ...overrides,
+  } as Ingredient;
+}
+
+function renderMiscDetailsScreen({
+  miscIdParam = "misc-whirlfloc-uuid",
+  returnToParam,
+  returnRecipeIdParam,
+  returnCategoryParam,
+  returnSearchParam,
+}: RenderMiscDetailsScreenOptions = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Number.POSITIVE_INFINITY,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MiscDetailsScreen
+        miscIdParam={miscIdParam}
+        returnToParam={returnToParam}
+        returnRecipeIdParam={returnRecipeIdParam}
+        returnCategoryParam={returnCategoryParam}
+        returnSearchParam={returnSearchParam}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("MiscDetailsScreen", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockedGetIngredientDetails.mockReset();
+  });
+
+  it("shows the loading state before the misc data resolves", () => {
+    // A deferred query that never resolves on its own — enough to observe
+    // the in-flight state without racing the assertion against resolution.
+    mockedGetIngredientDetails.mockReturnValue(new Promise(() => {}));
+
+    renderMiscDetailsScreen({ miscIdParam: "misc-whirlfloc-uuid" });
+
+    expect(screen.getByTestId("beer-mug-loader")).toBeTruthy();
+  });
+
+  it("renders the misc fiche fields", async () => {
+    mockedGetIngredientDetails.mockResolvedValue(buildMiscIngredient());
+
+    renderMiscDetailsScreen({ miscIdParam: "misc-whirlfloc-uuid" });
+
+    expect(await screen.findByText("Whirlfloc")).toBeTruthy();
+    expect(screen.getByText("Accessoire de brassage")).toBeTruthy();
+    expect(screen.getByText("Type")).toBeTruthy();
+    // getMiscTypeLabel("fining") → "Clarifiant" (real translation module,
+    // not mocked — it is the app's own domain, not a boundary).
+    expect(screen.getByText("Clarifiant")).toBeTruthy();
+    expect(screen.getByText("Ajout")).toBeTruthy();
+    // getMiscUseLabel("boil") → "Ébullition".
+    expect(screen.getByText("Ébullition")).toBeTruthy();
+    expect(screen.getByText("Rôle")).toBeTruthy();
+    expect(screen.getByText("Clarté")).toBeTruthy();
+    expect(screen.getByText("Durée")).toBeTruthy();
+    expect(screen.getByText("15 min")).toBeTruthy();
+    expect(screen.getByText("À quoi ça sert")).toBeTruthy();
+    expect(
+      screen.getByText("Clarifiant utilisé en fin d'ébullition."),
+    ).toBeTruthy();
+  });
+
+  it("shows the not-found state when the misc id does not resolve", async () => {
+    mockedGetIngredientDetails.mockResolvedValueOnce(null);
+
+    renderMiscDetailsScreen({ miscIdParam: "misc-missing" });
+
+    expect(await screen.findByText("Accessoire introuvable")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Cet accessoire n'existe pas ou n'est plus au catalogue.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("shows an error card when the query fails", async () => {
+    // getErrorMessage surfaces the error's own message (falling back to the
+    // generic copy only when the error has none) — same contract asserted
+    // on the sibling EquipmentScreen sad-path test.
+    mockedGetIngredientDetails.mockRejectedValue(
+      new Error("Catalogue injoignable"),
+    );
+
+    renderMiscDetailsScreen({ miscIdParam: "misc-whirlfloc-uuid" });
+
+    expect(await screen.findByText("Catalogue injoignable")).toBeTruthy();
+  });
+
+  // Regression guard for the bug fixed alongside this test: a hand-rolled
+  // whitelist in `normalizeIngredientCategory` (malt/hop/yeast only) used to
+  // silently drop "misc", so `buildIngredientCategoryBackNavigationParams`
+  // returned null and "Retour" fell through to pushing the raw, unresolved
+  // `returnTo` template string ("/(app)/ingredients/[category]") instead of
+  // a route with params. `normalizeIngredientCategory` now delegates to the
+  // shared `isIngredientCategory` guard, so misc is recognized again.
+  it("navigates back to the filtered Accessoires list, preserving the misc category", async () => {
+    mockedGetIngredientDetails.mockResolvedValue(buildMiscIngredient());
+
+    renderMiscDetailsScreen({
+      miscIdParam: "misc-whirlfloc-uuid",
+      returnToParam: "/(app)/ingredients/[category]",
+      returnCategoryParam: "misc",
+      returnSearchParam: "whirlfloc",
+    });
+
+    expect(await screen.findByText("Whirlfloc")).toBeTruthy();
+
+    fireEvent.press(screen.getByText("Retour"));
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/(app)/ingredients/[category]",
+      params: {
+        category: "misc",
+        search: "whirlfloc",
+      },
+    });
+  });
+
+  // Edge — no return context at all still resolves to a real route, not a
+  // dangling template.
+  it("falls back to the shop when no return context is provided", async () => {
+    mockedGetIngredientDetails.mockResolvedValue(buildMiscIngredient());
+
+    renderMiscDetailsScreen({ miscIdParam: "misc-whirlfloc-uuid" });
+
+    expect(await screen.findByText("Whirlfloc")).toBeTruthy();
+
+    fireEvent.press(screen.getByText("Retour"));
+
+    expect(mockPush).toHaveBeenCalledWith("/(app)/shop");
+  });
+});

--- a/packages/mobile-app/src/features/ingredients/presentation/__tests__/misc.presentation.test.ts
+++ b/packages/mobile-app/src/features/ingredients/presentation/__tests__/misc.presentation.test.ts
@@ -1,0 +1,51 @@
+import {
+  getMiscTypeLabel,
+  getMiscUseLabel,
+} from "@/features/ingredients/presentation/misc.presentation";
+
+describe("misc.presentation", () => {
+  // Happy path — the catalog serves raw BeerXML enums; a French app aimed at
+  // novices must not print "water_agent" at them.
+  it.each([
+    ["spice", "Épice"],
+    ["fining", "Clarifiant"],
+    ["water_agent", "Sel d'eau"],
+    ["herb", "Plante"],
+    ["flavor", "Arôme"],
+    ["other", "Autre"],
+  ])("translates the %s type", (raw, expected) => {
+    expect(getMiscTypeLabel(raw)).toBe(expected);
+  });
+
+  it.each([
+    ["mash", "Empâtage"],
+    ["boil", "Ébullition"],
+    ["primary", "Fermentation primaire"],
+    ["secondary", "Fermentation secondaire"],
+    ["bottling", "Embouteillage"],
+  ])("translates the %s use", (raw, expected) => {
+    expect(getMiscUseLabel(raw)).toBe(expected);
+  });
+
+  // Edge — the catalog columns are free-form strings, so casing and padding
+  // are not guaranteed.
+  it("tolerates casing and surrounding whitespace", () => {
+    expect(getMiscTypeLabel("  FINING ")).toBe("Clarifiant");
+    expect(getMiscUseLabel("Boil")).toBe("Ébullition");
+  });
+
+  // Sad — an enum the catalog adds before this map knows it must still show.
+  // Passing it through beats hiding it: a visible oddity gets reported, a
+  // silently dropped spec makes the ingredient look incomplete.
+  it("passes an unmapped value through untouched", () => {
+    expect(getMiscTypeLabel("nanobubbles")).toBe("nanobubbles");
+    expect(getMiscUseLabel("whirlpool")).toBe("whirlpool");
+  });
+
+  // Edge — every misc spec is nullable in the catalog.
+  it("returns null when the value is absent", () => {
+    expect(getMiscTypeLabel(undefined)).toBeNull();
+    expect(getMiscUseLabel(undefined)).toBeNull();
+    expect(getMiscTypeLabel("")).toBeNull();
+  });
+});

--- a/packages/mobile-app/src/features/ingredients/presentation/ingredient-category.constants.ts
+++ b/packages/mobile-app/src/features/ingredients/presentation/ingredient-category.constants.ts
@@ -4,12 +4,14 @@ const INGREDIENT_CATEGORY_VALUES: readonly IngredientCategory[] = [
   "malt",
   "hop",
   "yeast",
+  "misc",
 ];
 
 export const ingredientCategoryLabels: Record<IngredientCategory, string> = {
   malt: "Malts",
   hop: "Hops",
   yeast: "Yeasts",
+  misc: "Misc",
 };
 
 export function isIngredientCategory(

--- a/packages/mobile-app/src/features/ingredients/presentation/ingredient-category.presentation.ts
+++ b/packages/mobile-app/src/features/ingredients/presentation/ingredient-category.presentation.ts
@@ -31,6 +31,16 @@ export const ingredientCategoryPresentationById: Record<
     iconName: "flask-outline",
     iconColor: colors.brand.secondary,
   },
+  // "L'Épicerie" revives the name the shop rayon used to carry: cryptic as a
+  // rayon label (a novice looking for adjuncts would not find it), but apt as
+  // a page title, where it sits with La Malterie / La Houblonnière / Le
+  // Fermentoir. The rayon says what it is; the page keeps the personality.
+  misc: {
+    pageName: "L'Épicerie",
+    emoji: "🌶️",
+    iconName: "restaurant-outline",
+    iconColor: colors.semantic.warning,
+  },
 };
 
 export function getIngredientCategoryPageTitle(

--- a/packages/mobile-app/src/features/ingredients/presentation/ingredient-navigation-context.ts
+++ b/packages/mobile-app/src/features/ingredients/presentation/ingredient-navigation-context.ts
@@ -1,5 +1,6 @@
 import { normalizeRouteParam } from "@/core/navigation/route-params";
 import { IngredientCategory } from "@/features/ingredients/domain/ingredient.types";
+import { isIngredientCategory } from "@/features/ingredients/presentation/ingredient-category.constants";
 
 type OptionalRouteParam = string | string[] | undefined;
 
@@ -206,9 +207,8 @@ export function buildIngredientDetailsReturnParams(
 function normalizeIngredientCategory(
   value?: string,
 ): IngredientCategory | undefined {
-  if (value === "malt" || value === "hop" || value === "yeast") {
-    return value;
-  }
-
-  return undefined;
+  // Delegate to the single source of truth (INGREDIENT_CATEGORY_VALUES) rather
+  // than re-listing categories here — a hand-rolled whitelist silently dropped
+  // "misc" and broke back-navigation from the Accessoires rayon.
+  return value !== undefined && isIngredientCategory(value) ? value : undefined;
 }

--- a/packages/mobile-app/src/features/ingredients/presentation/misc.presentation.ts
+++ b/packages/mobile-app/src/features/ingredients/presentation/misc.presentation.ts
@@ -1,0 +1,48 @@
+/**
+ * French labels for the BeerXML `<MISC>` enums.
+ *
+ * The catalog serves these raw (`fining`, `water_agent`, `boil`), which is
+ * fine for a spec but not for a novice: "water_agent" tells them nothing.
+ * Shared by the category list and the datasheet so a misc reads the same
+ * wherever it appears — the list rendered raw values while the fiche
+ * translated them, which is exactly the drift this module prevents.
+ */
+const MISC_TYPE_LABELS: Record<string, string> = {
+  spice: "Épice",
+  fining: "Clarifiant",
+  water_agent: "Sel d'eau",
+  herb: "Plante",
+  flavor: "Arôme",
+  other: "Autre",
+};
+
+const MISC_USE_LABELS: Record<string, string> = {
+  mash: "Empâtage",
+  boil: "Ébullition",
+  primary: "Fermentation primaire",
+  secondary: "Fermentation secondaire",
+  bottling: "Embouteillage",
+};
+
+function translate(
+  raw: string | undefined,
+  labels: Record<string, string>,
+): string | null {
+  if (!raw) {
+    return null;
+  }
+  // Fall back to the raw value rather than dropping it: an enum the catalog
+  // adds before this map knows it is still information, and hiding it would
+  // make the ingredient look incomplete.
+  return labels[raw.trim().toLocaleLowerCase()] ?? raw;
+}
+
+/** e.g. `"fining"` → `"Clarifiant"`; unknown values pass through. */
+export function getMiscTypeLabel(miscType?: string): string | null {
+  return translate(miscType, MISC_TYPE_LABELS);
+}
+
+/** e.g. `"boil"` → `"Ébullition"`; unknown values pass through. */
+export function getMiscUseLabel(useAt?: string): string | null {
+  return translate(useAt, MISC_USE_LABELS);
+}

--- a/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
+++ b/packages/mobile-app/src/features/recipes/application/recipes.use-cases.ts
@@ -22,7 +22,10 @@ import {
 } from "@/mocks/demo-data";
 
 import { dataSource } from "@/core/data/data-source";
-import { Ingredient } from "@/features/ingredients/domain/ingredient.types";
+import {
+  Ingredient,
+  IngredientCategory,
+} from "@/features/ingredients/domain/ingredient.types";
 
 export type RecipeDetailsIngredientItem = {
   ingredientId: string;
@@ -52,6 +55,24 @@ export type RecipeDetailsViewModel = {
   ingredients: RecipeDetailsIngredientItem[];
   equipment: RecipeDetailsEquipmentItem[];
 };
+
+/**
+ * Narrows a catalog `IngredientCategory` onto the recipe view's own grouping.
+ *
+ * The recipe detail groups ingredients as malt / hop / yeast / other, and
+ * `misc` (finings, spices, water agents) belongs in "other" there: a brewer
+ * reading a recipe treats them as adjuncts, and a fifth group would split the
+ * list for no gain. Written as an explicit whitelist rather than a cast so a
+ * future category cannot silently land in the wrong bucket.
+ */
+function toRecipeIngredientGroupKey(
+  category: IngredientCategory | undefined,
+): RecipeDetailsIngredientItem["category"] {
+  if (category === "malt" || category === "hop" || category === "yeast") {
+    return category;
+  }
+  return "other";
+}
 
 export async function listRecipes(): Promise<Recipe[]> {
   // « Mes recettes » = owned only. A demo recipe without an `ownerId` is a
@@ -187,7 +208,7 @@ export async function getRecipeDetailsViewModel(
         return {
           ingredientId: ref.ingredientId,
           name: ingredient?.name ?? "Ingrédient inconnu",
-          category: ingredient?.category ?? "other",
+          category: toRecipeIngredientGroupKey(ingredient?.category),
           amount: ref.amount,
           unit: ref.unit,
           timing: ref.timing,

--- a/packages/mobile-app/src/features/shop/presentation/__tests__/ShopScreen.test.tsx
+++ b/packages/mobile-app/src/features/shop/presentation/__tests__/ShopScreen.test.tsx
@@ -56,6 +56,7 @@ describe("ShopScreen", () => {
       { category: "malt", count: 10 },
       { category: "hop", count: 4 },
       { category: "yeast", count: 4 },
+      { category: "misc", count: 4 },
     ]);
   });
 
@@ -90,11 +91,25 @@ describe("ShopScreen", () => {
     renderShopScreen();
     await screen.findByText("10");
 
+    // Accessoires left this list when its catalog was wired — the guard
+    // forcing that re-decision is the point of keeping it narrow.
     expect(screen.queryByLabelText("Ouvrir le rayon Kits")).toBeNull();
     expect(screen.queryByLabelText("Ouvrir le rayon Matériel")).toBeNull();
-    expect(screen.queryByLabelText("Ouvrir le rayon Accessoires")).toBeNull();
     // `Badge` uppercases its label by design (design-system § Badge).
-    expect(screen.getAllByText("BIENTÔT")).toHaveLength(3);
+    expect(screen.getAllByText("BIENTÔT")).toHaveLength(2);
+  });
+
+  it("opens the misc catalog from the Accessoires rayon", async () => {
+    renderShopScreen();
+
+    fireEvent.press(
+      await screen.findByLabelText("Ouvrir le rayon Accessoires"),
+    );
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: "/(app)/ingredients/[category]",
+      params: { category: "misc" },
+    });
   });
 
   // #1444 deleted a catalog of invented prices. No price may render until

--- a/packages/mobile-app/src/features/shop/presentation/shop.constants.ts
+++ b/packages/mobile-app/src/features/shop/presentation/shop.constants.ts
@@ -46,11 +46,19 @@ export const SHOP_RAYONS: ShopRayon[] = [
     description: "Lagers, Ales, Weiße, Belgian...",
     catalogCategory: "yeast",
   },
-  // The three rayons below have no `catalogCategory` yet, for two different
-  // reasons. Kits has no source anywhere. Matériel and Accessoires ARE served
-  // by the backend already (`/catalog/equipment-templates`,
-  // `/catalog/misc-templates`) but nothing consumes them mobile-side: they
-  // wait on plumbing, not on data, and Lot 2 wires them.
+  {
+    id: "accessoires",
+    label: "Accessoires",
+    icon: "restaurant-outline",
+    description: "Adjuvants, épices et compléments aromatiques",
+    catalogCategory: "misc",
+  },
+  // The two below have no `catalogCategory`, for different reasons. Kits has
+  // no source anywhere. Matériel IS served by the backend already
+  // (`/catalog/equipment-templates`) but an EquipmentTemplate is not an
+  // Ingredient — its specs are BeerXML equipment (boil_size_l, tun_volume_l…),
+  // so wiring it needs a target kind this model cannot express yet, plus its
+  // own screens. That is its own lot, not a slice of this one.
   {
     id: "kits",
     label: "Kits",
@@ -63,13 +71,6 @@ export const SHOP_RAYONS: ShopRayon[] = [
     label: "Matériel",
     icon: "construct-outline",
     description: "Matériel de brassage, cuves et équipements clés",
-    catalogCategory: null,
-  },
-  {
-    id: "accessoires",
-    label: "Accessoires",
-    icon: "restaurant-outline",
-    description: "Adjuvants, épices et compléments aromatiques",
     catalogCategory: null,
   },
 ];

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -1244,6 +1244,55 @@ export const demoIngredients: Ingredient[] = [
     fermentationMinC: 18,
     fermentationMaxC: 26,
   },
+  // Misc — the BeerXML `<MISC>` class behind the Accessoires rayon: one per
+  // type a novice actually meets (fining, spice, water agent, herb), so the
+  // rayon demonstrates its breadth rather than four variations of one thing.
+  {
+    id: "misc-1",
+    name: "Whirlfloc",
+    category: "misc",
+    supplier: "Kerry",
+    miscType: "fining",
+    useAt: "boil",
+    useFor: "Clarté",
+    timeMin: 15,
+    notes:
+      "Comprimé de carraghénane ajouté en fin d'ébullition : il agglomère les protéines, qui décantent ensuite. Une bière plus limpide, sans rien changer au goût.",
+  },
+  {
+    id: "misc-2",
+    name: "Coriandre en grains",
+    category: "misc",
+    origin: "France",
+    miscType: "spice",
+    useAt: "boil",
+    useFor: "Belgian Wit",
+    timeMin: 5,
+    notes:
+      "Concassée juste avant l'ajout, en toute fin d'ébullition pour préserver ses huiles. Signature de la blanche belge, avec l'écorce d'orange amère.",
+  },
+  {
+    id: "misc-3",
+    name: "Gypse (sulfate de calcium)",
+    category: "misc",
+    miscType: "water_agent",
+    useAt: "mash",
+    useFor: "Profil d'eau",
+    notes:
+      "Durcit l'eau et accentue l'amertume : il pousse les IPA houblonnées. À doser avec le profil d'eau cible, jamais au hasard.",
+  },
+  {
+    id: "misc-4",
+    name: "Écorce d'orange amère",
+    category: "misc",
+    origin: "Curaçao",
+    miscType: "herb",
+    useAt: "boil",
+    useFor: "Belgian Wit",
+    timeMin: 5,
+    notes:
+      "L'agrume qui répond à la coriandre dans une blanche. Amère, pas sucrée : c'est l'écorce qui parfume, pas le fruit.",
+  },
 ];
 
 export const demoRecipeSteps: RecipeStep[] = [


### PR DESCRIPTION
## Summary

Makes the **Accessoires** shop rayon a live door into the misc (non-ingredient) catalog, on the same pattern as the malt/hop/yeast rayons. Wires the misc list + details use-cases, adds a `MiscDetailsScreen`, and routes the Accessoires rayon to it.

## What changed

- **Feature** — the previously inert `accessoires` rayon now points at the misc catalog (`shop.constants.ts`, `catalogCategory: null → "misc"`). New `MiscDetailsScreen`, misc list/details dispatch in `ingredients.use-cases.ts`, and the `miscToIngredient` mapper.
- **Regression fixed (found in local pre-push review)** — `normalizeIngredientCategory` in `ingredient-navigation-context.ts` hand-listed `malt|hop|yeast` and silently dropped `"misc"`, so pressing **Retour** from an Accessoires ingredient pushed the unresolved route template `/(app)/ingredients/[category]` instead of returning to the filtered list. Fixed by delegating to the shared `isIngredientCategory` guard — a single source of truth that removes the whole class of twin-guard drift.

## Tests

Added the coverage the review flagged (H/S/E):
- `ingredients.use-cases`: misc list/details delegate to `listMiscApi` / `getMiscDetailsApi` (a previously dead mock) and map `MiscProduct → Ingredient`; empty list → `[]`, missing id → `null`.
- `MiscDetailsScreen` (new suite): loading, happy, not-found, error, edge, and a **back-navigation regression guard** proven load-bearing against the pre-fix code (stashing the fix makes it fail on the raw template, restoring it makes it pass).
- `IngredientDetailsScreen`: delegates to `MiscDetailsScreen` for the misc category.

3 suites, **56 tests green**; `ci:check` (lint + typecheck + format) clean; rebased onto current `main`.

## Review trail

Local pre-push gate run: Claude `pr-pre-reviewer` + Codex CLI. Claude caught the navigation regression (Must Have); both flagged the misc test gap (now closed). Codex's "add a PROJECT_LOG entry" was deferred — this repo adds log entries post-merge as their own commit.

## Checklist

- [x] Happy + sad + edge cases covered
- [x] `tsc --noEmit` passes
- [x] Existing tests still green
- [x] No `any`, no default exports, no inline styles, theme tokens only
- [x] Local pre-push review gate passed (Must Have resolved)