### PR TITLE
feat(api): use the recipe's boil time as the BOIL step's real deadline

### DIFF
--- a/packages/api/src/batch/batch.service.spec.ts
+++ b/packages/api/src/batch/batch.service.spec.ts
@@ -15,6 +15,7 @@ import { BatchService } from './services/batch.service';
 import { BatchStatus } from './domain/enums/batch-status.enum';
 import { BatchStepOrmEntity } from './entities/batch-step.orm.entity';
 import { BatchStepStatus } from './domain/enums/batch-step-status.enum';
+import { RecipeStepType } from '../recipe/domain/enums/recipe-step-type.enum';
 import { MeasurementOrmEntity } from './entities/measurement.orm.entity';
 import { MeasurementType } from './domain/enums/measurement-type.enum';
 import { ObservationOrmEntity } from './entities/observation.orm.entity';
@@ -200,6 +201,46 @@ describe('BatchService', () => {
     expect(reloaded[0].planned_duration_min).toBe(60);
     expect(reloaded[3].pedagogical_tip).toBeTruthy();
     expect(reloaded[3].planned_duration_min).toBeNull();
+  });
+
+  it("startMine() uses the recipe's boil time for the BOIL step's planned duration", async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, {
+      name: 'Long-boil IPA',
+      boil_time_min: 90,
+    });
+
+    const { steps } = await batchService.startMine(ownerId, recipe.id);
+    const boilStep = steps.find((step) => step.type === RecipeStepType.BOIL);
+
+    // Real recipe boil time (90), not the generic step-guidance default (60).
+    expect(boilStep?.planned_duration_min).toBe(90);
+  });
+
+  it('startMine() falls back to the guidance default when the recipe has no boil time', async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, {
+      name: 'No-boil-time',
+    });
+
+    const { steps } = await batchService.startMine(ownerId, recipe.id);
+    const boilStep = steps.find((step) => step.type === RecipeStepType.BOIL);
+
+    expect(boilStep?.planned_duration_min).toBe(60);
+  });
+
+  it("launchMine() also uses the recipe's boil time on the launched BOIL step", async () => {
+    const ownerId = 'user-1';
+    const recipe = await recipeService.create(ownerId, {
+      name: 'Draft long-boil',
+      boil_time_min: 90,
+    });
+    const { batch: draft } = await batchService.prepareMine(ownerId, recipe.id);
+
+    const { steps } = await batchService.launchMine(ownerId, draft.id);
+    const boilStep = steps.find((step) => step.type === RecipeStepType.BOIL);
+
+    expect(boilStep?.planned_duration_min).toBe(90);
   });
 
   it('getMineById() should enforce ownership', async () => {

--- a/packages/api/src/batch/domain/services/batch-domain.service.ts
+++ b/packages/api/src/batch/domain/services/batch-domain.service.ts
@@ -1,4 +1,5 @@
 import { RecipeStep } from '../../../recipe/domain/entities/recipe-step.entity';
+import { RecipeStepType } from '../../../recipe/domain/enums/recipe-step-type.enum';
 
 import { BatchStatus } from '../enums/batch-status.enum';
 import { BatchStepStatus } from '../enums/batch-step-status.enum';
@@ -11,6 +12,12 @@ export interface StartBatchInput {
   ownerId: UserId;
   recipeId: RecipeId;
   steps: ReadonlyArray<RecipeStep>;
+  /**
+   * The recipe's boil time (minutes), used as the BOIL step's real planned
+   * duration instead of the generic step-guidance default. Null/absent → the
+   * default stands.
+   */
+  boilTimeMin?: number | null;
 }
 
 export interface PrepareBatchInput {
@@ -68,7 +75,11 @@ export class BatchDomainService {
    * `launchedAt` (the draft → in_progress transition of brew-day/07). The
    * first step opens in PRÉP (no step `startedAt`) per brew-day/06.
    */
-  launchBatch(batch: Batch, recipeSteps: ReadonlyArray<RecipeStep>): Batch {
+  launchBatch(
+    batch: Batch,
+    recipeSteps: ReadonlyArray<RecipeStep>,
+    boilTimeMin?: number | null,
+  ): Batch {
     if (batch.launchedAt !== undefined) {
       throw new Error('Batch already launched');
     }
@@ -80,7 +91,7 @@ export class BatchDomainService {
       ...batch,
       status: BatchStatus.IN_PROGRESS,
       currentStepOrder: 0,
-      steps: this.snapshotSteps(recipeSteps),
+      steps: this.snapshotSteps(recipeSteps, boilTimeMin),
       updatedAt: now,
       startedAt: now,
       launchedAt: now,
@@ -89,7 +100,11 @@ export class BatchDomainService {
 
   /** Prepare + launch in one shot — the direct POST /batches path. */
   startBatch(input: StartBatchInput): Batch {
-    return this.launchBatch(this.prepareBatch(input), input.steps);
+    return this.launchBatch(
+      this.prepareBatch(input),
+      input.steps,
+      input.boilTimeMin,
+    );
   }
 
   /**
@@ -97,11 +112,20 @@ export class BatchDomainService {
    * step starts pending except step 0, which opens as the current step in the
    * PRÉP phase (no `startedAt` until the brewer activates it — F1).
    */
-  private snapshotSteps(recipeSteps: ReadonlyArray<RecipeStep>): BatchStep[] {
+  private snapshotSteps(
+    recipeSteps: ReadonlyArray<RecipeStep>,
+    boilTimeMin?: number | null,
+  ): BatchStep[] {
     const sortedSteps = [...recipeSteps].sort((a, b) => a.order - b.order);
     return sortedSteps.map((step) => {
       const isFirst = step.order === 0;
       const guidance = getStepGuidance(step.type);
+      // The BOIL step gets the recipe's real boil time when it carries one
+      // (a positive value); otherwise the generic step-guidance default stands.
+      const plannedDurationMin =
+        step.type === RecipeStepType.BOIL && boilTimeMin && boilTimeMin > 0
+          ? boilTimeMin
+          : (guidance?.plannedDurationMin ?? undefined);
       return {
         order: step.order,
         type: step.type,
@@ -111,7 +135,7 @@ export class BatchDomainService {
         startedAt: undefined,
         completedAt: undefined,
         pedagogicalTip: guidance?.pedagogicalTip,
-        plannedDurationMin: guidance?.plannedDurationMin ?? undefined,
+        plannedDurationMin,
         // An empty list (e.g. PACKAGING — the B3 bottling gate covers it)
         // stays undefined so the column persists null and mobile renders no
         // empty PRÉP block.

--- a/packages/api/src/batch/services/batch.service.ts
+++ b/packages/api/src/batch/services/batch.service.ts
@@ -119,6 +119,7 @@ export class BatchService {
   ) {}
 
   async startMine(ownerId: string, recipeId: string): Promise<BatchWithSteps> {
+    const recipe = await this.recipeService.getReadableById(ownerId, recipeId);
     const recipeSteps = await this.recipeService.listMineSteps(
       ownerId,
       recipeId,
@@ -136,6 +137,7 @@ export class BatchService {
       ownerId,
       recipeId,
       steps: snapshotSteps,
+      boilTimeMin: recipe.boil_time_min ?? null,
     });
 
     return this.batchRepo.manager.transaction(async (manager) => {
@@ -233,6 +235,10 @@ export class BatchService {
     this.assertMutable(batch);
     this.assertDraft(batch);
 
+    const recipe = await this.recipeService.getReadableById(
+      ownerId,
+      batch.recipe_id,
+    );
     const recipeSteps = await this.recipeService.listMineSteps(
       ownerId,
       batch.recipe_id,
@@ -245,7 +251,12 @@ export class BatchService {
     }));
 
     const launched = this.runStepTransition(
-      (draft) => this.domain.launchBatch(draft, snapshotSteps),
+      (draft) =>
+        this.domain.launchBatch(
+          draft,
+          snapshotSteps,
+          recipe.boil_time_min ?? null,
+        ),
       this.toDomain(batch, []),
     );
 


### PR DESCRIPTION
## Summary

Follow-up to the dashboard real-deadlines feature (#1512). The batch launch snapshot gave every **BOIL** step the generic step-guidance default (60 min) for `planned_duration_min`, so the dashboard's real-deadline path showed a fixed 60-minute boil for every batch — even though the recipe already stores the real `boil_time_min`.

- Thread the recipe's `boil_time_min` into the launch snapshot (both the direct `startMine` and the draft `launchMine` paths) via a `boilTimeMin` param on `BatchDomainService.startBatch`/`launchBatch`/`snapshotSteps`.
- Apply it to the BOIL step's `planned_duration_min` when the recipe carries a positive value; otherwise the guidance default stands.
- Uses data already in the recipe model — **no migration, no fabricated value**.
- The recipe is read via `getReadableById` (owner-or-public), matching the existing `listMineSteps` authorization — **no change to who can start/launch a batch**.

Fermentation/packaging still carry no real duration (that needs new recipe data + an educated-default UX) and remain a tracked follow-up — they keep showing "En cours".

## Checklist

- [x] H/S/E: boil time applied (startMine + launchMine), default fallback when absent
- [x] `nest build` + `lint:check` pass · full API suite **1069** tests (3 new)
- [x] No migration, no `any`, no raw SQL, no authorization change
- [x] Pre-push review (Claude + Codex) — 0 Must Have; Should Haves (authz-preservation via `getReadableById`, `launchMine` test) addressed