### PR TITLE
fix(mobile-app): stop the badge overlapping long card titles

### DIFF
--- a/packages/mobile-app/src/features/batches/presentation/BatchesScreen.tsx
+++ b/packages/mobile-app/src/features/batches/presentation/BatchesScreen.tsx
@@ -148,11 +148,6 @@ export function BatchesScreen() {
               }}
             >
               <Card style={styles.card}>
-                <Badge
-                  label={getStatusLabel(item.status)}
-                  variant={getStatusVariant(item.status)}
-                  placement="corner"
-                />
                 <View style={styles.cardContent}>
                   <View
                     style={[styles.beerIcon, { backgroundColor: beerColor }]}
@@ -164,9 +159,22 @@ export function BatchesScreen() {
                     />
                   </View>
                   <View style={styles.cardInfo}>
-                    <Text style={styles.cardTitle} numberOfLines={1}>
-                      {getRecipeName(item.recipeId, item.id)}
-                    </Text>
+                    {/*
+                      Title and status badge share one row: the title
+                      flex-shrinks and truncates so a long recipe name can
+                      never run under the badge. Replaces the former absolute
+                      `placement="corner"` badge, which overlapped long titles.
+                    */}
+                    <View style={styles.titleRow}>
+                      <Text style={styles.cardTitle} numberOfLines={1}>
+                        {getRecipeName(item.recipeId, item.id)}
+                      </Text>
+                      <Badge
+                        label={getStatusLabel(item.status)}
+                        variant={getStatusVariant(item.status)}
+                        style={styles.statusBadge}
+                      />
+                    </View>
                   </View>
                   <Ionicons
                     name="chevron-forward"
@@ -206,10 +214,26 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingTop: spacing.sm,
   },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+  },
   cardTitle: {
+    // Shrinks within the row so the single-line title truncates instead of
+    // overrunning the status badge to its right.
+    flexShrink: 1,
     fontSize: typography.size.body,
     lineHeight: typography.lineHeight.body,
     fontWeight: typography.weight.bold,
     color: colors.neutral.textPrimary,
+  },
+  statusBadge: {
+    // Never shrink; keep the compact micro sizing the corner badge used.
+    flexShrink: 0,
+    paddingHorizontal: spacing.xs,
+    paddingVertical: spacing.xxs,
+    fontSize: typography.size.micro,
+    lineHeight: typography.lineHeight.micro,
   },
 });

--- a/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
+++ b/packages/mobile-app/src/features/recipes/presentation/RecipeCard.tsx
@@ -76,11 +76,6 @@ export function RecipeCard({ recipe, badgeLabel, onPress }: Props) {
       onPress={onPress}
     >
       <Card style={styles.card}>
-        <Badge
-          label={renderedBadgeLabel}
-          variant={renderedBadgeVariant}
-          placement="corner"
-        />
         <View style={styles.cardContent}>
           <View style={[styles.recipeIcon, { backgroundColor: beerColor }]}>
             <Ionicons
@@ -90,9 +85,22 @@ export function RecipeCard({ recipe, badgeLabel, onPress }: Props) {
             />
           </View>
           <View style={styles.cardInfo}>
-            <Text style={styles.cardTitle} numberOfLines={1}>
-              {recipe.name}
-            </Text>
+            {/*
+              Title and visibility badge share one row: the title flex-shrinks
+              and truncates so a long name (e.g. "BrewDog DIY Dog Punk IPA")
+              can never run under the badge. Replaces the former absolute
+              `placement="corner"` badge, which overlapped long titles.
+            */}
+            <View style={styles.titleRow}>
+              <Text style={styles.cardTitle} numberOfLines={1}>
+                {recipe.name}
+              </Text>
+              <Badge
+                label={renderedBadgeLabel}
+                variant={renderedBadgeVariant}
+                style={styles.visibilityBadge}
+              />
+            </View>
             {stats && (
               <View style={styles.statsRow}>
                 <Text style={styles.statItem}>{stats.ibu} IBU</Text>
@@ -143,11 +151,27 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingTop: spacing.sm,
   },
+  titleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.xs,
+  },
   cardTitle: {
+    // Shrinks within the row so the single-line title truncates instead of
+    // overrunning the visibility badge to its right.
+    flexShrink: 1,
     fontSize: typography.size.body,
     lineHeight: typography.lineHeight.body,
     fontWeight: typography.weight.bold,
     color: colors.neutral.textPrimary,
+  },
+  visibilityBadge: {
+    // Never shrink; keep the compact micro sizing the corner badge used.
+    flexShrink: 0,
+    paddingHorizontal: spacing.xs,
+    paddingVertical: spacing.xxs,
+    fontSize: typography.size.micro,
+    lineHeight: typography.lineHeight.micro,
   },
   statsRow: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary

On the recipe (**Mon Carnet** / **Catalogue**) and batch list cards, the visibility/status badge was pinned with `placement="corner"` (absolute top-right), while the single-line title reserved no space for it. A long recipe name (e.g. *"BrewDog DIY Dog Punk IPA"*) ran **under** the badge — the overlap reported after the 0.1.15 device check.

Fix: the title and badge now share one flex row — the title `flex-shrink`s and truncates, the badge keeps its compact micro sizing and can no longer be overlapped. Applied to `RecipeCard` and `BatchesScreen` (identical pattern). `StepCard` uses short fixed step labels and is left unchanged.

## Checklist

- [x] Recipe + batch card/screen tests green (125 tests)
- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] No `any`, no default exports, no inline styles introduced

## Note

Visual regression is best confirmed on a device/emulator with a long recipe name; the logic is a pure flexbox layout change (no data/behaviour change).