### PR TITLE
feat(recipes): show a recipe's creation date on its card

### DIFF
--- a/packages/mobile-app/src/core/utils/__tests__/format.test.ts
+++ b/packages/mobile-app/src/core/utils/__tests__/format.test.ts
@@ -1,0 +1,37 @@
+import { formatFrDate, formatQuantity } from "@/core/utils/format";
+
+describe("formatQuantity", () => {
+  it("happy: keeps an integer amount integer", () => {
+    expect(formatQuantity(5, "g")).toBe("5 g");
+  });
+
+  it("happy: rounds a fractional amount to two decimals", () => {
+    expect(formatQuantity(0.905, "kg")).toBe("0.91 kg");
+  });
+
+  it("edge: a non-finite amount degrades to 0", () => {
+    expect(formatQuantity(Number.NaN, "L")).toBe("0 L");
+    expect(formatQuantity(Number.POSITIVE_INFINITY, "L")).toBe("0 L");
+  });
+});
+
+describe("formatFrDate", () => {
+  // Mid-month, midday UTC: the day may shift ±1 across timezones but the month
+  // and year never do, so asserting "janvier 2026" stays deterministic on any
+  // runner (TZ is not pinned by the jest config).
+  it("happy: formats an ISO instant as a long French date", () => {
+    expect(formatFrDate("2026-01-15T12:00:00.000Z")).toMatch(
+      /^\d{1,2} janvier 2026$/,
+    );
+  });
+
+  it("sad: returns null for a missing value", () => {
+    expect(formatFrDate(null)).toBeNull();
+    expect(formatFrDate(undefined)).toBeNull();
+    expect(formatFrDate("")).toBeNull();
+  });
+
+  it("edge: returns null for an unparseable value rather than 'Invalid Date'", () => {
+    expect(formatFrDate("not-a-date")).toBeNull();
+  });
+});

--- a/packages/mobile-app/src/core/utils/format.ts
+++ b/packages/mobile-app/src/core/utils/format.ts
@@ -18,3 +18,27 @@ export function formatQuantity(amount: number, unit: string): string {
 
   return `${roundedAmount} ${unit}`;
 }
+
+/**
+ * Format an ISO date string for display in French ("12 juillet 2026").
+ *
+ * Returns `null` for a missing or unparseable value so callers can omit the
+ * line entirely rather than render "Invalid Date" — a recipe or batch whose
+ * `createdAt` never arrived should show no date, not a broken one.
+ */
+export function formatFrDate(iso: string | null | undefined): string | null {
+  if (!iso) {
+    return null;
+  }
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(date);
+}

--- a/packages/mobile-app/src/features/batches/presentation/BatchClosureView.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchClosureView.tsx
@@ -5,6 +5,7 @@ import { StyleSheet, Text, View } from "react-native";
 import { colors, radius, shadows, spacing, typography } from "@/core/theme";
 import { Card } from "@/core/ui/Card";
 import { PrimaryButton } from "@/core/ui/PrimaryButton";
+import { formatFrDate } from "@/core/utils/format";
 import { Batch } from "@/features/batches/domain/batch.types";
 import { Tasting } from "@/features/batches/domain/bottling.types";
 
@@ -20,22 +21,6 @@ type Props = {
   /** Fired by the "Noter ma dégustation" CTA. */
   onRateTasting: () => void;
 };
-
-/** Formats an ISO instant as a short French date (e.g. "12 mai 2026"). */
-function formatFrDate(iso: string | null | undefined): string | null {
-  if (!iso) {
-    return null;
-  }
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  return new Intl.DateTimeFormat("fr-FR", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  }).format(date);
-}
 
 /**
  * Live closure / celebration view for a COMPLETED batch (B3).

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
@@ -7,6 +7,7 @@ import { DifficultyBadge } from "@/features/recipes/presentation/components/Diff
 import { Ionicons } from "@expo/vector-icons";
 import React from "react";
 import { Recipe } from "@/features/recipes/domain/recipe.types";
+import { formatFrDate } from "@/core/utils/format";
 import { getSrmColor } from "@/features/tools/data/catalogs/srm";
 
 const ebcToSrm = (ebc: number): number => ebc * 0.508;
@@ -57,6 +58,11 @@ export function RecipeCard({ recipe, badgeLabel, onPress }: Props) {
   const renderedBadgeLabel = badgeLabel ?? VISIBILITY_LABELS[recipe.visibility];
   const renderedBadgeVariant = VISIBILITY_VARIANTS[recipe.visibility];
 
+  // Novice differentiator: two recipes can legitimately share a name, so the
+  // card carries its creation date to tell them apart. Omitted entirely when
+  // the date is missing/unparseable rather than showing a broken value.
+  const createdAtLabel = formatFrDate(recipe.createdAt);
+
   return (
     <Pressable
       accessibilityRole="button"
@@ -95,6 +101,9 @@ export function RecipeCard({ recipe, badgeLabel, onPress }: Props) {
                 level={recipe.difficultyEffective}
                 style={styles.difficultyBadge}
               />
+            ) : null}
+            {createdAtLabel ? (
+              <Text style={styles.createdAt}>Créée le {createdAtLabel}</Text>
             ) : null}
           </View>
           <Ionicons
@@ -141,6 +150,11 @@ const styles = StyleSheet.create({
   },
   difficultyBadge: {
     marginTop: spacing.xs,
+  },
+  createdAt: {
+    marginTop: spacing.xs,
+    fontSize: typography.size.label,
+    color: colors.neutral.muted,
   },
   statItem: {
     fontSize: typography.size.label,

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
@@ -63,10 +63,16 @@ export function RecipeCard({ recipe, badgeLabel, onPress }: Props) {
   // the date is missing/unparseable rather than showing a broken value.
   const createdAtLabel = formatFrDate(recipe.createdAt);
 
+  // Carry the date into the accessible label too, so screen-reader users get the
+  // same differentiator between two same-named recipes that sighted users do.
+  const accessibilityLabel = createdAtLabel
+    ? `Ouvrir la recette ${recipe.name}, créée le ${createdAtLabel}`
+    : `Ouvrir la recette ${recipe.name}`;
+
   return (
     <Pressable
       accessibilityRole="button"
-      accessibilityLabel={`Ouvrir la recette ${recipe.name}`}
+      accessibilityLabel={accessibilityLabel}
       onPress={onPress}
     >
       <Card style={styles.card}>

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/CatalogScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/CatalogScreen.test.tsx
@@ -85,7 +85,9 @@ describe("CatalogScreen (Issue #779 — KISS Recipe Catalog mini)", () => {
     expect(await screen.findByText("Punk IPA")).toBeTruthy();
     expect(screen.getByText("Hazy Jane")).toBeTruthy();
 
-    fireEvent.press(screen.getByLabelText("Ouvrir la recette Punk IPA"));
+    // Prefix match: the card's accessible label now appends ", créée le <date>"
+    // when the recipe has a createdAt (date omitted here for timezone-robustness).
+    fireEvent.press(screen.getByLabelText(/^Ouvrir la recette Punk IPA/));
 
     expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/r-public-1");
   });

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeCard.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeCard.test.tsx
@@ -94,6 +94,32 @@ describe("RecipeCard — creation date (novice differentiator for same-named rec
     expect(screen.queryByText(/^Créée le /)).toBeNull();
   });
 
+  it("happy: carries the creation date into the accessible label so screen readers get the differentiator", () => {
+    render(
+      <RecipeCard
+        recipe={{ ...baseRecipe, createdAt: "2026-01-15T12:00:00.000Z" }}
+        onPress={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByLabelText(
+        /^Ouvrir la recette Session IPA, créée le \d{1,2} janvier 2026$/,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("edge: accessible label falls back to the name alone when there is no date", () => {
+    render(
+      <RecipeCard
+        recipe={{ ...baseRecipe, createdAt: "" }}
+        onPress={() => {}}
+      />,
+    );
+
+    expect(screen.getByLabelText("Ouvrir la recette Session IPA")).toBeTruthy();
+  });
+
   it("sad: omits the date line for an unparseable createdAt rather than showing 'Invalid Date'", () => {
     render(
       <RecipeCard

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeCard.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipeCard.test.tsx
@@ -68,3 +68,40 @@ describe("RecipeCard — difficulty badge", () => {
     expect(screen.queryByText("FACILE")).toBeNull();
   });
 });
+
+describe("RecipeCard — creation date (novice differentiator for same-named recipes)", () => {
+  it("happy: shows the creation date so two same-named recipes are distinguishable", () => {
+    // Mid-month, midday UTC: the day may shift ±1 by timezone but the month
+    // and year stay put, keeping this deterministic on any runner.
+    render(
+      <RecipeCard
+        recipe={{ ...baseRecipe, createdAt: "2026-01-15T12:00:00.000Z" }}
+        onPress={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/^Créée le \d{1,2} janvier 2026$/)).toBeTruthy();
+  });
+
+  it("edge: omits the date line entirely when createdAt is missing", () => {
+    render(
+      <RecipeCard
+        recipe={{ ...baseRecipe, createdAt: "" }}
+        onPress={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText(/^Créée le /)).toBeNull();
+  });
+
+  it("sad: omits the date line for an unparseable createdAt rather than showing 'Invalid Date'", () => {
+    render(
+      <RecipeCard
+        recipe={{ ...baseRecipe, createdAt: "not-a-date" }}
+        onPress={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText(/^Créée le /)).toBeNull();
+  });
+});

--- a/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipesScreen.test.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/__tests__/RecipesScreen.test.tsx
@@ -138,7 +138,9 @@ describe("RecipesScreen — Mes Recettes Hub (Issue #740 Round 2)", () => {
 
     await screen.findByText("My Saison");
 
-    fireEvent.press(screen.getByLabelText("Ouvrir la recette My Saison"));
+    // Prefix match: the card's accessible label now appends ", créée le <date>"
+    // when the recipe has a createdAt (date omitted here for timezone-robustness).
+    fireEvent.press(screen.getByLabelText(/^Ouvrir la recette My Saison/));
 
     expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/r-mine-1");
   });
@@ -166,7 +168,7 @@ describe("RecipesScreen — Mes Recettes Hub (Issue #740 Round 2)", () => {
 
     await screen.findByText("Punk IPA Clone");
 
-    fireEvent.press(screen.getByLabelText("Ouvrir la recette Punk IPA Clone"));
+    fireEvent.press(screen.getByLabelText(/^Ouvrir la recette Punk IPA Clone/));
 
     expect(mockPush).toHaveBeenCalledWith("/(app)/recipes/r-public-1");
   });


### PR DESCRIPTION
## Summary

Adds a subtle **"Créée le <date>"** line to the recipe card so two recipes that share a name are distinguishable at a glance. This came out of the 2026-07-21 device smoke-test, where two "Session IPA Citra" cards looked identical.

Confirmed the duplicate is **data, not a rendering bug**: the list keys by recipe `id` (`RecipesScreen.tsx` `keyExtractor={(item) => item.id}`) and no React duplicate-key warning fires, and `listRecipes` returns `listMine()` with no client-side merge/dedup. So the two are distinct owned records — the card just needed a differentiator.

## What changed

- `RecipeCard.tsx` — renders `Créée le <formatFrDate(recipe.createdAt)>` under the difficulty badge. Omitted entirely when `createdAt` is missing/unparseable (no "Invalid Date").
- `src/core/utils/format.ts` — hosts the French date formatter `formatFrDate`, **moved verbatim** from where it lived privately in `BatchClosureView`; both call sites now import it.
- `BatchClosureView.tsx` — drops its local copy, imports the shared one.

**On the 2-occurrence extraction** (ADR-0001 rule-of-three): this is not a speculative abstraction — it is a byte-identical function moved unchanged into `format.ts`, the module already designated as the shared home for pure formatting helpers (`formatQuantity`). No new parameters or guessed-at flexibility were added; it removes a duplication rather than inventing an abstraction.

## Tests

- `format.test.ts` (new) — `formatFrDate` happy/sad/edge + backfills `formatQuantity` coverage that was missing. Timezone-robust assertions (mid-month midday UTC; verified stable under UTC+14 and UTC−12) since jest does not pin `TZ`.
- `RecipeCard.test.tsx` — date shown (happy), omitted on missing (`""`) and unparseable (`"not-a-date"`) `createdAt`.

3 suites, 17 tests green; `ci:check` (lint + typecheck + format) clean.

## Review trail

Local pre-push gate: Claude `pr-pre-reviewer` (0 Must Have) + Codex CLI (no actionable issues). Both Should Haves taken (import order in `BatchClosureView`, the unparseable-date component test).

## Note on scope

This is the frontend differentiator for legitimately same-**named** recipes. Enforcing that two strictly-**identical** recipes can't coexist is a separate backend feature (content-hash uniqueness) being designed conception-first — the two are complementary.

## Checklist

- [x] Happy + sad + edge cases covered
- [x] `tsc --noEmit` passes
- [x] Existing tests still green
- [x] No `any`, no default exports, no inline styles, theme tokens only
- [x] Local pre-push review gate passed (0 Must Have)