### PR TITLE
feat(dashboard): real batch deadlines from the backend (drop hardcoded schedule)

### DIFF
--- a/docs/architecture/diagrams/dashboard-deadlines/00-conception.md
+++ b/docs/architecture/diagrams/dashboard-deadlines/00-conception.md
@@ -1,0 +1,66 @@
+# Dashboard real deadlines — conception
+
+## Problem
+
+The home dashboard ("Tableau de bord brassage") shows, under a **"Temps réel"**
+caption, per-active-batch deadlines and urgency: *"En retard de Nh"*, urgency
+pills, *"Actions 24h"*, *"Alertes critiques"*. Today these are **fabricated
+client-side** from a hardcoded brewing schedule (`BREWING_STEPS` in
+`DashboardScreen.tsx`: Empâtage 2h, Ébullition 8h, Fermentation 24h,
+Conditionnement 7d, Embouteillage 10d) indexed by the batch's fetched
+`current_step_order`. The label "Temps réel" is therefore misleading: the
+numbers are a baked-in projection, not the batch's real schedule.
+
+The real data already exists in the backend: each `batch_step` snapshots
+`planned_duration_min`, `label`, `type`, and `started_at` at launch, and the
+batch carries `current_step_order` + `started_at`. The gap is only that the
+**list endpoint** (`GET /batches` → `BatchSummaryDto`) does not expose the
+current step's timing, so the dashboard cannot compute a real deadline and
+falls back to the hardcoded schedule.
+
+## Decision (approach "B'") — validated 2026-07-21
+
+Backend owns the schedule **data + rules**; the client owns only the trivial,
+now-relative presentation so the countdown stays live without re-fetching.
+
+1. **Enrich `GET /batches`** (`BatchSummaryDto`) — no new endpoint. The
+   dashboard already fetches this list, so there is no extra round-trip.
+2. The backend computes and returns, per batch, the current step's:
+   - `current_step_label` — the real snapshotted step label.
+   - `current_step_due_at` — `current_step.started_at + planned_duration_min`
+     (absolute instant, computed backend). `null` when the current step has no
+     `started_at`/`planned_duration_min` yet (not started, or legacy row).
+   - `current_step_is_critical` — **derived from the step `type`** (a backend
+     rule, no schema change): fermentation / conditioning / bottling-class step
+     types are quality-critical.
+3. **Mobile** drops `BREWING_STEPS` entirely. It computes only the presentation
+   bucket ("En retard de Nh" / "Urgent" / "Bientôt" / "Dans Nj") from
+   `current_step_due_at` vs the device `now`. The 8h "Urgent" threshold stays
+   client-side — it is UI presentation, not domain data.
+4. The **"Temps réel"** caption becomes truthful (real snapshotted step timing +
+   backend-derived criticality).
+
+### Sub-decisions
+
+| # | Decision | Chosen | Rationale |
+|---|----------|--------|-----------|
+| 1 | Endpoint shape | **Enrich `GET /batches`** | Dashboard already fetches it; zero extra round-trip; the fields are a natural part of a batch summary. |
+| 2 | Criticality source | **Derive from `batch_step.type`** | No migration; the rule lives in one backend place; `type` (RecipeStepType) already classifies the step. |
+| 3 | Urgency threshold (8h) | **Client-side bucketing from `due_at`** | The bucket is now-relative presentation; keeping it client-side lets the countdown stay live without polling. |
+
+## ADR alignment
+
+Consistent with the project's "compute in the backend" pattern —
+[ADR-0020](../../decisions/0020-equipment-driven-volume-planning.md)
+(volume), [ADR-0024](../../decisions/0024-recipe-difficulty-scoring.md)
+(difficulty), [ADR-0026](../../decisions/0026-equipment-capacity-fit-check.md)
+(fit-check). The schedule/criticality domain logic moves out of the mobile
+client into the backend; the client renders.
+
+## Non-goals
+
+- No polling / websockets — "Temps réel" here means "reflects the batch's real
+  snapshotted schedule", refreshed on the dashboard's existing fetch + a live
+  client-side countdown. A push/refresh strategy is a separate concern.
+- No change to how steps are snapshotted at launch (already correct).
+- The demo-mode hero/ribbon path is untouched (already demo-gated).

--- a/docs/architecture/diagrams/dashboard-deadlines/01-sequence.md
+++ b/docs/architecture/diagrams/dashboard-deadlines/01-sequence.md
@@ -1,0 +1,40 @@
+# Dashboard real deadlines — sequence
+
+Request flow when the dashboard loads its "Alertes & échéances" section.
+Backend computes the absolute deadline + criticality from the snapshotted
+step; the client derives only the live now-relative bucket.
+
+```mermaid
+sequenceDiagram
+    actor Novice
+    participant Dash as DashboardScreen (mobile)
+    participant API as GET /batches (BatchController)
+    participant Svc as BatchService.listMine
+    participant Repo as Batch + BatchStep repos
+
+    Novice->>Dash: opens home (Tableau de bord)
+    Dash->>API: GET /batches (JWT)
+    API->>Svc: listMine(userId)
+    Svc->>Repo: load owned batches + their steps
+    Repo-->>Svc: batches[], steps[]
+    loop per batch
+        Svc->>Svc: currentStep = steps[current_step_order]
+        Svc->>Svc: due_at = currentStep.started_at + planned_duration_min (null if absent)
+        Svc->>Svc: is_critical = isQualityCriticalType(currentStep.type)
+    end
+    Svc-->>API: BatchSummaryDto[] (+ current_step_label, current_step_due_at, current_step_is_critical)
+    API-->>Dash: 200 BatchSummaryDto[]
+    Dash->>Dash: bucket = classify(current_step_due_at, now)  %% En retard de Nh / Urgent / Bientôt
+    Dash-->>Novice: real deadlines + urgency + critical count ("Temps réel", now honest)
+```
+
+## Notes
+
+- No new endpoint and no extra round-trip: the dashboard already calls
+  `GET /batches`.
+- `due_at` is absolute, computed once per request from the snapshotted step; the
+  client re-derives the human "Nh / Nj" and the urgency bucket against its own
+  clock, so the countdown stays live between fetches.
+- When `current_step_due_at` is `null` (step not started / legacy row), the
+  dashboard shows a neutral state (no fabricated deadline) instead of a baked-in
+  projection — this is the honesty fix.

--- a/docs/architecture/diagrams/dashboard-deadlines/02-data-flow.md
+++ b/docs/architecture/diagrams/dashboard-deadlines/02-data-flow.md
@@ -1,0 +1,66 @@
+# Dashboard real deadlines — data flow
+
+Where each value the user sees comes from, after the fix. The hardcoded
+`BREWING_STEPS` planning is removed; the only client-side computation is the
+now-relative presentation bucket.
+
+```mermaid
+flowchart TD
+    subgraph DB["Persisted (snapshotted at launch)"]
+        PD["batch_step.planned_duration_min"]
+        SA["batch_step.started_at"]
+        TY["batch_step.type (RecipeStepType)"]
+        LB["batch_step.label"]
+        CO["batch.current_step_order"]
+    end
+
+    subgraph Backend["BatchService.listMine (computed backend)"]
+        CS["currentStep = steps[current_step_order]"]
+        DUE["current_step_due_at = started_at + planned_duration_min"]
+        CRIT["current_step_is_critical = isQualityCriticalType(type)"]
+        LBL["current_step_label = label"]
+    end
+
+    subgraph DTO["BatchSummaryDto (over the wire)"]
+        F1["current_step_label"]
+        F2["current_step_due_at (nullable)"]
+        F3["current_step_is_critical"]
+    end
+
+    subgraph Client["DashboardScreen (presentation only)"]
+        BUCKET["classify(due_at, now) → En retard de Nh / Urgent / Bientôt / Dans Nj"]
+        COUNTS["Actions 24h = count(due_at in [now, now+24h]) · Alertes critiques = count(is_critical)"]
+        RENDER["Alertes & échéances list + KPI grid ('Temps réel', honest)"]
+    end
+
+    CO --> CS
+    LB --> LBL
+    SA --> DUE
+    PD --> DUE
+    TY --> CRIT
+    CS --> DUE
+    CS --> CRIT
+    CS --> LBL
+    DUE --> F2
+    CRIT --> F3
+    LBL --> F1
+    F2 --> BUCKET
+    F2 --> COUNTS
+    F3 --> COUNTS
+    F1 --> RENDER
+    BUCKET --> RENDER
+    COUNTS --> RENDER
+
+    REMOVED["REMOVED: BREWING_STEPS.expectedHours + isCriticalQuality (hardcoded schedule)"]
+    REMOVED -. deleted .-> RENDER
+```
+
+## Rule: `isQualityCriticalType(type)`
+
+Criticality is derived from `batch_step.type` (RecipeStepType), not a new
+column. Quality-critical types are the post-boil biological/packaging phases
+where a missed deadline degrades the beer (fermentation, conditioning /
+cold-crash, bottling / carbonation). Mash/boil steps are time-sensitive but not
+"quality-critical" in the dashboard's alert sense. The exact enum→boolean map is
+pinned in the backend rule + covered by a unit test, so adding a step type
+forces an explicit criticality decision.

--- a/docs/architecture/diagrams/dashboard-deadlines/03-class.md
+++ b/docs/architecture/diagrams/dashboard-deadlines/03-class.md
@@ -1,0 +1,81 @@
+# Dashboard real deadlines — class / DTO contract
+
+The enriched `BatchSummaryDto` and the backend criticality rule. New fields are
+marked `+NEW`. The DTO builder gains the batch's current `BatchStep` so it can
+compute the deadline; the service is responsible for loading it (one batched
+query, no N+1).
+
+```mermaid
+classDiagram
+    class BatchSummaryDto {
+        +string id
+        +string owner_id
+        +string recipe_id
+        +EffectiveBatchStatus status
+        +int? current_step_order
+        +Date? started_at
+        +Date? fermentation_started_at
+        +Date? completed_at
+        +...existing lifecycle timestamps
+        +string? current_step_label  «NEW»
+        +Date? current_step_due_at  «NEW»
+        +boolean current_step_is_critical  «NEW»
+        +fromEntity(e, currentStep?) BatchSummaryDto
+    }
+
+    class BatchStepOrmEntity {
+        +string batch_id
+        +int step_order
+        +RecipeStepType type
+        +string label
+        +Date? started_at
+        +int? planned_duration_min
+        +BatchStepStatus status
+    }
+
+    class BatchStepCriticality {
+        <<domain rule>>
+        +isQualityCriticalType(type) boolean
+    }
+
+    class BatchService {
+        +listMine(userId) BatchSummaryDto[]
+        -loadCurrentSteps(batches) Map~batchId, BatchStep~
+    }
+
+    BatchService ..> BatchSummaryDto : builds
+    BatchService ..> BatchStepOrmEntity : loads current step per batch
+    BatchSummaryDto ..> BatchStepCriticality : is_critical
+    BatchSummaryDto ..> BatchStepOrmEntity : due_at = started_at + planned_duration_min
+```
+
+## Field semantics
+
+| Field | Type | Computation | Null when |
+|-------|------|-------------|-----------|
+| `current_step_label` | `string?` | `currentStep.label` | no current step (draft / completed) |
+| `current_step_due_at` | `Date?` | `currentStep.started_at + planned_duration_min min` | current step missing, not started, or no planned duration |
+| `current_step_is_critical` | `boolean` | `isQualityCriticalType(currentStep.type)` | defaults `false` when no current step |
+
+## `isQualityCriticalType(type: RecipeStepType): boolean`
+
+```
+FERMENTATION → true    // missed deadline degrades the beer
+PACKAGING    → true    // conditioning / carbonation window
+MASH         → false
+BOIL         → false
+WHIRLPOOL    → false
+```
+
+Pinned by a unit test with an exhaustive `RecipeStepType` switch (a new enum
+member fails compilation / the test until its criticality is decided). This
+replaces the client's hardcoded `isCriticalQuality` booleans.
+
+## Client contract (mobile)
+
+`BatchSummary` (mobile domain) gains `currentStepLabel: string | null`,
+`currentStepDueAt: string | null`, `currentStepIsCritical: boolean`.
+`DashboardScreen` deletes `BREWING_STEPS`, `getDueAtForCurrentStep`, and the
+per-step `expectedHours`/`isCriticalQuality` tables; `getAlertStatus` now
+buckets `currentStepDueAt` vs `now`, and a `null` due date renders a neutral
+"no deadline yet" row instead of a fabricated one.

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -337,13 +337,19 @@ describe('BatchService', () => {
 
     let list = await batchService.listMine(ownerId);
     expect(list).toHaveLength(2);
-    expect(list.every((batch) => batch.owner_id === ownerId)).toBe(true);
-    expect(list.map((b) => b.id)).toEqual([batchB.batch.id, batchA.batch.id]);
+    expect(list.every((row) => row.batch.owner_id === ownerId)).toBe(true);
+    expect(list.map((row) => row.batch.id)).toEqual([
+      batchB.batch.id,
+      batchA.batch.id,
+    ]);
 
     await batchService.completeMineCurrentStep(ownerId, batchA.batch.id);
 
     list = await batchService.listMine(ownerId);
-    expect(list.map((b) => b.id)).toEqual([batchA.batch.id, batchB.batch.id]);
+    expect(list.map((row) => row.batch.id)).toEqual([
+      batchA.batch.id,
+      batchB.batch.id,
+    ]);
   });
 
   it('listMine() should preserve cancelled and archived soft lifecycle stamps', async () => {
@@ -372,7 +378,7 @@ describe('BatchService', () => {
     const list = await batchService.listMine(ownerId);
 
     expect(list).toHaveLength(2);
-    const byId = new Map(list.map((batch) => [batch.id, batch]));
+    const byId = new Map(list.map((row) => [row.batch.id, row.batch]));
     expect(byId.get(cancelled.batch.id)?.status).toBe(BatchStatus.IN_PROGRESS);
     expect(byId.get(cancelled.batch.id)?.cancelled_at).toEqual(cancelledAt);
     expect(byId.get(cancelled.batch.id)?.archived_at).toBeNull();
@@ -384,6 +390,34 @@ describe('BatchService', () => {
   it('listMine() should return empty array when no batches', async () => {
     const list = await batchService.listMine('user-1');
     expect(list).toEqual([]);
+  });
+
+  it('listMine() should attach the current step matching current_step_order', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, {
+      name: 'Deadline batch',
+    });
+    const { batch } = await batchService.startMine(ownerId, recipe.id);
+
+    const [row] = await batchService.listMine(ownerId);
+
+    expect(row.batch.id).toBe(batch.id);
+    expect(row.batch.current_step_order).not.toBeNull();
+    expect(row.currentStep).not.toBeNull();
+    expect(row.currentStep?.step_order).toBe(row.batch.current_step_order);
+  });
+
+  it('listMine() should attach a null current step for an unlaunched draft', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, {
+      name: 'Draft batch',
+    });
+    await batchService.prepareMine(ownerId, recipe.id);
+
+    const [row] = await batchService.listMine(ownerId);
+
+    expect(row.batch.current_step_order).toBeNull();
+    expect(row.currentStep).toBeNull();
   });
 
   it('cancelMine() should soft-cancel an in-progress batch and keep its journal', async () => {
@@ -1235,10 +1269,10 @@ describe('BatchService', () => {
     const { batch } = await batchService.prepareMine(ownerId, recipe.id);
 
     const rows = await batchService.listMine(ownerId);
-    expect(rows.map((row) => row.id)).toContain(batch.id);
+    expect(rows.map((row) => row.batch.id)).toContain(batch.id);
 
     await batchService.deleteMine(ownerId, batch.id);
     const after = await batchService.listMine(ownerId);
-    expect(after.map((row) => row.id)).not.toContain(batch.id);
+    expect(after.map((row) => row.batch.id)).not.toContain(batch.id);
   });
 });

--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -420,6 +420,25 @@ describe('BatchService', () => {
     expect(row.currentStep).toBeNull();
   });
 
+  it('listMine() should attach the right current step to each of two batches sharing a step order', async () => {
+    const ownerId = 'user-1';
+    const recipeA = await recipeService.create(ownerId, { name: 'Batch A' });
+    const recipeB = await recipeService.create(ownerId, { name: 'Batch B' });
+    const startedA = await batchService.startMine(ownerId, recipeA.id);
+    const startedB = await batchService.startMine(ownerId, recipeB.id);
+
+    const list = await batchService.listMine(ownerId);
+    const byId = new Map(list.map((row) => [row.batch.id, row]));
+    const rowA = byId.get(startedA.batch.id);
+    const rowB = byId.get(startedB.batch.id);
+
+    // Both freshly-started batches sit at the same step order; the composite
+    // (batch_id, step_order) key must attach each batch its own step.
+    expect(rowA?.batch.current_step_order).toBe(rowB?.batch.current_step_order);
+    expect(rowA?.currentStep?.batch_id).toBe(startedA.batch.id);
+    expect(rowB?.currentStep?.batch_id).toBe(startedB.batch.id);
+  });
+
   it('cancelMine() should soft-cancel an in-progress batch and keep its journal', async () => {
     const ownerId = 'user-1';
     const recipe = await recipeService.create(ownerId, { name: 'My IPA' });

--- a/packages/api/src/batch/controllers/batch.controller.spec.ts
+++ b/packages/api/src/batch/controllers/batch.controller.spec.ts
@@ -365,6 +365,32 @@ describe('BatchController', () => {
       expect(result).toBeDefined();
     });
 
+    it('maps the current step schedule onto the detail DTO', async () => {
+      // A fermentation current step with a real deadline — the detail
+      // endpoint must carry the same current_step_* fields as the list.
+      const fermentationStep: BatchStepOrmEntity = {
+        ...mockSteps[0],
+        step_order: 3,
+        type: RecipeStepType.FERMENTATION,
+        label: 'Fermentation',
+        started_at: new Date('2026-07-01T10:00:00.000Z'),
+        planned_duration_min: 120,
+      };
+      const batch = { ...mockBatchOrm, current_step_order: 3 };
+      jest.spyOn(service, 'getMineById').mockResolvedValue({
+        batch,
+        steps: [mockSteps[0], fermentationStep],
+      });
+
+      const result = await controller.getMineById(mockUser, batch.id);
+
+      expect(result.current_step_label).toBe('Fermentation');
+      expect(result.current_step_is_critical).toBe(true);
+      expect(result.current_step_due_at).toEqual(
+        new Date('2026-07-01T12:00:00.000Z'),
+      );
+    });
+
     it('should throw NotFoundException when batch not found', async () => {
       // Setup
       const getMineByIdSpy = jest

--- a/packages/api/src/batch/controllers/batch.controller.spec.ts
+++ b/packages/api/src/batch/controllers/batch.controller.spec.ts
@@ -292,11 +292,18 @@ describe('BatchController', () => {
    * GET /batches - List batches
    */
   describe('listMine() - GET /batches', () => {
-    it('should list all batches for current user', async () => {
-      // Setup
+    it('should list batches with the current-step schedule mapped into the DTO', async () => {
+      // Setup — a fermentation current step (critical) with a real deadline.
+      const currentStep: BatchStepOrmEntity = {
+        ...mockSteps[0],
+        type: RecipeStepType.FERMENTATION,
+        label: 'Fermentation',
+        started_at: new Date('2026-07-01T10:00:00.000Z'),
+        planned_duration_min: 60,
+      };
       const listMineSpy = jest
         .spyOn(service, 'listMine')
-        .mockResolvedValue([mockBatchOrm]);
+        .mockResolvedValue([{ batch: mockBatchOrm, currentStep }]);
 
       // Execute
       const result = await controller.listMine(mockUser);
@@ -304,6 +311,24 @@ describe('BatchController', () => {
       // Verify
       expect(listMineSpy).toHaveBeenCalledWith(mockUser.id);
       expect(result).toHaveLength(1);
+      expect(result[0].current_step_label).toBe('Fermentation');
+      expect(result[0].current_step_is_critical).toBe(true);
+      expect(result[0].current_step_due_at).toEqual(
+        new Date('2026-07-01T11:00:00.000Z'),
+      );
+    });
+
+    it('should map a null current step to a neutral schedule (draft/completed)', async () => {
+      const listMineSpy = jest
+        .spyOn(service, 'listMine')
+        .mockResolvedValue([{ batch: mockBatchOrm, currentStep: null }]);
+
+      const result = await controller.listMine(mockUser);
+
+      expect(listMineSpy).toHaveBeenCalledWith(mockUser.id);
+      expect(result[0].current_step_label).toBeNull();
+      expect(result[0].current_step_due_at).toBeNull();
+      expect(result[0].current_step_is_critical).toBe(false);
     });
 
     it('should return empty array when no batches', async () => {

--- a/packages/api/src/batch/controllers/batch.controller.ts
+++ b/packages/api/src/batch/controllers/batch.controller.ts
@@ -130,7 +130,9 @@ export class BatchController {
   @ApiOkResponse({ type: BatchSummaryDto, isArray: true })
   async listMine(@CurrentUser() user: User): Promise<BatchSummaryDto[]> {
     const rows = await this.service.listMine(user.id);
-    return rows.map((row) => BatchSummaryDto.fromEntity(row));
+    return rows.map((row) =>
+      BatchSummaryDto.fromEntity(row.batch, row.currentStep),
+    );
   }
 
   @Get(':id')

--- a/packages/api/src/batch/domain/batch-step-schedule.spec.ts
+++ b/packages/api/src/batch/domain/batch-step-schedule.spec.ts
@@ -1,8 +1,5 @@
 import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
-import {
-  computeStepDueAt,
-  isQualityCriticalType,
-} from './batch-step-schedule';
+import { computeStepDueAt, isQualityCriticalType } from './batch-step-schedule';
 
 describe('isQualityCriticalType', () => {
   it('flags the biological/packaging phases as critical', () => {

--- a/packages/api/src/batch/domain/batch-step-schedule.spec.ts
+++ b/packages/api/src/batch/domain/batch-step-schedule.spec.ts
@@ -1,0 +1,61 @@
+import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
+import {
+  computeStepDueAt,
+  isQualityCriticalType,
+} from './batch-step-schedule';
+
+describe('isQualityCriticalType', () => {
+  it('flags the biological/packaging phases as critical', () => {
+    expect(isQualityCriticalType(RecipeStepType.FERMENTATION)).toBe(true);
+    expect(isQualityCriticalType(RecipeStepType.PACKAGING)).toBe(true);
+  });
+
+  it('does not flag the process phases', () => {
+    expect(isQualityCriticalType(RecipeStepType.MASH)).toBe(false);
+    expect(isQualityCriticalType(RecipeStepType.BOIL)).toBe(false);
+    expect(isQualityCriticalType(RecipeStepType.WHIRLPOOL)).toBe(false);
+  });
+
+  it('covers every RecipeStepType (guards against an unclassified new member)', () => {
+    for (const type of Object.values(RecipeStepType)) {
+      expect(typeof isQualityCriticalType(type)).toBe('boolean');
+    }
+  });
+});
+
+describe('computeStepDueAt', () => {
+  it('adds the planned duration (minutes) to the start instant', () => {
+    const due = computeStepDueAt({
+      started_at: new Date('2026-07-01T10:00:00.000Z'),
+      planned_duration_min: 90,
+    });
+    expect(due).toEqual(new Date('2026-07-01T11:30:00.000Z'));
+  });
+
+  it('returns null when the step has not started', () => {
+    expect(
+      computeStepDueAt({ started_at: null, planned_duration_min: 60 }),
+    ).toBeNull();
+  });
+
+  it('returns null when the step carries no planned duration', () => {
+    expect(
+      computeStepDueAt({
+        started_at: new Date('2026-07-01T10:00:00.000Z'),
+        planned_duration_min: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('treats a zero planned duration as due at the start instant (not null)', () => {
+    const startedAt = new Date('2026-07-01T10:00:00.000Z');
+    expect(
+      computeStepDueAt({ started_at: startedAt, planned_duration_min: 0 }),
+    ).toEqual(startedAt);
+  });
+
+  it('returns null for a null/undefined step', () => {
+    expect(computeStepDueAt(null)).toBeNull();
+    expect(computeStepDueAt(undefined)).toBeNull();
+  });
+});

--- a/packages/api/src/batch/domain/batch-step-schedule.ts
+++ b/packages/api/src/batch/domain/batch-step-schedule.ts
@@ -1,0 +1,49 @@
+import { RecipeStepType } from '../../recipe/domain/enums/recipe-step-type.enum';
+
+/**
+ * Minimal shape needed to derive a step's deadline — the persisted launch
+ * snapshot fields. Accepts the ORM entity or any structurally-compatible row.
+ */
+export interface ScheduledStep {
+  started_at?: Date | null;
+  planned_duration_min?: number | null;
+}
+
+/**
+ * Whether a missed deadline on this step type degrades the beer, so the
+ * dashboard should surface it as a critical alert. Derived from the step
+ * `type` — no dedicated column. The exhaustive `switch` (no `default`) makes a
+ * new `RecipeStepType` member a compile error until its criticality is decided.
+ *
+ * Quality-critical: FERMENTATION (biological window) and PACKAGING
+ * (conditioning / carbonation). MASH / BOIL / WHIRLPOOL are time-sensitive
+ * process steps but not "quality-critical" in the alert sense.
+ */
+export function isQualityCriticalType(type: RecipeStepType): boolean {
+  switch (type) {
+    case RecipeStepType.FERMENTATION:
+    case RecipeStepType.PACKAGING:
+      return true;
+    case RecipeStepType.MASH:
+    case RecipeStepType.BOIL:
+    case RecipeStepType.WHIRLPOOL:
+      return false;
+  }
+}
+
+/**
+ * Absolute instant a step is due: when it started plus its planned duration.
+ * `null` when the step is absent, has not started, or carries no planned
+ * duration — the dashboard shows a neutral "no deadline yet" state rather than
+ * a fabricated one.
+ */
+export function computeStepDueAt(
+  step: ScheduledStep | null | undefined,
+): Date | null {
+  if (!step || !step.started_at || step.planned_duration_min == null) {
+    return null;
+  }
+  return new Date(
+    step.started_at.getTime() + step.planned_duration_min * 60_000,
+  );
+}

--- a/packages/api/src/batch/dtos/batch-summary.dto.ts
+++ b/packages/api/src/batch/dtos/batch-summary.dto.ts
@@ -5,7 +5,12 @@ import {
   EFFECTIVE_BATCH_STATUSES,
 } from '../domain/enums/batch-status.enum';
 import type { EffectiveBatchStatus } from '../domain/enums/batch-status.enum';
+import {
+  computeStepDueAt,
+  isQualityCriticalType,
+} from '../domain/batch-step-schedule';
 import { BatchOrmEntity } from '../entities/batch.orm.entity';
+import { BatchStepOrmEntity } from '../entities/batch-step.orm.entity';
 
 export class BatchSummaryDto {
   @ApiProperty()
@@ -59,7 +64,25 @@ export class BatchSummaryDto {
   @ApiProperty()
   updated_at: Date;
 
-  static fromEntity(e: BatchOrmEntity): BatchSummaryDto {
+  // Current step's real schedule, so the dashboard can show a true deadline
+  // instead of a hardcoded projection. `current_step` is the step matching the
+  // batch's `current_step_order`; null for a draft/completed batch.
+  @ApiPropertyOptional({ nullable: true })
+  current_step_label?: string | null;
+
+  // `current_step.started_at + planned_duration_min`; null when the step has
+  // not started or carries no planned duration.
+  @ApiPropertyOptional({ nullable: true, type: Date })
+  current_step_due_at?: Date | null;
+
+  // Derived from the current step's type (fermentation / packaging).
+  @ApiProperty()
+  current_step_is_critical: boolean;
+
+  static fromEntity(
+    e: BatchOrmEntity,
+    currentStep?: BatchStepOrmEntity | null,
+  ): BatchSummaryDto {
     return {
       id: e.id,
       owner_id: e.owner_id,
@@ -80,6 +103,11 @@ export class BatchSummaryDto {
       archived_at: e.archived_at ?? null,
       created_at: e.created_at,
       updated_at: e.updated_at,
+      current_step_label: currentStep?.label ?? null,
+      current_step_due_at: computeStepDueAt(currentStep),
+      current_step_is_critical: currentStep
+        ? isQualityCriticalType(currentStep.type)
+        : false,
     };
   }
 }

--- a/packages/api/src/batch/dtos/batch.dto.ts
+++ b/packages/api/src/batch/dtos/batch.dto.ts
@@ -20,8 +20,14 @@ export class BatchDto extends BatchSummaryDto {
     batch: BatchOrmEntity,
     steps: BatchStepOrmEntity[],
   ): BatchDto {
+    const currentStep =
+      batch.current_step_order != null
+        ? (steps.find(
+            (step) => step.step_order === batch.current_step_order,
+          ) ?? null)
+        : null;
     return {
-      ...BatchSummaryDto.fromEntity(batch),
+      ...BatchSummaryDto.fromEntity(batch, currentStep),
       steps: steps.map((step) => BatchStepDto.fromEntity(step)),
       prep_checked_ids: batch.prep_checked_ids ?? null,
     };

--- a/packages/api/src/batch/dtos/batch.dto.ts
+++ b/packages/api/src/batch/dtos/batch.dto.ts
@@ -22,9 +22,8 @@ export class BatchDto extends BatchSummaryDto {
   ): BatchDto {
     const currentStep =
       batch.current_step_order != null
-        ? (steps.find(
-            (step) => step.step_order === batch.current_step_order,
-          ) ?? null)
+        ? (steps.find((step) => step.step_order === batch.current_step_order) ??
+          null)
         : null;
     return {
       ...BatchSummaryDto.fromEntity(batch, currentStep),

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -51,6 +51,16 @@ export interface BatchWithSteps {
   steps: BatchStepOrmEntity[];
 }
 
+export interface BatchWithCurrentStep {
+  batch: BatchOrmEntity;
+  currentStep: BatchStepOrmEntity | null;
+}
+
+/** Composite key for the (batch_id, step_order) primary key of a batch step. */
+function stepKey(batchId: string, stepOrder: number): string {
+  return `${batchId}:${stepOrder}`;
+}
+
 export interface CreateMeasurementInput {
   type: MeasurementType;
   value: number;
@@ -244,11 +254,46 @@ export class BatchService {
     });
   }
 
-  async listMine(ownerId: string): Promise<BatchOrmEntity[]> {
-    return this.batchRepo.find({
+  async listMine(ownerId: string): Promise<BatchWithCurrentStep[]> {
+    const batches = await this.batchRepo.find({
       where: { owner_id: ownerId },
       order: { updated_at: 'DESC' },
     });
+
+    const currentSteps = await this.loadCurrentSteps(batches);
+    return batches.map((batch) => ({
+      batch,
+      currentStep:
+        batch.current_step_order != null
+          ? (currentSteps.get(stepKey(batch.id, batch.current_step_order)) ??
+            null)
+          : null,
+    }));
+  }
+
+  /**
+   * Loads, in a single query, the current step of each batch that has one.
+   * Keyed by `batchId:stepOrder` so batches sharing a step order don't
+   * collide — avoids an N+1 over the batch list.
+   */
+  private async loadCurrentSteps(
+    batches: BatchOrmEntity[],
+  ): Promise<Map<string, BatchStepOrmEntity>> {
+    const conditions = batches
+      .filter((batch) => batch.current_step_order != null)
+      .map((batch) => ({
+        batch_id: batch.id,
+        step_order: batch.current_step_order as number,
+      }));
+
+    if (conditions.length === 0) {
+      return new Map();
+    }
+
+    const steps = await this.stepRepo.find({ where: conditions });
+    return new Map(
+      steps.map((step) => [stepKey(step.batch_id, step.step_order), step]),
+    );
   }
 
   async getMineById(ownerId: string, id: string): Promise<BatchWithSteps> {

--- a/packages/mobile-app/src/features/batches/data/batches.api.ts
+++ b/packages/mobile-app/src/features/batches/data/batches.api.ts
@@ -25,6 +25,9 @@ type BatchSummaryDto = {
   fermentation_completed_at?: string | null;
   bottled_at?: string | null;
   completed_at?: string | null;
+  current_step_label?: string | null;
+  current_step_due_at?: string | null;
+  current_step_is_critical?: boolean;
   created_at: string;
   updated_at: string;
 };
@@ -81,6 +84,9 @@ function mapBatchSummary(dto: BatchSummaryDto): BatchSummary {
     fermentationCompletedAt: dto.fermentation_completed_at ?? null,
     bottledAt: dto.bottled_at ?? null,
     completedAt: dto.completed_at ?? null,
+    currentStepLabel: dto.current_step_label ?? null,
+    currentStepDueAt: dto.current_step_due_at ?? null,
+    currentStepIsCritical: dto.current_step_is_critical ?? false,
     createdAt: dto.created_at,
     updatedAt: dto.updated_at,
   };

--- a/packages/mobile-app/src/features/batches/domain/batch.types.ts
+++ b/packages/mobile-app/src/features/batches/domain/batch.types.ts
@@ -34,6 +34,15 @@ export type BatchSummary = {
   // (ADR/state-05); bottledAt is the dedicated timestamp.
   bottledAt?: string | null;
   completedAt?: string | null;
+  // Current step's real schedule (from the launch snapshot), so the dashboard
+  // shows a true deadline instead of a hardcoded projection. `currentStepDueAt`
+  // is null when the step has not started / has no planned duration; the label
+  // is null and `currentStepIsCritical` false when there is no current step
+  // (draft / completed batch). Optional so older fixtures/demo rows omit them;
+  // the API mapping always populates them.
+  currentStepLabel?: string | null;
+  currentStepDueAt?: string | null;
+  currentStepIsCritical?: boolean;
   createdAt: string;
   updatedAt: string;
 };

--- a/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
+++ b/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
@@ -24,15 +24,16 @@ const FERMENTATION_DAYS = 7;
 const BOTTLING_DAYS = 10;
 
 type PeriodKey = "year" | "90d" | "30d";
-type AlertStatus = "Bientôt" | "Urgent" | "En retard";
+type AlertStatus = "Planifié" | "Bientôt" | "Urgent" | "En retard";
 
 type DashboardAlert = {
   id: string;
   batchId: string;
   batchName: string;
   currentStepLabel: string;
-  nextStepLabel: string;
-  dueAt: Date;
+  // Null when the current step has not started / carries no planned duration:
+  // the alert shows a neutral "En cours" state instead of a fabricated deadline.
+  dueAt: Date | null;
   status: AlertStatus;
   isCriticalQuality: boolean;
 };
@@ -64,6 +65,10 @@ type TimelineStep = {
   state: "past" | "current" | "next";
 };
 
+// Illustrative brewing sequence for the 3-step timeline strip and the
+// demo-only hero card. It NO LONGER drives the live "Alertes & échéances"
+// deadlines/urgency/criticality — those now come from the backend
+// (batch.currentStepDueAt / currentStepIsCritical), see buildBatchAlert.
 const BREWING_STEPS: BrewStepConfig[] = [
   { label: "Empâtage", expectedHours: 2, isCriticalQuality: false },
   { label: "Ébullition", expectedHours: 8, isCriticalQuality: false },
@@ -170,6 +175,7 @@ const ALERT_STATUS_PRIORITY: Record<AlertStatus, number> = {
   "En retard": 0,
   Urgent: 1,
   Bientôt: 2,
+  Planifié: 3,
 };
 
 // `value` is nullable since batch.startedAt is null while a batch is an « en
@@ -201,7 +207,10 @@ function clampStepIndex(stepOrder?: number | null): number {
   return Math.min(Math.max(normalized, 0), BREWING_STEPS.length - 1);
 }
 
-function getAlertStatus(dueAt: Date, now: Date): AlertStatus {
+function getAlertStatus(dueAt: Date | null, now: Date): AlertStatus {
+  if (dueAt === null) {
+    return "Planifié";
+  }
   const timeUntilDue = dueAt.getTime() - now.getTime();
   if (timeUntilDue < 0) {
     return "En retard";
@@ -212,7 +221,11 @@ function getAlertStatus(dueAt: Date, now: Date): AlertStatus {
   return "Bientôt";
 }
 
-function formatRelativeDue(dueAt: Date, now: Date): string {
+function formatRelativeDue(dueAt: Date | null, now: Date): string {
+  if (dueAt === null) {
+    return "En cours";
+  }
+
   const diff = dueAt.getTime() - now.getTime();
 
   if (diff < 0) {
@@ -253,13 +266,12 @@ function isWithinSelectedPeriod(
   return date >= threshold;
 }
 
-function getDueAtForCurrentStep(startedAt: Date, stepIndex: number): Date {
-  const totalExpectedHours = BREWING_STEPS.slice(0, stepIndex + 1).reduce(
-    (total, step) => total + step.expectedHours,
-    0,
-  );
-
-  return new Date(startedAt.getTime() + totalExpectedHours * HOUR_MS);
+function parseDueAt(iso: string | null): Date | null {
+  if (!iso) {
+    return null;
+  }
+  const parsed = new Date(iso);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
 }
 
 function buildBatchAlert(
@@ -270,21 +282,18 @@ function buildBatchAlert(
     return null;
   }
 
-  const stepIndex = clampStepIndex(batch.currentStepOrder);
-  const currentStep = BREWING_STEPS[stepIndex];
-  const nextStep = BREWING_STEPS[stepIndex + 1];
-  const startedAt = parseDateOrNow(batch.startedAt, now);
-  const dueAt = getDueAtForCurrentStep(startedAt, stepIndex);
+  // Real schedule from the backend (current step's snapshotted timing), not a
+  // hardcoded projection. A null deadline renders a neutral "En cours" state.
+  const dueAt = parseDueAt(batch.currentStepDueAt ?? null);
 
   return {
-    id: `${batch.id}-${currentStep.label}`,
+    id: `${batch.id}-${batch.currentStepOrder ?? "step"}`,
     batchId: batch.id,
     batchName: `Brassin #${batch.id.slice(0, 6)}`,
-    currentStepLabel: currentStep.label,
-    nextStepLabel: nextStep?.label ?? "Finalisation",
+    currentStepLabel: batch.currentStepLabel ?? "Étape en cours",
     dueAt,
     status: getAlertStatus(dueAt, now),
-    isCriticalQuality: currentStep.isCriticalQuality,
+    isCriticalQuality: batch.currentStepIsCritical ?? false,
   };
 }
 
@@ -398,7 +407,10 @@ export function DashboardScreen() {
             );
           }
 
-          return a.dueAt.getTime() - b.dueAt.getTime();
+          // Undated alerts (no started deadline) sort after dated ones.
+          return (
+            (a.dueAt?.getTime() ?? Infinity) - (b.dueAt?.getTime() ?? Infinity)
+          );
         }),
     [activeBatches, referenceDate],
   );
@@ -424,6 +436,9 @@ export function DashboardScreen() {
   const actionsDueCount = useMemo(
     () =>
       filteredAlerts.filter((alert) => {
+        if (alert.dueAt === null) {
+          return false;
+        }
         const diff = alert.dueAt.getTime() - referenceDate.getTime();
         return diff >= 0 && diff <= DAY_MS;
       }).length,
@@ -459,7 +474,10 @@ export function DashboardScreen() {
         return alertA.isCriticalQuality ? -1 : 1;
       }
 
-      return alertA.dueAt.getTime() - alertB.dueAt.getTime();
+      return (
+        (alertA.dueAt?.getTime() ?? Infinity) -
+        (alertB.dueAt?.getTime() ?? Infinity)
+      );
     };
 
     return [...filteredActiveBatches].sort(compareBatches).slice(0, 2);
@@ -847,7 +865,7 @@ export function DashboardScreen() {
           <Card style={styles.sectionCard}>
             <View style={styles.sectionHeader}>
               <Text style={styles.sectionTitle}>Alertes & échéances</Text>
-              <Text style={styles.sectionMeta}>Temps réel</Text>
+              <Text style={styles.sectionMeta}>Échéances réelles</Text>
             </View>
 
             {filteredAlerts.length === 0 ? (
@@ -873,7 +891,7 @@ export function DashboardScreen() {
                           {alert.batchName}
                         </Text>
                         <Text style={styles.alertMetaText}>
-                          {alert.currentStepLabel} → {alert.nextStepLabel}
+                          {alert.currentStepLabel}
                         </Text>
                         <Text style={styles.alertDueText}>
                           {formatRelativeDue(alert.dueAt, referenceDate)}
@@ -1003,8 +1021,7 @@ export function DashboardScreen() {
                     </View>
 
                     <Text style={styles.activeBatchMeta}>
-                      {alert?.currentStepLabel ?? "Étape en cours"} →{" "}
-                      {alert?.nextStepLabel ?? "Étape suivante"}
+                      {alert?.currentStepLabel ?? "Étape en cours"}
                     </Text>
 
                     <View style={styles.timelineRow}>

--- a/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
+++ b/packages/mobile-app/src/features/dashboard/presentation/DashboardScreen.tsx
@@ -60,15 +60,10 @@ type BrewStepConfig = {
   isCriticalQuality: boolean;
 };
 
-type TimelineStep = {
-  label: string;
-  state: "past" | "current" | "next";
-};
-
-// Illustrative brewing sequence for the 3-step timeline strip and the
-// demo-only hero card. It NO LONGER drives the live "Alertes & échéances"
-// deadlines/urgency/criticality — those now come from the backend
-// (batch.currentStepDueAt / currentStepIsCritical), see buildBatchAlert.
+// Illustrative brewing sequence for the demo-only hero card. It does NOT drive
+// the live "Alertes & échéances" deadlines/urgency/criticality — those come
+// from the backend (batch.currentStepDueAt / currentStepIsCritical), see
+// buildBatchAlert.
 const BREWING_STEPS: BrewStepConfig[] = [
   { label: "Empâtage", expectedHours: 2, isCriticalQuality: false },
   { label: "Ébullition", expectedHours: 8, isCriticalQuality: false },
@@ -295,20 +290,6 @@ function buildBatchAlert(
     status: getAlertStatus(dueAt, now),
     isCriticalQuality: batch.currentStepIsCritical ?? false,
   };
-}
-
-function getTimelineSteps(stepOrder?: number | null): TimelineStep[] {
-  const stepIndex = clampStepIndex(stepOrder);
-  const previousLabel =
-    stepIndex > 0 ? BREWING_STEPS[stepIndex - 1].label : "Préparation";
-  const currentLabel = BREWING_STEPS[stepIndex].label;
-  const nextLabel = BREWING_STEPS[stepIndex + 1]?.label ?? "Finalisation";
-
-  return [
-    { label: previousLabel, state: "past" },
-    { label: currentLabel, state: "current" },
-    { label: nextLabel, state: "next" },
-  ];
 }
 
 function getStatusColors(status: string): {
@@ -984,7 +965,6 @@ export function DashboardScreen() {
                 const statusColors = getStatusColors(
                   alert?.status ?? "Bientôt",
                 );
-                const timeline = getTimelineSteps(batch.currentStepOrder);
 
                 return (
                   <Pressable
@@ -1023,32 +1003,6 @@ export function DashboardScreen() {
                     <Text style={styles.activeBatchMeta}>
                       {alert?.currentStepLabel ?? "Étape en cours"}
                     </Text>
-
-                    <View style={styles.timelineRow}>
-                      {timeline.map((step) => {
-                        const dotStyle =
-                          step.state === "past"
-                            ? styles.timelineDotPast
-                            : step.state === "current"
-                              ? styles.timelineDotCurrent
-                              : styles.timelineDotNext;
-
-                        return (
-                          <View
-                            key={`${batch.id}-${step.label}`}
-                            style={styles.timelineItem}
-                          >
-                            <View style={[styles.timelineDot, dotStyle]} />
-                            <Text
-                              style={styles.timelineLabel}
-                              numberOfLines={1}
-                            >
-                              {step.label}
-                            </Text>
-                          </View>
-                        );
-                      })}
-                    </View>
                   </Pressable>
                 );
               })}
@@ -1451,33 +1405,6 @@ const styles = StyleSheet.create({
     color: colors.neutral.textPrimary,
   },
   activeBatchMeta: {
-    fontSize: typography.size.caption,
-    color: colors.neutral.textSecondary,
-  },
-  timelineRow: {
-    flexDirection: "row",
-    gap: spacing.xs,
-  },
-  timelineItem: {
-    flex: 1,
-    alignItems: "center",
-    gap: spacing.xxs,
-  },
-  timelineDot: {
-    width: 10,
-    height: 10,
-    borderRadius: radius.full,
-  },
-  timelineDotPast: {
-    backgroundColor: colors.semantic.success,
-  },
-  timelineDotCurrent: {
-    backgroundColor: colors.brand.secondary,
-  },
-  timelineDotNext: {
-    backgroundColor: colors.neutral.muted,
-  },
-  timelineLabel: {
     fontSize: typography.size.caption,
     color: colors.neutral.textSecondary,
   },

--- a/packages/mobile-app/src/features/dashboard/presentation/__tests__/DashboardScreen.test.tsx
+++ b/packages/mobile-app/src/features/dashboard/presentation/__tests__/DashboardScreen.test.tsx
@@ -229,6 +229,8 @@ describe("DashboardScreen — real deadlines (from the backend, not BREWING_STEP
 
     expect(await screen.findByText("Alertes & échéances")).toBeTruthy();
     expect(screen.getByText("En cours")).toBeTruthy();
+    // Neutral "Planifié" status pill rather than a fabricated urgency.
+    expect(screen.getAllByText("Planifié").length).toBeGreaterThan(0);
     // No fabricated "En retard de Nh" projection for an undated step.
     expect(screen.queryByText(/En retard de/)).toBeNull();
   });

--- a/packages/mobile-app/src/features/dashboard/presentation/__tests__/DashboardScreen.test.tsx
+++ b/packages/mobile-app/src/features/dashboard/presentation/__tests__/DashboardScreen.test.tsx
@@ -183,6 +183,57 @@ describe("DashboardScreen", () => {
   });
 });
 
+describe("DashboardScreen — real deadlines (from the backend, not BREWING_STEPS)", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    dataSourceMock.useDemoData = false;
+    sessionUserMock.id = "u1";
+    sessionUserMock.firstName = "Benoit";
+  });
+
+  it("renders the real overdue deadline and step label from the batch summary", async () => {
+    const threeHoursAgo = new Date(
+      Date.now() - 3 * 60 * 60 * 1000,
+    ).toISOString();
+    (listBatches as jest.Mock).mockResolvedValue([
+      {
+        ...liveBatch,
+        id: "b-overdue",
+        currentStepLabel: "Fermentation",
+        currentStepDueAt: threeHoursAgo,
+        currentStepIsCritical: true,
+      },
+    ]);
+
+    renderDashboardScreen();
+
+    expect(await screen.findByText("Alertes & échéances")).toBeTruthy();
+    // Deadline computed from the backend due date, not a hardcoded schedule.
+    expect(screen.getAllByText(/En retard de \d+h/).length).toBeGreaterThan(0);
+    // Real snapshotted step label, no fabricated "→ next step".
+    expect(screen.getAllByText("Fermentation").length).toBeGreaterThan(0);
+  });
+
+  it("renders a neutral 'En cours' state when the current step has no deadline yet", async () => {
+    (listBatches as jest.Mock).mockResolvedValue([
+      {
+        ...liveBatch,
+        id: "b-no-deadline",
+        currentStepLabel: "Empâtage",
+        currentStepDueAt: null,
+        currentStepIsCritical: false,
+      },
+    ]);
+
+    renderDashboardScreen();
+
+    expect(await screen.findByText("Alertes & échéances")).toBeTruthy();
+    expect(screen.getByText("En cours")).toBeTruthy();
+    // No fabricated "En retard de Nh" projection for an undated step.
+    expect(screen.queryByText(/En retard de/)).toBeNull();
+  });
+});
+
 describe("DashboardScreen — demo-mode hero", () => {
   // Anchor the fil-rouge fermentation start 5 days ago so the ribbon
   // computes a sensible "J+5" value at render time. The mash batch

--- a/packages/mobile-app/src/mocks/demo-data.ts
+++ b/packages/mobile-app/src/mocks/demo-data.ts
@@ -2638,6 +2638,11 @@ export const demoBatchSummaries: BatchSummary[] = [
     fermentationStartedAt: null,
     fermentationCompletedAt: null,
     completedAt: null,
+    currentStepLabel: "Empâtage",
+    // Null on the fixed-date demo so the alert reads a neutral "En cours"
+    // rather than a stale "En retard"; criticality is what matters here.
+    currentStepDueAt: null,
+    currentStepIsCritical: false,
     createdAt: "2026-05-19T09:00:00.000Z",
     updatedAt: "2026-05-19T09:30:00.000Z",
   },
@@ -2651,6 +2656,9 @@ export const demoBatchSummaries: BatchSummary[] = [
     fermentationStartedAt: "2026-05-14T11:30:00.000Z",
     fermentationCompletedAt: null,
     completedAt: null,
+    currentStepLabel: "Fermentation",
+    currentStepDueAt: null,
+    currentStepIsCritical: true,
     createdAt: "2026-05-14T09:00:00.000Z",
     updatedAt: "2026-05-19T08:00:00.000Z",
   },
@@ -2664,6 +2672,10 @@ export const demoBatchSummaries: BatchSummary[] = [
     fermentationStartedAt: "2026-04-22T11:30:00.000Z",
     fermentationCompletedAt: "2026-05-06T11:30:00.000Z",
     completedAt: "2026-05-12T15:00:00.000Z",
+    // Completed batch: no active step, so it never surfaces as an alert.
+    currentStepLabel: null,
+    currentStepDueAt: null,
+    currentStepIsCritical: false,
     createdAt: "2026-04-22T09:00:00.000Z",
     updatedAt: "2026-05-12T15:00:00.000Z",
   },


### PR DESCRIPTION
## Summary

The home dashboard's **"Alertes & échéances"** deadlines, urgency pills, "Actions 24h" and "Alertes critiques" were fabricated client-side from a hardcoded `BREWING_STEPS` schedule (Empâtage 2h, Ébullition 8h, Fermentation 24h…) — surfaced under a misleading **"Temps réel"** caption. This replaces that projection with the batch's **real** snapshotted step schedule, which the backend already stores.

### API
- `GET /batches` (`BatchSummaryDto`) and `GET /batches/:id` (`BatchDto`) now carry, per batch, the current step's:
  - `current_step_label`
  - `current_step_due_at` = `started_at + planned_duration_min` (computed backend; `null` when not started / no planned duration)
  - `current_step_is_critical`, derived from the step `type` (fermentation / packaging) via a new `isQualityCriticalType` rule (exhaustive `switch`).
- `BatchService.listMine` loads each batch's current step in a **single batched query** (composite `(batch_id, step_order)` key, no N+1) and returns `{ batch, currentStep }`.

### Mobile
- `DashboardScreen` drops `BREWING_STEPS` from the alert path; `buildBatchAlert` reads the backend fields. A null deadline renders a neutral **"En cours" / "Planifié"** state instead of a fabricated "En retard de Nh".
- The fabricated "→ next step" label and the `BREWING_STEPS`-driven "Brassins actifs" timeline strip are removed (they could disagree with the real current-step label).
- `BREWING_STEPS` remains only for the demo-only hero card. The **"Temps réel"** caption becomes **"Échéances réelles"** (honest: real deadlines refreshed on load, not live-ticking).

### Conception (UML-first)
`docs/architecture/diagrams/dashboard-deadlines/` — 00-conception, 01-sequence, 02-data-flow, 03-class. Consistent with the compute-in-backend pattern (ADR-0020/0024/0026). No migration (no column added).

## Checklist

- [x] Happy + sad + edge (overdue-critical, undated "En cours", null step, same-`step_order` collision, detail-endpoint mapping)
- [x] `nest build` passes · API **1030** tests
- [x] Mobile `ci:check` (lint + typecheck + format) · **1472** tests
- [x] No `any`, no default exports, no raw SQL in services, no inline styles introduced
- [x] Pre-push review run twice (initial + fix verification), all Must Haves resolved

## Follow-up (out of scope)

Other data-provenance audit items (calculator catalog snapshots, scan mock repository, local-only consent/preferences per ADR-0003) are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)